### PR TITLE
refactor(query): use explicit Wellcrafted query API

### DIFF
--- a/.agents/skills/query-layer/SKILL.md
+++ b/.agents/skills/query-layer/SKILL.md
@@ -31,7 +31,7 @@ Use this pattern when you need to:
 - Decide whether work belongs in `$lib/rpc`, `$lib/operations`, or `$lib/services`
 - Implement runtime service selection based on user settings
 - Add optimistic cache updates for instant UI feedback
-- Understand the dual interface pattern (reactive vs imperative)
+- Understand hook-local adapters and reusable query definitions
 
 ## Core Architecture
 
@@ -50,8 +50,23 @@ Use this pattern when you need to:
 - Call services with injected settings/configuration
 - Preserve typed service and operation errors unless the adapter introduces a new local failure
 - Manage TanStack Query cache for optimistic updates
-- Provide dual interfaces: reactive (`.options`) and imperative (`.execute()`)
+- Provide hook-ready `.options` for shared definitions and explicit imperative APIs where they exist
 - Own shared cache identity through exported `*Keys` maps
+
+## Wellcrafted Query API Shape
+
+| Scope | Query | Mutation |
+| --- | --- | --- |
+| Hook-local | `queryOptions(input)` | `mutationOptions(input)` |
+| Reusable definition | `defineQuery(input)` | `defineMutation(input)` |
+
+Use `queryOptions` and `mutationOptions` at one hook call site when no imperative API or shared query identity is needed.
+
+Use `defineQuery` and `defineMutation` in shared `$lib/rpc` / `$lib/query` modules.
+
+Queries expose `.options`, `.fetch()`, and `.ensure()`. They are not callable.
+
+Mutations expose `.options` and are callable. They do not expose `.execute()`.
 
 ## Canonical Whispering RPC Module Shape
 
@@ -100,7 +115,7 @@ Rules:
 
 Use `$lib/rpc` as the shared TanStack observation surface. It may wrap a direct service/state call, or a `$lib/operations` entry point when UI needs shared mutation identity: multiple consumers, cache invalidation, optimistic updates, `useIsMutating`, or a named mutation key over that operation.
 
-Keep orchestration in `$lib/operations`: delivery, reporting, sounds, analytics, clipboard writes, and multi-step workflows. A one-off component can observe an operation locally with `createMutation(() => ({ mutationFn }))` instead of promoting it into `$lib/rpc`.
+Keep orchestration in `$lib/operations`: delivery, reporting, sounds, analytics, clipboard writes, and multi-step workflows. A one-off component can observe a Result-returning operation locally with `createMutation(() => mutationOptions({ mutationKey, mutationFn }))` instead of promoting it into `$lib/rpc`.
 
 Lack of cache invalidation is not a reason to avoid `createMutation` in a Svelte component. If the template observes operation lifecycle state such as `isPending`, disabled controls, loading text, success handling, or error handling, local `createMutation` is the preferred wrapper.
 
@@ -124,17 +139,18 @@ TaggedError<'Name'>           same error            report.error({ cause: error 
 
 Only define an RPC-local error when the adapter itself discovers a failure that no lower layer can own, such as a missing recording lookup before calling an operation.
 
-## Dual Interface Pattern
+## Reactive And Imperative Use
 
-Query-layer adapters provide two ways to use shared operations. Component-local operations can use the same reactive shape with inline `createMutation(() => ({ mutationFn }))`.
+Query-layer adapters provide reactive hook usage and explicit imperative usage. Component-local Result-returning operations can use the same reactive shape with `mutationOptions`.
 
-### Reactive Interface: `.options` Or Local `mutationFn`
+### Reactive Interface: `.options` Or Hook-Local Options
 
-Use in Svelte components when the template reads lifecycle state. Pass `.options` (a static object) inside an accessor function for shared RPC operations. For one-off component operations, pass a local `mutationFn`:
+Use in Svelte components when the template reads lifecycle state. Pass `.options` (a static object) inside an accessor function for shared RPC operations. For one-off component operations, use `queryOptions` or `mutationOptions`:
 
 ```svelte
 <script lang="ts">
 	import { createQuery, createMutation } from '@tanstack/svelte-query';
+	import { mutationOptions } from 'wellcrafted/query';
 	import { rpc } from '$lib/rpc';
 	import { exportRecordingsMarkdown } from '$lib/recording-markdown-export';
 
@@ -146,9 +162,12 @@ Use in Svelte components when the template reads lifecycle state. Pass `.options
 		() => rpc.transformer.transformRecording.options,
 	);
 
-	const exportMarkdown = createMutation(() => ({
-		mutationFn: exportRecordingsMarkdown,
-	}));
+	const exportMarkdown = createMutation(() =>
+		mutationOptions({
+			mutationKey: ['recordings', 'exportMarkdown'],
+			mutationFn: exportRecordingsMarkdown,
+		}),
+	);
 </script>
 
 {#if playbackUrl.isPending}
@@ -160,7 +179,7 @@ Use in Svelte components when the template reads lifecycle state. Pass `.options
 {/if}
 ```
 
-### Imperative Interface: `.execute()` / `.fetch()` / Direct Await
+### Imperative Interface: Queries Choose Cache Policy, Mutations Are Callable
 
 Use outside component context, or inside Svelte workflows that do not expose pending, success, or error state to the template:
 
@@ -192,14 +211,18 @@ async function stopAndTranscribe(toastId: string) {
 }
 ```
 
+Use `.fetch()` when the user action asks for freshness or validation against current external state. Use `.ensure()` when cache-first behavior is acceptable, such as preloaders or setup flows.
+
 ### When to Use Each
 
 | Situation | Pattern |
 | --------- | ------- |
 | Component reads server or async data | `createQuery(() => rpc.thing.options)` |
 | Shared mutation identity, invalidation, optimistic update, or multiple consumers | `defineMutation` in `$lib/rpc`, consumed with `createMutation(() => rpc.thing.options)` |
-| One-off Svelte button/action with observed pending, success, or error state | Local `createMutation(() => ({ mutationFn }))` |
-| `.ts` file, command workflow, service orchestration, or Svelte action with no observed lifecycle state | `.execute()`, `.fetch()`, or direct `await` |
+| One-off Svelte button/action with observed pending, success, or error state | Local `createMutation(() => mutationOptions({ mutationKey, mutationFn }))` |
+| Imperative query read | `rpc.thing(...).fetch()` or `rpc.thing(...).ensure()` |
+| Imperative mutation | `rpc.thing(input)` |
+| Plain operation with no observed lifecycle state | Direct `await operation(input)` |
 
 ## Key Rules
 

--- a/.agents/skills/svelte/SKILL.md
+++ b/.agents/skills/svelte/SKILL.md
@@ -85,11 +85,15 @@ For a component-local operation lifecycle, do not add a new RPC adapter only to 
 ```svelte
 <script lang="ts">
 	import { createMutation } from '@tanstack/svelte-query';
+	import { mutationOptions } from 'wellcrafted/query';
 	import { startManualRecording } from '$lib/operations/recording';
 
-	const startRecording = createMutation(() => ({
-		mutationFn: startManualRecording,
-	}));
+	const startRecording = createMutation(() =>
+		mutationOptions({
+			mutationKey: ['recording', 'startManual'],
+			mutationFn: startManualRecording,
+		}),
+	);
 </script>
 ```
 

--- a/.agents/skills/svelte/references/mutations-and-workspace-inputs.md
+++ b/.agents/skills/svelte/references/mutations-and-workspace-inputs.md
@@ -10,9 +10,9 @@ In `.svelte` files, use `createMutation` for user-triggered async operations whe
 
 `createMutation` is the component operation lifecycle primitive. It is not reserved for cache invalidation, retry policy, or shared mutation keys.
 
-Use `defineMutation` in `$lib/rpc` when the operation has shared query-layer identity: multiple consumers, cache invalidation, optimistic updates, `useIsMutating`, or a reusable RPC boundary. For a one-off component action, keep the operation as a plain function in `$lib/operations`, `$lib/services`, or a focused module, then wrap it locally with `createMutation(() => ({ mutationFn }))`.
+Use `defineMutation` in `$lib/rpc` when the operation has shared query-layer identity: multiple consumers, cache invalidation, optimistic updates, `useIsMutating`, or a reusable RPC boundary. For a one-off Result-returning component action, keep the operation as a plain function in `$lib/operations`, `$lib/services`, or a focused module, then wrap it locally with `createMutation(() => mutationOptions({ mutationKey, mutationFn }))`.
 
-Use direct `await` or `.execute()` when no template lifecycle state is observed, when the code runs outside component context, or when a sequential workflow would become harder to read as mutation callbacks.
+Use direct `await` when no template lifecycle state is observed, when the code runs outside component context, or when a sequential workflow would become harder to read as mutation callbacks. Shared Wellcrafted mutations are callable, so imperative RPC mutation usage is `await rpc.thing(input)`.
 
 ## Async Button Pattern
 
@@ -65,30 +65,33 @@ For component-local operation lifecycle, wrap the function locally:
 ```svelte
 <script lang="ts">
 	import { createMutation } from '@tanstack/svelte-query';
+	import { mutationOptions } from 'wellcrafted/query';
 	import { exportRecordingsMarkdown } from '$lib/recording-markdown-export';
 	import { report } from '$lib/report';
 
-	const exportMarkdown = createMutation(() => ({
-		mutationFn: exportRecordingsMarkdown,
-	}));
+	const exportMarkdown = createMutation(() =>
+		mutationOptions({
+			mutationKey: ['recordings', 'exportMarkdown'],
+			mutationFn: exportRecordingsMarkdown,
+		}),
+	);
 </script>
 
 <Button
 	onclick={() => {
 		exportMarkdown.mutate(undefined, {
-			onSuccess: ({ data, error }) => {
-				if (error !== null) {
-					report.error({
-						title: 'Recording markdown export failed',
-						cause: error,
-					});
-					return;
-				}
+			onSuccess: (data) => {
 				if (data.status === 'cancelled') return;
 
 				report.success({
 					title: 'Recording markdown exported',
 					description: `Wrote ${data.written} ${data.written === 1 ? 'file' : 'files'} to ${data.dir}.`,
+				});
+			},
+			onError: (error) => {
+				report.error({
+					title: 'Recording markdown export failed',
+					cause: error,
 				});
 			},
 		});
@@ -103,11 +106,11 @@ Do not create an RPC adapter only to get `isPending` for one component. Local `c
 
 ## Direct Await Pattern
 
-In `.ts` files, use `.execute()` or direct `await` because `createMutation` requires component context:
+In `.ts` files, use direct `await` because `createMutation` requires component context. For shared Wellcrafted mutations, call the mutation definition directly:
 
 ```typescript
 // In a .ts file (e.g., load function, utility)
-const result = await rpc.sessions.createSession.execute({
+const result = await rpc.sessions.createSession({
 	body: { title: 'New Session' },
 });
 

--- a/apps/dashboard/src/routes/(signed-in)/+layout.svelte
+++ b/apps/dashboard/src/routes/(signed-in)/+layout.svelte
@@ -1,16 +1,20 @@
 <script lang="ts">
 	import { Button } from '@epicenter/ui/button';
 	import * as Card from '@epicenter/ui/card';
-	import { createResultMutation } from '@epicenter/svelte/query';
 	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
+	import { createMutation } from '@tanstack/svelte-query';
+	import { mutationOptions } from 'wellcrafted/query';
 	import UserMenu from '$lib/components/UserMenu.svelte';
 	import { auth } from '$platform/auth';
 
 	let { children } = $props();
 
-	const startSignIn = createResultMutation(() => ({
-		mutationFn: () => auth.startSignIn(),
-	}));
+	const startSignIn = createMutation(() =>
+		mutationOptions({
+			mutationKey: ['auth', 'startSignIn'],
+			mutationFn: () => auth.startSignIn(),
+		}),
+	);
 </script>
 
 {#if auth.state.status === 'signed-in'}

--- a/apps/honeycrisp/src/routes/(signed-in)/+layout.svelte
+++ b/apps/honeycrisp/src/routes/(signed-in)/+layout.svelte
@@ -1,17 +1,21 @@
 <script lang="ts">
 	import { WorkspaceGate } from '@epicenter/svelte/workspace-gate';
-	import { createResultMutation } from '@epicenter/svelte/query';
 	import { Button } from '@epicenter/ui/button';
 	import * as Tooltip from '@epicenter/ui/tooltip';
 	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
+	import { createMutation } from '@tanstack/svelte-query';
+	import { mutationOptions } from 'wellcrafted/query';
 	import { requireHoneycrisp, session } from '$lib/session';
 	import { auth } from '$platform/auth';
 
 	let { children } = $props();
 
-	const startSignIn = createResultMutation(() => ({
-		mutationFn: () => auth.startSignIn(),
-	}));
+	const startSignIn = createMutation(() =>
+		mutationOptions({
+			mutationKey: ['auth', 'startSignIn'],
+			mutationFn: () => auth.startSignIn(),
+		}),
+	);
 </script>
 
 {#if session.current}

--- a/apps/whispering/specs/20250107T093000-fix-duplicate-recording-service-errors.md
+++ b/apps/whispering/specs/20250107T093000-fix-duplicate-recording-service-errors.md
@@ -38,7 +38,7 @@ Each service should have its own specific error type:
 In commands.ts, change error handling from:
 
 ```typescript
-rpc.notify.error.execute({
+rpc.notify.error({
 	id: toastId,
 	title: '❌ Failed to start recording',
 	description: 'Your recording could not be started. Please try again.',
@@ -49,7 +49,7 @@ rpc.notify.error.execute({
 To:
 
 ```typescript
-rpc.notify.error.execute({
+rpc.notify.error({
 	id: toastId,
 	title: '❌ Failed to start recording',
 	description: startRecordingError.message,

--- a/apps/whispering/src/lib/rpc/README.md
+++ b/apps/whispering/src/lib/rpc/README.md
@@ -61,6 +61,8 @@ For one-off local lifecycle state, wrap the operation in the component instead:
 
 Cross-adapter coordination still belongs in operations. An RPC file should not import a sibling RPC module just to sequence work.
 
+If the one-off operation returns a Wellcrafted `Result`, use `mutationOptions({ mutationKey, mutationFn })` at the hook call site so TanStack receives data and error through its normal channels.
+
 ## Canonical module shape
 
 Keep each adapter file in source-of-truth order:
@@ -128,7 +130,18 @@ transcribeRecording: defineMutation({
 
 ## Imperative escape hatches
 
-Every `defineQuery`/`defineMutation` returned object is also directly callable and exposes `.fetch()` / `.execute()` for imperative use. Prefer plain async functions in `$lib/operations/` for code that is not observed by a component, instead of reaching for `.execute()` on a mutation.
+Queries expose `.fetch()` and `.ensure()` for imperative reads. Use `.fetch()` when freshness matters, and `.ensure()` when cache-first behavior is acceptable.
+
+Mutations are callable for imperative writes:
+
+```ts
+const { error } = await rpc.transformer.transformRecording({
+  recordingId,
+  transformation,
+});
+```
+
+Prefer plain async functions in `$lib/operations/` for code that is not observed by a component, instead of promoting every workflow into `$lib/rpc`.
 
 ## Architecture context
 
@@ -136,7 +149,7 @@ Every `defineQuery`/`defineMutation` returned object is also directly callable a
 UI (.svelte)
   │  createQuery(() => rpc.<x>.options)         ← shared cached reads
   │  createMutation(() => rpc.<y>.options)      ← shared mutations w/ cache invalidation
-  │  createMutation(() => ({ mutationFn: ... }))← local lifecycle over an orchestration
+  │  createMutation(() => mutationOptions(...)) ← local lifecycle over an orchestration
   │  await <operation>(...)                     ← fire-and-forget orchestrations
   ▼
 $lib/rpc/*          TanStack adapters (this directory)

--- a/apps/whispering/src/lib/rpc/README.md
+++ b/apps/whispering/src/lib/rpc/README.md
@@ -46,13 +46,26 @@ For one-off local lifecycle state, wrap the operation in the component instead:
 ```svelte
 <script lang="ts">
   import { createMutation } from '@tanstack/svelte-query';
+  import { mutationOptions } from 'wellcrafted/query';
   import {
     startManualRecording,
     stopManualRecording,
   } from '$lib/operations/recording';
 
-  const startMutation = createMutation(() => ({ mutationFn: startManualRecording }));
-  const stopMutation  = createMutation(() => ({ mutationFn: stopManualRecording  }));
+  const startMutation = createMutation(() =>
+    mutationOptions({
+      mutationKey: ['recording', 'startManual'],
+      mutationFn: startManualRecording,
+    }),
+  );
+
+  const stopMutation = createMutation(() =>
+    mutationOptions({
+      mutationKey: ['recording', 'stopManual'],
+      mutationFn: stopManualRecording,
+    }),
+  );
+
   const isPreparing = $derived(startMutation.isPending || stopMutation.isPending);
 </script>
 

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
@@ -6,6 +6,7 @@
 	import * as Select from '@epicenter/ui/select';
 	import InfoIcon from '@lucide/svelte/icons/info';
 	import { createMutation } from '@tanstack/svelte-query';
+	import { mutationOptions } from 'wellcrafted/query';
 	import {
 		BITRATE_OPTIONS,
 		RECORDING_MODE_OPTIONS,
@@ -71,9 +72,12 @@
 			deviceConfig.get('recording.method') === 'navigator',
 	);
 
-	const exportMarkdown = createMutation(() => ({
-		mutationFn: whispering.actions.recordings_export_markdown,
-	}));
+	const exportMarkdown = createMutation(() =>
+		mutationOptions({
+			mutationKey: ['recordings', 'exportMarkdown'],
+			mutationFn: whispering.actions.recordings_export_markdown,
+		}),
+	);
 
 	function getManualDeviceId(method: 'cpal' | 'navigator') {
 		switch (method) {
@@ -252,19 +256,18 @@
 						variant="outline"
 						onclick={() => {
 							exportMarkdown.mutate(undefined, {
-								onSuccess: ({ data, error }) => {
-									if (error !== null) {
-										report.error({
-											title: 'Recording markdown export failed',
-											cause: error,
-										});
-										return;
-									}
+								onSuccess: (data) => {
 									if (data.status === 'cancelled') return;
 
 									report.success({
 										title: 'Recording markdown exported',
 										description: `Wrote ${data.written} ${data.written === 1 ? 'file' : 'files'} to ${data.dir}.`,
+									});
+								},
+								onError: (error) => {
+									report.error({
+										title: 'Recording markdown export failed',
+										cause: error,
 									});
 								},
 							});

--- a/apps/whispering/src/routes/transform-clipboard/+page.svelte
+++ b/apps/whispering/src/routes/transform-clipboard/+page.svelte
@@ -8,27 +8,25 @@
 	import { emit, listen, type UnlistenFn } from '@tauri-apps/api/event';
 	import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 	import { onDestroy, onMount } from 'svelte';
+	import { queryOptions } from 'wellcrafted/query';
 	import TransformationPickerBody from '$lib/components/TransformationPickerBody.svelte';
 	import { deliverTransformationResult } from '$lib/operations/delivery';
 	import { report } from '$lib/report';
 	import { sound } from '$lib/operations/sound';
 	import { tauri } from '$lib/tauri';
 	import { rpc } from '$lib/rpc';
-	import { defineQuery } from '$lib/rpc/client';
 	import { services } from '$lib/services';
 	import * as transformClipboardWindow from './transformClipboardWindow.tauri';
 
 	const combobox = useCombobox();
 
-	const readFromClipboard = defineQuery({
-		queryKey: ['text', 'readFromClipboard'],
-		queryFn: () => services.text.readFromClipboard(),
-	});
-
-	const clipboardQuery = createQuery(() => ({
-		...readFromClipboard.options,
-		refetchInterval: 1000,
-	}));
+	const clipboardQuery = createQuery(() =>
+		queryOptions({
+			queryKey: ['text', 'readFromClipboard'],
+			queryFn: () => services.text.readFromClipboard(),
+			refetchInterval: 1000,
+		}),
+	);
 
 	const clipboardText = $derived(clipboardQuery.data ?? '');
 

--- a/bun.lock
+++ b/bun.lock
@@ -917,7 +917,7 @@
     "typescript": "^5.9.3",
     "virtua": "^0.48.5",
     "vite": "^7.2.4",
-    "wellcrafted": "^0.40.0",
+    "wellcrafted": "^0.42.0",
     "wrangler": "^4.71.0",
     "y-indexeddb": "^9.0.12",
     "y-protocols": "^1.0.7",
@@ -3793,7 +3793,7 @@
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
-    "wellcrafted": ["wellcrafted@0.40.0", "", {}, "sha512-pQ7qPobDYPHU0kqk+M1SnMMhaKDx0NdTTA6ga55Ud0n0uQDzjLXsbLN7C6KVxz0RCQFwLSW8El6J0F0w5MVOUQ=="],
+    "wellcrafted": ["wellcrafted@0.42.0", "", {}, "sha512-bpSDxPYhuy1Z/xb3ReT2PIpNf36V7DczRlqjxw8hl8oQXxssvzj82PPI1PJ9hNg1gvEL+GXNHDlawafctlYwmw=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
@@ -4006,8 +4006,6 @@
     "@tauri-apps/plugin-os/@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
 
     "@tauri-apps/plugin-process/@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
-
-    "@tauri-apps/plugin-shell/@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
 
     "@tauri-apps/plugin-updater/@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
 

--- a/docs/articles/20260315T214827-query-layer-before-workspace-migration.md
+++ b/docs/articles/20260315T214827-query-layer-before-workspace-migration.md
@@ -1,8 +1,10 @@
 # The Query Layer That Did Everything
 
-> **Historical snapshot**: This is the query layer README from before the workspace migration moved domain data (recordings, transformations, runs) to Yjs-backed workspace state modules. At this point, TanStack Query managed all CRUD operations—the query layer co-located service calls, runtime settings injection, and cache manipulation in one place. The architecture has since evolved: workspace state handles domain CRUD, and the query layer focuses on audio blob access, external API calls, hardware state, and coordination logic. See `apps/whispering/src/lib/query/README.md` for the current version.
+> **Historical snapshot**: This is the query layer README from before the workspace migration moved domain data (recordings, transformations, runs) to Yjs-backed workspace state modules. At this point, TanStack Query managed all CRUD operations: the query layer co-located service calls, runtime settings injection, and cache manipulation in one place. The architecture has since evolved: workspace state handles domain CRUD, and the RPC layer focuses on audio blob access, external API calls, hardware state, and coordination logic. See `apps/whispering/src/lib/rpc/README.md` for the current version.
 
-The key architectural insight worth preserving: the query layer co-locates three things in one place—the service call, runtime settings injection based on reactive variables, and cache manipulation (also reactive). This creates a layer that bridges reactivity with services in an intuitive way, and gives developers a consistent place to put this logic. Whether the cache lives in TanStack Query or Yjs, the co-location principle still holds.
+> **Do not copy the Wellcrafted query API examples from older revisions of this article.** Current shared queries expose `.options`, `.fetch()`, and `.ensure()` and are not callable. Current shared mutations expose `.options` and are callable. Svelte Query hooks should receive an accessor, such as `createQuery(() => rpc.thing.options)` or `createMutation(() => rpc.thing.options)`.
+
+The key architectural insight worth preserving: the query layer co-locates three things in one place: the service call, runtime settings injection based on reactive variables, and cache manipulation. This creates a layer that bridges reactivity with services in an intuitive way, and gives developers a consistent place to put this logic. Whether the cache lives in TanStack Query or Yjs, the co-location principle still holds.
 
 ---
 
@@ -18,14 +20,14 @@ export const { defineQuery, defineMutation } =
 	createQueryFactories(queryClient);
 ```
 
-These factory functions `defineQuery` and `defineMutations` take in query options with result query functions, you get two ways to use it:
+These factory functions `defineQuery` and `defineMutation` take in Result-aware query or mutation options:
 
 1. **`.options`** - A static object containing query/mutation options. Wrap in an accessor function for reactive use: `() => x.options`
-2. **`.fetch()`/`.execute()`** - Imperative fetching/execution without subscriptions. These still go through TanStack Query's cache/mutation cache, so mutations still register and can be debugged in the devtools.
+2. **`.fetch()` / `.ensure()` for queries, direct calls for mutations** - Imperative usage without subscriptions. These still go through TanStack Query's cache or mutation cache, so mutations still register and can be debugged in the devtools.
 
-## The Dual Interface Pattern
+## Reactive And Imperative Pattern
 
-Every operation in the query layer provides **two interfaces** to match how you want to use it:
+Query layer definitions support reactive hook usage and explicit imperative usage:
 
 ### Reactive Interface (`.options`) - Automatic State Management
 
@@ -59,16 +61,16 @@ Examples:
 - Automatic re-renders when data changes
 - Cache synchronization across components
 
-### Imperative Interface (`.execute()`) - Direct Execution
+### Imperative Interface - Direct Execution
 
 ```typescript
 // Imperative in actions - lightweight and fast
 const { data, error } =
-	await rpc.recordings.deleteRecording.execute(recordingId);
+	await rpc.recordings.deleteRecording(recordingId);
 // No observers, no subscriptions, just the result
 ```
 
-**Perfect for** when you don't need the overhead of observers or subscriptions, and when you want to call operations outside of component lifecycle. This avoids having to create mutations first or prop-drill mutation functions down to child components. You can call `.execute()` directly from anywhere without being constrained by component boundaries.
+**Perfect for** when you don't need the overhead of observers or subscriptions, and when you want to call operations outside of component lifecycle. This avoids having to create mutations first or prop-drill mutation functions down to child components. Mutations can be called directly from anywhere without being constrained by component boundaries.
 
 Examples:
 
@@ -152,7 +154,7 @@ startRecording: defineMutation({
 		const { data: deviceAcquisitionOutcome, error: startRecordingError } =
 			await services.recorder.startRecording(recordingSettings, {
 				sendStatus: (options) =>
-					notify.loading.execute({ id: toastId, ...options }),
+					notify.loading({ id: toastId, ...options }),
 			});
 
 		// Transform service error to WhisperingError
@@ -170,7 +172,7 @@ startRecording: defineMutation({
 	// WhisperingError is now available in onError hook
 	onError: (error) => {
 		// error is WhisperingError, ready for toast display
-		notify.error.execute(error);
+		notify.error(error);
 	},
 });
 ```
@@ -202,7 +204,7 @@ startRecording: defineMutation({
 
 3. **UI Layer**: Receives `WhisperingError` in hooks, perfect for toasts
    ```typescript
-   onError: (error) => notify.error.execute(error); // error is WhisperingError
+   onError: (error) => notify.error(error); // error is WhisperingError
    ```
 
 ### Why This Pattern?
@@ -249,7 +251,7 @@ if (getRecorderStateError) {
 		description: getRecorderStateError.message,
 		action: { type: 'more-details', error: getRecorderStateError },
 	});
-	notify.error.execute({ id: nanoid(), ...whisperingError.error });
+	notify.error({ id: nanoid(), ...whisperingError.error });
 	return whisperingError;
 }
 ```
@@ -287,7 +289,7 @@ getRecorderState: defineQuery({
 
 // In UI/command layer - use WhisperingError directly
 if (error) {
-	notify.error.execute(error); // No re-wrapping!
+	notify.error(error); // No re-wrapping!
 }
 ```
 
@@ -308,9 +310,9 @@ Unlike server-side rendered applications where the query client lifecycle is man
 - Direct Query Client Access: We can call `queryClient.fetchQuery()` and `queryClient.getMutationCache().build()` directly
 - Imperative Control: No need to go through reactive hooks for one-time operations
 - Performance Benefits: We can build mutations using direct execution rather than creating unnecessary subscribers
-- Flexible Interfaces: Both reactive (`.options`) and imperative (`.execute()`, `.fetch()`) patterns work seamlessly
+- Flexible Interfaces: Both reactive (`.options`) and imperative (`.fetch()`, `.ensure()`, or direct mutation call) patterns work seamlessly
 
-This enables our unique dual interface pattern where every query and mutation provides both reactive and imperative APIs.
+This enables a query layer where every shared definition has a reactive hook bridge and explicit imperative behavior.
 
 ## What is RPC?
 
@@ -334,13 +336,13 @@ The `notify` API demonstrates how the query layer coordinates multiple services:
 import { notify } from '$lib/query';
 
 // Shows BOTH a toast (in-app) AND OS notification
-await notify.success.execute({
+await notify.success({
 	title: 'Recording saved',
 	description: 'Your recording has been transcribed',
 });
 
 // Loading states only show toasts (no OS notification spam)
-const loadingId = await notify.loading.execute({
+const loadingId = await notify.loading({
 	title: 'Processing...',
 });
 notify.dismiss(loadingId);
@@ -361,7 +363,7 @@ The name "RPC" is inspired by Remote Procedure Calls, but adapted for our needs:
 
 > **Author's Note**: I know, I know... "RPC" traditionally stands for "Remote Procedure Call," but I've reused the acronym to mean because it's fun and technically this builds off the Result type. People are already familiar with the RPC mental model, and honestly it just feels good to write `rpc`. Plus, it sounds way cooler than "query namespace" or whatever. 🤷‍♂️
 
-## The .execute() Performance Advantage
+## The Direct Mutation Call Performance Advantage
 
 When you call `createMutation()`, you're creating a _mutation observer_ that subscribes to reactive state changes. If you don't need the reactive state (like `isPending`, `isError`, etc.), you're paying a performance cost for functionality you're not using.
 
@@ -369,7 +371,7 @@ When you call `createMutation()`, you're creating a _mutation observer_ that sub
 
 ```typescript
 // ❌ createMutation() approach - Creates subscriber
-const mutation = createMutation(rpc.recordings.createRecording.options);
+const mutation = createMutation(() => rpc.recordings.createRecording.options);
 // This creates a mutation observer that:
 // - Subscribes to state changes
 // - Triggers component re-renders
@@ -388,8 +390,8 @@ mutation.mutate(recording, {
 ```
 
 ```typescript
-// ✅ .execute() approach - Direct execution
-const { data, error } = await rpc.recordings.createRecording.execute(recording);
+// ✅ Direct mutation call approach - Direct execution
+const { data, error } = await rpc.recordings.createRecording(recording);
 // This directly:
 // - Executes the mutation immediately
 // - Returns a simple Result<T, E>
@@ -400,7 +402,7 @@ const { data, error } = await rpc.recordings.createRecording.execute(recording);
 
 ### When to Use Each Approach
 
-**Use `.execute()` when:**
+**Use direct mutation calls when:**
 
 - Event handlers that just need the result
 - Sequential operations in commands/workflows
@@ -461,7 +463,7 @@ RPC provides:
 1. **Services**: Pure functions that return `Result<T, E>` (never throw)
 2. **Query Layer**: Uses WellCrafted's factories to wrap service functions
 3. **RPC Namespace**: Bundles all queries into one global object for easy access
-4. **UI Components**: Choose reactive (`.options`) or imperative (`.execute()`) based on needs
+4. **UI Components**: Choose reactive (`.options`) or imperative direct mutation calls based on needs
 
 ## Real-World RPC Usage Throughout the App
 
@@ -497,11 +499,11 @@ RPC provides:
 // From: /lib/deliverTextToUser.ts
 // ✅ Direct execution - no reactive overhead
 async function copyToClipboard(text: string) {
-	const { error } = await rpc.clipboard.copyToClipboard.execute({ text });
+	const { error } = await rpc.clipboard.copyToClipboard({ text });
 
 	if (error) {
 		// Using the notify API to show both toast and OS notification
-		await notify.error.execute({
+		await notify.error({
 			title: 'Error copying to clipboard',
 			description: error.message,
 			action: { type: 'more-details', error },
@@ -514,14 +516,14 @@ async function copyToClipboard(text: string) {
 // copyMutation.mutate({ text }); // Creates observer, manages state we don't need
 ```
 
-### 3. Sequential Operations - The .execute() Sweet Spot
+### 3. Sequential Operations - The Direct Mutation Call Sweet Spot
 
 ```typescript
 // From: /lib/commands.ts
-// ✅ Perfect use case for .execute() - sequential workflow without UI reactivity
+// ✅ Perfect use case for direct mutation calls - sequential workflow without UI reactivity
 async function stopAndTranscribe() {
 	// Step 1: Stop recording
-	const { data: blob, error } = await rpc.manualRecorder.stopRecording.execute({
+	const { data: blob, error } = await rpc.manualRecorder.stopRecording({
 		toastId,
 	});
 
@@ -531,11 +533,11 @@ async function stopAndTranscribe() {
 	}
 
 	// Step 2: Play sound effect (fire-and-forget)
-	rpc.sound.playSoundIfEnabled.execute('manual-stop');
+	rpc.sound.playSoundIfEnabled('manual-stop');
 
 	// Step 3: Create recording in database
 	const { data: recording, error: createError } =
-		await rpc.recordings.createRecording.execute({
+		await rpc.recordings.createRecording({
 			blob,
 			timestamp: new Date(),
 			transcriptionStatus: 'PENDING',
@@ -544,7 +546,7 @@ async function stopAndTranscribe() {
 	if (createError) return;
 
 	// Step 4: Transcribe the recording
-	await rpc.transcription.transcribeRecording.execute(recording);
+	await rpc.transcription.transcribeRecording(recording);
 }
 
 // ❌ With createMutation (overkill for workflows)
@@ -558,7 +560,7 @@ async function stopAndTranscribe() {
 ```typescript
 // From: /routes/(config)/settings/recording/SelectRecordingDevice.svelte
 // Enumerate available recording devices
-const devices = createQuery(rpc.recorder.enumerateDevices.options);
+const devices = createQuery(() => rpc.recorder.enumerateDevices.options);
 ```
 
 ### 5. Options Factory Pattern for Conditional Queries
@@ -647,7 +649,7 @@ The easiest way to understand the query layer is to see it in action:
 	import { rpc } from '$lib/query';
 
 	// This automatically subscribes to all recordings
-	const recordingsQuery = createQuery(rpc.recordings.getAllRecordings.options);
+	const recordingsQuery = createQuery(() => rpc.recordings.getAllRecordings.options);
 </script>
 
 {#if recordingsQuery.isPending}
@@ -665,9 +667,9 @@ Or imperatively in an event handler:
 
 ```typescript
 async function handleDelete(id: string) {
-	const { error } = await rpc.recordings.deleteRecording.execute(id);
+	const { error } = await rpc.recordings.deleteRecording(id);
 	if (error) {
-		notify.error.execute({
+		notify.error({
 			title: 'Failed to delete',
 			description: error.message,
 		});
@@ -684,7 +686,7 @@ WellCrafted handles the `Result<T, E>` unwrapping, so TanStack Query gets regula
 These factory functions (`defineQuery` and `defineMutation`) take query options with result functions - functions that return `Result<T, E>`. From there, you get two ways to use it:
 
 - `.options` - Static object with query/mutation options (wrap in accessor: `() => x.options`)
-- `.fetch()` / `.execute()` - Direct execution methods
+- `.fetch()` / `.ensure()` for queries, direct calls for mutations - Direct execution methods
 
 **`defineQuery`** - For data fetching:
 
@@ -733,7 +735,7 @@ const mutation = createMutation(() => createRecording.options);
 // - Useful for loading states and error displays
 
 // ✅ Imperative interface - direct execution
-const { error } = await createRecording.execute(recording);
+const { error } = await createRecording(recording);
 // - Uses queryClient.getMutationCache().build() directly
 // - Returns simple Result<T, E>
 // - No reactive state management
@@ -801,7 +803,7 @@ function transcribeBlob(blob: Blob) {
 transcribeRecording: defineMutation({
   mutationFn: async (recording) => {
     // Step 1: Update status
-    await recordings.updateRecording.execute({
+    await recordings.updateRecording({
       ...recording,
       transcriptionStatus: 'TRANSCRIBING',
     });
@@ -810,7 +812,7 @@ transcribeRecording: defineMutation({
     const { data, error } = await transcribeBlob(recording.blob);
 
     // Step 3: Update with results
-    await recordings.updateRecording.execute({
+    await recordings.updateRecording({
       ...recording,
       transcribedText: data,
       transcriptionStatus: error ? 'FAILED' : 'DONE',
@@ -849,7 +851,7 @@ transcribeRecording: defineMutation({
 
 ```typescript
 async function handleDelete(recording: Recording) {
-	const { error } = await rpc.recordings.deleteRecording.execute(recording);
+	const { error } = await rpc.recordings.deleteRecording(recording);
 
 	if (error) {
 		toast.error({
@@ -875,17 +877,17 @@ Each feature file typically exports an object with:
 
 ## Actions: Always Return Ok
 
-Actions in the query layer always return `Ok` after handling errors. They notify the user and return success because the action itself executed—error handling is part of that execution.
+Actions in the query layer always return `Ok` after handling errors. They notify the user and return success because the action itself executed; error handling is part of that execution.
 
 ```typescript
 const startManualRecording = defineMutation({
 	mutationFn: async () => {
-		const { error } = await recorder.startRecording.execute();
+		const { error } = await recorder.startRecording();
 		if (error) {
-			notify.error.execute(error); // Notify user
+			notify.error(error); // Notify user
 			return Ok(undefined); // Action succeeded
 		}
-		notify.success.execute({ title: 'Recording started' });
+		notify.success({ title: 'Recording started' });
 		return Ok(undefined);
 	},
 });
@@ -898,11 +900,11 @@ Actions are UI-boundary mutations invoked from anywhere: command registry (`/lib
 1. Always use Result types - Never throw errors in query/mutation functions
 2. **Mutation Pattern Preference**:
    - **In `.svelte` files**: Always prefer `createMutation` unless you have a specific reason not to (e.g., you don't need pending states)
-   - **In `.ts` files**: Always use `.execute()` since createMutation requires component context
+   - **In `.ts` files**: Use direct mutation calls since createMutation requires component context
    - This gives you consistent loading states, error handling, and better UX in components
 3. **Mutation callback pattern**: When using `createMutation`, pass callbacks as the second argument to `.mutate()` for maximum context
 4. Choose the right interface for the job:
-   - Use `.execute()` in `.ts` files and when you don't need pending state
+   - Use direct mutation calls in `.ts` files and when you don't need pending state
    - Use `createMutation()` when you need reactive state for UI feedback
 5. Keep queries simple - Complex logic belongs in services or orchestration mutations
 6. Update cache optimistically - Better UX for mutations
@@ -915,7 +917,7 @@ Actions are UI-boundary mutations invoked from anywhere: command registry (`/lib
 
 ```typescript
 // In component
-const recordingsQuery = createQuery(rpc.recordings.getAllRecordings.options);
+const recordingsQuery = createQuery(() => rpc.recordings.getAllRecordings.options);
 
 // In template
 {#if recordingsQuery.isPending}Loading...{/if}
@@ -962,7 +964,7 @@ const { data, error } = await rpc.recordings.getAllRecordings.fetch();
 // - Perfect for prefetching or one-time fetches
 
 // ✅ Mutations - uses queryClient.getMutationCache().build() directly
-const { data, error } = await rpc.recordings.createRecording.execute(recording);
+const { data, error } = await rpc.recordings.createRecording(recording);
 // - Direct execution without mutation observer
 // - No reactive state management overhead
 // - Ideal for event handlers and workflows
@@ -971,7 +973,7 @@ const { data, error } = await rpc.recordings.createRecording.execute(recording);
 ### Error Handling Pattern
 
 ```typescript
-const { data, error } = await rpc.clipboard.copyToClipboard.execute({ text });
+const { data, error } = await rpc.clipboard.copyToClipboard({ text });
 if (error) {
 	toast.error({
 		title: 'Failed to copy',

--- a/docs/articles/accessor-pattern-explained.md
+++ b/docs/articles/accessor-pattern-explained.md
@@ -1,356 +1,152 @@
-# The Accessor Pattern: Why Your Svelte 5 Queries Need Functions, Not Values
+# The Accessor Pattern: Why Svelte 5 Queries Need Functions
 
-> **Note**: Some older examples in this article mention `rpc.db.recordings.getById` and `dbKeys`, which were removed when recordings migrated to Yjs workspace state modules. The accessor pattern itself is still essential. It applies to remaining TanStack Query usage, such as `rpc.audio.getPlaybackUrl(() => id)`.
+Svelte 5 query definitions should receive live values through accessor functions, not snapshots. If `recordingId` can change, pass `() => recordingId`.
 
+```svelte
+<script lang="ts">
+	import { createQuery } from '@tanstack/svelte-query';
+	import { rpc } from '$lib/rpc';
 
-You change `recordingId` from `'abc'` to `'xyz'`, but the audio player doesn't update. The UI is stuck showing the old recording. You've just hit the accessor pattern problem.
+	let recordingId = $state('abc');
 
-Here's what happened: you passed a value directly to your query instead of a function that returns the value. This broke Svelte 5's reactivity chain, and now your component can't track changes.
-
-## The Pattern
-
-When using TanStack Query with Svelte 5, you need to pass accessor functions (getters) instead of values directly:
-
-```typescript
-// ❌ WRONG: Passing value directly
-const query = createQuery(
-  rpc.db.recordings.getById(recordingId).options
-);
-
-// ✅ CORRECT: Passing accessor function
-const query = createQuery(
-  rpc.db.recordings.getById(() => recordingId).options
-);
+	const playbackUrl = createQuery(() =>
+		rpc.audio.getPlaybackUrl(() => recordingId).options,
+	);
+</script>
 ```
 
-That `() => recordingId` is not just syntax ceremony. It's the boundary that preserves reactive tracking.
+There are two functions in that line, and both matter:
 
-## Why Accessor Functions?
+```txt
+createQuery(() => ...)
+  outer accessor: lets TanStack re-read the whole options object
 
-Svelte 5 uses signals for reactivity. When you create `$state`, you're creating a signal that tracks subscriptions.
-
-```typescript
-let recordingId = $state('abc');  // This creates a signal
+getPlaybackUrl(() => recordingId)
+  inner accessor: lets the query key and query function read the current id
 ```
 
-The problem is what happens when you pass this to a function.
+## The Failure Mode
 
-### What's Really Happening: State Variables Are Getters
-
-Here's the key insight: when you use `$state` in Svelte 5, you're not creating a simple variable. You're creating a getter function that Svelte can track.
-
-Think about JavaScript object getters:
-
-```javascript
-const counter = {
-  _count: 0,
-  get count() {
-    return this._count;
-  }
-};
-
-// Looks like property access:
-console.log(counter.count);
-// But actually calls the getter function behind the scenes
-```
-
-Svelte 5's `$state` works the same way. When you write:
+Passing a value directly captures the value at the time the query definition is created.
 
 ```typescript
 let recordingId = $state('abc');
-```
 
-Accessing `recordingId` looks like reading a variable, but it's actually calling a getter function. This is how Svelte tracks which components depend on this value. Every time you read `recordingId`, Svelte can register: "This code depends on recordingId's current value."
-
-That's why `() => recordingId` works. You're creating a lazy function that:
-1. Gets called by TanStack Query when it needs the value
-2. Calls Svelte's getter (by accessing `recordingId`)
-3. Establishes a reactive subscription in the process
-
-The accessor function `() => recordingId` is essentially saying: "Don't give me the value now. Give me a way to call the getter later, so Svelte can track the subscription when you do."
-
-Without the accessor wrapper, you'd be passing the result of calling the getter (the value `'abc'`), not the getter itself. The reactive tracking chain would be broken.
-
-### Passing Values Directly Breaks Reactivity
-
-```typescript
-// This evaluates recordingId RIGHT NOW
-const query = createQuery(
-  rpc.db.recordings.getById(recordingId).options
+const playbackUrl = createQuery(() =>
+	rpc.audio.getPlaybackUrl(recordingId).options,
 );
 ```
 
-What actually runs:
+The first render creates a query for `abc`. If `recordingId` later changes to `xyz`, the query definition still has the old value. Svelte cannot track the read because it already happened outside the accessor boundary.
+
+The accessor version keeps the read lazy:
 
 ```typescript
-// Step 1: Svelte evaluates recordingId (current value: 'abc')
-// Step 2: Passes 'abc' to getById
-// Step 3: Creates query with key ['db', 'recordings', 'abc']
-```
-
-Later, when you update `recordingId`:
-
-```typescript
-recordingId = 'xyz';  // Signal updates
-// BUT: Query still has key ['db', 'recordings', 'abc']
-// The reactive chain is broken
-```
-
-The query was created with the VALUE at that moment (`'abc'`), not with a SUBSCRIPTION to the signal. When the signal changes, nothing tells the query to update.
-
-### Passing Accessor Functions Preserves Reactivity
-
-```typescript
-// This creates a getter function
-const query = createQuery(
-  rpc.db.recordings.getById(() => recordingId).options
+const playbackUrl = createQuery(() =>
+	rpc.audio.getPlaybackUrl(() => recordingId).options,
 );
 ```
 
-What actually runs:
+When TanStack Query re-evaluates the options, `recordingId` is read inside Svelte's tracking context. The query key changes, the query function sees the new id, and the UI follows.
+
+## Query Definitions
+
+Shared Wellcrafted query definitions usually accept accessors for values that can change in Svelte components:
 
 ```typescript
-// Step 1: Pass FUNCTION to getById
-// Step 2: getById calls the function to get current value
-// Step 3: Creates query with key based on function result
-// Step 4: TanStack Query can call this function again later
+import type { Accessor } from '@tanstack/svelte-query';
+import { defineKeys } from 'wellcrafted/query';
+import { defineQuery } from '$lib/rpc/client';
+import { services } from '$lib/services';
+
+export const audioKeys = defineKeys({
+	playbackUrl: (id: string) => ['audio', 'playbackUrl', id] as const,
+});
+
+export const audio = {
+	getPlaybackUrl: (recordingId: Accessor<string>) =>
+		defineQuery({
+			queryKey: audioKeys.playbackUrl(recordingId()),
+			queryFn: () => services.blobs.audio.ensurePlaybackUrl(recordingId()),
+		}),
+};
 ```
 
-Now when you update `recordingId`:
-
-```typescript
-recordingId = 'xyz';  // Signal updates
-// TanStack Query re-evaluates the function
-// Gets new value 'xyz'
-// Updates query key to ['db', 'recordings', 'xyz']
-// Fetches new data
-```
-
-The accessor function creates a lazy evaluation boundary. Instead of capturing a snapshot, you're passing a recipe that can be evaluated again when needed.
-
-## The Lazy Evaluation Boundary Concept
-
-Think of it like the difference between a photo and a live camera feed.
-
-**Passing a value directly** is like taking a photo:
-```typescript
-// "Here's what recordingId looks like RIGHT NOW"
-getById(recordingId)  // Snapshot: 'abc'
-```
-
-**Passing an accessor function** is like giving someone a live camera:
-```typescript
-// "Here's how to check what recordingId is at any time"
-getById(() => recordingId)  // Live feed: check current value
-```
-
-The accessor function `() => recordingId` creates a boundary where Svelte's reactivity system can establish subscriptions. When TanStack Query calls this function, it happens within a reactive context that tracks which signals are accessed.
-
-This is how Svelte knows: "This query depends on the recordingId signal. When that signal changes, re-evaluate everything that depends on it."
-
-## How the Pattern Works in Practice
-
-Here's the actual implementation from our codebase:
-
-```typescript
-// In /lib/query/db.ts
-getById: (id: Accessor<string>) =>
-  defineQuery({
-    queryKey: dbKeys.recordings.byId(id()),
-    queryFn: () => services.db.recordings.getById(id()),
-  }),
-```
-
-The `Accessor<string>` type is defined by TanStack Query:
+`Accessor<T>` is just:
 
 ```typescript
 type Accessor<T> = () => T;
 ```
 
-It's just a function that returns a value. Simple.
+The type is small, but the boundary is important. It tells the query layer, "read this value when you build the options, not before."
 
-When you use it in a component:
+## Hook-Local Options
 
-```typescript
-// In a component
-let recordingId = $state('abc');
+The same rule applies when there is no shared RPC definition. Use `queryOptions` for a hook-local Result-returning query, and keep reactive reads inside the hook accessor.
 
-const recordingQuery = createQuery(
-  rpc.db.recordings.getById(() => recordingId).options
-);
+```svelte
+<script lang="ts">
+	import { createQuery } from '@tanstack/svelte-query';
+	import { queryOptions } from 'wellcrafted/query';
+	import { services } from '$lib/services';
 
-// Later...
-recordingId = 'xyz';  // Query automatically updates!
+	let recordingId = $state('abc');
+
+	const transcript = createQuery(() =>
+		queryOptions({
+			queryKey: ['recording', recordingId, 'transcript'],
+			queryFn: () => services.recordings.getTranscript(recordingId),
+			enabled: recordingId.length > 0,
+		}),
+	);
+</script>
 ```
 
-The flow:
+This query does not need a reusable `.fetch()` or `.ensure()` method, so `queryOptions` is the right tool.
 
-1. `getById(() => recordingId)` receives the accessor function
-2. Inside `getById`, it calls `id()` to get the current value
-3. TanStack Query stores this accessor for future re-evaluation
-4. When `recordingId` changes, Svelte's reactivity system triggers
-5. TanStack Query re-evaluates the accessor, gets new value
-6. Query key changes, new data is fetched
+## Imperative Reads Are Different
 
-## Real Examples from Our Codebase
-
-### Example 1: Recording Row Actions
+`.fetch()` and `.ensure()` are one-time reads. They do not subscribe the UI to future value changes.
 
 ```typescript
-// From: /routes/(config)/recordings/row-actions/RecordingRowActions.svelte
-let { recordingId } = $props<{ recordingId: string }>();
-
-const recordingQuery = createQuery(
-  rpc.db.recordings.getById(() => recordingId).options,
-);
-
-const recording = $derived(recordingQuery.data);
+const { data, error } = await rpc.audio
+	.getPlaybackUrl(() => recordingId)
+	.fetch();
 ```
 
-Why the accessor? Because `recordingId` comes from props, which can change when you select different rows in the table. The accessor ensures the query updates when props change.
+That is fine in an event handler where you want one fresh read. It is not a replacement for `createQuery` in a component that should update when `recordingId` changes.
 
-### Example 2: Transformation Row Actions
+Use the policies deliberately:
 
-```typescript
-// From: /routes/(config)/transformations/TransformationRowActions.svelte
-let { transformationId } = $props<{ transformationId: string }>();
+```txt
+.fetch()
+  freshness-aware read. TanStack checks staleTime and may refetch.
 
-const transformationQuery = createQuery(
-  rpc.db.transformations.getById(() => transformationId).options,
-);
-
-const transformation = $derived(transformationQuery.data);
+.ensure()
+  cache-first read. TanStack returns cached data when it exists.
 ```
 
-Same pattern. The component receives an ID via props, wraps it in an accessor, and the query stays reactive to prop changes.
+Queries are not callable, so there is no `await userQuery()`. Mutations are callable, so there is no `await saveUser.execute(input)`.
 
-### Example 3: Transformation Runs
+## Quick Reference
 
-```typescript
-// From: /lib/query/db.ts
-runs: {
-  getByRecordingId: (recordingId: Accessor<string>) =>
-    defineQuery({
-      queryKey: dbKeys.runs.byRecordingId(recordingId()),
-      queryFn: () => services.db.runs.getByRecordingId(recordingId()),
-    }),
+```txt
+Shared reactive query:
+  createQuery(() => rpc.audio.getPlaybackUrl(() => recordingId).options)
 
-  getLatestByRecordingId: (recordingId: Accessor<string>) =>
-    defineQuery({
-      queryKey: dbKeys.runs.byRecordingId(recordingId()),
-      queryFn: () => services.db.runs.getByRecordingId(recordingId()),
-      select: (data) => data.at(0),
-    }),
-},
+Hook-local Result query:
+  createQuery(() => queryOptions({ queryKey, queryFn }))
+
+Imperative query:
+  await rpc.audio.getPlaybackUrl(() => recordingId).fetch()
+  await rpc.audio.getPlaybackUrl(() => recordingId).ensure()
+
+Shared mutation:
+  createMutation(() => rpc.transformer.transformRecording.options)
+  await rpc.transformer.transformRecording(input)
+
+Hook-local Result mutation:
+  createMutation(() => mutationOptions({ mutationKey, mutationFn }))
 ```
 
-These queries need reactive recordingIds because they're used in contexts where the selected recording can change.
-
-## What Happens If You Don't Use Accessors?
-
-Let's trace through the broken version:
-
-```typescript
-// BAD: Direct value
-let recordingId = $state('abc');
-
-const query = createQuery(
-  rpc.db.recordings.getById(recordingId).options  // Evaluates to 'abc' NOW
-);
-
-// The query is created with:
-// queryKey: ['db', 'recordings', 'abc']
-// queryFn: () => services.db.recordings.getById('abc')
-```
-
-Later:
-
-```typescript
-recordingId = 'xyz';  // Signal updates
-
-// But the query STILL has:
-// queryKey: ['db', 'recordings', 'abc']
-// queryFn: () => services.db.recordings.getById('abc')
-
-// Your UI shows old data from recording 'abc'
-// Even though you wanted recording 'xyz'
-```
-
-The value was captured at creation time. When the signal changes, the query doesn't know to update.
-
-### With Accessor Functions
-
-```typescript
-// GOOD: Accessor function
-let recordingId = $state('abc');
-
-const query = createQuery(
-  rpc.db.recordings.getById(() => recordingId).options
-);
-
-// The query is created with:
-// queryKey: ['db', 'recordings', <result of calling accessor>]
-// queryFn: () => services.db.recordings.getById(<result of calling accessor>)
-```
-
-Later:
-
-```typescript
-recordingId = 'xyz';  // Signal updates
-
-// TanStack Query re-evaluates:
-// - Calls () => recordingId
-// - Gets 'xyz'
-// - Updates queryKey to ['db', 'recordings', 'xyz']
-// - Fetches new data for recording 'xyz'
-
-// Your UI updates with the new recording!
-```
-
-The accessor function is called EACH TIME the query needs to evaluate. This maintains the reactive subscription.
-
-## Common Mistake: Using .fetch() For Reactive Reads
-
-You might see this pattern and think you can skip the accessor when using `.fetch()`:
-
-```typescript
-// This seems fine, right?
-const { data, error } = await rpc.audio.getPlaybackUrl(() => recordingId).fetch();
-```
-
-This works, but it's not reactive. `.fetch()` is for imperative, one-time queries. It doesn't subscribe to changes.
-
-For reactive queries in components, always use `createQuery` with accessors:
-
-```typescript
-// Reactive: updates when recordingId changes
-const query = createQuery(
-  rpc.audio.getPlaybackUrl(() => recordingId).options
-);
-```
-
-The accessor pattern is specifically for maintaining reactivity with TanStack Query's subscription system.
-
-## When You Don't Need Accessors
-
-If the value never changes, you can pass it directly:
-
-```typescript
-// This is fine - the ID is hardcoded
-const query = createQuery(
-  rpc.db.recordings.getById(() => 'fixed-id-123').options
-);
-
-// Or if you're using .fetch() imperatively
-const { data } = await rpc.audio.getPlaybackUrl(() => someId).fetch();
-```
-
-But in practice, most component queries need reactivity. When in doubt, use an accessor.
-
-## The Takeaway
-
-Svelte 5's signals require accessor functions to preserve reactive tracking. When you pass `() => value` instead of `value`, you create a lazy evaluation boundary that allows TanStack Query to re-evaluate the query when the underlying signal changes.
-
-Not every data access needs a service. And not every reactive value can be passed directly. The accessor pattern bridges Svelte 5's signal-based reactivity with TanStack Query's subscription system.
-
-Remember: values are snapshots, accessors are live feeds. Choose accordingly.
+When in doubt, ask what the caller needs. If the template reads loading, data, or error state, use a hook. If the caller needs one query result outside reactive UI, choose `.fetch()` or `.ensure()`. If the caller is running a mutation imperatively, call the mutation.

--- a/docs/articles/accessor-pattern-explained.md
+++ b/docs/articles/accessor-pattern-explained.md
@@ -1,5 +1,6 @@
 # The Accessor Pattern: Why Your Svelte 5 Queries Need Functions, Not Values
-> **Note**: The code examples below use `rpc.db.recordings.getById` and `dbKeys`, which were removed when recordings migrated to Yjs workspace state modules. The accessor pattern itself is still essential—it applies to all remaining TanStack Query usage (e.g., `rpc.audio.getPlaybackUrl(() => id)`).
+
+> **Note**: Some older examples in this article mention `rpc.db.recordings.getById` and `dbKeys`, which were removed when recordings migrated to Yjs workspace state modules. The accessor pattern itself is still essential. It applies to remaining TanStack Query usage, such as `rpc.audio.getPlaybackUrl(() => id)`.
 
 
 You change `recordingId` from `'abc'` to `'xyz'`, but the audio player doesn't update. The UI is stuck showing the old recording. You've just hit the accessor pattern problem.
@@ -308,13 +309,13 @@ recordingId = 'xyz';  // Signal updates
 
 The accessor function is called EACH TIME the query needs to evaluate. This maintains the reactive subscription.
 
-## Common Mistake: Using .fetch() or .execute()
+## Common Mistake: Using .fetch() For Reactive Reads
 
 You might see this pattern and think you can skip the accessor when using `.fetch()`:
 
 ```typescript
 // This seems fine, right?
-const { data, error } = await rpc.db.transformations.getById(() => transformationId).fetch();
+const { data, error } = await rpc.audio.getPlaybackUrl(() => recordingId).fetch();
 ```
 
 This works, but it's not reactive. `.fetch()` is for imperative, one-time queries. It doesn't subscribe to changes.
@@ -322,9 +323,9 @@ This works, but it's not reactive. `.fetch()` is for imperative, one-time querie
 For reactive queries in components, always use `createQuery` with accessors:
 
 ```typescript
-// Reactive - updates when transformationId changes
+// Reactive: updates when recordingId changes
 const query = createQuery(
-  rpc.db.transformations.getById(() => transformationId).options
+  rpc.audio.getPlaybackUrl(() => recordingId).options
 );
 ```
 
@@ -341,7 +342,7 @@ const query = createQuery(
 );
 
 // Or if you're using .fetch() imperatively
-const { data } = await rpc.db.recordings.getById(() => someId).fetch();
+const { data } = await rpc.audio.getPlaybackUrl(() => someId).fetch();
 ```
 
 But in practice, most component queries need reactivity. When in doubt, use an accessor.

--- a/docs/articles/tanstack-query-accessor-pattern-svelte5.md
+++ b/docs/articles/tanstack-query-accessor-pattern-svelte5.md
@@ -1,95 +1,127 @@
-# The TanStack Query Accessor Pattern in Svelte 5
+# The TanStack Query Accessor Pattern In Svelte 5
 
-I was building a recording player in Svelte 5 with TanStack Query to fetch audio URLs. Everything worked on the first load, but when I selected a different recording, the audio URL wouldn't update. The query stayed stuck on the old recording's URL.
+I was building a recording player in Svelte 5 with TanStack Query to fetch audio URLs. The first recording loaded, but selecting a different recording left the query stuck on the old URL.
 
-Here's the code I wrote:
+The bug was not in TanStack Query or the RPC layer. I had skipped the accessor that lets Svelte track the reactive input.
 
-```typescript
-const recordingId = $state('abc-123');
-const query = createQuery(rpc.audio.getPlaybackUrl(recordingId).options);
-```
-
-This looks right. `recordingId` is reactive. TanStack Query should pick up the change when it updates. But it doesn't.
-
-## The Fix
-
-Wrap reactive values in accessor functions:
+## The Broken Shape
 
 ```typescript
 const recordingId = $state('abc-123');
-const query = createQuery(rpc.audio.getPlaybackUrl(() => recordingId).options);
+
+const playbackUrl = createQuery(() =>
+	rpc.audio.getPlaybackUrl(recordingId).options,
+);
 ```
 
-That `() => recordingId` is the key. One character difference, completely different behavior.
+`recordingId` is reactive inside the component, but passing it directly sends the current string value into `getPlaybackUrl`. The RPC definition has no way to read the next value.
 
-## Why This Works
-
-Svelte 5's reactivity is based on signals and getters. When you write `recordingId` in your code, Svelte's compiler turns that into a getter call that tracks dependencies. But when you pass `recordingId` directly to a function, you're passing the current value. A snapshot. TanStack Query doesn't know it's reactive.
-
-When you pass `() => recordingId`, you're giving Query a function it can call. Every time Query calls that function, Svelte can track the dependency. Query can subscribe to changes. Now when `recordingId` updates, Query knows to refetch the audio URL.
-
-Here's the thing that took me too long to realize: Svelte's reactivity tracking happens at the call site. If you don't give TanStack Query a way to call into your reactive scope, it can't participate in reactivity tracking.
-
-## When to Use Accessor Functions
-
-If the value can change during the component's lifetime, use an accessor:
+## The Correct Shape
 
 ```typescript
-// Props: wrap in accessor
-const query = createQuery(rpc.audio.getPlaybackUrl(() => props.recordingId).options);
-
-// $state variables: wrap in accessor
 const recordingId = $state('abc-123');
-const query = createQuery(rpc.audio.getPlaybackUrl(() => recordingId).options);
 
-// $derived values: wrap in accessor
-const computedId = $derived(props.userId + '-' + props.timestamp);
-const query = createQuery(rpc.audio.getPlaybackUrl(() => computedId).options);
+const playbackUrl = createQuery(() =>
+	rpc.audio.getPlaybackUrl(() => recordingId).options,
+);
 ```
 
-If the value will never change, pass it directly:
+There are two accessors here:
 
 ```typescript
-// String literals: pass directly
-const query = createQuery(rpc.audio.getPlaybackUrl('static-id').options);
+createQuery(() =>
+	rpc.audio.getPlaybackUrl(() => recordingId).options,
+);
+```
 
-// Constants: pass directly
+- The outer `() => ...` is the Svelte Query options accessor.
+- The inner `() => recordingId` is the domain parameter accessor.
+
+The outer accessor lets Svelte Query re-read the options. The inner accessor lets the shared query definition read the current recording ID when it builds the key and query function.
+
+## When To Use A Parameter Accessor
+
+Use an accessor when the value can change during the component lifetime:
+
+```typescript
+const fromProps = createQuery(() =>
+	rpc.audio.getPlaybackUrl(() => props.recordingId).options,
+);
+
+const fromState = createQuery(() =>
+	rpc.audio.getPlaybackUrl(() => recordingId).options,
+);
+
+const fromDerived = createQuery(() =>
+	rpc.audio.getPlaybackUrl(() => computedId).options,
+);
+```
+
+Pass a plain value only when it is static for that query instance:
+
+```typescript
+const staticRecording = createQuery(() =>
+	rpc.audio.getPlaybackUrl('static-id').options,
+);
+
 const RECORDING_ID = 'abc-123';
-const query = createQuery(rpc.audio.getPlaybackUrl(RECORDING_ID).options);
+const constantRecording = createQuery(() =>
+	rpc.audio.getPlaybackUrl(RECORDING_ID).options,
+);
 ```
 
 ## Common Mistakes
 
-The method syntax trips people up. I've seen this written backwards:
+Put the parameter accessor in the RPC method call, then read `.options` as a property:
 
 ```typescript
-// Wrong: calling .options with the accessor
-createQuery(rpc.method.options(() => param));
+// Wrong
+createQuery(() => rpc.audio.getPlaybackUrl.options(() => recordingId));
 
-// Right: call the method with the accessor, then access .options
-createQuery(rpc.method(() => param).options);
+// Right
+createQuery(() => rpc.audio.getPlaybackUrl(() => recordingId).options);
 ```
 
-The accessor goes in the method call, not after `.options`. That's because the method (like `rpc.audio.getPlaybackUrl`) returns an object that has an `.options` property. You're calling the method with reactive parameters, then accessing its options.
-
-Another common mistake is forgetting the accessor for reactive values:
+Do not pass `.options` directly to `createQuery`:
 
 ```typescript
-// Wrong: passing reactive value directly
-const recordingId = $state('abc-123');
-createQuery(rpc.audio.getPlaybackUrl(recordingId).options);
-
-// Right: wrapping in accessor
-const recordingId = $state('abc-123');
+// Wrong
 createQuery(rpc.audio.getPlaybackUrl(() => recordingId).options);
+
+// Right
+createQuery(() => rpc.audio.getPlaybackUrl(() => recordingId).options);
 ```
 
-I made this mistake a lot early on because it looks so similar. The broken version even works on the first render. It only breaks when the value changes, which makes it harder to catch.
+Do not call `.options` like a function:
 
-## The Rule I Follow Now
+```typescript
+// Wrong
+createQuery(() => rpc.audio.getPlaybackUrl(() => recordingId).options());
 
-If it can change, use an accessor function. If it's static, pass it directly.
+// Right
+createQuery(() => rpc.audio.getPlaybackUrl(() => recordingId).options);
+```
 
-That's it. When I'm writing a Query and I'm about to pass a parameter, I ask: can this value change? If yes, wrap it in `() => value`. If no, pass it as-is. This simple rule has saved me from a lot of reactivity bugs.
+## Hook-Local Queries
 
-The accessor pattern is a small detail, but it's the difference between queries that update when they should and queries that mysteriously stay stuck on old data. Once you internalize it, it becomes second nature.
+If the query is only used at one hook call site, skip the shared RPC definition and use Wellcrafted `queryOptions` locally:
+
+```typescript
+import { createQuery } from '@tanstack/svelte-query';
+import { queryOptions } from 'wellcrafted/query';
+
+const devices = createQuery(() =>
+	queryOptions({
+		queryKey: ['devices'],
+		queryFn: () => enumerateDevices(),
+	}),
+);
+```
+
+Use a shared `defineQuery` when the query belongs in `$lib/rpc` or `$lib/query`, has reusable identity, or needs imperative `.fetch()` or `.ensure()` calls.
+
+## Rule
+
+If the parameter can change, pass `() => value` to the shared query definition. In Svelte components, wrap the whole options expression in `createQuery(() => ...)`.
+
+Queries are not callable. Use `.fetch()` when a user action needs a fresh read, and `.ensure()` when cache-first data is acceptable.

--- a/docs/patterns/why-callbacks-in-mutate.md
+++ b/docs/patterns/why-callbacks-in-mutate.md
@@ -1,63 +1,59 @@
-# Why I Pass Callbacks to .mutate() Instead of createMutation
+# Why I Pass Callbacks to `.mutate()`
 
-I was refactoring some mutation handlers and realized I kept running into the same problem. My success callbacks needed access to local component state—dialog refs, form values, navigation state—but I was defining them at the mutation creation level where that context didn't exist.
+TanStack Query mutations have two callback layers. Put shared lifecycle behavior on the mutation options. Put local UI behavior at the `.mutate()` call site.
 
-Here's the thing that took me too long to realize: TanStack Query lets you pass callbacks at two different points, and where you put them matters.
+That distinction matters in Svelte components because local UI state lives at the click handler, form handler, or dialog boundary.
 
-## The Two Patterns
+## The Two Callback Layers
 
-First, there's the pattern I was using:
+Use an options accessor when wiring a shared RPC mutation:
 
 ```typescript
-// Callbacks at mutation creation
-const deleteSessionMutation = createMutation(() => ({
-	...rpc.sessions.deleteSession.options,
-	onSuccess: () => {
-		// Can't access isDialogOpen here!
-		toast.success('Deleted');
-	},
-}));
+const deleteSessionMutation = createMutation(
+	() => rpc.sessions.deleteSession.options,
+);
 ```
 
-Then I discovered you can pass them when calling `.mutate()`:
+Then pass UI-specific callbacks when triggering the mutation:
 
 ```typescript
-// Callbacks at call site
-const deleteSessionMutation = createMutation(
-	rpc.sessions.deleteSession.options,
-);
-
-// Later, when triggering the mutation
 deleteSessionMutation.mutate(
 	{ sessionId },
 	{
 		onSuccess: () => {
-			isDialogOpen = false; // Now I can access local state!
+			isDialogOpen = false;
 			toast.success('Deleted');
 		},
 	},
 );
 ```
 
-That's it. No complex state management. No prop drilling. Just callbacks where they have the most context.
+The mutation definition stays reusable. The call site keeps access to local state, props, derived values, navigation, and refs.
 
-## Why This Works Better
+## Shared Callback Behavior
 
-When you're in a component and trigger a mutation, you usually want to do something with the UI afterward. Close a modal. Navigate somewhere. Update local state. Clear a form.
+If every call site needs the same behavior, compose that behavior into the hook options accessor:
 
-All of these things live in your component's scope. By defining callbacks at the call site, you get access to:
+```typescript
+const deleteSessionMutation = createMutation(() => ({
+	...rpc.sessions.deleteSession.options,
+	onSuccess: (data) => {
+		logAuditEvent('session_deleted', data.id);
+	},
+}));
+```
 
-- Component state (`$state` variables)
-- Props and derived values
-- Other mutations and queries
-- Navigation functions
-- Refs to DOM elements
+This is still component-level TanStack setup. The shared RPC definition remains the plain Wellcrafted mutation definition, and `.options` stays a property.
 
-Here's a real example from a file upload dialog:
+## Local Callback Behavior
+
+Prefer call-site callbacks for UI consequences:
 
 ```svelte
 <script lang="ts">
-	const copyToClipboard = createMutation(rpc.text.copyToClipboard.options);
+	const copyToClipboard = createMutation(
+		() => rpc.text.copyToClipboard.options,
+	);
 
 	let isDialogOpen = $state(false);
 	let selectedText = $state('');
@@ -69,15 +65,12 @@ Here's a real example from a file upload dialog:
 			{ text: selectedText },
 			{
 				onSuccess: () => {
-					// Access to everything in component scope
 					isDialogOpen = false;
 					selectedText = '';
-					toast.success('Copied to clipboard!');
+					toast.success('Copied to clipboard');
 				},
 				onError: (error) => {
-					// Even error handling can be contextual
-					console.error('Failed to copy:', selectedText);
-					toast.error(error.message);
+					report.error({ cause: error });
 				},
 			},
 		);
@@ -87,105 +80,32 @@ Here's a real example from a file upload dialog:
 </Button>
 ```
 
-## Different Actions, Different Behaviors
+Each interaction can do exactly what its UI context needs. A table row can show a small toast. A bulk action can update selection state. A dialog can close itself.
 
-Another pattern that emerges: the same mutation might need different success behaviors in different contexts.
+## Hook-Local Result Mutations
 
-```typescript
-// In a table row
-deleteRecording.mutate(id, {
-	onSuccess: () => toast.success('Recording deleted'),
-});
-
-// In a bulk action
-deleteRecording.mutate(id, {
-	onSuccess: () => {
-		remainingIds = remainingIds.filter((rid) => rid !== id);
-		if (remainingIds.length === 0) {
-			isSelecting = false;
-			toast.success('All recordings deleted!');
-		}
-	},
-});
-```
-
-Same mutation. Different contexts. Different callbacks.
-
-## The Loading State Still Works
-
-You might worry that moving callbacks out of `createMutation` breaks something. It doesn't. You still get all the reactive state:
-
-```svelte
-const saveSettings = createMutation(rpc.settings.save.options);
-
-<Button
-	disabled={saveSettings.isPending}
-	onclick={() => {
-		saveSettings.mutate(currentSettings, {
-			onSuccess: () => {
-				hasUnsavedChanges = false;
-				toast.success('Settings saved');
-			},
-		});
-	}}
->
-	{#if saveSettings.isPending}
-		Saving...
-	{:else}
-		Save
-	{/if}
-</Button>
-```
-
-Everything works exactly the same. You just have more flexibility.
-
-## When to Break the Rule
-
-Sometimes you do want callbacks at the mutation level. If every single call site needs identical behavior, put it there:
+When the operation is one-off and returns a Wellcrafted `Result`, use `mutationOptions` directly at the hook call site:
 
 ```typescript
-// Audit logging on every call
-const deleteSession = createMutation({
-	...rpc.sessions.deleteSession.options,
-	onSuccess: (data) => {
-		// This ALWAYS needs to happen
-		logAuditEvent('session_deleted', data.id);
-	},
-});
-```
+import { createMutation } from '@tanstack/svelte-query';
+import { mutationOptions } from 'wellcrafted/query';
 
-But even then, you can still add call-site callbacks. They'll both run.
-
-## The Pattern in Practice
-
-After adopting this pattern, my components got simpler. No more passing callbacks through props. No more lifting state up just to access it in a success handler.
-
-Each mutation call is self-contained:
-
-```typescript
-shareMutation.mutate(
-	{ sessionId },
-	{
-		onSuccess: ({ url }) => {
-			shareUrl = url;
-			isShareModalOpen = true;
-			navigator.clipboard.writeText(url);
-		},
-	},
+const startRecording = createMutation(() =>
+	mutationOptions({
+		mutationKey: ['recording', 'startManual'],
+		mutationFn: startManualRecording,
+	}),
 );
 ```
 
-You can read the click handler and understand everything that happens. The context is right there.
+Use a shared `defineMutation` only when the mutation belongs in `$lib/rpc` or `$lib/query` with reusable identity, cache invalidation, or multiple observers.
 
-## The Lesson
+## Rule
 
-Callbacks want context. Put them where the context lives.
+- Shared RPC mutation hook: `createMutation(() => rpc.thing.options)`
+- Shared callback for every call: `createMutation(() => ({ ...rpc.thing.options, onSuccess }))`
+- Local UI callback: `mutation.mutate(input, { onSuccess, onError })`
+- Hook-local Result operation: `createMutation(() => mutationOptions({ mutationKey, mutationFn }))`
+- Imperative shared mutation outside hooks: `await rpc.thing(input)`
 
-I was treating mutation creation like a service definition—trying to define all behavior upfront. But mutations in components aren't services. They're UI interactions. And UI interactions need access to UI state.
-
-So now I do this:
-
-- `createMutation(rpc.thing.options)` - just the options, no callbacks
-- `.mutate(data, { onSuccess, onError })` - callbacks with full context
-
-Less abstraction. More clarity. And my modals finally close when they're supposed to.
+Do not use `createMutation(rpc.thing.options)` directly. Svelte Query expects an accessor so reactive options can be tracked consistently.

--- a/docs/type-safe-context-factory-pattern.md
+++ b/docs/type-safe-context-factory-pattern.md
@@ -89,23 +89,40 @@ When you use `bind:value` with a getter and setter function, the type flows thro
 
 ## Query Factories
 
-You could import `defineQuery` and `defineMutation` separately and use them with any query client:
+The Wellcrafted query API has two scopes. Hook-local adapters (`queryOptions` and `mutationOptions`) do not need a client because they only produce hook options. Reusable definitions (`defineQuery` and `defineMutation`) do need a client because their imperative APIs run through TanStack Query.
 
 ```typescript
-// Before
 import { QueryClient } from '@tanstack/svelte-query';
-import { defineQuery, defineMutation } from 'wellcrafted/query';
+import {
+	createQueryFactories,
+	mutationOptions,
+	queryOptions,
+} from 'wellcrafted/query';
 
 const queryClient = new QueryClient();
-
-// defineQuery and defineMutation are separate imports
-// Nothing ties them to this specific queryClient
 ```
 
-The `createQueryFactories` factory takes a query client and returns both functions bound to it:
+Use hook-local adapters at one call site:
 
 ```typescript
-// After
+const user = createQuery(() =>
+	queryOptions({
+		queryKey: ['user', userId],
+		queryFn: () => services.getUser(userId),
+	}),
+);
+
+const save = createMutation(() =>
+	mutationOptions({
+		mutationKey: ['user', 'save'],
+		mutationFn: (input: SaveUserInput) => services.saveUser(input),
+	}),
+);
+```
+
+Use `createQueryFactories` when a shared query module needs reusable definitions:
+
+```typescript
 import { QueryClient } from '@tanstack/svelte-query';
 import { createQueryFactories } from 'wellcrafted/query';
 
@@ -113,7 +130,7 @@ const queryClient = new QueryClient();
 const { defineQuery, defineMutation } = createQueryFactories(queryClient);
 ```
 
-All queries and mutations defined with these functions share the same client. You can't accidentally use a query definition with the wrong client.
+All queries and mutations defined with these functions share the same client. Queries expose `.options`, `.fetch()`, and `.ensure()`; they are not callable. Mutations expose `.options` and are callable; they do not expose `.execute()`.
 
 ## When to Use It
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 			"drizzle-kit": "^0.31.7",
 			"drizzle-orm": "^0.44.7",
 			"nanoid": "latest",
-			"wellcrafted": "^0.40.0",
+			"wellcrafted": "^0.42.0",
 			"date-fns": "^4.1.0",
 			"@biomejs/biome": "^2.4.10",
 			"turbo": "^2.6.1",

--- a/packages/svelte-utils/src/account-popover/account-popover.svelte
+++ b/packages/svelte-utils/src/account-popover/account-popover.svelte
@@ -12,9 +12,13 @@
 	import LogOut from '@lucide/svelte/icons/log-out';
 	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
 	import User from '@lucide/svelte/icons/user';
-	import { createQuery, QueryClient } from '@tanstack/svelte-query';
+	import {
+		createMutation,
+		createQuery,
+		QueryClient,
+	} from '@tanstack/svelte-query';
 	import { extractErrorMessage } from 'wellcrafted/error';
-	import { createResultMutation } from '../query.js';
+	import { mutationOptions } from 'wellcrafted/query';
 
 	const accountProfileQueryClient = new QueryClient({
 		defaultOptions: {
@@ -94,22 +98,26 @@
 	const accountLabel = $derived(
 		profile.data?.user.email ?? (profile.error ? 'Offline' : 'Loading...'),
 	);
-	const signOut = createResultMutation(
-		() => ({
-			mutationFn: () => auth.signOut(),
-			onMutate: () => {
-				popoverOpen = false;
-			},
-			onError: (error) => {
-				toastOnError(error, 'Failed to sign out');
-			},
-		}),
+	const signOut = createMutation(
+		() =>
+			mutationOptions({
+				mutationKey: ['account', 'signOut'],
+				mutationFn: () => auth.signOut(),
+				onMutate: () => {
+					popoverOpen = false;
+				},
+				onError: (error) => {
+					toastOnError(error, 'Failed to sign out');
+				},
+			}),
 		() => accountProfileQueryClient,
 	);
-	const startSignIn = createResultMutation(
-		() => ({
-			mutationFn: () => auth.startSignIn(),
-		}),
+	const startSignIn = createMutation(
+		() =>
+			mutationOptions({
+				mutationKey: ['account', 'startSignIn'],
+				mutationFn: () => auth.startSignIn(),
+			}),
 		() => accountProfileQueryClient,
 	);
 

--- a/packages/svelte-utils/src/query.test.ts
+++ b/packages/svelte-utils/src/query.test.ts
@@ -20,6 +20,7 @@ type TestInput = {
 
 function createTypedMutation() {
 	return createResultMutation(() => ({
+		mutationKey: ['test', 'save'],
 		mutationFn: (_input: TestInput): Result<'saved', TestError> =>
 			Ok('saved' as const),
 		onError: (error) => {
@@ -35,6 +36,7 @@ function createTypedMutation() {
 
 function createAsyncTypedMutation() {
 	return createResultMutation(() => ({
+		mutationKey: ['test', 'async'],
 		mutationFn: async (): Promise<Result<42, TestError>> => Ok(42 as const),
 	}));
 }

--- a/packages/svelte-utils/src/query.ts
+++ b/packages/svelte-utils/src/query.ts
@@ -3,31 +3,10 @@ import {
 	type CreateMutationOptions,
 	type CreateMutationResult,
 	createMutation,
-	type MutationFunctionContext,
 	type QueryClient,
 } from '@tanstack/svelte-query';
-import {
-	type Result,
-	type UnwrapErr,
-	type UnwrapOk,
-	unwrap,
-} from 'wellcrafted/result';
-
-type MaybePromise<T> = T | Promise<T>;
-
-/**
- * The exact shape a Result-aware mutation function must return.
- *
- * This is intentionally local to the adapter. Callers should name the operation
- * itself, not the intermediate Result extraction type.
- */
-type ResultMutationFnReturn = MaybePromise<Result<unknown, unknown>>;
-
-type MutationData<TMutationFnReturn extends ResultMutationFnReturn> = UnwrapOk<
-	Awaited<TMutationFnReturn>
->;
-type MutationError<TMutationFnReturn extends ResultMutationFnReturn> =
-	UnwrapErr<Awaited<TMutationFnReturn>>;
+import { mutationOptions } from 'wellcrafted/query';
+import type { Result } from 'wellcrafted/result';
 
 /**
  * TanStack mutation options after translating the Result payload into
@@ -38,22 +17,18 @@ type MutationError<TMutationFnReturn extends ResultMutationFnReturn> =
  * mutation shape.
  */
 type ResultMutationOptions<
-	TMutationFnReturn extends ResultMutationFnReturn,
+	TData,
+	TError,
 	TVariables = void,
-	TOnMutateResult = unknown,
+	TContext = unknown,
 > = Omit<
-	CreateMutationOptions<
-		MutationData<TMutationFnReturn>,
-		MutationError<TMutationFnReturn>,
-		TVariables,
-		TOnMutateResult
-	>,
+	CreateMutationOptions<TData, TError, TVariables, TContext>,
 	'mutationFn'
 > & {
+	mutationKey: readonly unknown[];
 	mutationFn: (
 		variables: TVariables,
-		context: MutationFunctionContext,
-	) => TMutationFnReturn;
+	) => Result<TData, TError> | Promise<Result<TData, TError>>;
 };
 
 /**
@@ -66,8 +41,9 @@ type ResultMutationOptions<
  * lifecycle callbacks and template reads preserve the operation's own success
  * and error types.
  *
- * The operation itself still returns a Result. This adapter unwraps at the
- * TanStack boundary because TanStack records mutation errors from thrown values.
+ * Prefer calling TanStack's `createMutation` with Wellcrafted's
+ * `mutationOptions` directly. This helper stays as a compatibility wrapper for
+ * older internal call sites.
  *
  * Promote the operation to a shared `defineMutation` only when it needs a stable
  * mutation key, shared invalidation, optimistic updates, or multiple consumers.
@@ -76,6 +52,7 @@ type ResultMutationOptions<
  * ```svelte
  * <script lang="ts">
  * 	const startSignIn = createResultMutation(() => ({
+ * 		mutationKey: ['auth', 'startSignIn'],
  * 		mutationFn: () => auth.startSignIn(),
  * 	}));
  *
@@ -91,32 +68,16 @@ type ResultMutationOptions<
  * ```
  */
 export function createResultMutation<
-	TMutationFnReturn extends ResultMutationFnReturn,
+	TData,
+	TError,
 	TVariables = void,
-	TOnMutateResult = unknown,
+	TContext = unknown,
 >(
-	options: Accessor<
-		ResultMutationOptions<TMutationFnReturn, TVariables, TOnMutateResult>
-	>,
+	options: Accessor<ResultMutationOptions<TData, TError, TVariables, TContext>>,
 	queryClient?: Accessor<QueryClient>,
-): CreateMutationResult<
-	MutationData<TMutationFnReturn>,
-	MutationError<TMutationFnReturn>,
-	TVariables,
-	TOnMutateResult
-> {
-	return createMutation(() => {
-		const current = options();
-
-		return {
-			...current,
-			mutationFn: async (
-				variables: TVariables,
-				context: MutationFunctionContext,
-			) => {
-				const result = await current.mutationFn(variables, context);
-				return unwrap(result) as MutationData<TMutationFnReturn>;
-			},
-		};
-	}, queryClient);
+): CreateMutationResult<TData, TError, TVariables, TContext> {
+	return createMutation(
+		() => mutationOptions<TData, TError, TVariables, TContext>(options()),
+		queryClient,
+	);
 }

--- a/specs/20250118T192845-error-handling-pattern.md
+++ b/specs/20250118T192845-error-handling-pattern.md
@@ -1,6 +1,6 @@
 # Error Handling Pattern for Whispering
 
-> **Partially superseded**: The 3-layer architecture (Service → Query → Command) is still valid. However, the `createTaggedError` API examples here predate the flat `.withFields()` redesign and sealed `.withMessage()`. See `20260226T233600-tagged-error-minimal-design.md` for the current API design and the `services-layer` skill for up-to-date examples.
+> **Partially superseded**: The 3-layer architecture (Service -> Query -> Command) is still valid. However, the `createTaggedError` API examples here predate the flat `.withFields()` redesign and sealed `.withMessage()`. Shared Wellcrafted mutations are now called directly, while shared queries use `.fetch()` or `.ensure()`. See `20260226T233600-tagged-error-minimal-design.md` for the current API design and the `services-layer` skill for up-to-date examples.
 
 ## Overview
 This document defines the error handling pattern used throughout the Whispering codebase to ensure consistency and avoid redundant error wrapping.
@@ -20,7 +20,7 @@ This document defines the error handling pattern used throughout the Whispering 
 
 ### 3. Command Layer (`lib/query/commands.ts`)
 - Receives `WhisperingError` objects from the query layer
-- Passes errors directly to `notify.error.execute()` without re-wrapping
+- Passes errors directly to `notify.error()` without re-wrapping
 - Returns the error as-is for proper type flow
 
 ## Correct Pattern
@@ -65,7 +65,7 @@ getRecorderState: defineQuery({
 // In query/commands.ts
 if (startRecordingError) {
     // Pass WhisperingError directly - no re-wrapping!
-    notify.error.execute({ id: toastId, ...startRecordingError });
+    notify.error({ id: toastId, ...startRecordingError });
     return Err(startRecordingError);
 }
 ```
@@ -81,7 +81,7 @@ if (getRecorderStateError) {
         description: getRecorderStateError.message,
         action: { type: 'more-details', error: getRecorderStateError },
     });
-    notify.error.execute({ id: nanoid(), ...whisperingError.error });
+    notify.error({ id: nanoid(), ...whisperingError.error });
     return whisperingError;
 }
 ```

--- a/specs/20251013T151500-persistent-model-manager-implementation.md
+++ b/specs/20251013T151500-persistent-model-manager-implementation.md
@@ -1,5 +1,7 @@
 # Persistent Model Manager Implementation Plan
 
+> Historical note: this spec predates the current Wellcrafted query API. In Svelte components, pass an accessor to `createQuery` and `createMutation`. Shared query and mutation definitions expose `.options` as a property.
+
 ## Executive Decision: Smart Default with User Control
 
 After analyzing approaches and considering Whispering's user base, here's my recommendation:
@@ -438,7 +440,7 @@ const DEFAULT_MODEL_SETTINGS: ModelSettings = {
 
   let { settings = $bindable() }: Props = $props();
 
-  const updateMutation = createMutation(rpc.updateModelConfig.options);
+  const updateMutation = createMutation(() => rpc.updateModelConfig.options);
 
   function handleStrategyChange(value: ModelMemoryStrategy) {
     settings.memoryStrategy = value;
@@ -616,9 +618,10 @@ const DEFAULT_MODEL_SETTINGS: ModelSettings = {
   import * as rpc from '$lib/query';
   import { Badge } from '$lib/components/ui/badge';
 
-  const statusQuery = createQuery(rpc.getModelStatus.options, {
+  const statusQuery = createQuery(() => ({
+    ...rpc.getModelStatus.options,
     refetchInterval: 5000, // Update every 5 seconds
-  });
+  }));
 
   $: status = $statusQuery.data;
   $: isLoaded = status?.is_loaded ?? false;

--- a/specs/20251027T172102 transform-clipboard-command.md
+++ b/specs/20251027T172102 transform-clipboard-command.md
@@ -1,5 +1,7 @@
 # Transform Clipboard Command
 
+> Historical note: this spec predates the current Wellcrafted query API. Shared mutations are now called directly. Shared queries use `.fetch()` or `.ensure()`. Do not copy `.execute()` examples from older revisions of this plan.
+
 ## Date
 October 27, 2025
 
@@ -90,7 +92,7 @@ File: `apps/whispering/src/lib/commands.ts`
   id: 'transformClipboard',
   title: 'Transform clipboard text',
   on: 'Pressed',
-  callback: () => rpc.commands.transformClipboard.execute(undefined),
+  callback: () => rpc.commands.transformClipboard(),
 },
 ```
 
@@ -103,7 +105,7 @@ transformClipboard: defineMutation({
   mutationFn: async (): Promise<WhisperingResult<void>> => {
     // 1. Read clipboard
     const { data: clipboardText, error: readError } =
-      await rpc.text.readFromClipboard.execute();
+      await rpc.text.readFromClipboard.fetch();
 
     if (readError || !clipboardText?.trim()) {
       return WhisperingErr({
@@ -149,25 +151,25 @@ File: `apps/whispering/src/routes/+layout/AppShell.svelte`
     bind:open={transformClipboardPickerOpen}
     onSelect={async (transformation) => {
       const toastId = nanoid();
-      rpc.notify.loading.execute({
+      rpc.notify.loading({
         id: toastId,
         title: '🔄 Running transformation...',
         description: 'Transforming your clipboard text...',
       });
 
-      const { data: output, error } = await rpc.transformer.transformInput.execute({
+      const { data: output, error } = await rpc.transformer.transformInput({
         input: transformClipboardText,
         transformation,
       });
 
       if (error) {
-        rpc.notify.error.execute(error);
+        rpc.notify.error(error);
         return;
       }
 
-      rpc.sound.playSoundIfEnabled.execute('transformationComplete');
+      rpc.sound.playSoundIfEnabled('transformationComplete');
 
-      rpc.delivery.deliverTransformationResult.execute({
+      rpc.delivery.deliverTransformationResult({
         text: output,
         toastId,
       });
@@ -210,7 +212,7 @@ Add a second command that uses last-used:
   id: 'transformClipboardQuick',
   title: 'Transform clipboard (use last transformation)',
   on: 'Pressed',
-  callback: () => rpc.commands.transformClipboardQuick.execute(undefined),
+  callback: () => rpc.commands.transformClipboardQuick(),
 },
 ```
 

--- a/specs/20251030T000000 delete-transformation-runs.md
+++ b/specs/20251030T000000 delete-transformation-runs.md
@@ -1,5 +1,7 @@
 # Delete Transformation Runs Feature
 
+> Historical note: this spec predates the current Wellcrafted query API. Shared mutations are now called directly. Do not copy older `.execute()` examples from this plan.
+
 ## Problem
 Transformation runs currently have no way to be deleted. Users can see the history of transformation runs when viewing a transformation or recording, but there's no UI or backend support for deleting these runs. This can lead to:
 1. Accumulation of old/unnecessary run data
@@ -176,7 +178,7 @@ All delete functionality inlined into Runs.svelte using the confirmationDialog p
 - Uses `confirmationDialog.open()` for confirmation
 - Delete logic inlined directly in onclick handler
 - Disabled state during deletion
-- Uses `rpc.notify.success.execute()` and `rpc.notify.error.execute()` for notifications
+- Uses `rpc.notify.success()` and `rpc.notify.error()` for notifications
 
 **Clear All Runs Button** (in Runs.svelte):
 - Bulk deletion button at top of runs table

--- a/specs/20251204T015007 vad-createsubscriber-refactor.md
+++ b/specs/20251204T015007 vad-createsubscriber-refactor.md
@@ -1,5 +1,7 @@
 # VAD Recorder: Replace invalidateQueries with createSubscriber
 
+> Historical note: this spec predates the current Wellcrafted query API. If a component still consumes a shared query definition, use `createQuery(() => rpc.thing.options)`.
+
 ## Context
 
 The VAD recorder currently uses TanStack Query's `invalidateQueries` pattern to notify UI components of state changes. This works but is suboptimal because:
@@ -175,7 +177,7 @@ Option 1: Remove `getVadState` query entirely, access service directly:
 // Components would use:
 // services.vad.vadState (reactive getter)
 // instead of:
-// createQuery(rpc.vadRecorder.getVadState.options)
+// createQuery(() => rpc.vadRecorder.getVadState.options)
 ```
 
 Option 2: Thin wrapper for API consistency:
@@ -209,7 +211,7 @@ export const vadRecorder = {
 
 Before:
 ```svelte
-const getVadStateQuery = createQuery(rpc.vadRecorder.getVadState.options);
+const getVadStateQuery = createQuery(() => rpc.vadRecorder.getVadState.options);
 
 $effect(() => {
   if (getVadStateQuery.data === 'LISTENING') {
@@ -287,7 +289,7 @@ The final implementation went simpler than originally proposed. Instead of using
 **Before:**
 - Service layer: `$lib/services/vad-recorder.ts` (creates `VadServiceLive`)
 - Query layer: `$lib/query/vad-recorder.ts` (wraps service with `defineQuery`/`defineMutation`)
-- Components: Use `createQuery(rpc.vadRecorder.getVadState.options)`
+- Components: Use `createQuery(() => rpc.vadRecorder.getVadState.options)`
 
 **After:**
 - Single module: `$lib/query/vad.svelte.ts` with `$state` reactivity

--- a/specs/20251218T194432 query-layer-commands-refactor.md
+++ b/specs/20251218T194432 query-layer-commands-refactor.md
@@ -1,5 +1,7 @@
 # Query Layer Commands Refactor Plan
 
+> Historical note: this plan predates the current Wellcrafted query API. Keep the command-placement ideas, but do not copy the old mutation call syntax. Shared mutations are now called directly, queries use `.fetch()` or `.ensure()`, and `.options` is read through a Svelte Query accessor.
+
 ## Review of Changes
 
 ### Completed Refactoring
@@ -15,7 +17,7 @@ The refactoring has been successfully implemented with the following changes:
 
 2. **Updated `/apps/whispering/src/lib/commands.ts`**
    - Simplified to only contain command metadata and callbacks
-   - Each callback now uses `rpc.commands.*.execute()` pattern
+   - Each callback now calls `rpc.commands.*()` directly
    - Removed all implementation details and direct service calls
 
 3. **Updated `/apps/whispering/src/lib/query/index.ts`**
@@ -27,8 +29,8 @@ The refactoring has been successfully implemented with the following changes:
    - Removed unused imports
 
 5. **Updated `/apps/whispering/src/routes/+page.svelte`**
-   - Changed `rpc.recordings.uploadRecording.execute({ file })` 
-   - To: `rpc.commands.uploadRecording.execute({ file })`
+   - Changed `rpc.recordings.uploadRecording({ file })`
+   - To: `rpc.commands.uploadRecording({ file })`
 
 ### Benefits Achieved
 
@@ -146,9 +148,9 @@ export const commands = {
       }
 
       if (recorderState === 'RECORDING') {
-        return stopManualRecording.execute();
+        return stopManualRecording();
       } else {
-        return startManualRecording.execute();
+        return startManualRecording();
       }
     },
   }),
@@ -167,14 +169,14 @@ export const commands = {
     mutationFn: async () => {
       const toastId = nanoid();
       
-      notify.loading.execute({
+      notify.loading({
         id: toastId,
         title: '🎙️ Preparing to record...',
         description: 'Setting up your recording environment...',
       });
 
       const { data: deviceAcquisitionOutcome, error } = 
-        await manualRecorder.startRecording.execute({ toastId });
+        await manualRecorder.startRecording({ toastId });
 
       if (error) {
         return Err(WhisperingErr({
@@ -266,25 +268,25 @@ export const commands = [
     id: 'pushToTalk',
     title: 'Push to talk',
     on: 'Both',
-    callback: () => rpc.commands.pushToTalk.execute(),
+    callback: () => rpc.commands.pushToTalk(),
   },
   {
     id: 'toggleManualRecording',
     title: 'Toggle recording',
     on: 'Pressed',
-    callback: () => rpc.commands.toggleManualRecording.execute(),
+    callback: () => rpc.commands.toggleManualRecording(),
   },
   {
     id: 'cancelManualRecording',
     title: 'Cancel recording',
     on: 'Pressed',
-    callback: () => rpc.commands.cancelManualRecording.execute(),
+    callback: () => rpc.commands.cancelManualRecording(),
   },
   {
     id: 'toggleVadRecording',
     title: 'Toggle voice activated recording',
     on: 'Pressed',
-    callback: () => rpc.commands.toggleVadRecording.execute(),
+    callback: () => rpc.commands.toggleVadRecording(),
   },
   ...(window.__TAURI_INTERNALS__
     ? ([
@@ -292,13 +294,13 @@ export const commands = [
           id: 'toggleCpalRecording',
           title: 'Toggle CPAL recording',
           on: 'Pressed',
-          callback: () => rpc.commands.toggleCpalRecording.execute(),
+          callback: () => rpc.commands.toggleCpalRecording(),
         },
         {
           id: 'cancelCpalRecording',
           title: 'Cancel CPAL recording',
           on: 'Pressed',
-          callback: () => rpc.commands.cancelCpalRecording.execute(),
+          callback: () => rpc.commands.cancelCpalRecording(),
         },
       ] as const satisfies SatisfiedCommand[])
     : []),
@@ -356,7 +358,7 @@ uploadRecording: defineMutation({
     
     // Use the shared pipeline
     const toastId = nanoid();
-    await rpc.commands.processRecordingPipeline.execute({
+    await rpc.commands.processRecordingPipeline({
       blob: audioBlob,
       toastId,
       completionTitle: '📁 File uploaded successfully!',
@@ -370,7 +372,7 @@ uploadRecording: defineMutation({
 
 ## Benefits of This Refactoring
 
-1. **Consistency**: All commands follow the RPC pattern with `.execute()` calls
+1. **Consistency**: All commands follow the RPC pattern with direct mutation calls
 2. **Testability**: Commands can be tested independently as mutations
 3. **Reusability**: The `processRecordingPipeline` function can be used by any command that produces audio
 4. **Type Safety**: Commands return proper `Result<T, E>` types

--- a/specs/20260104T220837-remove-execute-calls.md
+++ b/specs/20260104T220837-remove-execute-calls.md
@@ -4,32 +4,40 @@
 **Status**: Completed
 **Branch**: `refactor/remove-execute-calls`
 
+> Historical note: this spec describes an older Wellcrafted API migration. The current API is stricter: shared queries are not callable and expose `.fetch()` plus `.ensure()` for imperative use; shared mutations are callable and do not expose public `.execute()`.
+
 ## Summary
 
-Simplify the codebase by removing redundant `.execute()` method calls on mutations. Since wellcrafted v0.26.0, mutation definitions are directly callable functions, making `.execute()` unnecessary.
+Simplify the codebase by removing redundant `.execute()` method calls on mutations. In the current Wellcrafted API, mutation definitions are directly callable functions and `.execute()` is not public API.
 
 ## Background
 
-The wellcrafted library (v0.26.0+) made query and mutation definitions directly callable:
+The current wellcrafted library keeps imperative query and mutation usage explicit:
 
 ```typescript
 const createUser = defineMutation({...});
 
-// OLD: Explicit .execute() call
+// Old: Explicit .execute() call
 const { data, error } = await createUser.execute({ name: 'John' });
 
-// NEW: Direct call (recommended)
+// Current: Direct mutation call
 const { data, error } = await createUser({ name: 'John' });
+
+const userQuery = defineQuery({...});
+
+// Current: Explicit query cache policy
+const fresh = await userQuery.fetch();
+const cached = await userQuery.ensure();
 ```
 
-Both patterns are equivalent; they reference the same function. The direct call is now the recommended primary pattern.
+Queries are not callable. Mutations are callable.
 
 ## Implementation Details
 
 ### How It Works (from wellcrafted source)
 
 ```typescript
-// wellcrafted uses Object.assign to make the function callable with properties
+// wellcrafted uses Object.assign to make mutation definitions callable with properties
 async function execute(variables: TVariables) {
 	try {
 		return Ok(await runMutation(queryClient, newOptions, variables));
@@ -40,7 +48,6 @@ async function execute(variables: TVariables) {
 
 return Object.assign(execute, {
 	options: newOptions, // Static property (not a function!)
-	execute, // Same function reference
 });
 ```
 
@@ -103,7 +110,7 @@ NEW: await rpc.db.recordings.delete(recording)
 
 ## Notes
 
-- `.execute()` still works and isn't deprecated; this is purely a simplification
+- `.execute()` was removed from the public Wellcrafted mutation surface after this migration
 - The change is cosmetic but improves code readability
 - No runtime behavior changes
 - `.options` is already a property (changed in v0.26.0), not `.options()`

--- a/specs/20260319T120000-skill-authoring-model.md
+++ b/specs/20260319T120000-skill-authoring-model.md
@@ -203,7 +203,7 @@ USER ASKS: "Write a Svelte component with a mutation"
      - Core patterns, $derived, reactive state conventions
      - Cross-references: "See references/tanstack-query-mutations.md"
   3. Agent reads references/tanstack-query-mutations.md (~150 lines)
-     - createMutation pattern, .execute() in .ts files, onSuccess/onError
+     - createMutation pattern, direct mutation calls in .ts files, `.fetch()` and `.ensure()` for queries, onSuccess/onError
 
   TOTAL CONTEXT: ~4,000 tokens (vs ~7,800 tokens loading everything)
 

--- a/specs/20260319T140003-autumn-phase3-billing-ui.md
+++ b/specs/20260319T140003-autumn-phase3-billing-ui.md
@@ -126,10 +126,10 @@ Build TanStack Query wrappers that call the `/api/autumn/*` routes. These are th
 - [ ] **A.7** Create `aggregateAutumnEvents(featureId, range)` — calls `POST /api/autumn/events.aggregate`
 - [ ] **A.8** Add error handling: expired sessions → re-auth, failed checkout → show error, network failures → retry
 
-**Pattern**: Each wrapper is a function that returns a TanStack Query `queryOptions` or `mutationOptions` object. Example:
+**Pattern**: Each wrapper is a function that returns a Wellcrafted `queryOptions` or `mutationOptions` object for TanStack Query. Example:
 
 ```ts
-import { queryOptions } from '@tanstack/svelte-query';
+import { queryOptions } from 'wellcrafted/query';
 
 export function autumnCustomerQuery() {
   return queryOptions({


### PR DESCRIPTION
Epicenter now consumes the Wellcrafted query API from the released package shape instead of carrying older callable-query and mutation `.execute()` assumptions. Wellcrafted split the surface into hook-local adapters and reusable QueryClient-bound definitions, so this branch updates the dependency, keeps shared query/RPC modules on `createQueryFactories`, and makes imperative query reads show their cache policy at the call site.

The main usage rule is now explicit:

```ts
await rpc.audio.getPlaybackUrl(() => recordingId).fetch();
await rpc.audio.getPlaybackUrl(() => recordingId).ensure();

await rpc.transformer.transformRecording(input);
```

Hook-local component operations that return `Result` now go through the Result-aware adapters directly:

```ts
createMutation(() =>
	mutationOptions({
		mutationKey: ['recording', 'startManual'],
		mutationFn: startManualRecording,
	}),
);
```

The rest of the branch updates living docs and agent guidance so future examples teach the same shape: queries expose `.options`, `.fetch()`, and `.ensure()`; mutations expose `.options` and are callable; `.options` is a property; and `defineQuery` / `defineMutation` from `wellcrafted/query` stay distinct from the workspace action helpers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782532421&installation_id=128463665&pr_number=1850&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1850&signature=4f8e469effce499f752daa50f59310ee5bc840b9c445ce1702c50e7cf450d041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->