### PR TITLE
fix: drain SQLite DB work before writer close

### DIFF
--- a/packages/workspace/src/document/materializer/sqlite/bun-sqlite.ts
+++ b/packages/workspace/src/document/materializer/sqlite/bun-sqlite.ts
@@ -110,17 +110,6 @@ export function attachBunSqliteMaterializer<
 		fts,
 		debounceMs,
 		waitFor,
-		onDisposed: () => {
-			try {
-				client.close();
-			} catch (cause) {
-				log.warn(
-					new Error('attachBunSqliteMaterializer: client.close failed', {
-						cause,
-					}),
-				);
-			}
-		},
 		log,
 	});
 

--- a/packages/workspace/src/document/materializer/sqlite/bun-sqlite.ts
+++ b/packages/workspace/src/document/materializer/sqlite/bun-sqlite.ts
@@ -113,11 +113,11 @@ export function attachBunSqliteMaterializer<
 		log,
 	});
 
-	// Registered AFTER core's own destroy listener so dispose() runs first
-	// (cancels timers, detaches observers) before the database handle closes.
-	// `close()` can throw if the handle is already shut by a duplicate destroy;
-	// swallow and log rather than letting it escape the destroy listener.
-	ydoc.once('destroy', () => {
+	// Registered after core's destroy listener so disposal starts before the
+	// database handle closes. The close waits for core's sync queue to drain so
+	// an in-flight incremental flush cannot resume against a closed handle.
+	ydoc.once('destroy', async () => {
+		await core.whenDisposed;
 		try {
 			client.close();
 		} catch (cause) {

--- a/packages/workspace/src/document/materializer/sqlite/core.test.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.test.ts
@@ -57,10 +57,9 @@ type SetupBuildResult = {
 type SetupOptions = {
 	build?: (t: AttachedTables) => SetupBuildResult;
 	debounceMs?: number;
-	onDisposed?: () => void;
 };
 
-function setup({ build, debounceMs, onDisposed }: SetupOptions = {}) {
+function setup({ build, debounceMs }: SetupOptions = {}) {
 	const db = createTestDb();
 
 	const cache = createDisposableCache(
@@ -82,7 +81,6 @@ function setup({ build, debounceMs, onDisposed }: SetupOptions = {}) {
 				db,
 				debounceMs,
 				tables: built.tables,
-				onDisposed,
 				// biome-ignore lint/suspicious/noExplicitAny: tests erase row types through the setup helper
 				fts: built.fts as any,
 			});
@@ -144,7 +142,7 @@ function hasTable(db: Database, tableName: string) {
 
 async function cleanup(setupResult: ReturnType<typeof setup>) {
 	setupResult.workspace[Symbol.dispose]();
-	setupResult.db.close();
+	await Promise.resolve();
 }
 
 // ============================================================================
@@ -426,6 +424,8 @@ describe('attachSqliteMaterializerCore', () => {
 	describe('dispose', () => {
 		test('dispose cancels queued sync and ignores later writes', async () => {
 			const testSetup = setup();
+			const originalClose = testSetup.db.close.bind(testSetup.db);
+			testSetup.db.close = () => {};
 
 			try {
 				await testSetup.workspace.sqlite.whenFlushed;
@@ -446,24 +446,19 @@ describe('attachSqliteMaterializerCore', () => {
 
 				expect(getRows(testSetup.db, 'posts')).toEqual([]);
 			} finally {
-				testSetup.db.close();
+				originalClose();
 			}
 		});
 
-		test('runs onDisposed after an in-flight incremental sync', async () => {
+		test('closes SQLite after an in-flight incremental sync', async () => {
 			const insertStarted = createDeferred();
 			const allowInsert = createDeferred();
-			const disposed = createDeferred();
-			let onDisposedCalled = false;
-			const testSetup = setup({
-				debounceMs: 0,
-				onDisposed: () => {
-					onDisposedCalled = true;
-					disposed.resolve();
-				},
-			});
+			const closed = createDeferred();
+			const testSetup = setup({ debounceMs: 0 });
 			const originalPrepare = testSetup.db.prepare.bind(testSetup.db);
+			const originalClose = testSetup.db.close.bind(testSetup.db);
 			let insertRunCompleted = false;
+			let closeCalled = false;
 
 			testSetup.db.prepare = ((sql: string, params?: SQLQueryBindings) => {
 				const statement = originalPrepare(sql, params);
@@ -482,6 +477,11 @@ describe('attachSqliteMaterializerCore', () => {
 					get: statement.get.bind(statement),
 				};
 			}) as typeof testSetup.db.prepare;
+			testSetup.db.close = () => {
+				closeCalled = true;
+				closed.resolve();
+				originalClose();
+			};
 
 			try {
 				await testSetup.workspace.sqlite.whenFlushed;
@@ -496,16 +496,16 @@ describe('attachSqliteMaterializerCore', () => {
 				testSetup.workspace[Symbol.dispose]();
 				await Promise.resolve();
 
-				expect(onDisposedCalled).toBe(false);
+				expect(closeCalled).toBe(false);
 				expect(insertRunCompleted).toBe(false);
 
 				allowInsert.resolve();
-				await disposed.promise;
+				await closed.promise;
 
-				expect(onDisposedCalled).toBe(true);
+				expect(closeCalled).toBe(true);
 				expect(insertRunCompleted).toBe(true);
 			} finally {
-				testSetup.db.close();
+				if (!closeCalled) testSetup.db.close();
 			}
 		});
 	});

--- a/packages/workspace/src/document/materializer/sqlite/core.test.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.test.ts
@@ -140,8 +140,9 @@ function hasTable(db: Database, tableName: string) {
 	return row != null;
 }
 
-async function cleanup(setupResult: ReturnType<typeof setup>) {
+async function disposeAndYieldForClose(setupResult: ReturnType<typeof setup>) {
 	setupResult.workspace[Symbol.dispose]();
+	// In settled cleanup paths, disposal schedules close on the next microtask.
 	await Promise.resolve();
 }
 
@@ -229,7 +230,7 @@ describe('attachSqliteMaterializerCore', () => {
 					{ id: 'post-2', published: 1, title: 'Second row' },
 				]);
 			} finally {
-				await cleanup(testSetup);
+				await disposeAndYieldForClose(testSetup);
 			}
 		});
 
@@ -257,7 +258,7 @@ describe('attachSqliteMaterializerCore', () => {
 					{ id: 'post-1', published: null, title: 'Mirrored post' },
 				]);
 			} finally {
-				await cleanup(testSetup);
+				await disposeAndYieldForClose(testSetup);
 			}
 		});
 	});
@@ -285,7 +286,7 @@ describe('attachSqliteMaterializerCore', () => {
 					{ id: 'post-1', published: 1, title: 'Added later' },
 				]);
 			} finally {
-				await cleanup(testSetup);
+				await disposeAndYieldForClose(testSetup);
 			}
 		});
 
@@ -306,7 +307,7 @@ describe('attachSqliteMaterializerCore', () => {
 
 				expect(getRows(testSetup.db, 'posts')).toEqual([]);
 			} finally {
-				await cleanup(testSetup);
+				await disposeAndYieldForClose(testSetup);
 			}
 		});
 
@@ -332,7 +333,7 @@ describe('attachSqliteMaterializerCore', () => {
 					{ id: 'post-1', published: 0, title: 'After update' },
 				]);
 			} finally {
-				await cleanup(testSetup);
+				await disposeAndYieldForClose(testSetup);
 			}
 		});
 	});
@@ -363,7 +364,7 @@ describe('attachSqliteMaterializerCore', () => {
 					{ id: 'post-1', published: null, title: 'Persisted in Yjs' },
 				]);
 			} finally {
-				await cleanup(testSetup);
+				await disposeAndYieldForClose(testSetup);
 			}
 		});
 
@@ -396,7 +397,7 @@ describe('attachSqliteMaterializerCore', () => {
 				]);
 				expect(getRows(testSetup.db, 'notes')).toHaveLength(1);
 			} finally {
-				await cleanup(testSetup);
+				await disposeAndYieldForClose(testSetup);
 			}
 		});
 
@@ -412,7 +413,7 @@ describe('attachSqliteMaterializerCore', () => {
 					}),
 				).toThrow('not in the materialized table set');
 			} finally {
-				await cleanup(testSetup);
+				await disposeAndYieldForClose(testSetup);
 			}
 		});
 	});
@@ -508,6 +509,69 @@ describe('attachSqliteMaterializerCore', () => {
 				if (!closeCalled) testSetup.db.close();
 			}
 		});
+
+		test('closes SQLite after an in-flight rebuild', async () => {
+			const insertStarted = createDeferred();
+			const allowInsert = createDeferred();
+			const closed = createDeferred();
+			const testSetup = setup({ debounceMs: 0 });
+			const originalPrepare = testSetup.db.prepare.bind(testSetup.db);
+			const originalClose = testSetup.db.close.bind(testSetup.db);
+			let insertRunCompleted = false;
+			let closeCalled = false;
+
+			try {
+				await testSetup.workspace.sqlite.whenFlushed;
+
+				testSetup.workspace.tables.posts.set({
+					id: 'post-1',
+					title: 'Rebuilt row',
+					published: null,
+				});
+				await waitForSyncCycle();
+
+				testSetup.db.prepare = ((sql: string, params?: SQLQueryBindings) => {
+					const statement = originalPrepare(sql, params);
+					if (!sql.startsWith('INSERT INTO "posts"')) return statement;
+
+					return {
+						async run(...params: SQLQueryBindings[]) {
+							insertStarted.resolve();
+							await allowInsert.promise;
+							// biome-ignore lint/suspicious/noExplicitAny: Bun's generic statement type cannot express this wrapper
+							const result = (statement.run as any)(...params);
+							insertRunCompleted = true;
+							return result;
+						},
+						all: statement.all.bind(statement),
+						get: statement.get.bind(statement),
+					};
+				}) as typeof testSetup.db.prepare;
+				testSetup.db.close = () => {
+					closeCalled = true;
+					closed.resolve();
+					originalClose();
+				};
+
+				const rebuild = testSetup.workspace.sqlite.actions.sqlite_rebuild({});
+				await insertStarted.promise;
+
+				testSetup.workspace[Symbol.dispose]();
+				await Promise.resolve();
+
+				expect(closeCalled).toBe(false);
+				expect(insertRunCompleted).toBe(false);
+
+				allowInsert.resolve();
+				await rebuild;
+				await closed.promise;
+
+				expect(closeCalled).toBe(true);
+				expect(insertRunCompleted).toBe(true);
+			} finally {
+				if (!closeCalled) testSetup.db.close();
+			}
+		});
 	});
 
 	// ============================================================================
@@ -528,7 +592,7 @@ describe('attachSqliteMaterializerCore', () => {
 						.sqlite_search,
 				).toBeUndefined();
 			} finally {
-				await cleanup(testSetup);
+				await disposeAndYieldForClose(testSetup);
 			}
 		});
 
@@ -573,7 +637,7 @@ describe('attachSqliteMaterializerCore', () => {
 					expect(results[0]?.snippet).toContain('<mark>');
 					expect(typeof results[0]?.rank).toBe('number');
 				} finally {
-					await cleanup(testSetup);
+					await disposeAndYieldForClose(testSetup);
 				}
 			});
 
@@ -619,7 +683,7 @@ describe('attachSqliteMaterializerCore', () => {
 						'<mark>mirror</mark>',
 					);
 				} finally {
-					await cleanup(testSetup);
+					await disposeAndYieldForClose(testSetup);
 				}
 			});
 		}
@@ -638,7 +702,7 @@ describe('attachSqliteMaterializerCore', () => {
 				expect(isAction(sqlite.actions.sqlite_rebuild)).toBe(true);
 				expect(isMutation(sqlite.actions.sqlite_rebuild)).toBe(true);
 			} finally {
-				await cleanup(testSetup);
+				await disposeAndYieldForClose(testSetup);
 			}
 		});
 
@@ -659,7 +723,7 @@ describe('attachSqliteMaterializerCore', () => {
 					expect(isAction(sqliteWithFts.actions.sqlite_search)).toBe(true);
 					expect(isQuery(sqliteWithFts.actions.sqlite_search)).toBe(true);
 				} finally {
-					await cleanup(testSetup);
+					await disposeAndYieldForClose(testSetup);
 				}
 			});
 		}

--- a/packages/workspace/src/document/materializer/sqlite/core.test.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.test.ts
@@ -25,7 +25,11 @@ import {
 } from '../../../index.js';
 import { isAction, isMutation, isQuery } from '../../../shared/actions.js';
 import { column } from '../../column/index.js';
-import { attachSqliteMaterializerCore, type MirrorDatabase } from './core.js';
+import {
+	attachSqliteMaterializerCore,
+	type MirrorDatabase,
+	type MirrorStatement,
+} from './core.js';
 
 const postsTable = defineTable({
 	id: column.string(),
@@ -467,6 +471,60 @@ describe('attachSqliteMaterializerCore', () => {
 				await waitForSyncCycle();
 
 				expect(getRows(testSetup.db, 'posts')).toEqual([]);
+			} finally {
+				testSetup.db.close();
+			}
+		});
+
+		test('whenDisposed waits for an in-flight incremental sync', async () => {
+			const testSetup = setup({ debounceMs: 0 });
+			const insertStarted = createDeferred();
+			const allowInsert = createDeferred();
+			const originalPrepare = testSetup.db.prepare.bind(testSetup.db);
+			let insertRunCompleted = false;
+
+			testSetup.db.prepare = async (sql: string): Promise<MirrorStatement> => {
+				const statement = await originalPrepare(sql);
+				if (!sql.startsWith('INSERT INTO "posts"')) return statement;
+
+				return {
+					async run(...params: unknown[]) {
+						insertStarted.resolve();
+						await allowInsert.promise;
+						const result = statement.run(...params);
+						insertRunCompleted = true;
+						return result;
+					},
+					all: statement.all.bind(statement),
+					get: statement.get.bind(statement),
+				};
+			};
+
+			try {
+				await testSetup.workspace.sqlite.whenFlushed;
+
+				testSetup.workspace.tables.posts.set({
+					id: 'post-1',
+					title: 'In-flight row',
+					published: null,
+				});
+				await insertStarted.promise;
+
+				let disposed = false;
+				testSetup.workspace.sqlite.whenDisposed.then(() => {
+					disposed = true;
+				});
+
+				testSetup.workspace[Symbol.dispose]();
+				await Promise.resolve();
+
+				expect(disposed).toBe(false);
+				expect(insertRunCompleted).toBe(false);
+
+				allowInsert.resolve();
+				await testSetup.workspace.sqlite.whenDisposed;
+
+				expect(insertRunCompleted).toBe(true);
 			} finally {
 				testSetup.db.close();
 			}

--- a/packages/workspace/src/document/materializer/sqlite/core.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.ts
@@ -79,7 +79,6 @@ export function attachSqliteMaterializerCore<
 		fts,
 		debounceMs = 100,
 		waitFor,
-		onDisposed,
 		log = createLogger('sqlite-materializer'),
 	}: {
 		db: Database;
@@ -102,11 +101,6 @@ export function attachSqliteMaterializerCore<
 		 * for no gate.
 		 */
 		waitFor?: Promise<unknown>;
-		/**
-		 * Runs after the materializer has detached observers and the current
-		 * incremental sync queue has drained.
-		 */
-		onDisposed?: () => void | Promise<void>;
 		/**
 		 * Logger for background failures (debounced sync flush, FTS query).
 		 * Defaults to a console-backed logger with source `sqlite-materializer`.
@@ -257,9 +251,11 @@ export function attachSqliteMaterializerCore<
 		isDisposed = true;
 		flushAfterDebounce.cancel();
 		for (const entry of registered.values()) entry.unsubscribe?.();
-		syncQueue.then(onDisposed).catch((cause: unknown) => {
-			log.error(SqliteMaterializerError.DisposeFailed({ cause }));
-		});
+		syncQueue
+			.then(() => db.close())
+			.catch((cause: unknown) => {
+				log.error(SqliteMaterializerError.DisposeFailed({ cause }));
+			});
 	}
 
 	ydoc.once('destroy', dispose);

--- a/packages/workspace/src/document/materializer/sqlite/core.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.ts
@@ -165,6 +165,10 @@ export function attachSqliteMaterializerCore<
 	let pendingSync = new Map<string, Set<string>>();
 	let syncQueue = Promise.resolve();
 	let isDisposed = false;
+	let resolveWhenDisposed!: () => void;
+	const whenDisposed = new Promise<void>((resolve) => {
+		resolveWhenDisposed = resolve;
+	});
 
 	// ── SQL primitives ───────────────────────────────────────────
 
@@ -287,6 +291,7 @@ export function attachSqliteMaterializerCore<
 		isDisposed = true;
 		flushAfterDebounce.cancel();
 		for (const entry of registered.values()) entry.unsubscribe?.();
+		syncQueue.finally(resolveWhenDisposed);
 	}
 
 	ydoc.once('destroy', dispose);
@@ -358,7 +363,7 @@ export function attachSqliteMaterializerCore<
 			})
 		: defineActions({ sqlite_rebuild: rebuildAction });
 
-	return { whenFlushed, actions };
+	return { whenFlushed, whenDisposed, actions };
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/workspace/src/document/materializer/sqlite/core.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.ts
@@ -6,9 +6,8 @@
  * Public callers use `attachBunSqliteMaterializer`, which owns the native
  * client lifecycle and forwards the client here.
  *
- * Teardown is hooked to the ydoc via `ydoc.once('destroy', ...)`. The
- * `attachBunSqliteMaterializer` registers its own destroy handler too to close
- * the underlying native client.
+ * Teardown is hooked to the ydoc via `ydoc.once('destroy', ...)`. Core closes
+ * the underlying native client after queued database work drains.
  *
  * @internal
  * @module
@@ -41,14 +40,14 @@ export type FtsConfig<TTables extends TablesRecord> = {
 		: never;
 };
 
-/** Errors surfaced by the SQLite materializer's async background sync loop. */
+/** Errors surfaced by the SQLite materializer's async database work queue. */
 const SqliteMaterializerError = defineErrors({
 	/** Debounced flush of pending row writes to the mirror database failed. */
 	SyncFailed: ({ cause }: { cause: unknown }) => ({
 		message: `[sqlite-materializer] Failed to sync SQLite materializer: ${extractErrorMessage(cause)}`,
 		cause,
 	}),
-	/** Post-sync disposal tail failed after the materializer detached. */
+	/** Post-queue disposal tail failed after the materializer detached. */
 	DisposeFailed: ({ cause }: { cause: unknown }) => ({
 		message: `[sqlite-materializer] Failed to dispose SQLite materializer: ${extractErrorMessage(cause)}`,
 		cause,
@@ -121,7 +120,7 @@ export function attachSqliteMaterializerCore<
 			: undefined;
 
 	let pendingSync = new Map<string, Set<string>>();
-	let syncQueue = Promise.resolve();
+	let dbQueue = Promise.resolve();
 	let isDisposed = false;
 
 	// ── SQL primitives ───────────────────────────────────────────
@@ -165,8 +164,14 @@ export function attachSqliteMaterializerCore<
 
 	// ── Sync engine ──────────────────────────────────────────────
 
+	function enqueueDbWork(work: () => Promise<void>): Promise<void> {
+		const result = dbQueue.then(work);
+		dbQueue = result.catch(() => {});
+		return result;
+	}
+
 	const flushAfterDebounce = debounce(() => {
-		syncQueue = syncQueue.then(flushPendingSync).catch((cause: unknown) => {
+		void enqueueDbWork(flushPendingSync).catch((cause: unknown) => {
 			log.error(SqliteMaterializerError.SyncFailed({ cause }));
 		});
 	}, debounceMs);
@@ -219,29 +224,37 @@ export function attachSqliteMaterializerCore<
 					`Cannot rebuild "${tableName}": not in the materialized table set.`,
 				);
 			}
+
+			return enqueueDbWork(async () => {
+				if (isDisposed) return;
+
+				await db.run('BEGIN');
+				try {
+					await db.run(`DELETE FROM ${quoteIdentifier(tableName)}`);
+					await fullLoadTable(tableName, entry.table);
+					await db.run('COMMIT');
+				} catch (error: unknown) {
+					await db.run('ROLLBACK');
+					throw error;
+				}
+			});
+		}
+
+		return enqueueDbWork(async () => {
+			if (isDisposed) return;
+
 			await db.run('BEGIN');
 			try {
-				await db.run(`DELETE FROM ${quoteIdentifier(tableName)}`);
-				await fullLoadTable(tableName, entry.table);
+				for (const [name] of registered)
+					await db.run(`DELETE FROM ${quoteIdentifier(name)}`);
+				for (const [name, entry] of registered)
+					await fullLoadTable(name, entry.table);
 				await db.run('COMMIT');
 			} catch (error: unknown) {
 				await db.run('ROLLBACK');
 				throw error;
 			}
-			return;
-		}
-
-		await db.run('BEGIN');
-		try {
-			for (const [name] of registered)
-				await db.run(`DELETE FROM ${quoteIdentifier(name)}`);
-			for (const [name, entry] of registered)
-				await fullLoadTable(name, entry.table);
-			await db.run('COMMIT');
-		} catch (error: unknown) {
-			await db.run('ROLLBACK');
-			throw error;
-		}
+		});
 	}
 
 	// ── Disposal ────────────────────────────────────────────────
@@ -251,7 +264,7 @@ export function attachSqliteMaterializerCore<
 		isDisposed = true;
 		flushAfterDebounce.cancel();
 		for (const entry of registered.values()) entry.unsubscribe?.();
-		syncQueue
+		void dbQueue
 			.then(() => db.close())
 			.catch((cause: unknown) => {
 				log.error(SqliteMaterializerError.DisposeFailed({ cause }));
@@ -269,26 +282,30 @@ export function attachSqliteMaterializerCore<
 		await waitFor;
 		if (isDisposed) return;
 
-		for (const [tableName, entry] of registered) {
-			await db.run(generateDdl(tableName, entry.table.schema));
-		}
+		await enqueueDbWork(async () => {
+			if (isDisposed) return;
 
-		// FTS DDL + triggers run after table DDL and before the bulk insert, so
-		// the AFTER INSERT triggers populate `<table>_fts` for free during the
-		// existing full-load. This is the load-bearing ordering invariant.
-		await ftsLayer?.beforeFullLoad();
+			for (const [tableName, entry] of registered) {
+				await db.run(generateDdl(tableName, entry.table.schema));
+			}
 
-		if (isDisposed) return;
+			// FTS DDL + triggers run after table DDL and before the bulk insert, so
+			// the AFTER INSERT triggers populate `<table>_fts` for free during the
+			// existing full-load. This is the load-bearing ordering invariant.
+			await ftsLayer?.beforeFullLoad();
 
-		await db.run('BEGIN');
-		try {
-			for (const [tableName, entry] of registered)
-				await fullLoadTable(tableName, entry.table);
-			await db.run('COMMIT');
-		} catch (error: unknown) {
-			await db.run('ROLLBACK');
-			throw error;
-		}
+			if (isDisposed) return;
+
+			await db.run('BEGIN');
+			try {
+				for (const [tableName, entry] of registered)
+					await fullLoadTable(tableName, entry.table);
+				await db.run('COMMIT');
+			} catch (error: unknown) {
+				await db.run('ROLLBACK');
+				throw error;
+			}
+		});
 
 		if (isDisposed) return;
 

--- a/packages/workspace/src/document/materializer/sqlite/core.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.ts
@@ -289,10 +289,11 @@ export function attachSqliteMaterializerCore<
 				await db.run(generateDdl(tableName, entry.table.schema));
 			}
 
-			// FTS DDL + triggers run after table DDL and before the bulk insert, so
-			// the AFTER INSERT triggers populate `<table>_fts` for free during the
-			// existing full-load. This is the load-bearing ordering invariant.
-			await ftsLayer?.beforeFullLoad();
+			if (ftsLayer !== undefined) {
+				// FTS triggers must exist before the bulk insert so full-load rows
+				// populate `<table>_fts` through the normal INSERT triggers.
+				await ftsLayer.setupForBulkLoad();
+			}
 
 			if (isDisposed) return;
 

--- a/packages/workspace/src/document/materializer/sqlite/fts.ts
+++ b/packages/workspace/src/document/materializer/sqlite/fts.ts
@@ -194,10 +194,10 @@ async function ftsSearch(
  * Internal factory that owns the materializer's FTS surface.
  *
  * Constructed by `attachSqliteMaterializerCore` only when the caller passed an
- * `fts` option. Holds the FTS column map, exposes a `beforeFullLoad()` setup
- * pass that runs after table DDL and before the bulk insert (so triggers
- * populate `<table>_fts` for free during the existing full-load), and surfaces
- * the `search` action that lands on `materializer.actions.sqlite_search`.
+ * `fts` option. Holds the FTS column map, exposes a `setupForBulkLoad()` pass
+ * that installs FTS virtual tables and triggers after table DDL and before the
+ * bulk insert, and surfaces the `search` action that lands on
+ * `materializer.actions.sqlite_search`.
  *
  * Pure construction at call time: registers no listeners and runs no DDL.
  * Returning the factory unconditionally would be fine; the caller decides
@@ -222,7 +222,7 @@ export function createSqliteFtsLayer<TTables extends TablesRecord>({
 		}
 	}
 
-	async function beforeFullLoad(): Promise<void> {
+	async function setupForBulkLoad(): Promise<void> {
 		for (const [tableName, columns] of ftsColumns) {
 			await setupFtsTable(db, tableName, columns);
 		}
@@ -255,7 +255,7 @@ export function createSqliteFtsLayer<TTables extends TablesRecord>({
 		},
 	});
 
-	return { beforeFullLoad, search };
+	return { setupForBulkLoad, search };
 }
 
 // ════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
The SQLite collapse makes Bun the only writer path, which also makes teardown ownership clearer: the materializer core owns writer database lifetime and receives the actual Bun `Database`. Previously the Bun wrapper closed the handle from a separate destroy listener immediately after core disposal started. That was fine for queued work that had not begun, but an already-running async DB operation could still resume and touch the database after `client.close()`.

This keeps teardown inside core instead of adding a new public disposal surface or threading a callback prop. On destroy, core cancels future debounce work, detaches observers, waits for the current writer DB queue to drain, and then closes the Bun SQLite handle. The queue now covers initial DDL/full-load, incremental sync, and `sqlite_rebuild`, so close cannot race any of the materializer-owned writer operations.

The regression coverage pauses an incremental insert mid-run and separately pauses a rebuild insert mid-run. Both tests destroy the workspace and assert `db.close()` does not run until the blocked write is allowed to finish.
