### PR TITLE
Split daemon invoke and dispatch

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -42,9 +42,9 @@ The materializer is the same SQL surface the daemon serves to the SPA: column-ty
 
 For ranked search with snippets, use `openSqliteReader({ filePath: sqlitePath(...) })`; it wraps the same database and exposes a `search()` helper. For typed Drizzle queries, pass the returned `db` to `drizzle(db, { schema })` (the per-app schema lives in the app's npm package).
 
-## Writes: typed actions through the daemon
+## Writes: typed invoke through the daemon
 
-`connectDaemonActions<TActions>({ mount, projectDir })` returns a typed proxy. `mount` is the mount name (`'fuji'` for the Fuji example); the proxy translates `fuji.entries_update({ ... })` into a `POST /run` over the daemon's Unix socket in the OS runtime directory. The daemon invokes the action in-process against the live Y.Doc and returns a JSON `Result<T>`.
+`connectDaemonActions<TActions>({ mount, projectDir })` returns a typed proxy. `mount` is the mount name (`'fuji'` for the Fuji example); the proxy translates `fuji.entries_update({ ... })` into a `POST /invoke` over the daemon's Unix socket in the OS runtime directory. The daemon invokes the action in-process against the live Y.Doc and returns a JSON `Result<T>`.
 
 The mount name comes from the `Mount.name` field on the value `epicenter.config.ts` default-exports. App-package factories like `fuji()` carry their canonical name internally.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -5,13 +5,14 @@
 Each verb is a one-line shell shortcut for one workspace primitive:
 
 ```
-                 +--------+---------------------------------------------+
-                 | Verb   | Workspace primitive                         |
-                 +--------+---------------------------------------------+
-   Enumerate     | list   | Object.entries(collaboration.actions)       |
-   Invoke        | run    | actions[key](input) or dispatch(peer, ...)  |
-   Presence      | peers  | collaboration.devices.list()                |
-                 +--------+---------------------------------------------+
+                 +------------+---------------------------------------------+
+                 | Verb       | Workspace primitive                         |
+                 +------------+---------------------------------------------+
+   Enumerate     | list       | Object.entries(collaboration.actions)       |
+   Invoke        | run        | local daemon invoke                         |
+   Dispatch      | run --peer | relay dispatch to a live peer               |
+   Presence      | peers      | collaboration.devices.list()                |
+                 +------------+---------------------------------------------+
 
  Supporting systems: auth (machine session), daemon (process lifecycle)
 ```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -64,7 +64,7 @@ epicenter peers -C ~/vault
 ```ts
 import { fuji } from '@epicenter/fuji/project';
 
-export default fuji();
+export default [fuji()];
 ```
 
 The factory carries the canonical mount name (`fuji`), so the CLI addresses actions as `fuji.<action_key>` regardless of the project folder name.

--- a/packages/cli/src/commands/run-peer-errors.test.ts
+++ b/packages/cli/src/commands/run-peer-errors.test.ts
@@ -1,8 +1,8 @@
 /**
  * Error-emission tests for the `run --peer` path.
  *
- * Covers every `DispatchError` variant. Capture `console.error` and assert
- * line-by-line. Dispatch errors are constructed via
+ * Covers every `DispatchError` variant that can reach `RemoteCallFailed`.
+ * Capture `console.error` and assert line-by-line. Dispatch errors are constructed via
  * `DispatchError.X({...}).error` so they match the wire shape exactly.
  */
 
@@ -61,17 +61,6 @@ describe('emitRemoteCallError', () => {
 		);
 		expect(cap.lines).toEqual([
 			'error: "tabs_close" failed on macbook-pro: handler boom',
-		]);
-	});
-
-	test('RecipientOffline labels the peer as gone', () => {
-		cap = captureErrors();
-		emitRemoteCallError(
-			'macbook-pro',
-			DispatchError.RecipientOffline({ to: 'macbook-pro' }).error,
-		);
-		expect(cap.lines).toEqual([
-			'error: peer macbook-pro went offline before responding',
 		]);
 	});
 

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -79,18 +79,23 @@ export const runCommand = cmd({
 			process.exitCode = 1;
 			return;
 		}
-		const result =
-			peerTarget === undefined
-				? await daemon.invoke({
-						actionPath: argv.action,
-						input: actionInput,
-					})
-				: await daemon.dispatch({
-						actionPath: argv.action,
-						input: actionInput,
-						to: peerTarget,
-						waitMs,
-					});
+		if (peerTarget === undefined) {
+			renderRunResult(
+				await daemon.invoke({
+					actionPath: argv.action,
+					input: actionInput,
+				}),
+				argv.format,
+			);
+			return;
+		}
+
+		const result = await daemon.dispatch({
+			actionPath: argv.action,
+			input: actionInput,
+			to: peerTarget,
+			waitMs,
+		});
 		renderRunResult(result, argv.format);
 	},
 });
@@ -170,7 +175,7 @@ function emitPeerNotFound(
  */
 export function emitRemoteCallError(
 	peerTarget: string,
-	cause: DispatchError,
+	cause: Exclude<DispatchError, { name: 'RecipientOffline' }>,
 ): void {
 	switch (cause.name) {
 		case 'Cancelled':
@@ -188,9 +193,6 @@ export function emitRemoteCallError(
 			console.error(
 				`error: "${cause.action}" failed on ${peerTarget}: ${cause.cause}`,
 			);
-			return;
-		case 'RecipientOffline':
-			console.error(`error: peer ${peerTarget} went offline before responding`);
 			return;
 		case 'NetworkFailed':
 			console.error(

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -21,10 +21,10 @@
 import type { DispatchError } from '@epicenter/workspace';
 import {
 	type DaemonError,
-	type RunError as DaemonRunError,
 	getDaemon,
-	type RunRequest,
-	type RunSyncStatus,
+	type InvokeError,
+	type PeerDispatchError,
+	type PeerDispatchSyncStatus,
 } from '@epicenter/workspace/node';
 import { extractErrorMessage } from 'wellcrafted/error';
 import type { Result } from 'wellcrafted/result';
@@ -58,7 +58,7 @@ export const runCommand = cmd({
 			.option('C', projectOption)
 			.option('peer', {
 				type: 'string',
-				description: 'Invoke on a remote peer by peer id',
+				description: 'Dispatch to a remote peer by peer id',
 			})
 			.option('wait', {
 				type: 'number',
@@ -73,26 +73,30 @@ export const runCommand = cmd({
 		const waitMs = argv.wait ?? DEFAULT_PEER_WAIT_MS;
 		const actionInput = await resolveInput(argv.input);
 
-		const runRequest: RunRequest = {
-			actionPath: argv.action,
-			input: actionInput,
-			peerTarget,
-			waitMs,
-		};
-
 		const { data: daemon, error: daemonErr } = await getDaemon(argv.C);
 		if (daemonErr) {
 			console.error(daemonErr.message);
 			process.exitCode = 1;
 			return;
 		}
-		const result = await daemon.run(runRequest);
+		const result =
+			peerTarget === undefined
+				? await daemon.invoke({
+						actionPath: argv.action,
+						input: actionInput,
+					})
+				: await daemon.dispatch({
+						actionPath: argv.action,
+						input: actionInput,
+						to: peerTarget,
+						waitMs,
+					});
 		renderRunResult(result, argv.format);
 	},
 });
 
 function renderRunResult(
-	result: Result<unknown, DaemonRunError | DaemonError>,
+	result: Result<unknown, InvokeError | PeerDispatchError | DaemonError>,
 	format: OutputFormat | undefined,
 ): void {
 	if (result.error === null) {
@@ -116,14 +120,14 @@ function renderRunResult(
 			return;
 		case 'PeerNotFound':
 			emitPeerNotFound(
-				result.error.peerTarget,
+				result.error.to,
 				result.error.waitMs,
 				result.error.syncStatus,
 			);
 			process.exitCode = 3;
 			return;
 		case 'RemoteCallFailed': {
-			emitRemoteCallError(result.error.peerTarget, result.error.cause);
+			emitRemoteCallError(result.error.to, result.error.cause);
 			process.exitCode = 2;
 			return;
 		}
@@ -149,7 +153,7 @@ async function resolveInput(input: string | undefined): Promise<unknown> {
 function emitPeerNotFound(
 	target: string,
 	waitMs: number,
-	syncStatus: RunSyncStatus,
+	syncStatus: PeerDispatchSyncStatus,
 ): void {
 	console.error(`error: no peer matches peer id "${target}" after ${waitMs}ms`);
 	console.error(`  reason: ${describePeerMissReason(syncStatus)}`);
@@ -171,7 +175,7 @@ export function emitRemoteCallError(
 	switch (cause.name) {
 		case 'Cancelled':
 			// The daemon owns the dispatch `AbortSignal` (`AbortSignal.timeout(waitMs)`
-			// in run-handler.ts), so a `Cancelled` dispatch error that reaches the
+			// in action-handler.ts), so a `Cancelled` dispatch error that reaches the
 			// CLI is always the `--wait` deadline. Its abort reason is a
 			// `DOMException`, which cannot survive the daemon's JSON response, so
 			// it is not inspected here.
@@ -198,7 +202,7 @@ export function emitRemoteCallError(
 	}
 }
 
-function describePeerMissReason(status: RunSyncStatus): string {
+function describePeerMissReason(status: PeerDispatchSyncStatus): string {
 	if (status.phase === 'connected') {
 		return 'connected, but no matching peer was visible';
 	}

--- a/packages/cli/src/commands/up.test.ts
+++ b/packages/cli/src/commands/up.test.ts
@@ -112,7 +112,7 @@ function writeDemoConfig(): void {
 		[
 			"import demo from './workspaces/demo/daemon.ts';",
 			'',
-			'export default demo;',
+			'export default [demo];',
 			'',
 		].join('\n'),
 	);
@@ -182,7 +182,7 @@ describe('runUp: happy path', () => {
 			expect(handle.mounts[0]?.mount).toBe('demo');
 			expect(
 				readFileSync(join(workDir, 'epicenter.config.ts'), 'utf8'),
-			).toContain('export default demo');
+			).toContain('export default [demo]');
 
 			const sockPath = socketPathFor(workDir);
 			expect(existsSync(sockPath)).toBe(true);

--- a/packages/workspace/src/client/connect-daemon-actions.ts
+++ b/packages/workspace/src/client/connect-daemon-actions.ts
@@ -7,7 +7,7 @@
  * a flat action proxy backed by a unix-socket `DaemonClient`.
  * `TActions` is type-only: no workspace code runs in the caller process.
  * `DaemonActions<TActions>` rewrites each snake_case action key into the
- * daemon `/run` result shape.
+ * daemon `/invoke` result shape.
  *
  * @example
  * ```ts

--- a/packages/workspace/src/client/daemon-actions.test.ts
+++ b/packages/workspace/src/client/daemon-actions.test.ts
@@ -6,21 +6,22 @@
 
 import { describe, expect, test } from 'bun:test';
 import { Ok } from 'wellcrafted/result';
-import type { RunRequest } from '../daemon/app.js';
+import type { InvokeRequest } from '../daemon/app.js';
 import type { DaemonClient } from '../daemon/client.js';
 import { buildDaemonActions } from './daemon-actions.js';
 
 function makeStubClient() {
-	const calls: { method: 'run'; arg: unknown }[] = [];
+	const calls: { method: 'invoke'; arg: unknown }[] = [];
 	const unreachable = () => {
 		throw new Error('stub: not used by these tests');
 	};
 	const client = {
 		peers: unreachable as DaemonClient['peers'],
 		list: unreachable as DaemonClient['list'],
-		run: (input: RunRequest) => {
-			calls.push({ method: 'run', arg: input });
-			return Promise.resolve(Ok(null)) as ReturnType<DaemonClient['run']>;
+		dispatch: unreachable as DaemonClient['dispatch'],
+		invoke: (input: InvokeRequest) => {
+			calls.push({ method: 'invoke', arg: input });
+			return Promise.resolve(Ok(null)) as ReturnType<DaemonClient['invoke']>;
 		},
 	} satisfies DaemonClient;
 	return { client, calls };
@@ -29,7 +30,7 @@ function makeStubClient() {
 const WORKSPACE = 'demo';
 
 describe('buildDaemonActions workspace facade', () => {
-	test('action dispatches literal workspace path over /run', async () => {
+	test('action invokes literal workspace path over /invoke', async () => {
 		const { client, calls } = makeStubClient();
 		// biome-ignore lint/suspicious/noExplicitAny: smoke test: shape is irrelevant
 		const workspace: any = buildDaemonActions(client, WORKSPACE);
@@ -37,24 +38,10 @@ describe('buildDaemonActions workspace facade', () => {
 		await workspace.entries_get('xyz');
 
 		expect(calls).toHaveLength(1);
-		expect(calls[0]!.method).toBe('run');
+		expect(calls[0]!.method).toBe('invoke');
 		expect(calls[0]!.arg).toMatchObject({
 			actionPath: 'demo.entries_get',
 			input: 'xyz',
-		});
-	});
-
-	test('action options override the daemon wait budget', async () => {
-		const { client, calls } = makeStubClient();
-		// biome-ignore lint/suspicious/noExplicitAny: smoke test
-		const workspace: any = buildDaemonActions(client, WORKSPACE);
-
-		await workspace.status(undefined, { waitMs: 100 });
-
-		expect(calls[0]!.arg).toMatchObject({
-			actionPath: 'demo.status',
-			input: undefined,
-			waitMs: 100,
 		});
 	});
 });

--- a/packages/workspace/src/client/daemon-actions.ts
+++ b/packages/workspace/src/client/daemon-actions.ts
@@ -1,31 +1,24 @@
 /**
  * `buildDaemonActions`: typed proxy that turns a `DaemonClient` into a flat
  * action-root facade. Local call sites use the same snake_case key the action
- * was authored under (`workspace.tabs_open(...)`); each call dispatches
- * over the unix socket via `client.run`.
+ * was authored under (`workspace.tabs_open(...)`); each call invokes the
+ * daemon's local action registry over the unix socket via `client.invoke`.
  *
  * The proxy is one level: property access returns a function, calling that
- * function fires `client.run` with `${mount}.${path}`. `then` is masked at
+ * function fires `client.invoke` with `${mount}.${path}`. `then` is masked at
  * the root so accidental `await workspace` does not turn it thenable.
  */
 
 import type { Result } from 'wellcrafted/result';
+import type { InvokeError } from '../daemon/action-errors.js';
 import { joinDaemonActionPath } from '../daemon/action-path.js';
 import type { DaemonClient, DaemonError } from '../daemon/client.js';
-import type { RunError } from '../daemon/run-errors.js';
 import type { Action, ActionRegistry } from '../shared/actions.js';
 import type { Simplify } from '../shared/types.js';
 
-const DEFAULT_RUN_WAIT_MS = 5_000;
-
-export type DaemonActionOptions = {
-	/** Override the daemon `/run` wait budget in milliseconds. */
-	waitMs?: number;
-};
-
 type WithDaemonOptions<Args extends readonly unknown[]> = Args extends []
-	? [input?: undefined, options?: DaemonActionOptions]
-	: [...Args, options?: DaemonActionOptions];
+	? [input?: undefined]
+	: Args;
 
 type DaemonSuccessOutput<TOutput> =
 	Awaited<TOutput> extends Result<infer TData, unknown>
@@ -35,12 +28,12 @@ type DaemonSuccessOutput<TOutput> =
 type WrapDaemonAction<F> = F extends (...args: infer Args) => infer R
 	? (
 			...args: WithDaemonOptions<Args>
-		) => Promise<Result<DaemonSuccessOutput<R>, RunError | DaemonError>>
+		) => Promise<Result<DaemonSuccessOutput<R>, InvokeError | DaemonError>>
 	: never;
 
 /**
  * The daemon-callable shape of `TActions`. Each registry entry is awaited
- * and `Result`-wrapped at the daemon boundary. One level: keys are the
+ * and `Result`-wrapped at the invoke boundary. One level: keys are the
  * snake_case action keys exactly as the author wrote them.
  *
  * Wrapped in {@link Simplify} so IDE hover output shows the flattened call
@@ -54,8 +47,8 @@ export type DaemonActions<TActions> = Simplify<{
 
 /**
  * Compose the daemon action facade. Generic `TActions` is the in-process
- * `ActionRegistry`; `DaemonActions<TActions>` rewrites each entry to the
- * daemon `/run` result shape.
+ * `ActionRegistry`; `DaemonActions<TActions>` rewrites each entry to the local
+ * daemon invoke result shape.
  */
 export function buildDaemonActions<TActions extends ActionRegistry>(
 	client: DaemonClient,
@@ -65,11 +58,10 @@ export function buildDaemonActions<TActions extends ActionRegistry>(
 		get(_target, prop) {
 			if (typeof prop !== 'string') return undefined;
 			if (prop === 'then') return undefined;
-			return (input?: unknown, options?: DaemonActionOptions) =>
-				client.run({
+			return (input?: unknown) =>
+				client.invoke({
 					actionPath: joinDaemonActionPath(mount, prop),
 					input,
-					waitMs: options?.waitMs ?? DEFAULT_RUN_WAIT_MS,
 				});
 		},
 	}) as DaemonActions<TActions>;

--- a/packages/workspace/src/daemon/action-errors.ts
+++ b/packages/workspace/src/daemon/action-errors.ts
@@ -1,5 +1,5 @@
 /**
- * Domain errors and response envelopes for daemon action routes.
+ * Domain errors for daemon action routes.
  *
  * Local invoke and peer dispatch deliberately use separate response types:
  * local invoke executes this daemon's action registry, while peer dispatch
@@ -15,13 +15,17 @@ import {
 	extractErrorMessage,
 	type InferErrors,
 } from 'wellcrafted/error';
-import type { Result } from 'wellcrafted/result';
 
 import type { DispatchError } from '../document/dispatch.js';
 import type {
 	SyncError,
 	SyncFailedReason,
 } from '../document/internal/sync-supervisor.js';
+
+type PeerDispatchRemoteError = Exclude<
+	DispatchError,
+	{ name: 'RecipientOffline' }
+>;
 
 export type PeerDispatchSyncStatus =
 	| { phase: 'offline' }
@@ -87,7 +91,7 @@ export const PeerDispatchError = defineErrors({
 		syncStatus,
 	}: {
 		to: string;
-		cause: DispatchError;
+		cause: PeerDispatchRemoteError;
 		syncStatus: PeerDispatchSyncStatus;
 	}) => ({
 		message: `remote call failed: ${cause.name}`,
@@ -97,6 +101,3 @@ export const PeerDispatchError = defineErrors({
 	}),
 });
 export type PeerDispatchError = InferErrors<typeof PeerDispatchError>;
-
-export type InvokeResponse = Result<unknown, InvokeError>;
-export type PeerDispatchResponse = Result<unknown, PeerDispatchError>;

--- a/packages/workspace/src/daemon/action-errors.ts
+++ b/packages/workspace/src/daemon/action-errors.ts
@@ -1,10 +1,9 @@
 /**
- * Domain errors and response envelope for the `/run` route.
+ * Domain errors and response envelopes for daemon action routes.
  *
- * Lives daemon-side because the route owns the wire contract: `executeRun`
- * constructs `RunError` variants in `run-handler.ts`, and the response
- * envelope (`RunResponse`) is what the route serializes to JSON. The CLI
- * command imports both for renderer typing.
+ * Local invoke and peer dispatch deliberately use separate response types:
+ * local invoke executes this daemon's action registry, while peer dispatch
+ * asks a recipient device to decide whether it supports the action.
  *
  * Remote call failures keep the remote client error intact so the CLI owns
  * every presentation choice for peer disconnects, timeouts, and other
@@ -24,7 +23,7 @@ import type {
 	SyncFailedReason,
 } from '../document/internal/sync-supervisor.js';
 
-export type RunSyncStatus =
+export type PeerDispatchSyncStatus =
 	| { phase: 'offline' }
 	| {
 			phase: 'connecting';
@@ -34,19 +33,7 @@ export type RunSyncStatus =
 	| { phase: 'connected' }
 	| { phase: 'failed'; reason: SyncFailedReason };
 
-/**
- * CLI-specific failures of the `/run` route. Carrying the failure mode
- * in-band lets the renderer set `process.exitCode` from a single switch,
- * even when the result arrived over IPC.
- *
- * - `UsageError`: bad action key / missing sync; renderer exitCode=1.
- * - `RuntimeError`: action returned Err locally; renderer exitCode=2.
- * - `PeerNotFound`: `--peer <target>` did not resolve within `--wait`;
- *   renderer exitCode=3.
- * - `RemoteCallFailed`: peer resolved but the RPC call itself failed
- *   (timeout, peer disconnected mid-call, wire error); renderer exitCode=2.
- */
-export const RunError = defineErrors({
+export const InvokeError = defineErrors({
 	UsageError: ({
 		message,
 		suggestions,
@@ -58,39 +45,58 @@ export const RunError = defineErrors({
 		message: extractErrorMessage(cause),
 		cause,
 	}),
+});
+export type InvokeError = InferErrors<typeof InvokeError>;
+
+/**
+ * CLI-specific failures of peer dispatch. Carrying the failure mode in-band
+ * lets the renderer set `process.exitCode` from a single switch, even when the
+ * result arrived over IPC.
+ *
+ * - `UsageError`: bad action key / missing sync; renderer exitCode=1.
+ * - `PeerNotFound`: `--peer <target>` did not resolve within `--wait`;
+ *   renderer exitCode=3.
+ * - `RemoteCallFailed`: peer resolved but the RPC call itself failed
+ *   (timeout, peer disconnected mid-call, wire error); renderer exitCode=2.
+ */
+export const PeerDispatchError = defineErrors({
+	UsageError: ({
+		message,
+		suggestions,
+	}: {
+		message: string;
+		suggestions?: string[];
+	}) => ({ message, suggestions }),
 	PeerNotFound: ({
-		peerTarget,
+		to,
 		waitMs,
 		syncStatus,
 	}: {
-		peerTarget: string;
+		to: string;
 		waitMs: number;
-		syncStatus: RunSyncStatus;
+		syncStatus: PeerDispatchSyncStatus;
 	}) => ({
-		message: `no peer matches peer id "${peerTarget}"`,
-		peerTarget,
+		message: `no peer matches peer id "${to}"`,
+		to,
 		waitMs,
 		syncStatus,
 	}),
 	RemoteCallFailed: ({
 		cause,
-		peerTarget,
+		to,
 		syncStatus,
 	}: {
-		peerTarget: string;
+		to: string;
 		cause: DispatchError;
-		syncStatus: RunSyncStatus;
+		syncStatus: PeerDispatchSyncStatus;
 	}) => ({
 		message: `remote call failed: ${cause.name}`,
 		cause,
-		peerTarget,
+		to,
 		syncStatus,
 	}),
 });
-export type RunError = InferErrors<typeof RunError>;
+export type PeerDispatchError = InferErrors<typeof PeerDispatchError>;
 
-/**
- * Wire shape of `/run`'s response body. The renderer narrows on
- * `error.name`.
- */
-export type RunResponse = Result<unknown, RunError>;
+export type InvokeResponse = Result<unknown, InvokeError>;
+export type PeerDispatchResponse = Result<unknown, PeerDispatchError>;

--- a/packages/workspace/src/daemon/action-handler.test.ts
+++ b/packages/workspace/src/daemon/action-handler.test.ts
@@ -53,6 +53,22 @@ function fakeEntry({
 }
 
 describe('executeDispatch peer dispatch', () => {
+	test('rejects invalid wait budgets before creating an AbortSignal', async () => {
+		const result = await executeDispatch([fakeEntry({})], {
+			actionPath: 'demo.tabs_list',
+			input: undefined,
+			to: 'mac',
+			waitMs: -1,
+		});
+
+		const error = expectErr(result);
+		expect(error.name).toBe('UsageError');
+		if (error.name !== 'UsageError') {
+			throw new Error(`expected UsageError, got ${error.name}`);
+		}
+		expect(error.message).toBe('`waitMs` must be a non-negative integer.');
+	});
+
 	test('relay RecipientOffline surfaces as PeerNotFound with sync status', async () => {
 		const syncStatus = {
 			phase: 'connecting',

--- a/packages/workspace/src/daemon/action-handler.test.ts
+++ b/packages/workspace/src/daemon/action-handler.test.ts
@@ -1,12 +1,11 @@
 /**
- * executeRun peer dispatch tests.
+ * Daemon action handler tests.
  *
- * Verifies the daemon preserves remote dispatch outcomes in one `/run`
- * envelope before the response crosses the IPC boundary. The relay owns
- * reachability: a `RecipientOffline` dispatch error surfaces as
- * `PeerNotFound`, every other dispatch error as `RemoteCallFailed`. The
- * `collab.dispatch` path is faked here so the test can drive those outcomes
- * without spinning up real Yjs sync.
+ * Verifies local invoke and peer dispatch stay separate before the response
+ * crosses the IPC boundary. The relay owns reachability: a
+ * `RecipientOffline` dispatch error surfaces as `PeerNotFound`, every other
+ * dispatch error as `RemoteCallFailed`. The `collab.dispatch` path is faked
+ * here so the test can drive those outcomes without spinning up real Yjs sync.
  */
 
 import { describe, expect, test } from 'bun:test';
@@ -17,8 +16,8 @@ import { DispatchError, type DispatchRequest } from '../document/dispatch.js';
 import type { SyncStatus } from '../document/internal/sync-supervisor.js';
 import type { ActionRegistry } from '../shared/actions.js';
 import { defineMutation, defineQuery } from '../shared/actions.js';
-import type { RunSyncStatus } from './run-errors.js';
-import { executeRun } from './run-handler.js';
+import type { PeerDispatchSyncStatus } from './action-errors.js';
+import { executeDispatch, executeInvoke } from './action-handler.js';
 import type { DaemonServedMount } from './types.js';
 
 type FakeDispatch = <TOutput = unknown>(
@@ -53,7 +52,7 @@ function fakeEntry({
 	};
 }
 
-describe('executeRun peer dispatch', () => {
+describe('executeDispatch peer dispatch', () => {
 	test('relay RecipientOffline surfaces as PeerNotFound with sync status', async () => {
 		const syncStatus = {
 			phase: 'connecting',
@@ -64,17 +63,17 @@ describe('executeRun peer dispatch', () => {
 			phase: 'connecting',
 			retries: 2,
 			lastErrorType: 'connection',
-		} satisfies RunSyncStatus;
+		} satisfies PeerDispatchSyncStatus;
 		const entry = fakeEntry({
 			syncStatus,
 			dispatch: (async () =>
 				DispatchError.RecipientOffline({ to: 'ghost' })) as FakeDispatch,
 		});
 
-		const result = await executeRun([entry], {
+		const result = await executeDispatch([entry], {
 			actionPath: 'demo.tabs_list',
 			input: undefined,
-			peerTarget: 'ghost',
+			to: 'ghost',
 			waitMs: 25,
 		});
 
@@ -83,7 +82,7 @@ describe('executeRun peer dispatch', () => {
 		if (error.name !== 'PeerNotFound') {
 			throw new Error(`expected PeerNotFound, got ${error.name}`);
 		}
-		expect(error.peerTarget).toBe('ghost');
+		expect(error.to).toBe('ghost');
 		expect(error.syncStatus).toEqual(runSyncStatus);
 	});
 
@@ -98,10 +97,10 @@ describe('executeRun peer dispatch', () => {
 			}) as FakeDispatch,
 		});
 
-		const result = await executeRun([entry], {
+		const result = await executeDispatch([entry], {
 			actionPath: 'demo.tabs_list',
 			input: undefined,
-			peerTarget: 'mac',
+			to: 'mac',
 			waitMs: 25,
 		});
 
@@ -119,10 +118,10 @@ describe('executeRun peer dispatch', () => {
 				})) as FakeDispatch,
 		});
 
-		const result = await executeRun([entry], {
+		const result = await executeDispatch([entry], {
 			actionPath: 'demo.tabs_list',
 			input: undefined,
-			peerTarget: 'mac',
+			to: 'mac',
 			waitMs: 25,
 		});
 
@@ -133,9 +132,30 @@ describe('executeRun peer dispatch', () => {
 		}
 		expect(error.cause).toMatchObject({ name: 'ActionFailed' });
 	});
+
+	test('recipient owns action existence for peer dispatch', async () => {
+		let invokedAction = '';
+		const entry = fakeEntry({
+			actions: {},
+			dispatch: (async (req) => {
+				invokedAction = req.action;
+				return { data: 'ok', error: null };
+			}) as FakeDispatch,
+		});
+
+		const result = await executeDispatch([entry], {
+			actionPath: 'demo.peer_only_action',
+			input: undefined,
+			to: 'mac',
+			waitMs: 25,
+		});
+
+		expectOk(result);
+		expect(invokedAction).toBe('peer_only_action');
+	});
 });
 
-describe('executeRun mount-prefixed routing', () => {
+describe('executeInvoke mount-prefixed routing', () => {
 	test('invokes action under the selected mount', async () => {
 		const entry = fakeEntry({
 			mount: 'notes',
@@ -146,10 +166,9 @@ describe('executeRun mount-prefixed routing', () => {
 			},
 		});
 
-		const result = await executeRun([entry], {
+		const result = await executeInvoke([entry], {
 			actionPath: 'notes.notes_add',
 			input: { body: 'hello' },
-			waitMs: 25,
 		});
 
 		const data = expectOk(result);
@@ -166,10 +185,9 @@ describe('executeRun mount-prefixed routing', () => {
 			},
 		});
 
-		const result = await executeRun([entry], {
+		const result = await executeInvoke([entry], {
 			actionPath: 'notes.notes',
 			input: { body: 'hello' },
-			waitMs: 25,
 		});
 
 		const error = expectErr(result);
@@ -181,12 +199,11 @@ describe('executeRun mount-prefixed routing', () => {
 	});
 
 	test('unknown mount returns available mount suggestions', async () => {
-		const result = await executeRun(
+		const result = await executeInvoke(
 			[fakeEntry({}), fakeEntry({ mount: 'tasks', actions: {} })],
 			{
 				actionPath: 'missing.actions_add',
 				input: undefined,
-				waitMs: 25,
 			},
 		);
 

--- a/packages/workspace/src/daemon/action-handler.ts
+++ b/packages/workspace/src/daemon/action-handler.ts
@@ -1,49 +1,50 @@
 /**
- * Daemon-side dispatch for the `/run` route. The Hono handler in `app.ts`
- * forwards to `executeRun` here.
+ * Daemon-side action handlers for `/invoke` and `/dispatch`.
  *
- * `epicenter run` is a shell shortcut for one daemon runtime primitive:
+ * Local invoke and peer dispatch stay separate here because they have
+ * different authorities:
  *
- *   request.peerTarget === undefined  ->  invokeAction(...)
- *   request.peerTarget === <deviceId>  ->  collab.dispatch({ to, action, input, signal })
+ *   /invoke   -> this daemon's action registry decides action existence.
+ *   /dispatch -> the recipient peer decides action existence.
  *
- * The dispatch endpoint is HTTP-backed and addresses devices by `deviceId`
- * directly; the relay routes to the most-recently-connected socket for that
- * device. If the relay has no live socket for the target, the dispatch
- * resolves with `RecipientOffline`, which the `/run` route surfaces as
- * `PeerNotFound`; any other dispatch error is forwarded under
+ * Dispatch addresses devices by `deviceId` directly; the relay routes to the
+ * most-recently-connected socket for that device. If the relay has no live
+ * socket for the target, dispatch resolves with `RecipientOffline`, surfaced
+ * here as `PeerNotFound`; any other dispatch error is forwarded under
  * `RemoteCallFailed`.
  *
  * Power-user automation (loops, fan-out across peers, conditional dispatch)
  * lives in vault-style TypeScript scripts that load the workspace library
  * directly. The CLI deliberately does not grow flags that shadow scripting.
  *
- * `executeRun` returns a domain `RunResponse` that the route serializes
- * verbatim. Unexpected exceptions bubble to Hono's non-2xx response path
- * and surface as `HandlerCrashed` on the client side.
+ * Each function returns a domain response that the route serializes verbatim.
+ * Unexpected exceptions bubble to Hono's non-2xx response path and surface as
+ * `HandlerCrashed` on the client side.
  */
 
 import { Ok } from 'wellcrafted/result';
 import type { SyncStatus } from '../document/internal/sync-supervisor.js';
 import { invokeAction } from '../shared/actions.js';
-import { joinDaemonActionPath, parseDaemonActionPath } from './action-path.js';
-import type { RunRequest } from './app.js';
 import {
-	RunError,
-	type RunResponse,
-	type RunSyncStatus,
-} from './run-errors.js';
+	InvokeError,
+	type InvokeResponse,
+	PeerDispatchError,
+	type PeerDispatchResponse,
+	type PeerDispatchSyncStatus,
+} from './action-errors.js';
+import { joinDaemonActionPath, parseDaemonActionPath } from './action-path.js';
+import type { InvokeRequest, PeerDispatchRequest } from './app.js';
 import type { DaemonServedMount } from './types.js';
 
-export async function executeRun(
+export async function executeInvoke(
 	mounts: readonly DaemonServedMount[],
-	{ actionPath, input: actionInput, peerTarget, waitMs }: RunRequest,
-): Promise<RunResponse> {
+	{ actionPath, input: actionInput }: InvokeRequest,
+): Promise<InvokeResponse> {
 	const { mount, localPath } = parseDaemonActionPath(actionPath);
 	const mountRuntime = mounts.find((candidate) => candidate.mount === mount);
 	if (!mountRuntime) {
 		const available = mounts.map((candidate) => candidate.mount);
-		return RunError.UsageError({
+		return InvokeError.UsageError({
 			message: `No mount "${mount}". Available: ${available.join(', ')}`,
 			suggestions: available.map((name) => `  ${name}`),
 		});
@@ -53,77 +54,63 @@ export async function executeRun(
 	if (!action) {
 		const descendants = daemonActionSuggestionLines(mountRuntime, localPath);
 		if (descendants.length > 0) {
-			return RunError.UsageError({
+			return InvokeError.UsageError({
 				message: `"${actionPath}" is not a runnable action.`,
 				suggestions: descendants,
 			});
 		}
-		return RunError.UsageError({
+		return InvokeError.UsageError({
 			message: `"${actionPath}" is not defined.`,
 			suggestions: daemonActionNearestSiblingLines(mountRuntime, localPath),
 		});
 	}
 
-	if (peerTarget !== undefined) {
-		return invokeRemote({
-			actionInput,
-			localPath,
-			peerTarget,
-			mountRuntime,
-			waitMs,
-		});
-	}
-
 	const result = await invokeAction(action, actionInput);
 	if (result.error !== null) {
-		return RunError.RuntimeError({ cause: result.error });
+		return InvokeError.RuntimeError({ cause: result.error });
 	}
 	return Ok(result.data);
 }
 
-async function invokeRemote({
-	actionInput,
-	localPath,
-	peerTarget,
-	mountRuntime,
-	waitMs,
-}: {
-	actionInput: unknown;
-	localPath: string;
-	peerTarget: string;
-	mountRuntime: DaemonServedMount;
-	waitMs: number;
-}): Promise<RunResponse> {
+export async function executeDispatch(
+	mounts: readonly DaemonServedMount[],
+	{ actionPath, input: actionInput, to, waitMs }: PeerDispatchRequest,
+): Promise<PeerDispatchResponse> {
+	const { mount, localPath } = parseDaemonActionPath(actionPath);
+	const mountRuntime = mounts.find((candidate) => candidate.mount === mount);
+	if (!mountRuntime) {
+		const available = mounts.map((candidate) => candidate.mount);
+		return PeerDispatchError.UsageError({
+			message: `No mount "${mount}". Available: ${available.join(', ')}`,
+			suggestions: available.map((name) => `  ${name}`),
+		});
+	}
+
 	const { runtime } = mountRuntime;
 
 	const result = await runtime.collaboration.dispatch({
-		to: peerTarget,
+		to,
 		action: localPath,
 		input: actionInput,
 		signal: AbortSignal.timeout(waitMs),
 	});
 
 	if (result.error !== null) {
-		const syncStatus = toRunSyncStatus(runtime.collaboration.status);
-		// Translate the full `DispatchError` union into the `RunError`
-		// taxonomy. `RecipientOffline` is promoted to its own variant because
-		// the renderer maps it to a distinct exit code (3): "you addressed a
-		// device that isn't connected" stays separate from a call that
-		// reached the peer and failed. The relay owns reachability and sits
-		// in the dispatch path, so no client-side presence pre-check is
-		// needed (or correct). The other four variants collapse into
-		// `RemoteCallFailed` (exit code 2); the `satisfies never` default
-		// forces this mapping to be revisited if `DispatchError` grows.
+		const syncStatus = toPeerDispatchSyncStatus(runtime.collaboration.status);
 		switch (result.error.name) {
 			case 'RecipientOffline':
-				return RunError.PeerNotFound({ peerTarget, waitMs, syncStatus });
+				return PeerDispatchError.PeerNotFound({
+					to,
+					waitMs,
+					syncStatus,
+				});
 			case 'ActionNotFound':
 			case 'ActionFailed':
 			case 'Cancelled':
 			case 'NetworkFailed':
-				return RunError.RemoteCallFailed({
+				return PeerDispatchError.RemoteCallFailed({
 					cause: result.error,
-					peerTarget,
+					to,
 					syncStatus,
 				});
 			default:
@@ -133,7 +120,7 @@ async function invokeRemote({
 	return Ok(result.data);
 }
 
-function toRunSyncStatus(status: SyncStatus): RunSyncStatus {
+function toPeerDispatchSyncStatus(status: SyncStatus): PeerDispatchSyncStatus {
 	switch (status.phase) {
 		case 'offline':
 			return { phase: 'offline' };

--- a/packages/workspace/src/daemon/action-handler.ts
+++ b/packages/workspace/src/daemon/action-handler.ts
@@ -22,14 +22,12 @@
  * `HandlerCrashed` on the client side.
  */
 
-import { Ok } from 'wellcrafted/result';
+import { Ok, type Result } from 'wellcrafted/result';
 import type { SyncStatus } from '../document/internal/sync-supervisor.js';
 import { invokeAction } from '../shared/actions.js';
 import {
 	InvokeError,
-	type InvokeResponse,
 	PeerDispatchError,
-	type PeerDispatchResponse,
 	type PeerDispatchSyncStatus,
 } from './action-errors.js';
 import { joinDaemonActionPath, parseDaemonActionPath } from './action-path.js';
@@ -39,7 +37,7 @@ import type { DaemonServedMount } from './types.js';
 export async function executeInvoke(
 	mounts: readonly DaemonServedMount[],
 	{ actionPath, input: actionInput }: InvokeRequest,
-): Promise<InvokeResponse> {
+): Promise<Result<unknown, InvokeError>> {
 	const { mount, localPath } = parseDaemonActionPath(actionPath);
 	const mountRuntime = mounts.find((candidate) => candidate.mount === mount);
 	if (!mountRuntime) {
@@ -75,7 +73,13 @@ export async function executeInvoke(
 export async function executeDispatch(
 	mounts: readonly DaemonServedMount[],
 	{ actionPath, input: actionInput, to, waitMs }: PeerDispatchRequest,
-): Promise<PeerDispatchResponse> {
+): Promise<Result<unknown, PeerDispatchError>> {
+	if (!Number.isInteger(waitMs) || waitMs < 0) {
+		return PeerDispatchError.UsageError({
+			message: '`waitMs` must be a non-negative integer.',
+		});
+	}
+
 	const { mount, localPath } = parseDaemonActionPath(actionPath);
 	const mountRuntime = mounts.find((candidate) => candidate.mount === mount);
 	if (!mountRuntime) {

--- a/packages/workspace/src/daemon/action-path.ts
+++ b/packages/workspace/src/daemon/action-path.ts
@@ -1,11 +1,11 @@
 /**
  * Source of truth for mount-prefixed daemon action paths.
  *
- * `/list` publishes action keys in this format, and `/run` accepts the same
- * format from the CLI. Mount validation rejects dots in mount names, so the
- * first dot belongs to the mount boundary. Everything after it is the
- * mount-local action key. Valid action keys are snake_case, so additional dots
- * remain part of an invalid key and resolve as ActionNotFound.
+ * `/list` publishes action keys in this format, and `/invoke` / `/dispatch`
+ * accept the same format from clients. Mount validation rejects dots in mount
+ * names, so the first dot belongs to the mount boundary. Everything after it
+ * is the mount-local action key. Valid action keys are snake_case, so
+ * additional dots remain part of an invalid key and resolve as ActionNotFound.
  */
 type ParsedDaemonActionPath = {
 	mount: string;
@@ -16,7 +16,7 @@ type ParsedDaemonActionPath = {
  * Build the daemon-visible path for a mount-local action.
  *
  * Use this anywhere daemon output names an action for humans or clients. That
- * keeps `/list` manifest keys and `/run` suggestion lines aligned on the same
+ * keeps `/list` manifest keys and action suggestion lines aligned on the same
  * mount qualifier rule.
  */
 export function joinDaemonActionPath(mount: string, localPath: string): string {

--- a/packages/workspace/src/daemon/app.ts
+++ b/packages/workspace/src/daemon/app.ts
@@ -3,11 +3,12 @@
  * routes; the daemon server wires its fetch handler into Bun's listener and
  * the hand-rolled `daemonClient` in `./client.ts` POSTs against it.
  *
- * Each verb is a one-line shell shortcut for one daemon runtime primitive:
+ * Each route is a one-line shell shortcut for one daemon runtime primitive:
  *
- *   /peers  ->  collaboration.devices.list()                       all mounts
- *   /list   ->  flat manifest of `${mount}.${action_key}` -> meta   all mounts
- *   /run    ->  invokeAction(...) | collab.dispatch(...)            mount-routed
+ *   /peers    ->  collaboration.devices.list()                     all mounts
+ *   /list     ->  flat manifest of `${mount}.${action_key}` -> meta all mounts
+ *   /invoke   ->  invokeAction(...)                                 mount-routed
+ *   /dispatch ->  collab.dispatch(...)                              mount-routed
  *
  * Each route returns the handler's `Result<T, DomainErr>` body directly.
  * Unexpected exceptions propagate to Hono's default error handler (HTTP
@@ -20,12 +21,12 @@ import { type } from 'arktype';
 import { Hono } from 'hono';
 import { Ok } from 'wellcrafted/result';
 import { type ActionManifest, toActionMeta } from '../shared/actions.js';
+import { executeDispatch, executeInvoke } from './action-handler.js';
 import { joinDaemonActionPath } from './action-path.js';
-import { executeRun } from './run-handler.js';
 import type { DaemonServedMount } from './types.js';
 
 /**
- * Wire body for `/run`. The schema serves two roles:
+ * Wire body for `/invoke`. The schema serves two roles:
  *
  *   1. Runtime validation at the daemon boundary via
  *      `@hono/standard-validator`. A stale CLI gets a typed 400 instead of a
@@ -37,13 +38,24 @@ import type { DaemonServedMount } from './types.js';
  * value and the type).
  */
 
-export const RunRequest = type({
+export const InvokeRequest = type({
 	actionPath: 'string',
 	input: 'unknown',
-	'peerTarget?': 'string',
+});
+export type InvokeRequest = typeof InvokeRequest.infer;
+
+/**
+ * Wire body for `/dispatch`. Peer dispatch is deliberately separate from
+ * local invoke: the recipient device is the authority for action existence,
+ * and the relay owns reachability.
+ */
+export const PeerDispatchRequest = type({
+	actionPath: 'string',
+	input: 'unknown',
+	to: 'string',
 	waitMs: 'number',
 });
-export type RunRequest = typeof RunRequest.infer;
+export type PeerDispatchRequest = typeof PeerDispatchRequest.infer;
 
 /**
  * Row shape returned by `/peers`. One row per `(mount, deviceId)` pair,
@@ -64,9 +76,9 @@ export type PeerSnapshot = typeof PeerSnapshot.infer;
  * Build the daemon's Hono app. Tests import this directly; production serves
  * the app through the daemon server factory.
  *
- * `/list` exposes mount-prefixed action paths. `/run` uses that same prefix to
- * pick the hosted runtime before dispatching the action key locally or over
- * RPC.
+ * `/list` exposes mount-prefixed action paths. `/invoke` and `/dispatch` use
+ * that same prefix to pick the hosted runtime before executing locally or
+ * routing to a peer.
  */
 export function buildDaemonApp(mounts: readonly DaemonServedMount[]) {
 	return new Hono()
@@ -95,8 +107,12 @@ export function buildDaemonApp(mounts: readonly DaemonServedMount[]) {
 			}
 			return c.json(Ok(manifest));
 		})
-		.post('/run', sValidator('json', RunRequest), async (c) => {
+		.post('/invoke', sValidator('json', InvokeRequest), async (c) => {
 			const request = c.req.valid('json');
-			return c.json(await executeRun(mounts, request));
+			return c.json(await executeInvoke(mounts, request));
+		})
+		.post('/dispatch', sValidator('json', PeerDispatchRequest), async (c) => {
+			const request = c.req.valid('json');
+			return c.json(await executeDispatch(mounts, request));
 		});
 }

--- a/packages/workspace/src/daemon/client.ts
+++ b/packages/workspace/src/daemon/client.ts
@@ -7,7 +7,8 @@
  *   per route. Each method returns `Promise<Result<T, DomainErr | DaemonError>>`,
  *   merging transport and domain failures into one tagged union the
  *   renderer narrows by `error.name`.
- * - {@link getDaemon}: dispatch decision for `run` / `list` / `peers`.
+ * - {@link getDaemon}: dispatch decision for `invoke` / `dispatch` / `list`
+ *   / `peers`.
  *   Returns a typed client on success, or `Required` when the project has no
  *   live daemon.
  *
@@ -26,10 +27,13 @@ import {
 } from 'wellcrafted/error';
 import { Ok, type Result, tryAsync } from 'wellcrafted/result';
 import type { ActionManifest } from '../shared/actions.js';
-
-import type { PeerSnapshot, RunRequest } from './app.js';
+import type { InvokeError, PeerDispatchError } from './action-errors.js';
+import type {
+	InvokeRequest,
+	PeerDispatchRequest,
+	PeerSnapshot,
+} from './app.js';
 import { socketPathFor } from './paths.js';
-import type { RunError } from './run-errors.js';
 
 /**
  * Tagged-error variants returned by daemon client surfaces. Domain errors
@@ -165,8 +169,15 @@ export function daemonClient(
 	return {
 		peers: () => call<PeerSnapshot[], never>(socketPath, timeoutMs, '/peers'),
 		list: () => call<ActionManifest, never>(socketPath, timeoutMs, '/list'),
-		run: (request: RunRequest) =>
-			call<unknown, RunError>(socketPath, timeoutMs, '/run', request),
+		invoke: (request: InvokeRequest) =>
+			call<unknown, InvokeError>(socketPath, timeoutMs, '/invoke', request),
+		dispatch: (request: PeerDispatchRequest) =>
+			call<unknown, PeerDispatchError>(
+				socketPath,
+				timeoutMs,
+				'/dispatch',
+				request,
+			),
 	};
 }
 
@@ -182,8 +193,8 @@ export type DaemonClient = ReturnType<typeof daemonClient>;
  *   - `Required`: no daemon is running. Renderer prints the
  *     start-with-`daemon up` hint.
  *
- * `run`, `list`, and `peers` are mandatory-daemon commands; if they hit
- * no error they have a typed client to dispatch against.
+ * `invoke`, `dispatch`, `list`, and `peers` are mandatory-daemon commands; if
+ * they hit no error they have a typed client to call.
  */
 export async function getDaemon(
 	projectDir: string,

--- a/packages/workspace/src/daemon/list-mount.test.ts
+++ b/packages/workspace/src/daemon/list-mount.test.ts
@@ -3,7 +3,7 @@
  *
  * `/list` describes every hosted mount and prefixes each action key with the
  * mount name. The shared action path helpers are covered here because `/list`
- * and `/run` both rely on the same mount qualifier rules.
+ * and action execution both rely on the same mount qualifier rules.
  */
 
 import { describe, expect, test } from 'bun:test';

--- a/packages/workspace/src/daemon/mount-validation.ts
+++ b/packages/workspace/src/daemon/mount-validation.ts
@@ -1,5 +1,5 @@
 // Mount names are config-supplied identifiers (or carried by the Mount itself).
-// They become the prefix of `/list` manifest keys and `/run` action paths
+// They become the prefix of `/list` manifest keys and daemon action paths
 // (`${mount}.${action}`), so they must exclude `.` (the mount boundary) and
 // start with an alphanumeric. The leading-character class also rejects
 // `__proto__` and other underscore-led names.

--- a/packages/workspace/src/daemon/server.test.ts
+++ b/packages/workspace/src/daemon/server.test.ts
@@ -9,7 +9,7 @@
  * - valid mounts are served over the daemon client
  * - invalid mount declarations fail before binding a socket
  * - close stops the listener, removes the socket file, and can run twice
- * - /run dispatches a real action handler over the Unix socket
+ * - /invoke executes a real action handler over the Unix socket
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
@@ -145,7 +145,7 @@ describe('startDaemonServer', () => {
 		}
 	});
 
-	test('run dispatches to a real action handler over the socket', async () => {
+	test('invoke executes a real action handler over the socket', async () => {
 		const lease = claimTestLease();
 		const runtime = makeRuntime({
 			echo: defineQuery({ handler: () => 'hello' }),
@@ -158,10 +158,9 @@ describe('startDaemonServer', () => {
 		try {
 			const server = expectOk(serverResult);
 			const data = expectOk(
-				await daemonClient(server.socketPath).run({
+				await daemonClient(server.socketPath).invoke({
 					actionPath: 'demo.echo',
 					input: null,
-					waitMs: 25,
 				}),
 			);
 			expect(data).toBe('hello');

--- a/packages/workspace/src/daemon/server.test.ts
+++ b/packages/workspace/src/daemon/server.test.ts
@@ -10,6 +10,7 @@
  * - invalid mount declarations fail before binding a socket
  * - close stops the listener, removes the socket file, and can run twice
  * - /invoke executes a real action handler over the Unix socket
+ * - /dispatch forwards peer calls over the Unix socket
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
@@ -25,9 +26,13 @@ let originalRuntimeDir: string | undefined;
 let runtimeRoot: string;
 let workDir: string;
 
-function makeRuntime(
-	actions: ActionRegistry = {},
-): DaemonServedMount['runtime'] {
+function makeRuntime({
+	actions = {},
+	dispatch = async () => ({ data: null, error: null }) as never,
+}: {
+	actions?: ActionRegistry;
+	dispatch?: DaemonServedMount['runtime']['collaboration']['dispatch'];
+} = {}): DaemonServedMount['runtime'] {
 	return {
 		collaboration: {
 			actions,
@@ -35,7 +40,7 @@ function makeRuntime(
 				list: () => [],
 			},
 			status: { phase: 'connected' },
-			dispatch: async () => ({ data: null, error: null }) as never,
+			dispatch,
 		},
 	};
 }
@@ -148,7 +153,9 @@ describe('startDaemonServer', () => {
 	test('invoke executes a real action handler over the socket', async () => {
 		const lease = claimTestLease();
 		const runtime = makeRuntime({
-			echo: defineQuery({ handler: () => 'hello' }),
+			actions: {
+				echo: defineQuery({ handler: () => 'hello' }),
+			},
 		});
 		const serverResult = await startDaemonServer({
 			lease,
@@ -164,6 +171,65 @@ describe('startDaemonServer', () => {
 				}),
 			);
 			expect(data).toBe('hello');
+		} finally {
+			if (serverResult.error === null) await serverResult.data.close();
+			lease.release();
+		}
+	});
+
+	test('dispatch forwards mount-local action keys over the socket', async () => {
+		const lease = claimTestLease();
+		let invokedAction = '';
+		let invokedTo = '';
+		const runtime = makeRuntime({
+			dispatch: async (request) => {
+				invokedAction = request.action;
+				invokedTo = request.to;
+				return { data: 'remote-ok', error: null };
+			},
+		});
+		const serverResult = await startDaemonServer({
+			lease,
+			mounts: [{ mount: 'demo', runtime }],
+		});
+
+		try {
+			const server = expectOk(serverResult);
+			const data = expectOk(
+				await daemonClient(server.socketPath).dispatch({
+					actionPath: 'demo.peer_only_action',
+					input: null,
+					to: 'mac',
+					waitMs: 25,
+				}),
+			);
+			expect(data).toBe('remote-ok');
+			expect(invokedAction).toBe('peer_only_action');
+			expect(invokedTo).toBe('mac');
+		} finally {
+			if (serverResult.error === null) await serverResult.data.close();
+			lease.release();
+		}
+	});
+
+	test('dispatch rejects invalid wait budgets as a domain error', async () => {
+		const lease = claimTestLease();
+		const serverResult = await startDaemonServer({
+			lease,
+			mounts: [{ mount: 'demo', runtime: makeRuntime() }],
+		});
+
+		try {
+			const server = expectOk(serverResult);
+			const error = expectErr(
+				await daemonClient(server.socketPath).dispatch({
+					actionPath: 'demo.peer_only_action',
+					input: null,
+					to: 'mac',
+					waitMs: -1,
+				}),
+			);
+			expect(error.name).toBe('UsageError');
 		} finally {
 			if (serverResult.error === null) await serverResult.data.close();
 			lease.release();

--- a/packages/workspace/src/daemon/types.ts
+++ b/packages/workspace/src/daemon/types.ts
@@ -20,7 +20,7 @@ import type { MaybePromise } from '../shared/types.js';
 
 /**
  * Collaboration fields the daemon socket app reads while serving `/peers`,
- * `/list`, and `/run`.
+ * `/list`, `/invoke`, and `/dispatch`.
  */
 type DaemonServedCollaboration<
 	TActions extends ActionRegistry = ActionRegistry,

--- a/packages/workspace/src/node.ts
+++ b/packages/workspace/src/node.ts
@@ -13,9 +13,7 @@ export { ProjectConfigError } from './config/load-project-config.js';
 export { DEFAULT_PROJECT_CONFIG_SOURCE } from './config/project-config-source.js';
 export {
 	InvokeError,
-	type InvokeResponse,
 	PeerDispatchError,
-	type PeerDispatchResponse,
 	type PeerDispatchSyncStatus,
 } from './daemon/action-errors.js';
 export {

--- a/packages/workspace/src/node.ts
+++ b/packages/workspace/src/node.ts
@@ -6,15 +6,23 @@
  */
 
 export { connectDaemonActions } from './client/connect-daemon-actions.js';
-export type {
-	DaemonActionOptions,
-	DaemonActions,
-} from './client/daemon-actions.js';
+export type { DaemonActions } from './client/daemon-actions.js';
 export { buildDaemonActions } from './client/daemon-actions.js';
 export { findProjectRoot } from './client/find-project-root.js';
 export { ProjectConfigError } from './config/load-project-config.js';
 export { DEFAULT_PROJECT_CONFIG_SOURCE } from './config/project-config-source.js';
-export { PeerSnapshot, RunRequest } from './daemon/app.js';
+export {
+	InvokeError,
+	type InvokeResponse,
+	PeerDispatchError,
+	type PeerDispatchResponse,
+	type PeerDispatchSyncStatus,
+} from './daemon/action-errors.js';
+export {
+	InvokeRequest,
+	PeerDispatchRequest,
+	PeerSnapshot,
+} from './daemon/app.js';
 export {
 	type AttachProjectInfrastructureOptions,
 	attachProjectInfrastructure,
@@ -51,11 +59,6 @@ export {
 	metadataPathFor,
 	socketPathFor,
 } from './daemon/paths.js';
-export {
-	RunError,
-	type RunResponse,
-	type RunSyncStatus,
-} from './daemon/run-errors.js';
 export { sweepDaemonRuntimeFiles } from './daemon/runtime-files.js';
 export {
 	type DaemonServer,


### PR DESCRIPTION
This PR removes `run` as the daemon protocol model and splits action execution into two explicit socket routes.

The daemon now exposes `POST /invoke` for local action execution and `POST /dispatch` for peer RPC. The CLI command `epicenter run` stays as human-facing sugar: without `--peer` it calls local invoke, and with `--peer` it dispatches to the target device.

The important behavior change is that peer dispatch no longer checks the local action registry. The local daemon only resolves the mount and forwards the mount-local action key; the recipient peer remains the authority for whether that action exists.

I also updated the typed daemon action proxy, node exports, route tests, CLI docs, and scripting docs to use the new invoke/dispatch names.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782627899&installation_id=128463665&pr_number=1858&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1858&signature=7a74a0e48fe7cc9c3af6a0200aa255b91621007147dc6a262bddeee9c0972479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->