### PR TITLE
refactor: collapse the column export surface and drop dead enum-era types

### DIFF
--- a/apps/whispering/src/lib/constants/inference.ts
+++ b/apps/whispering/src/lib/constants/inference.ts
@@ -92,7 +92,7 @@ export const INFERENCE = {
 
 export type InferenceProviderId = keyof typeof INFERENCE;
 
-/** Convenience array for `type.enumerated(...INFERENCE_PROVIDER_IDS)` in schemas. */
+/** Every inference provider ID, e.g. for `column.enum(INFERENCE_PROVIDER_IDS)`. */
 export const INFERENCE_PROVIDER_IDS = Object.keys(
 	INFERENCE,
 ) as InferenceProviderId[];

--- a/apps/whispering/src/lib/constants/transcription.ts
+++ b/apps/whispering/src/lib/constants/transcription.ts
@@ -205,7 +205,7 @@ export const TRANSCRIPTION = {
 
 export type TranscriptionServiceId = keyof typeof TRANSCRIPTION;
 
-/** Convenience array for `type.enumerated(...TRANSCRIPTION_SERVICE_IDS)` in schemas. */
+/** Every transcription service ID, e.g. for `column.enum(TRANSCRIPTION_SERVICE_IDS)`. */
 export const TRANSCRIPTION_SERVICE_IDS = Object.keys(
 	TRANSCRIPTION,
 ) as TranscriptionServiceId[];

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -169,19 +169,6 @@ const TransformationRunResult = Type.Union([
 export type TransformationRunResult = Static<typeof TransformationRunResult>;
 
 /**
- * Results from runs that have reached a terminal state. Enumerated, not
- * negated: adding a new non-terminal status (e.g. `pending`) means adding
- * a variant above, not silently widening this union.
- */
-const TerminalTransformationRunResult = Type.Union([
-	CompletedResult,
-	FailedResult,
-]);
-export type TerminalTransformationRunResult = Static<
-	typeof TerminalTransformationRunResult
->;
-
-/**
  * Execution records for transformation pipelines. One run per invocation.
  * State queries filter by top-level `recordingId` / `transformationId` and
  * sort by `startedAt`; status-dependent fields live inside `result`.

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -12,32 +12,12 @@ import { type Static, Type } from 'typebox';
 // ── Constant imports ─────────────────────────────────────────────────────────
 
 import { RECORDING_MODES } from '$lib/constants/audio/recording-modes';
-import {
-	INFERENCE_PROVIDER_IDS,
-	type InferenceProviderId,
-} from '$lib/constants/inference';
+import { INFERENCE_PROVIDER_IDS } from '$lib/constants/inference';
 import {
 	TRANSCRIPTION,
 	TRANSCRIPTION_SERVICE_IDS,
-	type TranscriptionServiceId,
 } from '$lib/constants/transcription';
 import { ALWAYS_ON_TOP_MODES } from '$lib/constants/ui/always-on-top';
-
-/**
- * The constants files type `*_IDS` as plain mutable arrays for ergonomics in
- * UI code. `column.enum` needs a const-typed tuple to derive literal members,
- * so we re-narrow at the schema boundary without touching the constants.
- */
-const TRANSCRIPTION_SERVICE_ID_TUPLE =
-	TRANSCRIPTION_SERVICE_IDS as unknown as readonly [
-		TranscriptionServiceId,
-		...TranscriptionServiceId[],
-	];
-const INFERENCE_PROVIDER_ID_TUPLE =
-	INFERENCE_PROVIDER_IDS as unknown as readonly [
-		InferenceProviderId,
-		...InferenceProviderId[],
-	];
 
 /**
  * Tables store normalized domain entities. Each row is replaced atomically via
@@ -127,7 +107,7 @@ const transformationSteps = defineTable({
 	type: column.enum(['prompt_transform', 'find_replace']),
 
 	// Prompt transform: active provider
-	inferenceProvider: column.enum(INFERENCE_PROVIDER_ID_TUPLE),
+	inferenceProvider: column.enum(INFERENCE_PROVIDER_IDS),
 
 	// Prompt transform: per-provider model memory
 	openaiModel: column.string(),
@@ -323,7 +303,7 @@ const recording = {
  */
 const transcription = {
 	'transcription.service': defineKv(
-		column.enum(TRANSCRIPTION_SERVICE_ID_TUPLE),
+		column.enum(TRANSCRIPTION_SERVICE_IDS),
 		() => 'moonshine' as const,
 	),
 	'transcription.openai.model': defineKv(

--- a/apps/whispering/src/lib/workspace/index.ts
+++ b/apps/whispering/src/lib/workspace/index.ts
@@ -4,7 +4,6 @@ export {
 	type FailedResult,
 	type Recording,
 	type RunningResult,
-	type TerminalTransformationRunResult,
 	type Transformation,
 	type TransformationRun,
 	type TransformationRunResult,

--- a/packages/workspace/src/document/column/column.test-d.ts
+++ b/packages/workspace/src/document/column/column.test-d.ts
@@ -8,10 +8,10 @@
  * offending line during typecheck.
  */
 
-import { type Static, type TUnsafe, Type } from 'typebox';
+import type { Static, TUnsafe, Type } from 'typebox';
 import type { Brand } from 'wellcrafted/brand';
 import type { JsonValue } from 'wellcrafted/json';
-import { type ColumnError, column, type FlatJsonTSchema } from './index';
+import type { ColumnError, column, FlatJsonTSchema } from './index';
 
 // --------------------------------------------------------------------------
 // Helpers
@@ -23,6 +23,7 @@ type Equal<X, Y> =
 		: false;
 
 type Expect<T extends true> = T;
+type EmptyProperties = Record<string, never>;
 
 // --------------------------------------------------------------------------
 // ColumnError pattern
@@ -82,7 +83,10 @@ export type _AcceptNullable = Expect<
 type IsError<S> = S extends string ? true : false;
 
 export type _RejectObject = Expect<
-	Equal<IsError<FlatJsonTSchema<ReturnType<typeof Type.Object<{}>>>>, true>
+	Equal<
+		IsError<FlatJsonTSchema<ReturnType<typeof Type.Object<EmptyProperties>>>>,
+		true
+	>
 >;
 export type _RejectArray = Expect<
 	Equal<
@@ -159,6 +163,16 @@ export type _StringLiteralRejected = Expect<
 // column.string<NoteId>() returns a branded Unsafe schema.
 export type _StringBrandedReturnsUnsafe = ReturnType<
 	typeof column.string<NoteId>
+>;
+
+// --------------------------------------------------------------------------
+// column.enum static inference
+// --------------------------------------------------------------------------
+
+const statusIds = ['draft', 'published'] as Array<'draft' | 'published'>;
+type StatusSchema = ReturnType<typeof column.enum<typeof statusIds>>;
+export type _EnumArrayPreservesElementUnion = Expect<
+	Equal<Static<StatusSchema>, 'draft' | 'published'>
 >;
 
 // --------------------------------------------------------------------------

--- a/packages/workspace/src/document/column/column.test.ts
+++ b/packages/workspace/src/document/column/column.test.ts
@@ -46,6 +46,12 @@ describe('column.enum', () => {
 		expect(Value.Check(status, 'published')).toBe(true);
 		expect(Value.Check(status, 'archived')).toBe(false);
 	});
+
+	test('rejects empty value lists', () => {
+		expect(() => column.enum([])).toThrow(
+			'column.enum requires at least one value',
+		);
+	});
 });
 
 describe('column.json', () => {

--- a/packages/workspace/src/document/column/index.ts
+++ b/packages/workspace/src/document/column/index.ts
@@ -13,17 +13,4 @@ export {
 	isNullable,
 	type SqliteStorage,
 } from './derive';
-export {
-	boolean,
-	column,
-	dateTime,
-	enum_,
-	type Infer,
-	ianaTimeZone,
-	integer,
-	json,
-	literal,
-	nullable,
-	number,
-	string,
-} from './sugar';
+export { column, type Infer } from './sugar';

--- a/packages/workspace/src/document/column/sugar.ts
+++ b/packages/workspace/src/document/column/sugar.ts
@@ -11,17 +11,22 @@
  * - `ianaTimeZone` (custom format validated against `Intl.DateTimeFormat`,
  *   brand `IanaTimeZone`; registered once at module load)
  *
- * The rest are direct re-exports of `Type.X` so autocomplete on `column.`
- * lists the entire SQLite-safe constructor menu. They keep TypeBox's full
- * JSDoc / signature / overloads intact (single source of truth):
+ * The rest alias `Type.X` directly and are assembled onto the `column` object
+ * below, so autocomplete on `column.` lists the entire SQLite-safe constructor
+ * menu. They keep TypeBox's full JSDoc / signature / overloads intact (single
+ * source of truth):
  *
  *   column.number   = Type.Number
  *   column.integer  = Type.Integer
  *   column.boolean  = Type.Boolean
  *   column.literal  = Type.Literal
  *
+ * `column` is the only builder export (the `Infer` type aside): the builders
+ * are module-private and reachable solely as `column.X`, so there is one
+ * blessed way to construct a column.
+ *
  * `column.enum` is a small function (it builds a Union from a values array)
- * so it isn't a re-export, but it still defers all option-typing to TypeBox.
+ * so it isn't a plain alias, but it still defers all option-typing to TypeBox.
  *
  * Users may freely mix `column.X()` and raw `Type.X()`; the `FlatJsonTSchema`
  * constraint enforces safety regardless of which call site produced the
@@ -69,7 +74,7 @@ if (!Format.Has(IANA_TIME_ZONE_FORMAT)) {
  *   subtype is enforced at runtime is dishonest; use `column.literal('draft')`
  *   instead.
  */
-export function string<T extends string = string>(
+function string<T extends string = string>(
 	opts?: TStringOptions,
 ): string extends T ? TString : T extends BrandedString ? TUnsafe<T> : never {
 	return Type.String(opts) as string extends T
@@ -79,14 +84,14 @@ export function string<T extends string = string>(
 			: never;
 }
 
-/** Pass-through to `Type.Number`. Re-exported for autocomplete discoverability. */
-export const number = Type.Number;
+/** Pass-through to `Type.Number`, exposed as `column.number`. */
+const number = Type.Number;
 
 /** Pass-through to `Type.Integer`. */
-export const integer = Type.Integer;
+const integer = Type.Integer;
 
 /** Pass-through to `Type.Boolean`. */
-export const boolean = Type.Boolean;
+const boolean = Type.Boolean;
 
 /**
  * Pass-through to `Type.Literal`. Use for status enums and other
@@ -94,7 +99,7 @@ export const boolean = Type.Boolean;
  * library-managed via `defineTable`'s tuple position; do not declare
  * `_v` as a column.)
  */
-export const literal = Type.Literal;
+const literal = Type.Literal;
 
 type EnumMembers<T extends readonly TLiteralValue[]> = [
 	TLiteral<T[number] & TLiteralValue>,
@@ -109,7 +114,7 @@ type EnumMembers<T extends readonly TLiteralValue[]> = [
  * `Type.Enum` (`~kind: 'Enum'`) is rejected by `FlatJsonTSchema` in favor of
  * this shape so the CHECK generator has one shape to walk.
  */
-export function enum_<const T extends readonly TLiteralValue[]>(
+function enum_<const T extends readonly TLiteralValue[]>(
 	values: T,
 	opts?: TSchemaOptions,
 ): TUnion<EnumMembers<T>> {
@@ -136,7 +141,7 @@ export function enum_<const T extends readonly TLiteralValue[]>(
  * column.json(Type.Object({ x: Type.Number() }))  // Static = { x: number }
  * ```
  */
-export function json<S extends TSchema>(
+function json<S extends TSchema>(
 	schema: S,
 	opts?: TSchemaOptions,
 ): TUnsafe<
@@ -156,7 +161,7 @@ export function json<S extends TSchema>(
  * inner" instead of constructing the union by hand. Matches TypeBox issue #989
  * guidance on nullability.
  */
-export function nullable<S extends TSchema>(schema: S): TUnion<[S, TNull]> {
+function nullable<S extends TSchema>(schema: S): TUnion<[S, TNull]> {
 	return Type.Union([schema, Type.Null()]);
 }
 
@@ -176,7 +181,7 @@ export function nullable<S extends TSchema>(schema: S): TUnion<[S, TNull]> {
  * zone matters (calendar events, reminders); see the `<field>` + `<field>Zone`
  * naming convention in the workspace spec.
  */
-export function dateTime(opts?: TSchemaOptions): TUnsafe<DateTimeString> {
+function dateTime(opts?: TSchemaOptions): TUnsafe<DateTimeString> {
 	return Type.Unsafe<DateTimeString>(
 		Type.String({ format: 'date-time', ...opts }),
 	);
@@ -190,7 +195,7 @@ export function dateTime(opts?: TSchemaOptions): TUnsafe<DateTimeString> {
  * the runtime accepts is valid; any zone it rejects is not). No hand-tuned
  * regex.
  */
-export function ianaTimeZone(opts?: TSchemaOptions): TUnsafe<IanaTimeZone> {
+function ianaTimeZone(opts?: TSchemaOptions): TUnsafe<IanaTimeZone> {
 	return Type.Unsafe<IanaTimeZone>(
 		Type.String({ format: IANA_TIME_ZONE_FORMAT, ...opts }),
 	);

--- a/packages/workspace/src/document/column/sugar.ts
+++ b/packages/workspace/src/document/column/sugar.ts
@@ -44,7 +44,7 @@ import {
 import { Format } from 'typebox/format';
 import type { Brand } from 'wellcrafted/brand';
 import type { JsonValue } from 'wellcrafted/json';
-import { DateTimeString } from '../../shared/datetime-string';
+import type { DateTimeString } from '../../shared/datetime-string';
 import {
 	IANA_TIME_ZONE_FORMAT,
 	IanaTimeZone,
@@ -96,6 +96,11 @@ export const boolean = Type.Boolean;
  */
 export const literal = Type.Literal;
 
+type EnumMembers<T extends readonly TLiteralValue[]> = [
+	TLiteral<T[number] & TLiteralValue>,
+	...TLiteral<T[number] & TLiteralValue>[],
+];
+
 /**
  * Enum-of-literals column. Produces `Type.Union<TLiteral[]>` (anyOf-of-const).
  * The SQLite materializer's `deriveCheck` emits this shape as
@@ -107,11 +112,12 @@ export const literal = Type.Literal;
 export function enum_<const T extends readonly TLiteralValue[]>(
 	values: T,
 	opts?: TSchemaOptions,
-): TUnion<{ -readonly [K in keyof T]: TLiteral<T[K] & TLiteralValue> }> {
+): TUnion<EnumMembers<T>> {
+	if (values.length === 0) {
+		throw new Error('column.enum requires at least one value');
+	}
 	const members = values.map((v) => Type.Literal(v));
-	return Type.Union(members, opts) as TUnion<{
-		-readonly [K in keyof T]: TLiteral<T[K] & TLiteralValue>;
-	}>;
+	return Type.Union(members, opts) as TUnion<EnumMembers<T>>;
 }
 
 /**

--- a/scripts/claude-consult.ts
+++ b/scripts/claude-consult.ts
@@ -104,7 +104,8 @@ function parseArgs(argv: string[]) {
 	}
 
 	if (!options.question) fail('Missing required --question value');
-	if (options.budgetUsd < 1) fail('--budget-usd must be at least 1 so Claude can return a result');
+	if (options.budgetUsd < 1)
+		fail('--budget-usd must be at least 1 so Claude can return a result');
 
 	return options;
 }


### PR DESCRIPTION
The enum refactor just before this (`refactor: collapse enum tuple assertions`) let `column.enum(values)` take a plain `readonly TLiteralValue[]`, which deleted the per-call-site tuple casts in Whispering:

```ts
// Before: re-narrow a mutable array into a const tuple at the schema boundary
const INFERENCE_PROVIDER_ID_TUPLE = INFERENCE_PROVIDER_IDS as unknown as readonly [
  InferenceProviderId, ...InferenceProviderId[],
];
inferenceProvider: column.enum(INFERENCE_PROVIDER_ID_TUPLE),

// After
inferenceProvider: column.enum(INFERENCE_PROVIDER_IDS),
```

Once those casts were gone, a second look at the column module showed how much of its surface nothing actually reached. This PR finishes the collapse.

**The `column.*` builders were exported twice, and the standalone copies had zero consumers.**

Every builder (`string`, `number`, `enum_`, `json`, `nullable`, ...) was both a top-level `export` and a property on the `column` object. But the package root re-exports only `column`, there is no `./document/column` entry in the package `exports` map, and every call site in the repo writes `column.X()`. The ten standalone exports reached nobody.

```txt
Before:                                 After:
  column/index.ts                         column/index.ts
    export { boolean, string,               export { column, type Infer }
             enum_, json, ... }               (+ ColumnError, derive helpers)
    export { column }                     sugar.ts
  sugar.ts                                  builders are module-private,
    export function string() ...            assembled onto `column`
    export const number = ...
    export function enum_() ...             one blessed path:  column.X()
```

The call site is unchanged: `column.string()`, `column.enum([...])`. What changes is that there is now exactly one way to import a builder, so the convention enforces itself instead of needing review.

### Why the object namespace and not star imports?

The obvious alternative is top-level functions consumed as `import * as column`. Two reasons it loses.

`enum` is a reserved word, so `export function enum` is illegal. Under a star import you would be stuck writing `column.enum_(...)` at every call site (the exact wart valibot ships). The object form lets the property be `enum` while the backing function stays `enum_`: `{ enum: enum_ }` reads clean.

And we wrap TypeBox, whose own idiom is `Type.X`. Mirroring it as `column.X` is the most teachable shape, and it matches `z`, arktype's `type`, and Effect's `Schema`. Per-member tree-shaking, star import's one real advantage, is moot for a schema-definition module that pulls in TypeBox regardless.

**A dead transformation-result type came along for the ride.**

`TerminalTransformationRunResult` (schema const + exported type) had no consumer anywhere: the `result` columns use `TransformationRunResult`, and nothing imported the terminal variant. Its sibling result types stay, since their schemas build the `result` column and the heavily-used row types expose them transitively, so exporting them is the symmetric, expected surface. Only the genuinely unwired one goes.

Last, two constants comments still advertised `type.enumerated(...)` (arktype) when their real consumer is now `column.enum(...)`. Reworded to describe the array and name the actual caller.

Validation: workspace `tsc` clean (this also compiles the `column.test-d.ts` static enum-inference tests), 12/12 column runtime tests pass, Whispering `svelte-check` reports 0 errors.

Stacks on the enum-collapse commit, which isn't on `main` yet, so it rides in here. Net across the cleanup: 8 files, +59/-76.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782666054&installation_id=128463665&pr_number=1859&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1859&signature=f02ce700acdd5f83d8fd6cb2ea6f2b85962fca2822c4a9990d7b7cf6e340e374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->