### PR TITLE
docs(fuji): align mount config examples

### DIFF
--- a/apps/fuji/README.md
+++ b/apps/fuji/README.md
@@ -126,10 +126,10 @@ Fuji's mount is registered from the project root. It is not discovered from `.ep
 ```ts
 import { fuji } from '@epicenter/fuji/project';
 
-export default fuji();
+export default [fuji()];
 ```
 
-`fuji()` is a factory that returns a `Mount` carrying its own canonical name (`fuji`). Pass options to override defaults (`fuji({ markdownDir: '.', sqliteFile: '.epicenter/sqlite.db' })`).
+`fuji()` is a factory that returns a `Mount` carrying its own canonical name (`fuji`). `epicenter.config.ts` default-exports a mount list, so a one-mount project still wraps it in an array. Pass options to override defaults (`fuji({ markdownDir: '.', sqliteFile: '.epicenter/sqlite.db' })`).
 
 `epicenter daemon up -C <project>` starts every mount declared in `epicenter.config.ts` inside one daemon process. It creates `.epicenter/` for generated project data when it is missing, but sockets and daemon logs live in platform user paths instead of inside the project.
 

--- a/examples/fuji/README.md
+++ b/examples/fuji/README.md
@@ -4,10 +4,9 @@ The canonical Epicenter project layout demonstrated against `@epicenter/fuji`.
 
 ## What this shows
 
-One project, one workspace, defined inline in `epicenter.config.ts`. Table
-data lives as markdown at the project root and is committed to git. Runtime
-state (Yjs persistence, SQLite materializer) lives under `.epicenter/` and is
-gitignored.
+One project, one Fuji mount, declared in `epicenter.config.ts`. Table data lives
+as markdown at the project root and is committed to git. Runtime state (Yjs
+persistence, SQLite materializer) lives under `.epicenter/` and is gitignored.
 
 This example is the reference implementation of the layout spec at
 `specs/20260522T220000-workspace-project-layout.md`. If the spec changes,
@@ -88,8 +87,8 @@ workspace.
 - Browser or Tauri frontend. The example is daemon-hosted only.
 - Custom path overrides. Materializer paths use the spec's default
   (`.epicenter/sqlite.db` and `./entries/`).
-- Multi-workspace orchestration. One workspace per project is the canonical
-  shape; multi-workspace is a monorepo with sibling projects.
+- Multiple mounts. This example keeps the mount list small so the project
+  layout stays easy to inspect.
 
 ## See also
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -69,7 +69,7 @@ export default [fuji()];
 
 The factory carries the canonical mount name (`fuji`), so the CLI addresses actions as `fuji.<action_key>` regardless of the project folder name.
 
-For projects that host more than one app workspace, export an array:
+For projects that host more than one mount, add more entries to the array:
 
 ```ts
 import { fuji } from '@epicenter/fuji/project';


### PR DESCRIPTION
The Fuji docs still showed a bare `export default fuji()` config even though project configs now default-export a `Mount[]`. This updates the Fuji app README, the Fuji example README, and the CLI README to use the mount-list shape consistently and to describe multiple mounts with the current terminology.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782682603&installation_id=128463665&pr_number=1862&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1862&signature=222692784cade7a87a149abb5eb6f085b260f316ef4939d6de5f1c4c26a60734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->