### PR TITLE
fix(workspace): clarify bare mount config error

### DIFF
--- a/packages/workspace/src/config/load-project-config.test.ts
+++ b/packages/workspace/src/config/load-project-config.test.ts
@@ -73,7 +73,11 @@ describe('loadProjectConfig', () => {
 		writeConfig("export default { name: 'demo', open() {} };\n");
 
 		const { error } = await loadProjectConfig(projectDir);
-		expect(error?.name).toBe('ProjectConfigInvalid');
+		expect(error).toMatchObject({
+			name: 'ProjectConfigInvalid',
+			detail:
+				'the default export is a single Mount; wrap it in an array, for example `export default [fuji()]`',
+		});
 	});
 
 	test('rejects a Mount[] containing a non-Mount value', async () => {

--- a/packages/workspace/src/config/load-project-config.ts
+++ b/packages/workspace/src/config/load-project-config.ts
@@ -89,6 +89,13 @@ export async function loadProjectConfig(
 
 	const value = module.default;
 	if (Array.isArray(value) && value.every(isMount)) return Ok(value);
+	if (isMount(value)) {
+		return ProjectConfigError.ProjectConfigInvalid({
+			projectConfigPath,
+			detail:
+				'the default export is a single Mount; wrap it in an array, for example `export default [fuji()]`',
+		});
+	}
 	return ProjectConfigError.ProjectConfigInvalid({
 		projectConfigPath,
 		detail:


### PR DESCRIPTION
Project configs now default-export a mount list, so a bare single mount should fail with a direct explanation instead of the generic Mount[] validation message. This keeps the loader strict while giving one-mount projects the exact array-wrapping fix to apply.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782682856&installation_id=128463665&pr_number=1863&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1863&signature=6631a0d09c428e03cc85706dcd947edecbf91ba5bf28555f5052a022b33a9b11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->