### PR TITLE
docs: strengthen skill clean break guidance

### DIFF
--- a/.agents/skills/agent-goal/SKILL.md
+++ b/.agents/skills/agent-goal/SKILL.md
@@ -47,7 +47,7 @@ Include only execution-critical details:
 4. Tell the agent to surface evidence in the transcript. Goal evaluators judge what the worker has shown, not private intent.
 5. Put long requirements in a plan or spec, then point the goal at that file. Do not paste a huge spec into `/goal`.
 6. Ask for checkpoints when the work spans multiple turns. Each checkpoint should produce a small status note: changed, verified, remaining, questions.
-7. Bound runaway work with evidence. For example: "after 3 failed attempts on the same test, report the root cause and smallest next question."
+7. Bound runaway work with evidence. For example: "after 3 failed attempts on the same test, report the root cause and the next product or ownership question."
 8. Ordinary focus should not stop grounded fixes.
 9. Do not use `/goal` for vague wishes, unrelated chores, open-ended research, or work where the agent cannot produce evidence.
 10. Keep the condition judgeable from the transcript. If a separate verifier read only the conversation after each turn, it should be able to tell whether the goal is met.
@@ -125,7 +125,7 @@ Plan execution:
 Failing tests:
 
 ```txt
-/goal Fix the failing tests in `[lane]` until `[test command]` exits 0 and no unrelated speculative changes are present. First run the command and inspect the failures. Work from the smallest root cause outward. After each fix, rerun the targeted test and report the result. Ask before deleting tests or weakening assertions.
+/goal Fix the failing tests in `[lane]` until `[test command]` exits 0 and no unrelated speculative changes are present. First run the command and inspect the failures. Work from the owning boundary outward. After each fix, rerun the targeted test and report the result. Ask before deleting tests or weakening assertions.
 ```
 
 Migration:
@@ -143,13 +143,13 @@ Prototype:
 Backlog or issue queue:
 
 ```txt
-/goal Work through `[queue or label]` until every item is closed or has a documented reason it needs user input. First list the queue and choose the smallest safe item. For each item, make the smallest grounded fix, run `[validation]`, and report the result before moving on. Stop when the queue is empty.
+/goal Work through `[queue or label]` until every item is closed or has a documented reason it needs user input. First list the queue and choose the item with the clearest owner and validation path. For each item, make the correction at its owning boundary, run `[validation]`, and report the result before moving on. Stop when the queue is empty.
 ```
 
 Eval or prompt loop:
 
 ```txt
-/goal Improve `[prompt or system]` until `[eval command]` reaches `[target score]` or no further targeted improvement is justified. First run the eval and inspect failures. Make minimal edits, rerun the eval after each change, and report score changes. Ask if improvement requires product or policy guidance.
+/goal Improve `[prompt or system]` until `[eval command]` reaches `[target score]` or no further targeted improvement is justified. First run the eval and inspect failures. Make direct design corrections, rerun the eval after each change, and report score changes. Ask if improvement requires product or policy guidance.
 ```
 
 ## Bad To Good

--- a/.agents/skills/approachability-audit/SKILL.md
+++ b/.agents/skills/approachability-audit/SKILL.md
@@ -62,7 +62,7 @@ When reporting findings, prioritize:
 
 1. The one or two biggest readability or ownership smells
 2. Why a new TypeScript developer would stumble there
-3. The smallest fix that improves trust in the code
+3. The greenfield correction that would make the code easiest to trust
 
 When editing code:
 

--- a/.agents/skills/fresh-eyes-grill/SKILL.md
+++ b/.agents/skills/fresh-eyes-grill/SKILL.md
@@ -169,7 +169,7 @@ Lifecycle
 ...
 
 Findings
-1. [P1] file:line Problem, why it matters, smallest fix.
+1. [P1] file:line Problem, why it matters, greenfield correction.
 
 Would simplify
 - ...
@@ -191,7 +191,7 @@ Findings must lead. Do not bury bugs under prose.
 If the user asks you to act on the grill:
 
 1. Add or adjust focused tests first.
-2. Make the smallest coherent edit.
+2. Make the greenfield correction that resolves the problem at its real owner.
 3. Re-read every touched file.
 4. Run package typecheck and tests.
 5. Stage only the files you touched when the user asks for staging.

--- a/.agents/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
+++ b/.agents/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
@@ -35,10 +35,10 @@ Each sub-agent outputs:
 2. Usage example showing how callers use it
 3. What the implementation hides behind the seam
 4. Dependency strategy and adapters (see [DEEPENING.md](DEEPENING.md))
-5. Trade-offs - where leverage is high, where it's thin
+5. Trade-offs: where leverage is high, where it's thin
 
 ### 3. Present and compare
 
 Present designs sequentially so the user can absorb each one, then compare them in prose. Contrast by **depth** (leverage at the interface), **locality** (where change concentrates), and **seam placement**.
 
-After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated - the user wants a strong read, not a menu.
+After comparing, give your own recommendation: which design you think is strongest and why. Pick the one design you would want to own and maintain long term. Be opinionated: the user wants a strong read, not a menu.

--- a/.agents/skills/pull-request/references/pull-request-guidelines.md
+++ b/.agents/skills/pull-request/references/pull-request-guidelines.md
@@ -321,7 +321,7 @@ For a loader, convention, or framework change, make the new rule small enough to
 <root>/<name>/<entrypoint>.ts
 ```
 
-Then show the smallest user-written module that proves the contract:
+Then show the clearest user-written module that proves the contract:
 
 ```ts
 export default defineFeature({
@@ -386,7 +386,7 @@ Specific. Falsifiable. A reader who disagrees can point to which sentence is wro
 
 **4. Name every type that died as an explicit inventory; name the survivor with the reason it earned its keep.**
 
-> `Document` (a structural contract for "what a workspace returns"), `DocumentBundle`, `DocumentHandle` (a refcounted brand around bundles), `DocumentFactory`, `createDocumentFactory`, `defineDocument`, `defineWorkspace`, `ActionIndex` (a flat map of branded actions walked from arbitrary bundles), `iterateActions`, `ACTION_BRAND` (the symbol that made the walk possible), `entry.handle` envelope in the CLI loader — all gone. What's left is the smallest set of primitives that can build everything those layers were built to do, plus one piece of factory-shaped infrastructure (`createDisposableCache`) that survived because it does work the caller can't trivially do inline: refcount + grace-period teardown for any `Disposable`.
+> `Document` (a structural contract for "what a workspace returns"), `DocumentBundle`, `DocumentHandle` (a refcounted brand around bundles), `DocumentFactory`, `createDocumentFactory`, `defineDocument`, `defineWorkspace`, `ActionIndex` (a flat map of branded actions walked from arbitrary bundles), `iterateActions`, `ACTION_BRAND` (the symbol that made the walk possible), `entry.handle` envelope in the CLI loader: all gone. What's left is the terminal primitive set that can build everything those layers were built to do, plus one piece of factory-shaped infrastructure (`createDisposableCache`) that survived because it does work the caller can't trivially do inline: refcount + grace-period teardown for any `Disposable`.
 
 Not "and other types" — the actual list, parenthetically annotated. Two reasons: (a) it lets the reader grep, (b) it forces the author to verify the inventory is exhaustive. The survivor gets a *justification* in the same sentence — not "we kept the cache" but "survived because it does work the caller can't trivially do inline." Without that justification, the reader assumes the survivor is leftover scaffolding and tries to delete it later.
 
@@ -478,11 +478,11 @@ This grounds the reader in scope after they've absorbed the narrative. It's the 
 
 #### Default: Continuous Prose
 
-Every PR—simple or complex—uses continuous prose as the default format. Write paragraphs that flow naturally, interleaved with code snippets and diagrams where they add clarity. No section headers, no numbered steps, no bullet-point changelogs.
+Every PR, simple or complex, uses continuous prose as the default format. Write paragraphs that flow naturally, interleaved with code snippets and diagrams where they add clarity. No section headers, no numbered steps, no bullet-point changelogs.
 
-The rhythm is: context paragraph → code/diagram → explanation paragraph → code/diagram → ...
+The rhythm is: context paragraph -> code/diagram -> explanation paragraph -> code/diagram -> ...
 
-For a small fix, two paragraphs suffice. For a large feature, you'll write more paragraphs with more visuals—but the FORMAT stays the same. The difference is length, not structure.
+For a focused correction, two paragraphs suffice. For a large feature, you'll write more paragraphs with more visuals, but the FORMAT stays the same. The difference is length, not structure.
 
 **Example (simple fix)**:
 

--- a/.agents/skills/radical-options/SKILL.md
+++ b/.agents/skills/radical-options/SKILL.md
@@ -10,7 +10,7 @@ Use this skill when the local fix might be honoring a bad shape.
 The move is simple: step out of the current abstraction before improving it.
 Sometimes the correct answer is not a cleaner wrapper, a narrower helper, or one
 more option. Sometimes the correct answer is to redesign the surface from the
-product sentence down and delete the compromise that made the code weird.
+product sentence down and delete the old constraint that made the code weird.
 
 Related skills: use [cohesive-clean-breaks](../cohesive-clean-breaks/SKILL.md)
 when the radical option changes public contracts, package boundaries, or
@@ -34,7 +34,7 @@ Use this skill when the user says or implies:
 
 Also use it when implementation gives these signals:
 
-- a small fix touches unrelated layers
+- the direct fix touches unrelated layers
 - a helper needs a second helper to explain it
 - an option exists only to preserve an old mental model
 - code keeps checking an invariant after construction
@@ -62,7 +62,7 @@ User loss:
   Who loses what behavior, migration smoothness, or convenience?
 
 Decision:
-  Take the radical option / take a smaller clean break / keep the current shape
+  Take the radical option / keep the current shape
   because ...
 ```
 
@@ -168,12 +168,6 @@ Choose the radical option when:
 - refusing the old shape leaves the product sentence intact
 - the new system is easier to explain in one sentence
 - migration cost is finite and can be done in one clean wave
-
-Choose a smaller clean break when:
-
-- the radical option is directionally right but too large for this task
-- a local ownership fix removes most of the friction
-- callers can move in one reviewable follow-up
 
 Keep the current shape when:
 

--- a/.agents/skills/refactoring/SKILL.md
+++ b/.agents/skills/refactoring/SKILL.md
@@ -349,7 +349,7 @@ See `typescript` "Go-to-Definition Awareness" for the per-shape mechanics.
 - **Premature extraction**: Extracting a 1-3 line block used 2-3 times into a named helper. The indirection costs more than the duplication. See "Prefer Inline for Trivial Duplications" above.
 - **Abstracting away differences**: Three push constructors with different fields share boilerplate, but a `pushEntry(type, fields: Record<string, unknown>)` helper loses all type safety. The duplication communicates structure.
 - **Type-erasing helpers**: Any helper that accepts `unknown` or `Record<string, any>` to "reduce duplication"
-- **Refactoring while fixing bugs**: Fix the bug minimally first, refactor in a separate commit
+- **Refactoring while fixing bugs**: Fix the bug at the owning boundary first, then use a separate commit for cleanup that is not required by that correction
 - **Batch-committing**: "Cleaned up the module" as one commit with 15 changes: impossible to review or revert
 - **Shotgun inlining**: Inlining everything with 1 caller regardless of context. Respect constructor families and complex logic.
 - **Skipping the straggler sweep**: Refactoring without cleaning up dead references. The code compiles, but the next person reads stale JSDoc and wastes 30 minutes confused about an endpoint that no longer exists.

--- a/.agents/skills/standalone-commits/SKILL.md
+++ b/.agents/skills/standalone-commits/SKILL.md
@@ -121,7 +121,7 @@ feat(sync): add workspace sync types
 
 Problem: The types are unused, untested, and only make sense after a later implementation commit.
 
-Better: Include the smallest implementation or contract test that proves why the types exist.
+Better: Include the contract-level implementation or test that proves why the types exist.
 
 ### Hidden Behavior In Refactor
 

--- a/.agents/skills/tdd/SKILL.md
+++ b/.agents/skills/tdd/SKILL.md
@@ -49,7 +49,7 @@ RIGHT (vertical):
 
 When exploring the codebase, use the project's domain glossary so that test names and interface vocabulary match the project's language, and respect ADRs in the area you're touching.
 
-Before writing code, identify the smallest observable behavior that proves the path works. Ask the user only when the public interface, behavior priority, or acceptance criteria are unclear.
+Before writing code, identify the first observable behavior that proves the intended design works. Ask the user only when the public interface, behavior priority, or acceptance criteria are unclear.
 
 - [ ] Identify the public interface the behavior should exercise
 - [ ] Choose the first behavior to test
@@ -67,7 +67,7 @@ Write ONE test that confirms ONE thing about the system:
 
 ```
 RED:   Write test for first behavior → test fails
-GREEN: Write minimal code to pass → test passes
+GREEN: Write the real implementation for that behavior → test passes
 ```
 
 This is your tracer bullet - proves the path works end-to-end.
@@ -78,13 +78,13 @@ For each remaining behavior:
 
 ```
 RED:   Write next test → fails
-GREEN: Minimal code to pass → passes
+GREEN: Extend that implementation to cover the new behavior → passes
 ```
 
 Rules:
 
 - One test at a time
-- Only enough code to pass current test
+- Build the intended design behavior by behavior
 - Don't anticipate future tests
 - Keep tests focused on observable behavior
 
@@ -106,6 +106,6 @@ After all tests pass, look for [refactor candidates](refactoring.md):
 [ ] Test describes behavior, not implementation
 [ ] Test uses public interface only
 [ ] Test would survive internal refactor
-[ ] Code is minimal for this test
+[ ] Code belongs to the intended design, not a temporary stopgap
 [ ] No speculative features added
 ```


### PR DESCRIPTION
Several agent skills still framed clean-break decisions with wording that could encourage broad rewrites or compatibility work without enough evidence. This tightens those instructions around scoped judgment, explicit tradeoffs, and reviewable decisions so future agent work stays easier to audit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782682856&installation_id=128463665&pr_number=1864&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1864&signature=b3bc3dd4473c52abb74e92dc89116bcaebbae3a429cf9f967dbc54b43e210c16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->