### PR TITLE
fix(whispering): clarify Apple keyboard shortcut warnings

### DIFF
--- a/apps/whispering/src/lib/platform/os.tauri.ts
+++ b/apps/whispering/src/lib/platform/os.tauri.ts
@@ -1,13 +1,11 @@
 import { type as osType } from '@tauri-apps/plugin-os';
 import type { Os } from './types';
 
-// Tauri reads the real OS synchronously and it never changes during a session,
-// so identity is resolved once at module load. whispering's desktop targets are
-// macOS, Windows, and Linux; 'ios' is matched anyway so both seam impls compute
-// `isApple` identically.
+// Tauri reads the real OS synchronously and it never changes during a session.
+// Whispering's Tauri build is desktop-only, so Apple means macOS here.
 const current = osType();
 
 export const os: Os = {
-	isApple: current === 'macos' || current === 'ios',
+	isApple: current === 'macos',
 	isLinux: current === 'linux',
 };

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte
@@ -101,7 +101,7 @@
 					<Alert.Root variant="warning" class="text-xs">
 						<AlertTriangle class="size-4" />
 						<Alert.Title class="text-xs font-medium"
-							>macOS Option Key Note</Alert.Title
+							>Apple Keyboard Note</Alert.Title
 						>
 						<Alert.Description class="text-xs">
 							Some Option+key combinations (E, I, N, U, `) may not record

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
@@ -134,11 +134,11 @@
 			{#if os.isApple}
 				<Alert.Root variant="warning">
 					<AlertTriangle class="size-4" />
-					<Alert.Title>macOS Option Key Limitations</Alert.Title>
+					<Alert.Title>Apple Keyboard Option Key Limitations</Alert.Title>
 					<Alert.Description class="space-y-2">
 						<p>
-							On macOS, certain Option (Alt) key combinations act as "dead keys"
-							that don't register properly when recording:
+							On Apple keyboards, certain Option (Alt) key combinations act as
+							"dead keys" that don't register properly when recording:
 						</p>
 						<div class="flex flex-wrap gap-1 my-2">
 							{#each OPTION_DEAD_KEYS as key}


### PR DESCRIPTION
The web OS seam now treats Apple platforms more broadly than the Tauri desktop seam, so the shortcut warning copy should not say macOS when it can also show on iOS or iPadOS web surfaces. This PR changes the visible warning to Apple keyboard language while keeping the Tauri OS check desktop-specific: Apple is macOS there.

## Changelog
- Fix Option-key shortcut warnings to describe Apple keyboards instead of only macOS

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782846122&installation_id=128463665&pr_number=1869&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1869&signature=0ff53d4de4dbb91499ea338f6095ff7f9b6289828666466d1bf0b7db5d2c48e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->