### PR TITLE
docs: sweep stale references surfaced by the shared-wiki rename

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,6 @@
 # These paths contain the sync server and protocol (AGPL-3.0).
 
 /apps/api/              @braden-w
+/apps/self-host/        @braden-w
 /packages/sync/         @braden-w
-/packages/sync-client/  @braden-w
+/packages/server/       @braden-w

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,5 +20,5 @@ Use Closes #123 only when the PR fully resolves an issue.
 
 Paste screenshots or recordings for UI changes.
 
-PRs touching apps/api/, packages/sync/, or packages/sync-client/ require @braden-w review per CODEOWNERS.
+PRs touching apps/api/, apps/self-host/, packages/sync/, or packages/server/ require @braden-w review per CODEOWNERS.
 -->

--- a/.github/workflows/ci.format.yml
+++ b/.github/workflows/ci.format.yml
@@ -44,8 +44,6 @@ jobs:
         #
         # Excludes (per spec § Decisions Log):
         #   - The constants files themselves (they ARE the source of truth).
-        #   - apps/dashboard/src/lib/api.ts (same-origin deployment-internal
-        #     billing paths, scope-deferred).
         #   - *.test.ts / *.test.tsx (mock URL matchers are allowed to
         #     reference paths verbatim).
         #   - JSDoc/comment lines (descriptive prose, not constructions).
@@ -55,7 +53,7 @@ jobs:
               --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.wrangler --exclude-dir=.next \
               "['\"\`]/api/(session|owners|ai)([^a-z]|$)|['\"\`]/auth/(oauth2/[a-z]+|cli-callback)" \
               packages apps \
-              | grep -vE "packages/constants/src/(api|oauth)-routes\.ts|apps/dashboard/src/lib/api\.ts|packages/server/src/auth-pages/scripts/" \
+              | grep -vE "packages/constants/src/(api|oauth)-routes\.ts|packages/server/src/auth-pages/scripts/" \
               | grep -vE "^[^:]+:[0-9]+:[[:space:]]*(\*|//|/\*)" ; then
             echo "::error::Hardcoded API path literal found. Use API_ROUTES.* from @epicenter/constants/api-routes or OAUTH_ROUTES.* from @epicenter/constants/oauth-routes instead."
             exit 1

--- a/apps/self-host/README.md
+++ b/apps/self-host/README.md
@@ -60,7 +60,7 @@ createServerApp()
   // mountSessionApp(app, { ownership })              // GET /api/session
   // mountRoomsApp(app, { ownership })                // /api/owners/:ownerId/rooms/*
   // mountAssetsApp(app, { ownership })               // /api/owners/:ownerId/assets/*
-  // mountAiApp(app, { auth: requireBearerUser });    // POST /api/ai/chat
+  // mountAiApp(app, { auth: requireBearerUser, ownership }) // POST /api/ai/chat
 ```
 
 Deliberately absent: `mountBillingApi`, `chargeAiCreditsWithAutumn`, `syncAssetStorageWithAutumn`, any `apps/api/ui` static-asset fallback. The composition shape is the contract.

--- a/docs/architecture/account-and-document-ownership.md
+++ b/docs/architecture/account-and-document-ownership.md
@@ -65,7 +65,7 @@ guid.
 ```
 route     /api/owners/:ownerId/rooms/:room   (both modes)
 DO name   owners/${ownerId}/rooms/${room}    (room = ydoc.guid)
-builder   roomWsUrl({ baseURL, ownerId, guid: ydoc.guid, installationId })
+builder   roomWsUrl({ baseURL, ownerId, guid: ydoc.guid, deviceId })
 ```
 
 The DO partition is `owners/<ownerId>` in both modes. In personal mode

--- a/docs/articles/20260601T120000-personal-wiki-or-shared-wiki-the-permanent-refusal.md
+++ b/docs/articles/20260601T120000-personal-wiki-or-shared-wiki-the-permanent-refusal.md
@@ -26,8 +26,8 @@ Topology axis       how partitions are carved
 Once you name the axes separately, the factory functions write themselves. There is an ownership discriminant in `packages/server`, and call sites never type the discriminant directly:
 
 ```ts
-// Per-user: each identity owns their own partition
-perUser()
+// Personal: each identity owns their own partition
+personal()
 
 // Shared: one partition, members determined by admit()
 shared({ admit })

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -8,10 +8,10 @@ This page only makes claims visible in the current code:
 - `packages/workspace/src/document/attach-local-storage.ts`
 - `packages/workspace/src/document/wipe-local-storage.ts`
 - `packages/workspace/src/document/attach-encrypted-indexed-db.ts`
-- `apps/api/src/auth/encryption.ts`
-- `apps/api/src/auth/create-auth.ts`
+- `packages/server/src/auth/encryption.ts`
+- `packages/server/src/auth/create-auth.ts`
 - `packages/svelte-utils/src/session.svelte.ts`
-- `apps/api/src/room.ts`
+- `packages/server/src/room/backends/cloudflare/durable-object.ts`
 If something is not visible there, it is not presented as fact here.
 
 ## What this system is
@@ -48,14 +48,14 @@ encrypted CRDT value
 ```
 The HKDF info string at the owner derivation step is the literal `owner:{ownerId}`. The label fed into the HKDF call is the `ownerId` directly: the user's id in personal mode, the literal string `shared` in shared mode.
 
-On the server, `apps/api/src/auth/encryption.ts` reads `ENCRYPTION_SECRETS` from the worker env and calls `@epicenter/encryption`'s `deriveKeyring` to parse the root keyring and derive a per-owner keyring.
+On the server, `packages/server/src/auth/encryption.ts` reads `ENCRYPTION_SECRETS` from the worker env and calls `@epicenter/encryption`'s `deriveKeyring` to parse the root keyring and derive a per-owner keyring.
 It returns one `{ version, keyBytesBase64 }` entry per configured root keyring version.
 On the client, `createWorkspace({ id, keyring, tables, kv })` reads `keyring()` once at construction, decodes each `keyBytesBase64`, runs `deriveWorkspaceKey(ownerKey, id)`, and gets a 32-byte workspace key with `info = workspace:{id}`. The derived keyring activates every encrypted store atomically before any handle is returned.
 The highest version becomes the current key for new writes.
 
 ## How keys reach the client
 Keys come through `/api/session`.
-`apps/api/src/app.ts` mounts `GET /api/session` behind cookie-or-bearer authentication. A valid Better Auth cookie session or a valid API-audience bearer token for the user can fetch `{ user: { id, email }, ownerId, keyring }`, where `ownerId` is a branded id: the user's id in personal mode, the literal `shared` in shared mode.
+`packages/server/src/routes/session.ts` mounts `GET /api/session` behind cookie-or-bearer authentication (composed by `apps/api/worker/index.ts`). A valid Better Auth cookie session or a valid API-audience bearer token for the user can fetch `{ user: { id, email }, ownerId, keyring }`, where `ownerId` is a branded id: the user's id in personal mode, the literal `shared` in shared mode.
 `@epicenter/auth` calls `/api/session` at sign-in and at cold-boot when online, persists `{ ownerId, keyring }` alongside the OAuth grant in the persisted auth cell, and exposes them through `auth.state.ownerId` / `auth.state.keyring` whenever the auth state is not `signed-out`.
 Cold-boot offline keeps the cached `{ ownerId, keyring }` so the workspace can decrypt local Yjs data without a network roundtrip; the bearer is not attached to outbound requests until `/api/session` re-confirms the cell in this runtime.
 The workspace does not hold an independently mutable copy of the keys. `createWorkspace` takes a `keyring` callback and calls it once at construction; `attachLocalStorage` takes the same callback and calls it on every persisted update. Each encrypted store keeps the keyring derived at its `createWorkspace` boundary. Browser app session modules receive a flat `SignedIn` payload from `createSession`; that payload carries the lazy keyring reader and the stable owner:
@@ -298,7 +298,7 @@ The useful parts are clear.
 Values are encrypted before sync, the blob format is self-describing, key rotation is versioned, and the CRDT logic is reused instead of forked.
 The trust model is also clear.
 This is not a zero-knowledge design.
-The auth server can derive per-user transport keys from `ENCRYPTION_SECRETS`, while the sync relay forwards ciphertext values rather than plaintext values.
+The auth server can derive per-owner keyrings from `ENCRYPTION_SECRETS`, while the sync relay forwards ciphertext values rather than plaintext values.
 The sharp edge is logout behavior.
 App auth-transition hooks reload the browser client on logout or user switch, but an explicit in-memory key deactivation path is not present in the reviewed code.
 If you are deciding whether this architecture fits your threat model, focus on that line: the sync relay handles ciphertext values, but the deployment that owns `ENCRYPTION_SECRETS` remains inside the trust boundary.

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -85,7 +85,7 @@ The workspace bundle and the local-storage attachment cover the local-data surfa
 - `createWorkspace({ id, keyring, tables, kv })` allocates the `Y.Doc`, derives the per-workspace HKDF keyring, and constructs every encrypted table and KV store in one atomic call. The factory does not own local storage: it only allocates the doc, derives keys, and activates the encrypted CRDT wrappers.
 - `attachLocalStorage(ydoc, { server, ownerId, keyring })` opens `(server, ownerId)`-scoped encrypted IndexedDB persistence and pairs it with a matching `BroadcastChannel` under the same name. The `server` and `ownerId` are snapshotted at attach time (stable for the attachment lifetime), and `keyring` is a callback so the IDB layer picks up rotated keys on the next persisted update.
 
-The browser factory shape is (from `apps/fuji/src/lib/browser.ts`):
+The browser factory shape is (from `apps/fuji/src/lib/workspace/browser.ts`):
 ```ts
 export function openFujiBrowser({
 	signedIn,

--- a/docs/guides/consuming-epicenter-api.md
+++ b/docs/guides/consuming-epicenter-api.md
@@ -13,7 +13,7 @@
 >
 > - **Quick Start**: [`packages/workspace/README.md`](../../packages/workspace/README.md)
 > - **Multi-device sync**: [`packages/workspace/SYNC_ARCHITECTURE.md`](../../packages/workspace/SYNC_ARCHITECTURE.md)
-> - **Production wiring**: `apps/fuji/src/lib/browser.ts` (inline composition with per-row child docs), `apps/fuji/src/lib/session.ts` (session glue), `apps/tab-manager/src/lib/session.svelte.ts` (browser extension auth binding)
+> - **Production wiring**: `apps/fuji/src/lib/workspace/browser.ts` (inline composition with per-row child docs), `apps/fuji/src/lib/session.ts` (session glue), `apps/tab-manager/src/lib/session.svelte.ts` (browser extension auth binding)
 
 ## Overview
 

--- a/docs/guides/yjs-persistence-guide.md
+++ b/docs/guides/yjs-persistence-guide.md
@@ -17,7 +17,7 @@ YJS is a **CRDT (Conflict-free Replicated Data Type)** library. In Epicenter, YJ
 
 ## Current sync model
 
-The example below uses cloud sync: the client builds the URL with `roomWsUrl({ baseURL, owner, guid, installationId })` and the server resolves the room from the auth token.
+The example below uses cloud sync: the client builds the URL with `roomWsUrl({ baseURL, ownerId, guid, deviceId })` and the server resolves the room from the auth token.
 
 Each app composes its workspace inline in a browser opener:
 
@@ -37,7 +37,7 @@ export function openMyApp() {
 	});
 	const idb = attachIndexedDb(workspace.ydoc);                  // local persistence
 	const collaboration = openCollaboration(workspace.ydoc, {     // sync + presence + dispatch
-		url: roomWsUrl({ baseURL: auth.baseURL, owner, guid: workspace.ydoc.guid, installationId }),
+		url: roomWsUrl({ baseURL: auth.baseURL, ownerId, guid: workspace.ydoc.guid, deviceId }),
 		openWebSocket: auth.openWebSocket,
 		onReconnectSignal: auth.onStateChange,
 		waitFor: idb.whenLoaded,                                    // delta-only on reconnect

--- a/docs/licensing/licensing-strategy.md
+++ b/docs/licensing/licensing-strategy.md
@@ -190,7 +190,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
 
 ## Open questions and review triggers
 
-- Revisit if a meaningful external contributor lands a PR on `apps/api`, `apps/dashboard`, or `packages/sync`. Decide then whether to add CLA Assistant.
+- Revisit if a meaningful external contributor lands a PR on `apps/api`, `apps/self-host`, `packages/server`, or `packages/sync`. Decide then whether to add CLA Assistant.
 - Revisit if a specific paying customer requires a feature that AGPL would let them self-host for free. This is the trigger to populate the proprietary tier (one feature, scoped to a subdirectory). Until that happens, the tier stays empty by design.
 - Revisit if `apps/api` becomes painful to maintain as a kitchen sink, or a community member asks to self-host the sync protocol alone. This is the trigger to execute the `apps/sync-server` split.
 - Revisit if we sell self-hosted enterprise licenses. That would be the trigger for moving to a real dual-license posture (and retroactively adding CLAs).

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -11,7 +11,7 @@
  * primitive owns its auth + ownership wiring; the deployment passes only
  * the rule and any deployment policies (e.g. cloud billing middleware).
  * Sub-apps declare full URLs (including the `/api` prefix where
- * applicable). See `apps/api/src/index.ts` for the cloud composition.
+ * applicable). See `apps/api/worker/index.ts` for the cloud composition.
  */
 
 // Deploy-time admin operations (OAuth client seeding) live in each

--- a/packages/server/src/middleware/require-ownership.test.ts
+++ b/packages/server/src/middleware/require-ownership.test.ts
@@ -10,7 +10,7 @@
  *               URL `:ownerId` MUST equal `SHARED_OWNER_ID`.
  *
  * Mount the middleware on patterns that include `:ownerId` (mirroring
- * `apps/api/src/index.ts`): Hono only populates route params for handlers
+ * `apps/api/worker/index.ts`): Hono only populates route params for handlers
  * mounted at the matching pattern, so middleware mounted at `*` never
  * sees them.
  */

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -491,10 +491,10 @@ cache primitive.
 
 The `$derived` swaps handles when `fileId` changes; the `$effect` cleanup releases the old handle. Refcount 0 arms the cache's `gcTime` timer; a fresh open during the grace window cancels the pending teardown, so rapid navigation doesn't flap persistence or sync.
 
-Reference implementations: `apps/opensidian/src/lib/opensidian/browser.ts`,
+Reference implementations: `apps/opensidian/opensidian.browser.ts`,
 `apps/skills/src/lib/skills/browser.ts`,
 `apps/fuji/src/lib/workspace/browser.ts`,
-`apps/fuji/src/lib/workspace/project.ts`, `apps/honeycrisp/browser.ts`.
+`apps/fuji/src/lib/workspace/project.ts`, `apps/honeycrisp/honeycrisp.browser.ts`.
 
 ## Schema definition
 

--- a/packages/workspace/src/document/README.md
+++ b/packages/workspace/src/document/README.md
@@ -187,7 +187,7 @@ Tests live in `*.test.ts` next to the implementation. Use `createWorkspace({ id:
 
 ## Canonical references
 
-- `apps/whispering/src/lib/whispering/client.tauri.ts`: IndexedDB + BroadcastChannel + recording markdown export
+- `apps/whispering/src/lib/whispering/whispering.tauri.ts`: IndexedDB + BroadcastChannel + recording markdown export
 - `apps/fuji/src/lib/workspace/browser.ts`: encryption + IndexedDB + sync + server-owned presence
 - `apps/fuji/src/lib/workspace/project.ts`: daemon materializers and per-row body doc reads
 - `packages/workspace/README.md`: quick start

--- a/packages/workspace/src/document/dispatch.test.ts
+++ b/packages/workspace/src/document/dispatch.test.ts
@@ -9,7 +9,7 @@
  *     `dispatch_result.result` payloads.
  *
  * The relay's `dispatch_request` / `dispatch_result` round trip is covered
- * in `apps/api/src/room.test.ts`. The caller-side transport in
+ * in `packages/server/src/room/backends/cloudflare/durable-object.test.ts`. The caller-side transport in
  * `openCollaboration.dispatch` (pending map, response ceiling, abort,
  * disconnect sweep) is not yet unit-tested.
  */

--- a/specs/20260601T130000-personal-and-shared-wiki-rename.md
+++ b/specs/20260601T130000-personal-and-shared-wiki-rename.md
@@ -1,6 +1,6 @@
 # Personal and Shared Wiki: Greenfield Rename
 
-Status: proposed
+Status: executed (Phases 1-3) in PR #1874. Phase 4 (`apps/api` -> `apps/cloud`) deferred by design.
 Date: 2026-06-01
 Precondition: greenfield. No self-hosted deployment has written data under `owners/team/...`. This plan is only free to execute while that remains true.
 


### PR DESCRIPTION
PR #1874 renamed the multi-user mode from `team` to `shared` and moved `apps/team-api` to `apps/self-host`. The rename itself landed clean: a five-way audit (four code-surface passes plus an independent reviewer) plus a paranoid grep of live code, wrangler bindings, and durable strings turned up zero leftover `team` / `isMember` / `TEAM_OWNER_ID` symbols. The `'shared'` byte is consistent across the HKDF label, R2 prefix, Durable Object prefix, and IndexedDB prefix.

What the audit did surface was adjacent reference rot that the rename made newly visible. None of it is wrong behavior; all of it is documentation and config pointing at names that no longer exist. This sweeps it in four cohesive groups.

The first group finishes the rename's own paper trail. The launch article illustrated the personal factory as `perUser()`, a name the rename spec had explicitly rejected in favor of `personal()`; the spec still read `Status: proposed` after shipping; and the `apps/self-host` README's `mountAiApp` example had dropped `ownership`, redrawing the exact authorization-gap shape PR #1874 closed. The example now matches the real signature, where the AI mount takes both `auth` and `ownership`.

The second group repoints references to the deleted `apps/api/src/` tree. Server logic moved into `packages/server` and the cloud composition collapsed into `apps/api/worker/`, but `docs/encryption.md` and a few JSDoc and test comments still linked the old paths. The encryption doc's source list now points at `packages/server/src/auth/*`, the session route, and the Cloudflare durable object, and the "per-user transport keys" phrasing becomes "per-owner keyrings" to match the owner-partition model.

The third group aligns two guide examples to the live `roomWsUrl` builder, which takes `ownerId` and `deviceId` rather than the older `owner` and `installationId`, so the snippets would actually run.

The fourth group drops removed paths from CI and ownership config: `CODEOWNERS` and the PR template named a `packages/sync-client` that no longer exists and omitted both the renamed `apps/self-host` and the `packages/server` library that now holds the AGPL sync server, and the format gate carried a dead exclusion for the removed `apps/dashboard`. The licensing review-trigger list is realigned to the same current AGPL surfaces. The format-gate edit is provably outcome-neutral: the excluded path no longer matches anything.

Every code change is comment-only; there is no logic or behavior change in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782938003&installation_id=128463665&pr_number=1875&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1875&signature=2a872ef676700bc97e67b1c42dc0fcde46b7f31b9765341566011f0ae08123ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->