### PR TITLE
feat(workspace,cli): markdown_apply declarative reconcile (frontmatter v1)

### DIFF
--- a/apps/fuji/src/lib/workspace/project.ts
+++ b/apps/fuji/src/lib/workspace/project.ts
@@ -134,6 +134,10 @@ export function fuji(opts: FujiMountOptions = {}) {
 							frontmatter: { ...entry },
 							body: await readEntryBody(entry),
 						}),
+						// NOTE: no `fromMarkdown` yet, so `markdown_apply` refuses this
+						// table (it cannot round-trip the body, which lives in a separate
+						// content doc). Fuji's apply integration (body write + soft-delete
+						// onDelete) ships with the body import work.
 					},
 				},
 				git: opts.git,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,4 +1,5 @@
 import yargs from 'yargs';
+import { applyCommand } from './commands/apply.js';
 import { authCommand } from './commands/auth.js';
 import { daemonCommand } from './commands/daemon.js';
 import { listCommand } from './commands/list.js';
@@ -19,6 +20,7 @@ const REMOVED_DAEMON_COMMANDS = new Set(['up', 'down', 'ps', 'logs']);
  *   - `list`:  tree view of runnable actions (local schema is authoritative)
  *   - `run`:   invoke one by mount-prefixed action path; `--peer` dispatches over RPC
  *   - `peers`: enumerate other clients currently online via the workspace presence row
+ *   - `apply`: reconcile a mount's markdown files into its workspace (disk is desired state)
  *
  * Specs: `specs/20260421T155436-cli-scripting-first-redesign.md` (base
  * surface), `specs/20260423T174126-cli-remote-peer-rpc.md` (`peers` + `--peer`).
@@ -38,6 +40,7 @@ export function createCLI() {
 				.command(listCommand)
 				.command(peersCommand)
 				.command(runCommand)
+				.command(applyCommand)
 				.demandCommand(1)
 				.strict()
 				.exitProcess(false)

--- a/packages/cli/src/commands/apply.ts
+++ b/packages/cli/src/commands/apply.ts
@@ -4,7 +4,7 @@
  * diffs the `.md` files against the live rows (by id) and applies creates,
  * updates, and deletes via the mount's `markdown_apply` action.
  *
- * `--dry-run` prints the plan without writing. `--allow-deletes <n>` raises the
+ * `--dry-run` prints the plan without writing. `--max-deletes <n>` raises the
  * delete guard (default 10; the run refuses rather than delete more). The plan
  * is written to stdout as JSON (scripting-first); a refused plan prints its
  * reason to stderr and exits non-zero, so a guard trip is observable in scripts.
@@ -115,7 +115,13 @@ function renderApply(
 
 	const plan = result.data as ApplyPlan;
 	// Guard the wire shape: a version-mismatched daemon could return anything.
-	if (typeof plan?.refused !== 'boolean' || !Array.isArray(plan?.deletes)) {
+	// Validate every array the renderer touches, not just `refused`, so a
+	// malformed `errors` cannot throw inside the refusal path below.
+	if (
+		typeof plan?.refused !== 'boolean' ||
+		!Array.isArray(plan?.deletes) ||
+		!Array.isArray(plan?.errors)
+	) {
 		fail('unexpected markdown_apply response (daemon version mismatch?)', {
 			code: 2,
 		});

--- a/packages/cli/src/commands/apply.ts
+++ b/packages/cli/src/commands/apply.ts
@@ -1,0 +1,140 @@
+/**
+ * `epicenter apply --mount <name>`: reconcile a mount's on-disk markdown INTO
+ * its workspace through the local daemon. Disk is the desired state: the daemon
+ * diffs the `.md` files against the live rows (by id) and applies creates,
+ * updates, and deletes via the mount's `markdown_apply` action.
+ *
+ * `--dry-run` prints the plan without writing. `--allow-deletes <n>` raises the
+ * delete guard (default 10; the run refuses rather than delete more). The plan
+ * is written to stdout as JSON (scripting-first); a refused plan prints its
+ * reason to stderr and exits non-zero, so a guard trip is observable in scripts.
+ *
+ * Requires a running daemon for the discovered project (see `epicenter daemon
+ * up`). A mount whose table customizes `toMarkdown` without a `fromMarkdown`
+ * (e.g. fuji entry bodies) is refused by the action as `RoundTripUnproven`.
+ *
+ * Exit codes:
+ *   1: usage error (unknown mount/action) or no daemon
+ *   2: runtime error invoking the action
+ *   4: the plan was refused (a guard tripped; nothing applied)
+ */
+
+import {
+	type DaemonError,
+	getDaemon,
+	type InvokeError,
+} from '@epicenter/workspace/node';
+import { extractErrorMessage } from 'wellcrafted/error';
+import type { Result } from 'wellcrafted/result';
+
+import { cmd } from '../util/cmd.js';
+import { projectOption } from '../util/common-options.js';
+import {
+	fail,
+	formatOptions,
+	type OutputFormat,
+	output,
+} from '../util/format-output.js';
+
+/** Wire shape of the `markdown_apply` result (untyped JSON over the socket). */
+type ApplyPlan = {
+	refused: boolean;
+	reason?: string;
+	creates: { tableName: string; id: string }[];
+	updates: { tableName: string; id: string }[];
+	deletes: { tableName: string; id: string }[];
+	skipped: { path: string }[];
+	errors: { path: string; tableName: string; error: unknown }[];
+};
+
+export const applyCommand = cmd({
+	command: 'apply',
+	describe:
+		"Reconcile a mount's markdown files into its workspace (disk is the desired state)",
+	builder: (yargs) =>
+		yargs
+			.option('mount', {
+				type: 'string',
+				demandOption: true,
+				describe: 'Mount name to reconcile, e.g. fuji',
+			})
+			.option('dryRun', {
+				type: 'boolean',
+				default: false,
+				describe: 'Compute and print the plan without writing',
+			})
+			.option('maxDeletes', {
+				type: 'number',
+				describe:
+					'Maximum rows the run may delete before it refuses (default 10)',
+			})
+			.option('C', projectOption)
+			.options(formatOptions)
+			.strict(),
+	handler: async (argv) => {
+		const { data: daemon, error: daemonErr } = await getDaemon(argv.C);
+		if (daemonErr) {
+			fail(daemonErr.message);
+			return;
+		}
+
+		const input: { dryRun: boolean; maxDeletes?: number } = {
+			dryRun: argv.dryRun,
+		};
+		if (argv.maxDeletes !== undefined) input.maxDeletes = argv.maxDeletes;
+
+		const result = await daemon.invoke({
+			actionPath: `${argv.mount}.markdown_apply`,
+			input,
+		});
+		renderApply(result, argv.format);
+	},
+});
+
+function renderApply(
+	result: Result<unknown, InvokeError | DaemonError>,
+	format: OutputFormat | undefined,
+): void {
+	if (result.error !== null) {
+		switch (result.error.name) {
+			case 'UsageError': {
+				const details = result.error.suggestions?.length
+					? ['', 'Exposed actions at this mount:', ...result.error.suggestions]
+					: [];
+				fail(result.error.message, { details });
+				return;
+			}
+			case 'RuntimeError':
+				fail(result.error.message, { code: 2 });
+				return;
+			default:
+				fail(result.error.message);
+				return;
+		}
+	}
+
+	const plan = result.data as ApplyPlan;
+	// Guard the wire shape: a version-mismatched daemon could return anything.
+	if (typeof plan?.refused !== 'boolean' || !Array.isArray(plan?.deletes)) {
+		fail('unexpected markdown_apply response (daemon version mismatch?)', {
+			code: 2,
+		});
+		return;
+	}
+
+	// Plan to stdout (machine-readable), regardless of outcome.
+	output(plan, { format });
+
+	// A refused plan applied nothing. Surface the reason plus the offending file
+	// paths, and exit with a code distinct from runtime error so scripts can tell
+	// "ran cleanly but declined" from "failed to run".
+	if (plan.refused) {
+		const details = plan.errors.map(
+			(e) => `  ${e.path} (${e.tableName}): ${extractErrorMessage(e.error)}`,
+		);
+		fail(plan.reason ?? 'apply refused; nothing was applied', {
+			code: 4,
+			details,
+		});
+	}
+}

--- a/packages/workspace/src/document/materializer/markdown/apply.test.ts
+++ b/packages/workspace/src/document/materializer/markdown/apply.test.ts
@@ -260,6 +260,29 @@ describe('markdown_apply', () => {
 		expect(workspace.tables.posts.has('one')).toBe(false); // nothing applied
 	});
 
+	test('strips unknown frontmatter keys (no smuggled data, no churn)', async () => {
+		const { workspace, materializer } = await setup();
+		// Extra keys plus a literal __proto__ key: must not reach the stored row
+		// and must not pollute the global prototype.
+		await writePost(
+			'x',
+			'---\nid: x\ntitle: T\npublished: true\nsneaky: evil\n__proto__: pwned\n---\n',
+		);
+
+		const plan = await materializer.actions.markdown_apply({});
+		expect(plan.refused).toBe(false);
+		expect(plan.creates.map((c) => c.id)).toEqual(['x']);
+
+		const row = workspace.tables.posts.get('x').data;
+		expect(Object.hasOwn(row ?? {}, 'sneaky')).toBe(false);
+		expect((Object.prototype as Record<string, unknown>).pwned).toBeUndefined();
+
+		// Re-applying the same dirty file is a no-op: cleaned desired equals stored.
+		const again = await materializer.actions.markdown_apply({});
+		expect(again.updates).toEqual([]);
+		expect(again.creates).toEqual([]);
+	});
+
 	test('refuses a table whose toMarkdown has no fromMarkdown', async () => {
 		// toMarkdown emits a body, but with no fromMarkdown apply would silently
 		// drop it. The guard must refuse before touching anything.

--- a/packages/workspace/src/document/materializer/markdown/apply.test.ts
+++ b/packages/workspace/src/document/materializer/markdown/apply.test.ts
@@ -20,7 +20,11 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdir, rm, unlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { Type } from 'typebox';
-import { createWorkspace, DateTimeString, defineTable } from '../../../index.js';
+import {
+	createWorkspace,
+	DateTimeString,
+	defineTable,
+} from '../../../index.js';
 import { column } from '../../column/index.js';
 import { attachMarkdownMaterializer } from './materializer.js';
 
@@ -145,7 +149,11 @@ describe('markdown_apply', () => {
 	test('delete guard refuses a large deletion and applies nothing', async () => {
 		const { workspace, materializer } = await setup();
 		for (const id of ['a', 'b', 'c']) {
-			workspace.tables.posts.set({ id, title: id.toUpperCase(), published: true });
+			workspace.tables.posts.set({
+				id,
+				title: id.toUpperCase(),
+				published: true,
+			});
 		}
 		await materializer.actions.markdown_pull();
 
@@ -337,7 +345,9 @@ describe('markdown_apply', () => {
 		const materializer = attachMarkdownMaterializer(workspace, {
 			dir: TEST_DIR,
 			perTable: {
-				posts: { toMarkdown: (r) => ({ frontmatter: { ...r }, body: 'prose' }) },
+				posts: {
+					toMarkdown: (r) => ({ frontmatter: { ...r }, body: 'prose' }),
+				},
 			},
 		});
 		await materializer.whenFlushed;
@@ -366,7 +376,9 @@ describe('markdown_apply', () => {
 		await removePost('c');
 
 		// maxDeletes:0 is the escape hatch against an accidental empty dir.
-		const refused = await materializer.actions.markdown_apply({ maxDeletes: 0 });
+		const refused = await materializer.actions.markdown_apply({
+			maxDeletes: 0,
+		});
 		expect(refused.refused).toBe(true);
 		expect(workspace.tables.posts.count()).toBe(3);
 

--- a/packages/workspace/src/document/materializer/markdown/apply.test.ts
+++ b/packages/workspace/src/document/materializer/markdown/apply.test.ts
@@ -1,0 +1,312 @@
+/**
+ * markdown_apply: declarative reconcile tests.
+ *
+ * apply treats the on-disk file set as the desired state and reconciles it INTO
+ * the tables, keyed by row id:
+ *   creates = file on disk, no row
+ *   updates = row + file disagree
+ *   deletes = row exists, file gone
+ *
+ * These tests prove the design does not lose data:
+ * - dryRun computes the plan and writes nothing
+ * - a removed file deletes its row (via onDelete; default hard delete)
+ * - the delete guard refuses a large deletion and applies nothing
+ * - a parse/validation failure refuses the whole run, so a broken file never
+ *   lets an unrelated file read as a delete
+ * - apply over an unchanged tree is a no-op (round-trip with the materializer)
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdir, rm, unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { Type } from 'typebox';
+import { createWorkspace, DateTimeString, defineTable } from '../../../index.js';
+import { column } from '../../column/index.js';
+import { attachMarkdownMaterializer } from './materializer.js';
+
+const postsTable = defineTable({
+	id: column.string(),
+	title: column.string(),
+	published: column.boolean(),
+});
+
+// Exercises the non-string column types that must round-trip through YAML
+// without showing a spurious update: number, nullable, and a json array.
+const typedTable = defineTable({
+	id: column.string(),
+	rating: column.number(),
+	archivedAt: column.nullable(column.dateTime()),
+	tags: column.json(Type.Array(Type.String())),
+});
+
+const tableDefinitions = { posts: postsTable, typed: typedTable };
+
+const TEST_DIR = join(import.meta.dir, '__test-apply__');
+
+beforeEach(async () => {
+	await mkdir(TEST_DIR, { recursive: true });
+});
+
+afterEach(async () => {
+	await rm(TEST_DIR, { recursive: true, force: true });
+});
+
+async function writePost(id: string, frontmatter: string) {
+	await mkdir(join(TEST_DIR, 'posts'), { recursive: true });
+	await writeFile(join(TEST_DIR, 'posts', `${id}.md`), frontmatter, 'utf-8');
+}
+
+async function removePost(id: string) {
+	await unlink(join(TEST_DIR, 'posts', `${id}.md`));
+}
+
+const post = (id: string, title: string, published = true) =>
+	`---\nid: ${id}\ntitle: ${title}\npublished: ${published}\n---\n`;
+
+type SetupOptions = {
+	onDelete?: (id: string) => void;
+};
+
+async function setup({ onDelete }: SetupOptions = {}) {
+	const workspace = createWorkspace({
+		id: 'test-apply',
+		tables: tableDefinitions,
+		kv: {},
+	});
+	const materializer = attachMarkdownMaterializer(workspace, {
+		dir: TEST_DIR,
+		perTable: { posts: { onDelete }, typed: {} },
+	});
+	await materializer.whenFlushed;
+	return { workspace, materializer };
+}
+
+describe('markdown_apply', () => {
+	test('dryRun computes the plan and writes nothing', async () => {
+		const { workspace, materializer } = await setup();
+		workspace.tables.posts.set({ id: 'a', title: 'Alpha', published: true });
+		workspace.tables.posts.set({ id: 'b', title: 'Beta', published: true });
+
+		// Disk: a unchanged, b edited, c new, (b/c differ from table) -> a is a no-op.
+		await materializer.actions.markdown_pull();
+		await writePost('b', post('b', 'Beta EDITED'));
+		await writePost('c', post('c', 'Gamma NEW'));
+
+		const plan = await materializer.actions.markdown_apply({ dryRun: true });
+
+		expect(plan.refused).toBe(false);
+		expect(plan.creates.map((c) => c.id).sort()).toEqual(['c']);
+		expect(plan.updates.map((u) => u.id).sort()).toEqual(['b']);
+		expect(plan.deletes).toEqual([]);
+
+		// Table is untouched by a dry run.
+		expect(workspace.tables.posts.get('b').data?.title).toBe('Beta');
+		expect(workspace.tables.posts.has('c')).toBe(false);
+	});
+
+	test('applies creates, updates, and deletes', async () => {
+		const { workspace, materializer } = await setup();
+		workspace.tables.posts.set({ id: 'a', title: 'Alpha', published: true });
+		workspace.tables.posts.set({ id: 'b', title: 'Beta', published: true });
+		workspace.tables.posts.set({ id: 'c', title: 'Gamma', published: true });
+		await materializer.actions.markdown_pull();
+
+		await writePost('b', post('b', 'Beta EDITED')); // update
+		await removePost('c'); // delete
+		await writePost('d', post('d', 'Delta NEW')); // create
+
+		const plan = await materializer.actions.markdown_apply({});
+
+		expect(plan.refused).toBe(false);
+		expect(plan.creates.map((c) => c.id)).toEqual(['d']);
+		expect(plan.updates.map((u) => u.id)).toEqual(['b']);
+		expect(plan.deletes.map((x) => x.id)).toEqual(['c']);
+
+		expect(workspace.tables.posts.get('a').data?.title).toBe('Alpha'); // untouched
+		expect(workspace.tables.posts.get('b').data?.title).toBe('Beta EDITED');
+		expect(workspace.tables.posts.get('c').data).toBeNull(); // hard-deleted
+		expect(workspace.tables.posts.get('d').data?.title).toBe('Delta NEW');
+	});
+
+	test('apply over an unchanged tree is a no-op', async () => {
+		const { workspace, materializer } = await setup();
+		workspace.tables.posts.set({ id: 'a', title: 'Alpha', published: true });
+		workspace.tables.posts.set({ id: 'b', title: 'Beta', published: false });
+		await materializer.actions.markdown_pull();
+
+		const plan = await materializer.actions.markdown_apply({});
+
+		expect(plan.creates).toEqual([]);
+		expect(plan.updates).toEqual([]);
+		expect(plan.deletes).toEqual([]);
+		expect(plan.refused).toBe(false);
+	});
+
+	test('delete guard refuses a large deletion and applies nothing', async () => {
+		const { workspace, materializer } = await setup();
+		for (const id of ['a', 'b', 'c']) {
+			workspace.tables.posts.set({ id, title: id.toUpperCase(), published: true });
+		}
+		await materializer.actions.markdown_pull();
+
+		// Remove every file: 3 deletes, but cap at 1.
+		await removePost('a');
+		await removePost('b');
+		await removePost('c');
+
+		const plan = await materializer.actions.markdown_apply({ maxDeletes: 1 });
+
+		expect(plan.refused).toBe(true);
+		expect(plan.reason).toContain('deletes');
+		expect(plan.deletes).toHaveLength(3);
+		// Nothing was applied: all rows survive.
+		expect(workspace.tables.posts.count()).toBe(3);
+	});
+
+	test('a parse failure refuses the run; no unrelated row is deleted', async () => {
+		const { workspace, materializer } = await setup();
+		workspace.tables.posts.set({ id: 'a', title: 'Alpha', published: true });
+		workspace.tables.posts.set({ id: 'b', title: 'Beta', published: true });
+		await materializer.actions.markdown_pull();
+
+		// One file goes invalid (published is not a boolean) and another is removed.
+		await writePost('a', `---\nid: a\ntitle: Alpha\npublished: nope\n---\n`);
+		await removePost('b');
+
+		const plan = await materializer.actions.markdown_apply({});
+
+		expect(plan.refused).toBe(true);
+		expect(plan.errors).toHaveLength(1);
+		// The removed file did NOT delete row b, because the run was refused.
+		expect(workspace.tables.posts.has('b')).toBe(true);
+	});
+
+	test('onDelete hook handles removals instead of hard delete', async () => {
+		const softDeleted: string[] = [];
+		const { workspace, materializer } = await setup({
+			onDelete: (id) => softDeleted.push(id),
+		});
+		workspace.tables.posts.set({ id: 'a', title: 'Alpha', published: true });
+		await materializer.actions.markdown_pull();
+
+		await removePost('a');
+		const plan = await materializer.actions.markdown_apply({});
+
+		expect(plan.deletes.map((x) => x.id)).toEqual(['a']);
+		expect(softDeleted).toEqual(['a']);
+		// The hook ran instead of the default hard delete: the row is still present.
+		expect(workspace.tables.posts.has('a')).toBe(true);
+	});
+
+	test('non-string columns round-trip without a spurious update', async () => {
+		const { workspace, materializer } = await setup();
+		// number, a real datetime, a null, and a json array: the types most
+		// likely to drift through YAML and falsely register as edits.
+		workspace.tables.typed.set({
+			id: 't1',
+			rating: 4,
+			archivedAt: DateTimeString.now(),
+			tags: ['a', 'b'],
+		});
+		workspace.tables.typed.set({
+			id: 't2',
+			rating: 0,
+			archivedAt: null,
+			tags: [],
+		});
+		await materializer.actions.markdown_pull();
+
+		const plan = await materializer.actions.markdown_apply({ dryRun: true });
+
+		// Materialize then read back is the identity: nothing changed on disk.
+		expect(plan.updates).toEqual([]);
+		expect(plan.creates).toEqual([]);
+		expect(plan.deletes).toEqual([]);
+	});
+
+	test('a missing directory does not delete every row', async () => {
+		const { workspace, materializer } = await setup();
+		for (const id of ['a', 'b', 'c']) {
+			workspace.tables.posts.set({ id, title: id, published: true });
+		}
+		await materializer.actions.markdown_pull();
+
+		// Remove the whole posts directory (e.g. wrong path, unpopulated mount).
+		// A missing directory carries no desired state, so it must not read as
+		// "delete all three" even though the count is under the guard.
+		await rm(join(TEST_DIR, 'posts'), { recursive: true, force: true });
+
+		const plan = await materializer.actions.markdown_apply({});
+
+		expect(plan.refused).toBe(false);
+		expect(plan.deletes).toEqual([]);
+		expect(workspace.tables.posts.count()).toBe(3);
+	});
+
+	test('duplicate ids across files refuse the run', async () => {
+		const { workspace, materializer } = await setup();
+		await writePost('one', post('one', 'First', true));
+		// Two distinct files declaring the same id: the reconcile cannot pick one.
+		await writeFile(
+			join(TEST_DIR, 'posts', 'duplicate.md'),
+			post('one', 'Second', false),
+			'utf-8',
+		);
+
+		const plan = await materializer.actions.markdown_apply({});
+
+		expect(plan.refused).toBe(true);
+		expect(plan.errors).toHaveLength(1);
+		expect(workspace.tables.posts.has('one')).toBe(false); // nothing applied
+	});
+
+	test('refuses a table whose toMarkdown has no fromMarkdown', async () => {
+		// toMarkdown emits a body, but with no fromMarkdown apply would silently
+		// drop it. The guard must refuse before touching anything.
+		const workspace = createWorkspace({
+			id: 'test-guard',
+			tables: tableDefinitions,
+			kv: {},
+		});
+		const materializer = attachMarkdownMaterializer(workspace, {
+			dir: TEST_DIR,
+			perTable: {
+				posts: { toMarkdown: (r) => ({ frontmatter: { ...r }, body: 'prose' }) },
+			},
+		});
+		await materializer.whenFlushed;
+		workspace.tables.posts.set({ id: 'a', title: 'Alpha', published: true });
+		await materializer.actions.markdown_pull();
+
+		const plan = await materializer.actions.markdown_apply({});
+
+		expect(plan.refused).toBe(true);
+		expect((plan.errors[0]?.error as { name?: string })?.name).toBe(
+			'RoundTripUnproven',
+		);
+	});
+
+	test('an empty present directory deletes rows only under the guard', async () => {
+		const { workspace, materializer } = await setup();
+		for (const id of ['a', 'b', 'c']) {
+			workspace.tables.posts.set({ id, title: id, published: true });
+		}
+		await materializer.actions.markdown_pull();
+
+		// Remove the files but keep the (now empty) posts/ directory: this is a
+		// real "delete everything" intent, distinct from a missing directory.
+		await removePost('a');
+		await removePost('b');
+		await removePost('c');
+
+		// maxDeletes:0 is the escape hatch against an accidental empty dir.
+		const refused = await materializer.actions.markdown_apply({ maxDeletes: 0 });
+		expect(refused.refused).toBe(true);
+		expect(workspace.tables.posts.count()).toBe(3);
+
+		// Allowed: an empty present directory does delete all rows.
+		const applied = await materializer.actions.markdown_apply({});
+		expect(applied.deletes).toHaveLength(3);
+		expect(workspace.tables.posts.count()).toBe(0);
+	});
+});

--- a/packages/workspace/src/document/materializer/markdown/apply.test.ts
+++ b/packages/workspace/src/document/materializer/markdown/apply.test.ts
@@ -304,6 +304,28 @@ describe('markdown_apply', () => {
 		expect(again.creates).toEqual([]);
 	});
 
+	test('reads nested filenames so apply does not delete them', async () => {
+		// A filename that nests into a subdirectory must round-trip: a flat scan
+		// would miss it and apply would wrongly plan a delete.
+		const workspace = createWorkspace({
+			id: 'test-nested',
+			tables: tableDefinitions,
+			kv: {},
+		});
+		const materializer = attachMarkdownMaterializer(workspace, {
+			dir: TEST_DIR,
+			perTable: { posts: { filename: (r) => `archive/${r.id}.md` } },
+		});
+		await materializer.whenFlushed;
+		workspace.tables.posts.set({ id: 'a', title: 'Alpha', published: true });
+		await materializer.actions.markdown_pull(); // writes posts/archive/a.md
+
+		const plan = await materializer.actions.markdown_apply({ dryRun: true });
+		expect(plan.refused).toBe(false);
+		expect(plan.deletes).toEqual([]);
+		expect(plan.updates).toEqual([]);
+	});
+
 	test('refuses a table whose toMarkdown has no fromMarkdown', async () => {
 		// toMarkdown emits a body, but with no fromMarkdown apply would silently
 		// drop it. The guard must refuse before touching anything.

--- a/packages/workspace/src/document/materializer/markdown/apply.test.ts
+++ b/packages/workspace/src/document/materializer/markdown/apply.test.ts
@@ -198,6 +198,27 @@ describe('markdown_apply', () => {
 		expect(workspace.tables.posts.has('a')).toBe(true);
 	});
 
+	test('applies all writes in a single atomic Yjs transaction', async () => {
+		const { workspace, materializer } = await setup();
+		workspace.tables.posts.set({ id: 'a', title: 'Alpha', published: true });
+		workspace.tables.posts.set({ id: 'b', title: 'Beta', published: true });
+		await materializer.actions.markdown_pull();
+
+		await writePost('b', post('b', 'Beta EDITED')); // update
+		await removePost('a'); // delete
+		await writePost('c', post('c', 'Gamma')); // create
+
+		let updates = 0;
+		const onUpdate = () => updates++;
+		workspace.ydoc.on('update', onUpdate);
+		await materializer.actions.markdown_apply({});
+		workspace.ydoc.off('update', onUpdate);
+
+		// Create + update + delete land as ONE update, not three: peers never see
+		// a half-applied reconcile.
+		expect(updates).toBe(1);
+	});
+
 	test('non-string columns round-trip without a spurious update', async () => {
 		const { workspace, materializer } = await setup();
 		// number, a real datetime, a null, and a json array: the types most

--- a/packages/workspace/src/document/materializer/markdown/index.ts
+++ b/packages/workspace/src/document/materializer/markdown/index.ts
@@ -1,7 +1,9 @@
 export {
+	type ApplyPlan,
 	attachMarkdownMaterializer,
 	type GitAutosaveConfig,
 	type MarkdownMaterializer,
+	MaterializerApplyError,
 	MaterializerPushError,
 	type PushEvent,
 	type PushResult,

--- a/packages/workspace/src/document/materializer/markdown/materializer.ts
+++ b/packages/workspace/src/document/materializer/markdown/materializer.ts
@@ -75,6 +75,25 @@ export const MaterializerPushError = defineErrors({
 });
 export type MaterializerPushError = InferErrors<typeof MaterializerPushError>;
 
+export const MaterializerApplyError = defineErrors({
+	/** Two files on disk declare the same row `id`; the reconcile can't pick one. */
+	DuplicateId: ({ id, paths }: { id: string; paths: [string, string] }) => ({
+		message: `Two files declare id "${id}": ${paths.join(' and ')}. Remove one before applying.`,
+		id,
+		paths,
+	}),
+	/**
+	 * The table customizes `toMarkdown` but provides no `fromMarkdown`, so apply
+	 * cannot prove it round-trips (e.g. fuji writes a body its parser would drop).
+	 * Refusing is the safe move: a silently-discarded body is data loss.
+	 */
+	RoundTripUnproven: ({ tableName }: { tableName: string }) => ({
+		message: `Table "${tableName}" customizes toMarkdown but has no fromMarkdown; markdown_apply cannot round-trip it without silently dropping data. Add a fromMarkdown to enable apply for this table.`,
+		tableName,
+	}),
+});
+export type MaterializerApplyError = InferErrors<typeof MaterializerApplyError>;
+
 /**
  * A single event emitted during `push`. Three kinds:
  *
@@ -112,6 +131,44 @@ export type PushResult = {
 };
 
 /**
+ * Outcome of reading one `.md` file: a validated row, a non-note (skipped), or
+ * a failure. Shared by `push` (commit each row) and `apply` (diff the set).
+ */
+type ReadResult =
+	| { kind: 'row'; id: string; row: BaseRow; path: string }
+	| { kind: 'skipped'; path: string }
+	| {
+			kind: 'error';
+			path: string;
+			tableName: string;
+			error: MaterializerPushError | TableParseError;
+	  };
+
+/**
+ * The diff `markdown_apply` computes between the on-disk file set (desired) and
+ * the live valid rows (current), keyed by row `id`. When `refused` is true a
+ * guard tripped and NOTHING was applied; the plan still reports what would have
+ * happened. `creates`/`updates`/`deletes` carry ids only; `skipped`/`errors`
+ * carry the offending file path so a caller can surface them.
+ */
+export type ApplyPlan = {
+	refused: boolean;
+	reason?: string;
+	creates: { tableName: string; id: string }[];
+	updates: { tableName: string; id: string }[];
+	deletes: { tableName: string; id: string }[];
+	skipped: { path: string }[];
+	errors: { path: string; tableName: string; error: unknown }[];
+};
+
+/**
+ * Default ceiling on deletes in one `markdown_apply`. A run that would remove
+ * more rows than this refuses and reports the plan instead, so a stale or
+ * partial checkout cannot wipe a workspace. Raise per-call via `maxDeletes`.
+ */
+const DEFAULT_MAX_DELETES = 10;
+
+/**
  * Symmetric shape of a parsed markdown file. `toMarkdown` produces it,
  * `fromMarkdown` consumes it: `Parameters<fromMarkdown>[0]` ≡ `ReturnType<toMarkdown>`.
  */
@@ -131,8 +188,22 @@ export type MarkdownTableConfig<TRow extends BaseRow> = {
 	filename?: (row: TRow) => MaybePromise<string>;
 	/** Produce frontmatter + body for a row. Default: `{ frontmatter: row, body: undefined }`. */
 	toMarkdown?: (row: TRow) => MaybePromise<MarkdownShape>;
-	/** Parse frontmatter + body back into a row. Default: `parsed.frontmatter as TRow`. */
+	/**
+	 * Parse frontmatter + body back into a row. Default: `parsed.frontmatter as TRow`.
+	 *
+	 * For `markdown_apply` to be stable, this must be the exact inverse of
+	 * `toMarkdown`: a materialize-then-parse round trip has to reproduce the same
+	 * row, or apply reads every run as a spurious update. In particular keep
+	 * nullable columns symmetric (emit and parse `null`, do not drop the key),
+	 * since `Value.Equal` treats `null` and missing as different.
+	 */
 	fromMarkdown?: (parsed: MarkdownShape) => MaybePromise<TRow>;
+	/**
+	 * How `markdown_apply` removes a row whose `.md` file disappeared from disk.
+	 * Default: hard `table.delete(id)`. Pass a soft-delete (e.g. set `deletedAt`)
+	 * for tables that keep tombstones, so the removal still syncs to peers.
+	 */
+	onDelete?: (id: string) => MaybePromise<void>;
 };
 
 /**
@@ -196,6 +267,62 @@ async function rowToMarkdownFile<TRow extends BaseRow>(
 			: undefined;
 	const content = assembleMarkdown(shape.frontmatter, body);
 	return { filename, content };
+}
+
+/**
+ * Read one `.md` file into a validated row. The disk-to-row half shared by
+ * `push` (which then commits each row) and `apply` (which diffs the set):
+ * read, parse frontmatter, run `fromMarkdown`, validate against the latest
+ * schema. Never mutates the table. `path` is relative to the materializer base
+ * so two tables writing the same filename stay distinguishable.
+ */
+async function readTableFile(
+	entry: RegisteredTable,
+	directory: string,
+	subdir: string,
+	filename: string,
+): Promise<ReadResult> {
+	const tableName = entry.table.name;
+	const path = join(subdir, filename);
+
+	const { data: content, error: readError } = await tryAsync({
+		try: () => readFile(join(directory, filename), 'utf-8'),
+		catch: (cause) => MaterializerPushError.ReadFailed({ cause }),
+	});
+	if (readError) return { kind: 'error', path, tableName, error: readError };
+
+	const parsed = parseMarkdownFile(content);
+	if (!parsed) return { kind: 'skipped', path };
+
+	const fromMarkdown: (p: MarkdownShape) => MaybePromise<BaseRow> =
+		entry.config.fromMarkdown ?? defaultFromMarkdown;
+	const { data: row, error: callbackError } = await tryAsync({
+		try: async () => fromMarkdown(parsed),
+		catch: (cause) =>
+			MaterializerPushError.FromMarkdownCallbackFailed({ cause }),
+	});
+	if (callbackError)
+		return { kind: 'error', path, tableName, error: callbackError };
+	if (row == null) return { kind: 'skipped', path };
+
+	// Capture id before the type guard: a failed `Value.Check` narrows `row` to
+	// `never` in its false branch, so `row.id` is unreachable inside the block.
+	const rowId = row.id;
+	const latestSchema = entry.table.schema;
+	if (!Value.Check(latestSchema, row)) {
+		const errors = [...Value.Errors(latestSchema, row)].map((e) => ({
+			path: e.instancePath,
+			message: e.message,
+		}));
+		const { error: validationError } = TableParseError.ValidationFailed({
+			id: rowId,
+			errors,
+			row,
+		});
+		return { kind: 'error', path, tableName, error: validationError };
+	}
+
+	return { kind: 'row', id: rowId, row, path };
 }
 
 /**
@@ -440,90 +567,61 @@ export function attachMarkdownMaterializer<TTables extends TablesRecord>(
 
 	const whenFlushed = initialize();
 
+	// ── Disk read (shared by push + apply) ──────────────────────
+
+	// Read every `.md` in one table's directory into validated rows. `present`
+	// distinguishes a MISSING directory (cannot be read, so it carries no
+	// desired-state signal) from an EMPTY one (read fine, genuinely zero files):
+	// `apply` must not treat "directory gone" as "delete every row".
+	async function readTableDir(
+		entry: RegisteredTable,
+	): Promise<{ present: boolean; results: ReadResult[] }> {
+		const baseDir = await resolveDir();
+		const subdir = entry.config.dir ?? entry.table.name;
+		const directory = join(baseDir, subdir);
+
+		let files: string[];
+		try {
+			files = await readdir(directory);
+		} catch {
+			return { present: false, results: [] };
+		}
+
+		const results: ReadResult[] = [];
+		for (const filename of files) {
+			if (!filename.endsWith('.md')) continue;
+			results.push(await readTableFile(entry, directory, subdir, filename));
+		}
+		return { present: true, results };
+	}
+
 	// ── Push (imports markdown files into workspace tables) ─────
 
 	async function pushMarkdownFiles(): Promise<PushResult> {
-		const baseDir = await resolveDir();
 		const events: PushEvent[] = [];
 
 		for (const entry of registered.values()) {
 			const tableName = entry.table.name;
-			const subdir = entry.config.dir ?? tableName;
-			const directory = join(baseDir, subdir);
-
-			let files: string[];
-			try {
-				files = await readdir(directory);
-			} catch {
-				continue; // whole directory missing → silently skip the table
-			}
-
-			for (const filename of files) {
-				if (!filename.endsWith('.md')) continue;
-
-				// Relative to the materializer's base dir; disambiguates two
-				// tables writing files with the same name.
-				const path = join(subdir, filename);
-
-				// 1. Read
-				const { data: content, error: readError } = await tryAsync({
-					try: () => readFile(join(directory, filename), 'utf-8'),
-					catch: (cause) => MaterializerPushError.ReadFailed({ cause }),
-				});
-				if (readError) {
-					events.push({ kind: 'error', path, tableName, error: readError });
-					continue;
-				}
-
-				// 2. Parse frontmatter
-				const parsed = parseMarkdownFile(content);
-				if (!parsed) {
-					events.push({ kind: 'skipped', path });
-					continue;
-				}
-
-				// 3. Run user's fromMarkdown (or default), capture throws as errors
-				const fromMarkdown: (p: MarkdownShape) => MaybePromise<BaseRow> =
-					entry.config.fromMarkdown ?? defaultFromMarkdown;
-				const { data: row, error: callbackError } = await tryAsync({
-					try: async () => fromMarkdown(parsed),
-					catch: (cause) =>
-						MaterializerPushError.FromMarkdownCallbackFailed({ cause }),
-				});
-				if (callbackError) {
-					events.push({ kind: 'error', path, tableName, error: callbackError });
-					continue;
-				}
-				// tryAsync invariant: row is non-null once error is null; satisfies TS.
-				if (row == null) continue;
-
-				// 4. Validate the returned row against the latest schema.
-				//    `fromMarkdown` returns a user-facing row (no `_v`); validate
-				//    directly against the latest version's TObject.
-				const rowId = row.id;
-				const latestSchema = entry.table.schema;
-				if (!Value.Check(latestSchema, row)) {
-					const errors = [...Value.Errors(latestSchema, row)].map((e) => ({
-						path: e.instancePath,
-						message: e.message,
-					}));
-					const { error: validationError } = TableParseError.ValidationFailed({
-						id: rowId,
-						errors,
-						row,
+			const { results } = await readTableDir(entry);
+			for (const result of results) {
+				if (result.kind === 'row') {
+					entry.table.set(result.row);
+					events.push({
+						kind: 'imported',
+						path: result.path,
+						tableName,
+						id: result.id,
 					});
+				} else if (result.kind === 'skipped') {
+					events.push({ kind: 'skipped', path: result.path });
+				} else {
 					events.push({
 						kind: 'error',
-						path,
+						path: result.path,
 						tableName,
-						error: validationError,
+						error: result.error,
 					});
-					continue;
 				}
-
-				// 5. Commit
-				entry.table.set(row);
-				events.push({ kind: 'imported', path, tableName, id: rowId });
 			}
 		}
 
@@ -547,6 +645,137 @@ export function attachMarkdownMaterializer<TTables extends TablesRecord>(
 		}
 
 		return { imported, skipped, errored, events };
+	}
+
+	// ── Apply (declarative reconcile: disk is the desired state) ─
+
+	/**
+	 * Reconcile the on-disk file set INTO the tables, keyed by row `id`. The
+	 * inverse of materialize, and the safe form of "push everything up":
+	 *
+	 *   creates = ids on disk but not in the table
+	 *   updates = ids in both whose row fields differ
+	 *   deletes = ids in the table (valid rows) but not on disk
+	 *
+	 * Guards before any write: a parse/validation error or a duplicate id on ANY
+	 * file, or a delete count over `maxDeletes`, refuses the whole run and returns
+	 * the plan unapplied (so a stale checkout cannot silently wipe rows). A table
+	 * whose directory is MISSING contributes no deletes (a directory that cannot
+	 * be read is no signal, not "delete everything"). `dryRun` returns the same
+	 * plan without writing. Deletes route through the per-table `onDelete` hook
+	 * (default hard delete; pass soft-delete to keep tombstones).
+	 *
+	 * Single-writer assumption: apply snapshots `getAllValid()` then writes. It
+	 * does not guard against a remote sync update landing mid-run, so reconcile
+	 * from one place at a time (the daemon, or one device). Yjs still converges;
+	 * this is about not racing the plan, not about corruption.
+	 */
+	async function applyMarkdownFiles({
+		dryRun = false,
+		maxDeletes = DEFAULT_MAX_DELETES,
+	}: { dryRun?: boolean; maxDeletes?: number } = {}): Promise<ApplyPlan> {
+		const plan: ApplyPlan = {
+			refused: false,
+			creates: [],
+			updates: [],
+			deletes: [],
+			skipped: [],
+			errors: [],
+		};
+
+		// Compute every table's diff first; apply nothing until all guards pass.
+		const work: {
+			entry: RegisteredTable;
+			writes: BaseRow[];
+			deletes: string[];
+		}[] = [];
+
+		for (const entry of registered.values()) {
+			const tableName = entry.table.name;
+
+			// A custom toMarkdown with no inverse cannot be safely reconciled: apply
+			// would import only the frontmatter and silently drop whatever else
+			// toMarkdown emitted (e.g. a body in a separate doc). Refuse the table.
+			if (entry.config.toMarkdown && !entry.config.fromMarkdown) {
+				const { error } = MaterializerApplyError.RoundTripUnproven({ tableName });
+				plan.errors.push({ path: `${entry.config.dir ?? tableName}/`, tableName, error });
+				continue;
+			}
+
+			const { present, results } = await readTableDir(entry);
+			const desired = new Map<string, { row: BaseRow; path: string }>();
+			for (const result of results) {
+				if (result.kind === 'skipped') {
+					plan.skipped.push({ path: result.path });
+				} else if (result.kind === 'error') {
+					plan.errors.push({ path: result.path, tableName, error: result.error });
+				} else {
+					const prior = desired.get(result.id);
+					if (prior) {
+						const { error } = MaterializerApplyError.DuplicateId({
+							id: result.id,
+							paths: [prior.path, result.path],
+						});
+						plan.errors.push({ path: result.path, tableName, error });
+					} else {
+						desired.set(result.id, { row: result.row, path: result.path });
+					}
+				}
+			}
+
+			const current = new Map<string, BaseRow>();
+			for (const row of entry.table.getAllValid()) current.set(row.id, row);
+
+			const writes: BaseRow[] = [];
+			const deletes: string[] = [];
+
+			for (const [id, { row }] of desired) {
+				const existing = current.get(id);
+				if (existing === undefined) {
+					writes.push(row);
+					plan.creates.push({ tableName, id });
+				} else if (!Value.Equal(existing, row)) {
+					writes.push(row);
+					plan.updates.push({ tableName, id });
+				}
+			}
+			// Deletes only when the directory is genuinely present: a row whose
+			// file disappeared from an existing directory was removed on purpose;
+			// a missing directory tells us nothing about deletions.
+			if (present) {
+				for (const id of current.keys()) {
+					if (!desired.has(id)) {
+						deletes.push(id);
+						plan.deletes.push({ tableName, id });
+					}
+				}
+			}
+
+			work.push({ entry, writes, deletes });
+		}
+
+		// Guards: a broken file must never read as a delete, and a large deletion
+		// is refused rather than applied.
+		if (plan.errors.length > 0) {
+			plan.refused = true;
+			plan.reason = `${plan.errors.length} file(s) could not be applied (parse, validation, or duplicate id); refusing to apply.`;
+			return plan;
+		}
+		if (plan.deletes.length > maxDeletes) {
+			plan.refused = true;
+			plan.reason = `${plan.deletes.length} deletes exceed maxDeletes=${maxDeletes}; refusing to apply. Re-run with a higher limit to confirm.`;
+			return plan;
+		}
+		if (dryRun) return plan;
+
+		for (const { entry, writes, deletes } of work) {
+			for (const row of writes) entry.table.set(row);
+			const onDelete =
+				entry.config.onDelete ?? ((id: string) => entry.table.delete(id));
+			for (const id of deletes) await onDelete(id);
+		}
+
+		return plan;
 	}
 
 	// ── Rebuild (destructive: wipe output dir and re-materialize) ─
@@ -665,6 +894,26 @@ export function attachMarkdownMaterializer<TTables extends TablesRecord>(
 					),
 				}),
 				handler: ({ tableName }) => rebuildMarkdownFiles(tableName),
+			}),
+			markdown_apply: defineMutation({
+				title: 'Apply Markdown',
+				description:
+					'Declaratively reconcile .md files into registered tables, keyed by row id: create new files, update changed rows, and delete rows whose file disappeared. Refuses if any file fails to parse/validate or if deletes exceed the limit. Use dryRun to preview the plan.',
+				input: Type.Object({
+					dryRun: Type.Optional(
+						Type.Boolean({
+							description: 'Compute and return the plan without writing.',
+						}),
+					),
+					maxDeletes: Type.Optional(
+						Type.Number({
+							description:
+								'Refuse the run if it would delete more rows than this. Default 10.',
+						}),
+					),
+				}),
+				handler: ({ dryRun, maxDeletes }) =>
+					applyMarkdownFiles({ dryRun, maxDeletes }),
 			}),
 		}),
 	};

--- a/packages/workspace/src/document/materializer/markdown/materializer.ts
+++ b/packages/workspace/src/document/materializer/markdown/materializer.ts
@@ -202,8 +202,10 @@ export type MarkdownTableConfig<TRow extends BaseRow> = {
 	 * How `markdown_apply` removes a row whose `.md` file disappeared from disk.
 	 * Default: hard `table.delete(id)`. Pass a soft-delete (e.g. set `deletedAt`)
 	 * for tables that keep tombstones, so the removal still syncs to peers.
+	 * Must be synchronous so apply can run every write inside one Yjs
+	 * transaction (atomic, single propagated update).
 	 */
-	onDelete?: (id: string) => MaybePromise<void>;
+	onDelete?: (id: string) => void;
 };
 
 /**
@@ -589,8 +591,13 @@ export function attachMarkdownMaterializer<TTables extends TablesRecord>(
 		let files: string[];
 		try {
 			files = await readdir(directory);
-		} catch {
-			return { present: false, results: [] };
+		} catch (cause) {
+			// Only a genuinely absent directory is "no signal". A permission or IO
+			// error must surface, not be mistaken for "delete everything".
+			if ((cause as NodeJS.ErrnoException)?.code === 'ENOENT') {
+				return { present: false, results: [] };
+			}
+			throw cause;
 		}
 
 		const results: ReadResult[] = [];
@@ -675,6 +682,11 @@ export function attachMarkdownMaterializer<TTables extends TablesRecord>(
 	 * does not guard against a remote sync update landing mid-run, so reconcile
 	 * from one place at a time (the daemon, or one device). Yjs still converges;
 	 * this is about not racing the plan, not about corruption.
+	 *
+	 * Boundaries: scans are flat (one level per table directory), so a table
+	 * whose `filename` nests into subdirectories is not apply-supported. And the
+	 * frontmatter `id` is trusted to target a row, so apply assumes a
+	 * single-owner directory; do not point it at untrusted disk.
 	 */
 	async function applyMarkdownFiles({
 		dryRun = false,
@@ -774,12 +786,16 @@ export function attachMarkdownMaterializer<TTables extends TablesRecord>(
 		}
 		if (dryRun) return plan;
 
-		for (const { entry, writes, deletes } of work) {
-			for (const row of writes) entry.table.set(row);
-			const onDelete =
-				entry.config.onDelete ?? ((id: string) => entry.table.delete(id));
-			for (const id of deletes) await onDelete(id);
-		}
+		// One transaction over every write: peers and observers see the whole
+		// reconcile as a single atomic update, never a half-applied intermediate.
+		ydoc.transact(() => {
+			for (const { entry, writes, deletes } of work) {
+				for (const row of writes) entry.table.set(row);
+				const onDelete =
+					entry.config.onDelete ?? ((id: string) => entry.table.delete(id));
+				for (const id of deletes) onDelete(id);
+			}
+		});
 
 		return plan;
 	}

--- a/packages/workspace/src/document/materializer/markdown/materializer.ts
+++ b/packages/workspace/src/document/materializer/markdown/materializer.ts
@@ -577,10 +577,14 @@ export function attachMarkdownMaterializer<TTables extends TablesRecord>(
 
 	// ── Disk read (shared by push + apply) ──────────────────────
 
-	// Read every `.md` in one table's directory into validated rows. `present`
+	// Read every `.md` under one table's directory into validated rows. `present`
 	// distinguishes a MISSING directory (cannot be read, so it carries no
 	// desired-state signal) from an EMPTY one (read fine, genuinely zero files):
 	// `apply` must not treat "directory gone" as "delete every row".
+	//
+	// Recursive so it stays symmetric with the write side: `filename` callbacks
+	// (and `writeMarkdownFile`) may nest into subdirectories, so a one-level scan
+	// would miss those files and `apply` would then read them as deletes.
 	async function readTableDir(
 		entry: RegisteredTable,
 	): Promise<{ present: boolean; results: ReadResult[] }> {
@@ -588,9 +592,9 @@ export function attachMarkdownMaterializer<TTables extends TablesRecord>(
 		const subdir = entry.config.dir ?? entry.table.name;
 		const directory = join(baseDir, subdir);
 
-		let files: string[];
+		let entries: string[];
 		try {
-			files = await readdir(directory);
+			entries = await readdir(directory, { recursive: true });
 		} catch (cause) {
 			// Only a genuinely absent directory is "no signal". A permission or IO
 			// error must surface, not be mistaken for "delete everything".
@@ -601,9 +605,10 @@ export function attachMarkdownMaterializer<TTables extends TablesRecord>(
 		}
 
 		const results: ReadResult[] = [];
-		for (const filename of files) {
-			if (!filename.endsWith('.md')) continue;
-			results.push(await readTableFile(entry, directory, subdir, filename));
+		for (const relative of entries) {
+			// Recursive readdir yields directory entries too; only `.md` files parse.
+			if (!relative.endsWith('.md')) continue;
+			results.push(await readTableFile(entry, directory, subdir, relative));
 		}
 		return { present: true, results };
 	}
@@ -683,10 +688,9 @@ export function attachMarkdownMaterializer<TTables extends TablesRecord>(
 	 * from one place at a time (the daemon, or one device). Yjs still converges;
 	 * this is about not racing the plan, not about corruption.
 	 *
-	 * Boundaries: scans are flat (one level per table directory), so a table
-	 * whose `filename` nests into subdirectories is not apply-supported. And the
-	 * frontmatter `id` is trusted to target a row, so apply assumes a
-	 * single-owner directory; do not point it at untrusted disk.
+	 * Boundary: the frontmatter `id` is trusted to target a row, so apply assumes
+	 * a single-owner directory; do not point it at untrusted disk. (Reads are
+	 * recursive, so nested `filename` layouts round-trip symmetrically.)
 	 */
 	async function applyMarkdownFiles({
 		dryRun = false,

--- a/packages/workspace/src/document/materializer/markdown/materializer.ts
+++ b/packages/workspace/src/document/materializer/markdown/materializer.ts
@@ -695,7 +695,10 @@ export function attachMarkdownMaterializer<TTables extends TablesRecord>(
 	async function applyMarkdownFiles({
 		dryRun = false,
 		maxDeletes = DEFAULT_MAX_DELETES,
-	}: { dryRun?: boolean; maxDeletes?: number } = {}): Promise<ApplyPlan> {
+	}: {
+		dryRun?: boolean;
+		maxDeletes?: number;
+	} = {}): Promise<ApplyPlan> {
 		const plan: ApplyPlan = {
 			refused: false,
 			creates: [],
@@ -719,8 +722,14 @@ export function attachMarkdownMaterializer<TTables extends TablesRecord>(
 			// would import only the frontmatter and silently drop whatever else
 			// toMarkdown emitted (e.g. a body in a separate doc). Refuse the table.
 			if (entry.config.toMarkdown && !entry.config.fromMarkdown) {
-				const { error } = MaterializerApplyError.RoundTripUnproven({ tableName });
-				plan.errors.push({ path: `${entry.config.dir ?? tableName}/`, tableName, error });
+				const { error } = MaterializerApplyError.RoundTripUnproven({
+					tableName,
+				});
+				plan.errors.push({
+					path: `${entry.config.dir ?? tableName}/`,
+					tableName,
+					error,
+				});
 				continue;
 			}
 
@@ -730,7 +739,11 @@ export function attachMarkdownMaterializer<TTables extends TablesRecord>(
 				if (result.kind === 'skipped') {
 					plan.skipped.push({ path: result.path });
 				} else if (result.kind === 'error') {
-					plan.errors.push({ path: result.path, tableName, error: result.error });
+					plan.errors.push({
+						path: result.path,
+						tableName,
+						error: result.error,
+					});
 				} else {
 					const prior = desired.get(result.id);
 					if (prior) {

--- a/packages/workspace/src/document/materializer/markdown/materializer.ts
+++ b/packages/workspace/src/document/materializer/markdown/materializer.ts
@@ -305,24 +305,30 @@ async function readTableFile(
 		return { kind: 'error', path, tableName, error: callbackError };
 	if (row == null) return { kind: 'skipped', path };
 
-	// Capture id before the type guard: a failed `Value.Check` narrows `row` to
-	// `never` in its false branch, so `row.id` is unreachable inside the block.
-	const rowId = row.id;
+	// Strip any frontmatter key not in the schema BEFORE validating or storing.
+	// TypeBox objects allow additional properties, so without this a hand-edited
+	// file could smuggle arbitrary keys (including a literal `__proto__`) into the
+	// stored row, and unknown keys would also churn every apply as a false diff.
 	const latestSchema = entry.table.schema;
-	if (!Value.Check(latestSchema, row)) {
-		const errors = [...Value.Errors(latestSchema, row)].map((e) => ({
+	const cleaned = Value.Clean(latestSchema, row) as BaseRow;
+
+	// Capture id before the type guard: a failed `Value.Check` narrows the value
+	// to `never` in its false branch, so `.id` is unreachable inside the block.
+	const rowId = cleaned.id;
+	if (!Value.Check(latestSchema, cleaned)) {
+		const errors = [...Value.Errors(latestSchema, cleaned)].map((e) => ({
 			path: e.instancePath,
 			message: e.message,
 		}));
 		const { error: validationError } = TableParseError.ValidationFailed({
 			id: rowId,
 			errors,
-			row,
+			row: cleaned,
 		});
 		return { kind: 'error', path, tableName, error: validationError };
 	}
 
-	return { kind: 'row', id: rowId, row, path };
+	return { kind: 'row', id: rowId, row: cleaned, path };
 }
 
 /**

--- a/packages/workspace/src/document/materializer/markdown/reconcile-e2e.test.ts
+++ b/packages/workspace/src/document/materializer/markdown/reconcile-e2e.test.ts
@@ -1,0 +1,172 @@
+/**
+ * End-to-end reconcile: two peers converge through Yjs.
+ *
+ * This is the two-vault scenario compressed into one process. Two independent
+ * workspaces (peer A, peer B) are wired so each Yjs update flows to the other,
+ * exactly as the relay would carry it between two machines. Each peer
+ * materializes the same workspace to its own directory.
+ *
+ * The proof: edit markdown in peer A's directory, run `markdown_apply` on A,
+ * and peer B's directory converges to byte-identical output without any direct
+ * file copy. That single assertion exercises the whole loop:
+ *
+ *   apply (disk -> Yjs)  ->  Yjs update propagates  ->  B re-materializes (Yjs -> disk)
+ *   ->  deterministic output means dirA == dirB
+ *
+ * No relay, no cloud, no auth: the wire is `Y.applyUpdate`. If this converges,
+ * the real two-vault case converges too, because the only added piece there is
+ * a network in place of the function call.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { Type } from 'typebox';
+import * as Y from 'yjs';
+import { createWorkspace, defineTable } from '../../../index.js';
+import { column } from '../../column/index.js';
+import { attachMarkdownMaterializer } from './materializer.js';
+
+const postsTable = defineTable({
+	id: column.string(),
+	title: column.string(),
+	tags: column.json(Type.Array(Type.String())),
+	published: column.boolean(),
+});
+
+const tableDefinitions = { posts: postsTable };
+
+const ROOT = join(import.meta.dir, '__test-e2e__');
+const DIR_A = join(ROOT, 'peer-a');
+const DIR_B = join(ROOT, 'peer-b');
+
+beforeEach(async () => {
+	await mkdir(ROOT, { recursive: true });
+});
+
+afterEach(async () => {
+	await rm(ROOT, { recursive: true, force: true });
+});
+
+/** Read a peer's posts directory into a `{ filename: content }` map. */
+async function readTree(dir: string): Promise<Record<string, string>> {
+	const postsDir = join(dir, 'posts');
+	let names: string[];
+	try {
+		names = (await readdir(postsDir)).filter((n) => n.endsWith('.md'));
+	} catch {
+		return {};
+	}
+	const tree: Record<string, string> = {};
+	for (const name of names.sort()) {
+		tree[name] = await readFile(join(postsDir, name), 'utf-8');
+	}
+	return tree;
+}
+
+/** Poll until `predicate()` holds or the deadline passes. */
+async function waitUntil(
+	predicate: () => Promise<boolean>,
+	{ timeoutMs = 3000, stepMs = 25 } = {},
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await predicate()) return;
+		await new Promise((r) => setTimeout(r, stepMs));
+	}
+	throw new Error('waitUntil: predicate never became true');
+}
+
+async function treeKeys(dir: string): Promise<string[]> {
+	return Object.keys(await readTree(dir)).sort();
+}
+
+/** Two workspaces wired so every update on one is applied to the other. */
+async function setupPeers() {
+	const a = createWorkspace({ id: 'e2e', tables: tableDefinitions, kv: {} });
+	const b = createWorkspace({ id: 'e2e', tables: tableDefinitions, kv: {} });
+
+	// The "relay": forward updates both ways. The origin sentinel stops the echo.
+	const SYNC = 'peer-sync';
+	a.ydoc.on('update', (update: Uint8Array, origin: unknown) => {
+		if (origin !== SYNC) Y.applyUpdate(b.ydoc, update, SYNC);
+	});
+	b.ydoc.on('update', (update: Uint8Array, origin: unknown) => {
+		if (origin !== SYNC) Y.applyUpdate(a.ydoc, update, SYNC);
+	});
+
+	const matA = attachMarkdownMaterializer(a, {
+		dir: DIR_A,
+		perTable: { posts: {} },
+	});
+	const matB = attachMarkdownMaterializer(b, {
+		dir: DIR_B,
+		perTable: { posts: {} },
+	});
+	await Promise.all([matA.whenFlushed, matB.whenFlushed]);
+
+	return { a, b, matA, matB };
+}
+
+describe('two-peer reconcile convergence', () => {
+	test('an apply on peer A converges peer B byte-for-byte', async () => {
+		const { a, b, matA } = await setupPeers();
+
+		// Seed shared state through A; it propagates to B.
+		a.tables.posts.set({ id: 'a', title: 'Alpha', tags: ['x'], published: true });
+		a.tables.posts.set({ id: 'b', title: 'Beta', tags: [], published: true });
+		a.tables.posts.set({ id: 'c', title: 'Gamma', tags: ['y'], published: true });
+
+		// Both peers materialize the same three files. Wait on B's Y.Doc, not the
+		// files, so we know the update actually crossed before we edit.
+		await waitUntil(async () => b.tables.posts.count() === 3);
+		await waitUntil(async () => {
+			const keys = await treeKeys(DIR_B);
+			return keys.length === 3;
+		});
+
+		// "Agent" edits peer A's directory: edit one, remove one, add one.
+		const beta = join(DIR_A, 'posts', 'b.md');
+		await writeFile(
+			beta,
+			(await readFile(beta, 'utf-8')).replace('title: Beta', 'title: Beta EDITED'),
+			'utf-8',
+		);
+		await rm(join(DIR_A, 'posts', 'c.md'));
+		await writeFile(
+			join(DIR_A, 'posts', 'd.md'),
+			'---\nid: d\ntitle: Delta\ntags: []\npublished: false\n---\n',
+			'utf-8',
+		);
+
+		// Reconcile A's disk into A's Yjs. This is the only action taken.
+		const plan = await matA.actions.markdown_apply({});
+		expect(plan.refused).toBe(false);
+		expect(plan.updates.map((u) => u.id)).toEqual(['b']);
+		expect(plan.deletes.map((x) => x.id)).toEqual(['c']);
+		expect(plan.creates.map((c) => c.id)).toEqual(['d']);
+
+		// The far side converges through Yjs alone, no file copy. Gate on the
+		// PRECISE end state (b edited, c gone, d created) in peer B's OWN Y.Doc,
+		// so the wait can't pass at the stale a/b/c state.
+		await waitUntil(async () => {
+			const beta = b.tables.posts.get('b').data;
+			return (
+				b.tables.posts.count() === 3 &&
+				!b.tables.posts.has('c') &&
+				b.tables.posts.has('d') &&
+				beta?.title === 'Beta EDITED'
+			);
+		});
+		// And peer B's materialized directory converges to match peer A's.
+		await waitUntil(async () => {
+			const keys = await treeKeys(DIR_B);
+			return keys.join() === 'a.md,b.md,d.md';
+		});
+
+		const [treeA, treeB] = await Promise.all([readTree(DIR_A), readTree(DIR_B)]);
+		expect(Object.keys(treeB).sort()).toEqual(['a.md', 'b.md', 'd.md']);
+		expect(treeB).toEqual(treeA);
+		expect(treeB['b.md']).toContain('Beta EDITED');
+	});
+});

--- a/packages/workspace/src/document/materializer/markdown/reconcile-e2e.test.ts
+++ b/packages/workspace/src/document/materializer/markdown/reconcile-e2e.test.ts
@@ -120,9 +120,19 @@ describe('two-peer reconcile convergence', () => {
 		const { a, b, matA } = await setupPeers();
 
 		// Seed shared state through A; it propagates to B.
-		a.tables.posts.set({ id: 'a', title: 'Alpha', tags: ['x'], published: true });
+		a.tables.posts.set({
+			id: 'a',
+			title: 'Alpha',
+			tags: ['x'],
+			published: true,
+		});
 		a.tables.posts.set({ id: 'b', title: 'Beta', tags: [], published: true });
-		a.tables.posts.set({ id: 'c', title: 'Gamma', tags: ['y'], published: true });
+		a.tables.posts.set({
+			id: 'c',
+			title: 'Gamma',
+			tags: ['y'],
+			published: true,
+		});
 
 		// Wait until BOTH peers are fully materialized before editing. We edit and
 		// apply against DIR_A, so DIR_A must have all three files first, or apply
@@ -135,7 +145,10 @@ describe('two-peer reconcile convergence', () => {
 		const beta = join(DIR_A, 'posts', 'b.md');
 		await writeFile(
 			beta,
-			(await readFile(beta, 'utf-8')).replace('title: Beta', 'title: Beta EDITED'),
+			(await readFile(beta, 'utf-8')).replace(
+				'title: Beta',
+				'title: Beta EDITED',
+			),
 			'utf-8',
 		);
 		await rm(join(DIR_A, 'posts', 'c.md'));
@@ -175,7 +188,10 @@ describe('two-peer reconcile convergence', () => {
 			);
 		});
 
-		const [treeA, treeB] = await Promise.all([readTree(DIR_A), readTree(DIR_B)]);
+		const [treeA, treeB] = await Promise.all([
+			readTree(DIR_A),
+			readTree(DIR_B),
+		]);
 		expect(Object.keys(treeB).sort()).toEqual(['a.md', 'b.md', 'd.md']);
 		expect(treeB).toEqual(treeA);
 		expect(treeB['b.md']).toContain('Beta EDITED');

--- a/packages/workspace/src/document/materializer/markdown/reconcile-e2e.test.ts
+++ b/packages/workspace/src/document/materializer/markdown/reconcile-e2e.test.ts
@@ -59,7 +59,14 @@ async function readTree(dir: string): Promise<Record<string, string>> {
 	}
 	const tree: Record<string, string> = {};
 	for (const name of names.sort()) {
-		tree[name] = await readFile(join(postsDir, name), 'utf-8');
+		// Tolerate a file vanishing between readdir and readFile: the daemon's
+		// observer may unlink mid-snapshot. The convergence waitUntil retries, so
+		// a transient skip just means this poll sees an in-between state.
+		try {
+			tree[name] = await readFile(join(postsDir, name), 'utf-8');
+		} catch {
+			// skip; next poll re-reads a consistent directory
+		}
 	}
 	return tree;
 }
@@ -117,13 +124,12 @@ describe('two-peer reconcile convergence', () => {
 		a.tables.posts.set({ id: 'b', title: 'Beta', tags: [], published: true });
 		a.tables.posts.set({ id: 'c', title: 'Gamma', tags: ['y'], published: true });
 
-		// Both peers materialize the same three files. Wait on B's Y.Doc, not the
-		// files, so we know the update actually crossed before we edit.
+		// Wait until BOTH peers are fully materialized before editing. We edit and
+		// apply against DIR_A, so DIR_A must have all three files first, or apply
+		// would read a half-written directory and plan a spurious delete.
 		await waitUntil(async () => b.tables.posts.count() === 3);
-		await waitUntil(async () => {
-			const keys = await treeKeys(DIR_B);
-			return keys.length === 3;
-		});
+		await waitUntil(async () => (await treeKeys(DIR_A)).length === 3);
+		await waitUntil(async () => (await treeKeys(DIR_B)).length === 3);
 
 		// "Agent" edits peer A's directory: edit one, remove one, add one.
 		const beta = join(DIR_A, 'posts', 'b.md');
@@ -158,10 +164,15 @@ describe('two-peer reconcile convergence', () => {
 				beta?.title === 'Beta EDITED'
 			);
 		});
-		// And peer B's materialized directory converges to match peer A's.
+		// Both directories converge to byte-identical canonical output. Peer A
+		// re-materializes its own dir from Yjs after apply (async, overwriting the
+		// hand-edited files), so wait for BOTH sides to settle and agree, not just B.
 		await waitUntil(async () => {
-			const keys = await treeKeys(DIR_B);
-			return keys.join() === 'a.md,b.md,d.md';
+			const [a, b] = await Promise.all([readTree(DIR_A), readTree(DIR_B)]);
+			return (
+				Object.keys(b).join() === 'a.md,b.md,d.md' &&
+				JSON.stringify(a) === JSON.stringify(b)
+			);
 		});
 
 		const [treeA, treeB] = await Promise.all([readTree(DIR_A), readTree(DIR_B)]);

--- a/specs/20260601T120000-epicenter-apply-markdown-reconcile.md
+++ b/specs/20260601T120000-epicenter-apply-markdown-reconcile.md
@@ -1,0 +1,342 @@
+# epicenter apply: declarative markdown reconcile into Yjs
+
+Status: Phase 1 built (frontmatter reconcile); Phase 2 (bodies) and Phase 3 (CLI) pending
+Date: 2026-06-01
+Mounts touched: `apps/fuji`, `packages/workspace` (markdown materializer), `packages/cli`
+
+## v1 status (built)
+
+Shipped in `packages/workspace` markdown materializer:
+- `markdown_apply({ dryRun?, maxDeletes? }) -> ApplyPlan`: id-keyed declarative
+  reconcile (create/update/delete) with all-or-nothing guards.
+- Equality via `Value.Equal` (not a stringify hack).
+- Delete safety: a MISSING directory contributes no deletes (a `present` flag
+  distinguishes it from an empty one); a delete count over `maxDeletes` refuses;
+  `maxDeletes: 0` is the escape hatch.
+- Refuses on duplicate frontmatter id (`MaterializerApplyError.DuplicateId`) and
+  on any table that customizes `toMarkdown` without a `fromMarkdown`
+  (`RoundTripUnproven`), since that path would silently drop data.
+- Tests: 8 unit (`apply.test.ts`) + 1 two-peer convergence e2e
+  (`reconcile-e2e.test.ts`).
+
+NOT yet built: fuji body import (fuji has `toMarkdown` but no `fromMarkdown`, so
+apply currently REFUSES the fuji entries table by design), the `epicenter apply`
+CLI, and the real two-vault runbook. See Phases 2 and 3 below.
+
+## Problem
+
+The daemon materializes Yjs to markdown (one-way: `Yjs -> disk`). Editing the
+markdown does nothing: it is output. We want a coding agent (or a human in an
+editor) to edit the markdown directly and have those edits flow back into Yjs,
+which then propagates to every device through the existing relay.
+
+Today the write path is `action -> daemon socket -> Y.Doc -> materialize`. We are
+adding the inverse, gated and explicit: `disk -> Y.Doc`, called `apply`.
+
+This is the user's "push them all up" idea, made non-destructive. It is a
+declarative reconcile (desired-state apply), not a git diff: compare the full set
+of files on disk against the full set of rows in Yjs, key by frontmatter `id`,
+and apply the delta. Git stays history/backup/publish only; it is not the
+reconcile engine.
+
+## Model
+
+Two layers per entry, because fuji splits metadata from body:
+
+```
+fuji/entries/<slug>-<id>.md
+├── frontmatter (id, title, tags, pinned, date, ...)   -> root `entries` table row
+└── body (markdown below the second ---)               -> content doc entryContentDocGuid(id)
+```
+
+`apply` reconciles both layers. The root table row is a set-diff by `id`. The
+body is written into the per-entry content doc.
+
+Materialize and apply are inverses and must round-trip:
+
+```
+materialize:  row + body            ->  <slug>-<id>.md
+apply:        <slug>-<id>.md        ->  row + body
+invariant:    materialize(apply(files)) == files     (deterministic, byte-stable)
+```
+
+## What already exists (do not rebuild)
+
+```
+packages/workspace/.../markdown/materializer.ts
+  markdown_push     disk -> workspace, ADDITIVE. Reads .md, parses frontmatter,
+                    runs per-table fromMarkdown (default: frontmatter as row),
+                    validates against schema, table.set(row). No deletes, no
+                    dry-run, no body handling.
+  markdown_pull     workspace -> disk, additive.
+  markdown_rebuild  workspace -> disk, destructive sweep + rewrite.
+  createGitAutosave quietMs debounce + maxBatchMs cap, enqueue(path) on write.
+
+apps/fuji/src/lib/workspace/project.ts
+  readEntryBody(entry)   opens entryContentDocGuid(id), syncs, attachRichText().read(), destroys.
+  (NO writeEntryBody yet.)
+
+apps/fuji/src/lib/workspace/index.ts
+  entries_upsert   full-row insert/replace.
+  entries_delete   soft delete (sets deletedAt).
+  entryContentDocGuid(id), asEntryId, Entry type.
+```
+
+`markdown_push` already does creates + updates of the frontmatter row safely
+(schema-validated, id-keyed). The gaps are: deletes, dry-run, a delete guard, and
+bodies.
+
+## Design
+
+### Phase 1: generic `markdown_apply` (frontmatter rows only)
+
+Add one action to `attachMarkdownMaterializer`. It is the existing push read path
+plus a set-diff and a guarded delete. No body knowledge; fully generic and
+testable without content docs or the cloud.
+
+```ts
+markdown_apply({ dryRun?: boolean, maxDeletes?: number }) -> ApplyPlan
+
+type ApplyPlan = {
+  refused: boolean;          // true when a guard tripped; nothing was applied
+  reason?: string;
+  creates: { tableName: string; id: string }[];
+  updates: { tableName: string; id: string }[];
+  deletes: { tableName: string; id: string }[];
+  skipped: { path: string; reason: string }[];   // missing id, parse fail, validation fail
+  errors:  { path: string; error: unknown }[];
+};
+```
+
+Algorithm per registered table:
+
+```
+1. desired = read every .md in <dir>, parse frontmatter (reuse push's parse +
+   schema validation). Key by frontmatter.id. A file with no id, a parse failure,
+   or a validation failure goes to skipped/errors and is NEVER partially applied.
+
+2. current = table.getAllValid()  keyed by id.
+
+3. diff:
+   creates = desired - current
+   updates = (desired ∩ current) where row fields differ
+   deletes = current - desired
+
+4. guard (before any write):
+   if deletes.length > (maxDeletes ?? DEFAULT_MAX_DELETES) -> refused: true, return plan.
+   if errors.length > 0                                    -> refused: true, return plan.
+   (A broken file must never cause its row to be read as a delete.)
+
+5. if dryRun -> return plan, write nothing.
+
+6. apply:
+   creates + updates -> table.set(row)        (schema-validated row from step 1)
+   deletes           -> onDelete(id)          (configurable; fuji passes soft-delete)
+   return plan.
+```
+
+`onDelete` is a per-materializer config hook. Default is hard `table.delete(id)`.
+The fuji mount passes soft-delete (route through the same path as `entries_delete`
+so deleted rows keep tombstones and sync correctly). This satisfies "never
+silently delete": deletes are soft, counted, guarded, and shown in dry-run.
+
+`DEFAULT_MAX_DELETES`: start strict (e.g. 5, or 25% of current rows, whichever is
+larger). Tune after real use. Override with `--allow-deletes N` or `--force`.
+
+### Phase 2: fuji body import
+
+Add the symmetric inverse of `readEntryBody` to the fuji mount:
+
+```ts
+const writeEntryBody = async (entry: Entry, body: string): Promise<void> => {
+  const ydoc = new Y.Doc({ guid: entryContentDocGuid(entry.id), gc: true });
+  const collaboration = openCollaboration(ydoc, { /* same args as readEntryBody */ });
+  try {
+    await collaboration.whenConnected;
+    attachRichText(ydoc).applyText(body);   // see "body write" below
+  } finally {
+    ydoc.destroy();
+    await collaboration.whenDisposed;
+  }
+};
+```
+
+Wire it into the fuji `perTable.entries` config as the body half of apply. Two
+clean options; pick one in implementation:
+
+- (a) Give `markdown_apply` an optional `onBody(id, body)` per-table hook called
+  for each create/update during the apply phase (not dry-run). fuji passes
+  `writeEntryBody`. Keeps body out of the generic differ.
+- (b) Keep apply row-only and have the CLI call body writes after the row plan
+  applies. Simpler materializer, more orchestration in the CLI.
+
+Prefer (a): one action, one transaction boundary, body writes gated by the same
+dry-run/guard.
+
+Body write requirement (IMPORTANT): `applyText(body)` must apply a minimal text
+diff into the existing `Y.Text`, not delete-all-then-insert. Wholesale replace
+destroys concurrent-edit merge and makes every apply churn the content doc even
+when the body is unchanged. If `attachRichText` has no diff-apply method, add one
+(compute a common prefix/suffix and splice the middle). This also makes "did the
+body change?" detectable: a diff-apply that produces zero ops means no change.
+
+### Phase 3: CLI command
+
+```
+packages/cli: `epicenter apply`
+  --mount <name>        required; e.g. fuji
+  --dry-run             print the plan, change nothing
+  --allow-deletes <n>   raise the delete guard
+  --force               apply regardless of guard (still soft deletes)
+```
+
+Implementation: `connectDaemonActions<FujiActions & MaterializerActions>({ mount })`
+then call `markdown_apply({ dryRun, maxDeletes })`. Print the plan as a table.
+The daemon owns the Y.Doc and content-doc sync; the CLI never opens its own doc
+(matches the vault AGENTS.md contract).
+
+Reconcile trigger is explicit (`epicenter apply`) for v1. No filesystem watcher.
+A later option: run apply on `git commit` via a hook, since the commit is a clean
+"the agent is done" boundary. Out of scope here.
+
+## Multi-vault: why it works end to end
+
+A fuji mount derives its workspace doc guid from `FUJI_ID = 'epicenter-fuji'`, and
+syncs through the relay keyed by `ownerId + guid`. Two vaults on two machines (or
+two directories), both authed as the same user, both mounting fuji, resolve to the
+SAME relay room. They are already multi-device peers.
+
+```
+vault-A/fuji/entries/x.md  --(edit)-->  epicenter apply --mount fuji
+        |                                        |
+        |                                writes row + body into Y.Doc (A's daemon)
+        |                                        |
+        |                                  relay (ownerId + guid)
+        |                                        |
+        |                              A's update reaches B's daemon
+        |                                        |
+        |                                 B materializes x.md
+        v                                        v
+   diff vault-A/fuji/entries/x.md  ==  vault-B/fuji/entries/x.md   (must be empty)
+```
+
+The empty `diff` is the whole proof: it confirms (1) apply imported the edit, (2)
+the relay propagated it, (3) deterministic materialization reproduced byte-identical
+output on a different machine. No git involved in the loop.
+
+## Invariants (mapped to hard requirements)
+
+1. No silent delete: deletes are soft (`deletedAt`), counted, guarded by
+   `maxDeletes`, and shown in `--dry-run` before any write.
+2. Git never mutates the live dir: apply reads files and writes Yjs; it does not
+   run git. Git autosave is a separate, already-existing materialize-side concern.
+3. Import is explicit: `epicenter apply` is a command, never a watcher.
+4. Deterministic materialize: `materialize(apply(files)) == files`. Frontmatter
+   key order = schema order; filename = `slugFilename('title')` -> `<slug>-<id>.md`;
+   id is the stable suffix so a rename is an update, not delete+create.
+5. Yjs is truth: apply writes rows + body into Yjs; the relay does propagation.
+6. Prefer Yjs over raw git conflict: there are no git merges in this path at all.
+7. Offline: apply works against the local daemon; the relay flushes on reconnect.
+8. Human-safe branch: unchanged by this spec; main is the converged projection.
+
+## Tests
+
+### T1 (unit, fast, no cloud): reconcile + delete guard
+
+`packages/workspace/.../markdown/apply.test.ts`, same style as `materializer.test.ts`.
+
+```
+- seed table with rows A, B, C; materialize to a temp dir.
+- edit B's frontmatter on disk, delete C's file, add a new file D (valid frontmatter).
+- markdown_apply({ dryRun: true })  -> plan = { creates:[D], updates:[B], deletes:[C] },
+    table unchanged.
+- markdown_apply()                  -> table now has A, B(updated), D; C soft-deleted.
+- materialize again -> the on-disk tree matches { A, B', D } exactly (round-trip).
+```
+
+Guard test:
+
+```
+- delete 9 of 10 files; markdown_apply({ maxDeletes: 5 }) -> refused: true, table UNCHANGED.
+- markdown_apply({ maxDeletes: 5, force via allow-deletes }) -> applies, all soft-deleted.
+```
+
+Bad-file test:
+
+```
+- corrupt one file (no frontmatter); markdown_apply() -> that file in skipped/errors,
+    refused: true if errors>0, NO row deleted because of the unreadable file.
+```
+
+### T2 (in-process e2e, no cloud): two peers converge
+
+Prove apply -> propagate -> deterministic materialize without the relay, by wiring
+two Y.Docs directly (the standard Yjs peer-sim):
+
+```
+- docA, docB = two createFuji() instances; wire updates both ways
+    (docA.on('update', u => Y.applyUpdate(docB, u)) and the reverse).
+- attach a markdown materializer to docA -> dirA, docB -> dirB.
+- write/edit .md files in dirA; run markdown_apply on docA.
+- assert dirA tree == dirB tree (byte-identical), proving import + propagation + determinism.
+(Phase 1 only: frontmatter rows. Bodies need content-doc pairs; defer to T3 manual.)
+```
+
+### T3 (manual runbook, real cloud): two vaults
+
+The full thing the user wants to see, including bodies. See "Execution" below.
+
+## Execution (how to see it work)
+
+Phase 1 unit + in-process e2e (no auth, no cloud):
+
+```bash
+cd ~/Code/epicenter
+bun test packages/workspace/src/document/materializer/markdown/apply.test.ts
+```
+
+Single vault, live (needs `auth login` + daemon):
+
+```bash
+cd ~/Code/vault
+bun run daemon                      # terminal 1, foreground
+# terminal 2:
+$EP apply --mount fuji --dry-run    # print the plan, change nothing
+# edit a real file, e.g. change a title or body in fuji/entries/<file>.md
+$EP apply --mount fuji --dry-run    # plan now shows that one update
+$EP apply --mount fuji              # apply it
+bun run list-entries                # confirm the row changed
+# where: EP="bun ../epicenter/packages/cli/src/bin.ts"
+```
+
+Two vaults, end to end (the cross-repo proof):
+
+```bash
+# vault-B: same config + same auth, fresh local state, different directory
+cp -R ~/Code/vault ~/Code/vault-b && cd ~/Code/vault-b && rm -rf .epicenter
+bun run daemon                      # terminal B: builds local state from cloud
+
+cd ~/Code/vault && bun run daemon   # terminal A
+# terminal A2: edit fuji/entries/x.md, then:
+$EP apply --mount fuji
+# wait for sync, then compare the two repos' rendering of the same entry:
+diff ~/Code/vault/fuji/entries/x.md ~/Code/vault-b/fuji/entries/x.md   # expect: no output
+```
+
+Empty `diff` = the edit made it from vault-A's markdown, through Yjs and the relay,
+into vault-B's markdown, byte-for-byte. That is the design working end to end.
+
+## Open questions / risks
+
+- Body change detection cost: deciding "did the body change?" requires reading the
+  current content doc (a sync round-trip per entry). v1 may just diff-apply every
+  changed-frontmatter entry's body and rely on diff-apply producing zero ops when
+  unchanged. v2: store a body content-hash in frontmatter to skip untouched bodies.
+- `attachRichText` may not expose a diff-apply; if not, that is a prerequisite
+  sub-task (Phase 2 cannot ship a safe body import without it).
+- Concurrent apply from two vaults at once reintroduces the multi-writer question.
+  For now: apply from one place at a time. Yjs still merges correctly; this is about
+  not surprising the user, not about corruption.
+- `markdown_push` currently ignores bodies entirely; Phase 2's `onBody` hook (or the
+  fuji `fromMarkdown`) is what closes that gap. Confirm which seam before coding.
+```

--- a/specs/20260601T120000-epicenter-apply-markdown-reconcile.md
+++ b/specs/20260601T120000-epicenter-apply-markdown-reconcile.md
@@ -19,9 +19,15 @@ Shipped in `packages/workspace` markdown materializer:
 - Tests: 8 unit (`apply.test.ts`) + 1 two-peer convergence e2e
   (`reconcile-e2e.test.ts`).
 
+Also shipped: the `epicenter apply` CLI (Phase 3). Flags `--mount` (required),
+`--dry-run`, `--max-deletes`, `-C`, `--format`. Writes the ApplyPlan to stdout as
+JSON; a refused plan prints its reason + offending paths to stderr. Exit codes:
+1 usage / no daemon, 2 runtime error or bad response shape, 4 plan refused.
+
 NOT yet built: fuji body import (fuji has `toMarkdown` but no `fromMarkdown`, so
-apply currently REFUSES the fuji entries table by design), the `epicenter apply`
-CLI, and the real two-vault runbook. See Phases 2 and 3 below.
+apply REFUSES the fuji entries table as `RoundTripUnproven` by design), a CLI
+integration / exit-code test (needs a daemon harness; the action itself has 50
+passing tests), and the real two-vault runbook (needs `auth login`). See Phase 2.
 
 ## Ordering decision (Codex-reviewed)
 
@@ -316,17 +322,19 @@ cd ~/Code/epicenter
 bun test packages/workspace/src/document/materializer/markdown/apply.test.ts
 ```
 
-Single vault, live (needs `auth login` + daemon):
+Single vault, live (needs `auth login` + daemon). Use tab-manager: it is
+frontmatter-only so apply works today. fuji refuses until Phase 2 (bodies).
 
 ```bash
 cd ~/Code/vault
-bun run daemon                      # terminal 1, foreground
+bun ../epicenter/packages/cli/src/bin.ts auth login --server https://api.epicenter.so
+bun run daemon                          # terminal 1, foreground
 # terminal 2:
-$EP apply --mount fuji --dry-run    # print the plan, change nothing
-# edit a real file, e.g. change a title or body in fuji/entries/<file>.md
-$EP apply --mount fuji --dry-run    # plan now shows that one update
-$EP apply --mount fuji              # apply it
-bun run list-entries                # confirm the row changed
+$EP apply --mount tab-manager --dry-run # print the plan, change nothing
+# edit a real file, e.g. a title in tab-manager/savedTabs/<file>.md
+$EP apply --mount tab-manager --dry-run # plan now shows that one update
+$EP apply --mount tab-manager           # apply it
+$EP apply --mount fuji --dry-run        # demonstrates the RoundTripUnproven refusal (exit 4)
 # where: EP="bun ../epicenter/packages/cli/src/bin.ts"
 ```
 

--- a/specs/20260601T120000-epicenter-apply-markdown-reconcile.md
+++ b/specs/20260601T120000-epicenter-apply-markdown-reconcile.md
@@ -23,6 +23,27 @@ NOT yet built: fuji body import (fuji has `toMarkdown` but no `fromMarkdown`, so
 apply currently REFUSES the fuji entries table by design), the `epicenter apply`
 CLI, and the real two-vault runbook. See Phases 2 and 3 below.
 
+## Ordering decision (Codex-reviewed)
+
+Build the CLI (Phase 3) BEFORE fuji bodies (Phase 2). Rationale, agreed with a
+Codex consult: the CLI is a thin operator wrapper over the existing action
+contract and completes a live end-to-end slice on tab-manager (frontmatter-only)
+immediately, while body import is the riskier second seam (cross-doc content
+writes) and is testable in-process without a CLI. Do not debug first-time CLI UX
+and first-time body round-trip at the same time.
+
+Hardening folded in this round: writes are atomic (`ydoc.transact`), unknown
+frontmatter keys are stripped (`Value.Clean`), non-ENOENT read errors surface,
+duplicate ids and unproven round-trips refuse. Equality is `Value.Equal`.
+
+Phase 2 body refinements (from the consult):
+- Define `canonicalBodyString(rawBody): string` ONCE and call it from both
+  `toMarkdown` (export) and `fromMarkdown` (import) plus the hash, or the
+  `bodyHash` diverges after any normalization change and every apply churns.
+- NEVER trust a frontmatter-supplied `bodyHash` as source data; recompute it from
+  the parsed canonical body on import. `bodyHash` is a derived field and must be
+  stripped by `Value.Clean` before `table.set` unless it is a real schema column.
+
 ## Problem
 
 The daemon materializes Yjs to markdown (one-way: `Yjs -> disk`). Editing the


### PR DESCRIPTION
## What

Adds `markdown_apply`: a declarative reconcile that imports on-disk markdown back INTO Yjs (the inverse of the materializer), so a coding agent or a human editor can edit `.md` files and have those edits flow into Yjs and propagate to every device through the relay. Plus the `epicenter apply` CLI that drives it.

This is the "push them all up" idea made non-destructive: a desired-state apply, not a git diff. It compares the full set of files on disk against the full set of rows in Yjs, keys by frontmatter `id`, and applies the delta.

## Scope: frontmatter rows only

This v1 reconciles the frontmatter **row** for any registered table. It is the proven path (tab-manager is frontmatter-only and round-trips today).

Fuji entry **bodies** are deliberately out of scope here. Bodies live in a separate rich-text content doc, and the only round-trip available today is plaintext, which would flatten headings/lists/marks the moment an agent edits a structured body. Body import lands in a follow-up that ships together with a faithful markdown codec, so it can be lossless. The design for that (a `bodyHash` change signal, an `entry-body` codec, the browser maintaining the fingerprint) is staged on `feat/markdown-apply-reconcile`.

## How it stays safe

```
1. desired = read every .md, parse frontmatter, validate against schema, key by id
2. current = table.getAllValid(), keyed by id
3. diff:  creates = desired - current
          updates = (both) where Value.Equal says the row differs
          deletes = current - desired
4. guard BEFORE any write:
     any parse / validation / duplicate-id error  -> refuse, apply nothing
     deletes over maxDeletes (default 10)          -> refuse, apply nothing
     a MISSING directory contributes no deletes (absent != "delete everything")
5. dryRun -> return the plan, write nothing
6. apply  -> all writes in ONE ydoc.transact (peers see one atomic update)
             deletes route through a per-table onDelete hook (default hard delete)
```

- Unknown frontmatter keys are stripped (`Value.Clean`) before validate/store, so a hand-edited file cannot smuggle keys (including `__proto__`) or churn the diff.
- Directory reads are recursive, so nested `filename` layouts round-trip instead of reading as deletes.
- Equality is `Value.Equal` (not a stringify hack), so non-string columns (numbers, nullables, json arrays, datetimes) do not register spurious updates.

## CLI

`epicenter apply --mount <name> [--dry-run] [--max-deletes <n>]`. Writes the plan to stdout as JSON (scripting-first); a refused plan prints its reason to stderr. Exit codes: `1` usage / no daemon, `2` runtime error, `4` plan refused. The daemon owns the Y.Doc; the CLI never opens its own.

Spec: `specs/20260601T120000-epicenter-apply-markdown-reconcile.md`. The cross-machine two-vault live proof (T3) is the remaining manual validation (needs cloud auth).