### PR TITLE
ci: gate against dead file-path references in living docs

### DIFF
--- a/.github/workflows/ci.format.yml
+++ b/.github/workflows/ci.format.yml
@@ -32,6 +32,11 @@ jobs:
         run: bun run lint:check
       - name: Type check
         run: bun run typecheck
+      # Rejects backtick-wrapped apps/** and packages/** file paths in living
+      # docs that no longer resolve. Excludes specs, articles, skills, agent
+      # prompts, and Historical-marked docs. See scripts/check-doc-paths.ts.
+      - name: Check doc file references
+        run: bun run check:doc-paths
       # The Biome plugin at scripts/biome/c-json-errors.grit rejects ad-hoc
       # c.json({ ... }, 4xx/5xx) error literals as part of `bun run lint:check`
       # above; no separate step is needed. See

--- a/docs/guides/handoff-yjs-persistence-rollout.md
+++ b/docs/guides/handoff-yjs-persistence-rollout.md
@@ -1,5 +1,7 @@
 # YJS Persistence Rollout: Handoff Document
 
+<!-- doc-path-check: ignore-file (historical record; its paths are frozen) -->
+
 > **Historical.** This document describes the October 2025 `createWorkspace({ setupYDoc })` + `defineEpicenter({ workspaces: [...] })` flow. Both of those APIs are gone. Persistence today is a single `attachSqlite(ydoc, { filePath })` (or `attachIndexedDb(ydoc)` in the browser) call inside a `defineDocument((id) => { ... })` builder — see `apps/whispering/src/lib/client.ts` and `playground/opensidian-e2e/epicenter.config.ts` for the current pattern. Preserved for history.
 
 **Date**: October 14, 2025

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
 		"bench": "turbo run bench",
 		"check:ui-boundary": "bun run scripts/check-ui-boundary.ts",
 		"check:licenses": "bun run scripts/check-license-graph.ts",
+		"check:doc-paths": "bun run scripts/check-doc-paths.ts",
 		"claude:consult": "bun run scripts/claude-consult.ts",
 		"bump-version": "bun run scripts/bump-version.ts",
 		"clean": "bun run scripts/clean.ts",

--- a/scripts/check-doc-paths.ts
+++ b/scripts/check-doc-paths.ts
@@ -1,0 +1,89 @@
+/**
+ * Fail when a living doc cites a repo-rooted file path that no longer exists.
+ *
+ * Stale `apps/...`/`packages/...` references accrue after every refactor that
+ * moves or deletes files (the worker collapse, the dashboard removal, app
+ * restructures). They are invisible to typecheck and lint because they live in
+ * Markdown, so they rot silently until someone clicks a dead link. This walks
+ * every backtick-wrapped file path in the canonical docs and checks it resolves.
+ *
+ * Scope is deliberately narrow to stay false-positive free:
+ *   - Only backtick-wrapped tokens ending in a real source/doc extension are
+ *     treated as file claims (prose dir mentions and `@scope/pkg` names are not).
+ *   - A trailing `:42` line suffix is allowed and ignored.
+ *   - Tokens carrying a placeholder or glob (`<name>`, `*`, `{a,b}`, `...`) are
+ *     skipped: they are patterns, not paths.
+ *
+ * Excluded doc classes (their paths are illustrative or frozen in time):
+ *   - `specs/**` and `docs/articles/**`: dated records, kept stale on purpose.
+ *   - Any doc whose header is marked Historical / "Preserved for history".
+ *   - `.agents/**` and `.claude/**`: skill and agent prompts use example paths
+ *     like `apps/whatever/src/lib/feature.ts` as teaching stand-ins.
+ *
+ * Escape hatches for a deliberately non-existent path in an in-scope doc:
+ *   - `<!-- doc-path-check: ignore-file -->`      anywhere in the file, or
+ *   - `<!-- doc-path-check: ignore-next-line -->` on the line above the path.
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+
+const EXCLUDED_GLOBS = [
+	':!:**/specs/**',
+	':!:specs/**',
+	':!:docs/articles/**',
+	':!:.agents/**',
+	':!:.claude/**',
+	':!:**/CHANGELOG.md',
+	':!:**/node_modules/**',
+];
+
+const FILE_TOKEN =
+	/`([A-Za-z0-9._/-]+\.(?:ts|tsx|svelte|md|json|jsonc|js|mjs|cjs|rs|toml|ya?ml))(?::\d+)?`/g;
+const REPO_ROOTED = /^(apps|packages|docs|specs|scripts|examples|playground)\//;
+const PLACEHOLDER = /[<>*{}]|\.\.\./;
+const HISTORICAL_HEADER = /preserved for history|>\s*\*\*historical\b/i;
+const IGNORE_FILE = /<!--\s*doc-path-check:\s*ignore-file\s*-->/;
+const IGNORE_NEXT_LINE = /<!--\s*doc-path-check:\s*ignore-next-line\s*-->/;
+
+const docs = execSync(`git ls-files '*.md' ${EXCLUDED_GLOBS.join(' ')}`, {
+	encoding: 'utf8',
+})
+	.trim()
+	.split('\n')
+	.filter(Boolean);
+
+const violations: { file: string; line: number; path: string }[] = [];
+
+for (const file of docs) {
+	const text = readFileSync(file, 'utf8');
+	const lines = text.split('\n');
+	const isHistorical = HISTORICAL_HEADER.test(lines.slice(0, 15).join('\n'));
+	if (isHistorical || IGNORE_FILE.test(text)) continue;
+
+	lines.forEach((line, i) => {
+		const prev = lines[i - 1];
+		if (prev !== undefined && IGNORE_NEXT_LINE.test(prev)) return;
+		for (const match of line.matchAll(FILE_TOKEN)) {
+			const path = match[1];
+			if (path === undefined) continue;
+			if (!REPO_ROOTED.test(path) || PLACEHOLDER.test(path)) continue;
+			if (!existsSync(path)) violations.push({ file, line: i + 1, path });
+		}
+	});
+}
+
+if (violations.length === 0) {
+	console.log(`check:doc-paths: ${docs.length} docs scanned, all paths resolve.`);
+	process.exit(0);
+}
+
+console.error(`check:doc-paths: ${violations.length} dead file reference(s):\n`);
+for (const { file, line, path } of violations) {
+	console.error(`  ${file}:${line}  ${path}`);
+}
+console.error(
+	'\nRepoint each to the real path. If a path is intentionally illustrative,\n' +
+		'mark the line above it with `<!-- doc-path-check: ignore-next-line -->`.',
+);
+process.exit(1);

--- a/scripts/check-doc-paths.ts
+++ b/scripts/check-doc-paths.ts
@@ -74,11 +74,15 @@ for (const file of docs) {
 }
 
 if (violations.length === 0) {
-	console.log(`check:doc-paths: ${docs.length} docs scanned, all paths resolve.`);
+	console.log(
+		`check:doc-paths: ${docs.length} docs scanned, all paths resolve.`,
+	);
 	process.exit(0);
 }
 
-console.error(`check:doc-paths: ${violations.length} dead file reference(s):\n`);
+console.error(
+	`check:doc-paths: ${violations.length} dead file reference(s):\n`,
+);
 for (const { file, line, path } of violations) {
 	console.error(`  ${file}:${line}  ${path}`);
 }

--- a/scripts/check-doc-paths.ts
+++ b/scripts/check-doc-paths.ts
@@ -10,65 +10,74 @@
  * Scope is deliberately narrow to stay false-positive free:
  *   - Only backtick-wrapped tokens ending in a real source/doc extension are
  *     treated as file claims (prose dir mentions and `@scope/pkg` names are not).
- *   - A trailing `:42` line suffix is allowed and ignored.
- *   - Tokens carrying a placeholder or glob (`<name>`, `*`, `{a,b}`, `...`) are
- *     skipped: they are patterns, not paths.
+ *   - An optional `:42` / `:42:7` / `:42-50` line suffix is allowed and ignored.
+ *   - A token containing a `...` path ellipsis is skipped: it is a pattern.
  *
- * Excluded doc classes (their paths are illustrative or frozen in time):
- *   - `specs/**` and `docs/articles/**`: dated records, kept stale on purpose.
- *   - Any doc whose header is marked Historical / "Preserved for history".
- *   - `.agents/**` and `.claude/**`: skill and agent prompts use example paths
+ * Excluded from the scan, because their paths are illustrative or frozen:
+ *   - `specs/` and `docs/articles/` at any depth: dated records, kept stale.
+ *   - `.agents/` and `.claude/`: skill and agent prompts cite example paths
  *     like `apps/whatever/src/lib/feature.ts` as teaching stand-ins.
+ *   - any `CHANGELOG.md`.
+ *   - any doc carrying `<!-- doc-path-check: ignore-file -->`. Mark a historical
+ *     doc this way: a living doc that merely *mentions* history stays scanned.
  *
- * Escape hatches for a deliberately non-existent path in an in-scope doc:
- *   - `<!-- doc-path-check: ignore-file -->`      anywhere in the file, or
- *   - `<!-- doc-path-check: ignore-next-line -->` on the line above the path.
+ * For a single deliberately illustrative path inside a scanned doc, put
+ * `<!-- doc-path-check: ignore-next-line -->` on the line above it.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
-const EXCLUDED_GLOBS = [
-	':!:**/specs/**',
-	':!:specs/**',
-	':!:docs/articles/**',
-	':!:.agents/**',
-	':!:.claude/**',
-	':!:**/CHANGELOG.md',
-	':!:**/node_modules/**',
-];
+// Resolve the repo root so paths resolve regardless of the invoking cwd.
+const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+	encoding: 'utf8',
+}).trim();
 
-const FILE_TOKEN =
-	/`([A-Za-z0-9._/-]+\.(?:ts|tsx|svelte|md|json|jsonc|js|mjs|cjs|rs|toml|ya?ml))(?::\d+)?`/g;
-const REPO_ROOTED = /^(apps|packages|docs|specs|scripts|examples|playground)\//;
-const PLACEHOLDER = /[<>*{}]|\.\.\./;
-const HISTORICAL_HEADER = /preserved for history|>\s*\*\*historical\b/i;
-const IGNORE_FILE = /<!--\s*doc-path-check:\s*ignore-file\s*-->/;
-const IGNORE_NEXT_LINE = /<!--\s*doc-path-check:\s*ignore-next-line\s*-->/;
-
-const docs = execSync(`git ls-files '*.md' ${EXCLUDED_GLOBS.join(' ')}`, {
+// `git ls-files` is the load-bearing choice: it yields tracked files only, so
+// node_modules, dist, and every .gitignored output are skipped for free, which
+// `Bun.Glob` (no .gitignore awareness) cannot do. `-z` survives odd filenames.
+const tracked = execFileSync('git', ['ls-files', '-z', '*.md'], {
+	cwd: root,
 	encoding: 'utf8',
 })
-	.trim()
-	.split('\n')
+	.split('\0')
 	.filter(Boolean);
 
+const EXCLUDED_DIRS = ['specs', 'docs/articles', '.agents', '.claude'];
+const isExcludedDoc = (file: string) =>
+	file === 'CHANGELOG.md' ||
+	file.endsWith('/CHANGELOG.md') ||
+	EXCLUDED_DIRS.some(
+		(dir) => file.startsWith(`${dir}/`) || file.includes(`/${dir}/`),
+	);
+
+const FILE_TOKEN =
+	/`([A-Za-z0-9._/-]+\.(?:ts|tsx|svelte|md|json|jsonc|js|mjs|cjs|rs|toml|ya?ml))(?::\d+(?::\d+)?(?:-\d+)?)?`/g;
+const REPO_ROOTED = /^(apps|packages|docs|specs|scripts|examples|playground)\//;
+// `\b.*?-->` lets a marker carry a trailing reason, e.g.
+// `<!-- doc-path-check: ignore-file (frozen historical record) -->`.
+const IGNORE_FILE = /<!--\s*doc-path-check:\s*ignore-file\b.*?-->/;
+const IGNORE_NEXT_LINE = /<!--\s*doc-path-check:\s*ignore-next-line\b.*?-->/;
+
+const docs = tracked.filter((file) => !isExcludedDoc(file));
 const violations: { file: string; line: number; path: string }[] = [];
 
 for (const file of docs) {
-	const text = readFileSync(file, 'utf8');
-	const lines = text.split('\n');
-	const isHistorical = HISTORICAL_HEADER.test(lines.slice(0, 15).join('\n'));
-	if (isHistorical || IGNORE_FILE.test(text)) continue;
+	const text = readFileSync(join(root, file), 'utf8');
+	if (IGNORE_FILE.test(text)) continue;
 
+	const lines = text.split('\n');
 	lines.forEach((line, i) => {
 		const prev = lines[i - 1];
 		if (prev !== undefined && IGNORE_NEXT_LINE.test(prev)) return;
 		for (const match of line.matchAll(FILE_TOKEN)) {
 			const path = match[1];
 			if (path === undefined) continue;
-			if (!REPO_ROOTED.test(path) || PLACEHOLDER.test(path)) continue;
-			if (!existsSync(path)) violations.push({ file, line: i + 1, path });
+			if (!REPO_ROOTED.test(path) || path.includes('...')) continue;
+			if (!existsSync(join(root, path))) {
+				violations.push({ file, line: i + 1, path });
+			}
 		}
 	});
 }


### PR DESCRIPTION
Stale `apps/...` and `packages/...` references accrue after every refactor that moves or deletes files, and they escape typecheck and lint because they live in Markdown. The cleanup in #1875 fixed a dozen such references that three separate refactors (the `apps/api/src` worker collapse, the `apps/dashboard` removal, and several example-app restructures) had left dangling across canonical docs. Seven of them my own first manual audit missed; a path-resolution check found them mechanically. This adds that check so the class cannot recur.

`scripts/check-doc-paths.ts` walks every backtick-wrapped, repo-rooted file path in the living docs and fails if it does not resolve on disk. The scope is drawn tight enough to be false-positive free, which is what makes it safe to block on:

- Only tokens ending in a real source or doc extension are treated as file claims, so prose directory mentions and `@scope/package` names are ignored.
- A trailing `:42`, `:42:7`, or `:42-50` line suffix is allowed and stripped.
- A token carrying a `...` path ellipsis is skipped, because it is a pattern rather than a path.
- `specs/` and `docs/articles/` at any depth are excluded as dated records, along with `.agents/` and `.claude/`, whose skill and agent prompts cite example paths like `apps/whatever/src/lib/feature.ts` as teaching stand-ins, and any `CHANGELOG.md`.
- A genuinely frozen doc opts out with an explicit `<!-- doc-path-check: ignore-file -->` marker. A living doc that merely *mentions* history stays scanned, which is the point: the only historical doc here, the persistence-rollout handoff, carries the marker, while two living guides that contain a "Historical note" blockquote are now actually checked.

For a single deliberately illustrative path inside a scanned doc, a `<!-- doc-path-check: ignore-next-line -->` comment above it suppresses the check. Both markers may carry a trailing reason. It runs as `bun run check:doc-paths`, alongside the existing `check:licenses` and `check:ui-boundary` scripts, and is wired into the Code quality workflow next to the hardcoded-API-path check it mirrors. It uses `git ls-files` (tracked-only) rather than `Bun.Glob` (no .gitignore awareness, would scan ~1500 files to git's ~150) and resolves the repo root with `git rev-parse` so it works from any cwd. Currently green at 153 docs scanned.