### PR TITLE
fix(server): verify bearer tokens in-process; deployment-owned trust boundary

### DIFF
--- a/apps/api/worker/index.ts
+++ b/apps/api/worker/index.ts
@@ -32,6 +32,7 @@ import {
 	syncAssetStorageWithAutumn,
 } from './billing/policies.js';
 import { mountBillingApi } from './billing/routes.js';
+import { buildEpicenterTrustedOrigins } from './trusted-origins.js';
 
 const ownership = personal();
 
@@ -41,6 +42,11 @@ const ownership = personal();
 // scripts/dev.ts; production falls through to PRODUCTION_API_URL.
 const app = createServerApp({
 	resolveOrigin: (env) => env.API_PUBLIC_ORIGIN ?? PRODUCTION_API_URL,
+	resolveTrustedOrigins: buildEpicenterTrustedOrigins,
+	// Epicenter cloud serves app.epicenter.so and api.epicenter.so, which share
+	// a session via a cookie scoped to the registrable domain. cookie-config
+	// falls back to host-only on localhost regardless.
+	cookieDomain: '.epicenter.so',
 });
 
 // Public health endpoint at root.

--- a/apps/api/worker/trusted-origins.test.ts
+++ b/apps/api/worker/trusted-origins.test.ts
@@ -14,7 +14,9 @@ describe('buildEpicenterTrustedOrigins', () => {
 
 	test('contains exactly one chrome-extension origin (the pinned tab-manager)', () => {
 		const exts = PROD.filter((o) => o.startsWith('chrome-extension://'));
-		expect(exts).toEqual(['chrome-extension://mkbnicfhpacdofmoocppnjjmdfmkkgda']);
+		expect(exts).toEqual([
+			'chrome-extension://mkbnicfhpacdofmoocppnjjmdfmkkgda',
+		]);
 	});
 
 	test('a production deployment does not trust localhost dev origins', () => {

--- a/apps/api/worker/trusted-origins.test.ts
+++ b/apps/api/worker/trusted-origins.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import { APPS, localUrl } from '@epicenter/constants/apps';
+import { buildEpicenterTrustedOrigins } from './trusted-origins.js';
+
+const PROD = buildEpicenterTrustedOrigins('https://api.epicenter.so');
+const LOCAL = buildEpicenterTrustedOrigins('http://localhost:8787');
+
+describe('buildEpicenterTrustedOrigins', () => {
+	test('rejects arbitrary chrome-extension origins (no wildcard regression)', () => {
+		expect(PROD).not.toContain('chrome-extension://attackerid');
+		expect(PROD).not.toContain('chrome-extension://*');
+		expect(PROD.some((o) => o.includes('*'))).toBe(false);
+	});
+
+	test('contains exactly one chrome-extension origin (the pinned tab-manager)', () => {
+		const exts = PROD.filter((o) => o.startsWith('chrome-extension://'));
+		expect(exts).toEqual(['chrome-extension://mkbnicfhpacdofmoocppnjjmdfmkkgda']);
+	});
+
+	test('a production deployment does not trust localhost dev origins', () => {
+		expect(PROD).not.toContain(localUrl(APPS.FUJI));
+		expect(PROD).not.toContain(localUrl(APPS.API));
+		expect(PROD).not.toContain(`http://${new URL(APPS.API.url).host}`);
+		// `tauri://localhost` is a legitimate production origin, so the check is
+		// scoped to http(s) localhost dev servers rather than the substring.
+		expect(PROD.some((o) => o.startsWith('http://localhost'))).toBe(false);
+	});
+
+	test('a local deployment trusts the localhost dev origins', () => {
+		expect(LOCAL).toContain(localUrl(APPS.FUJI));
+		expect(LOCAL).toContain(localUrl(APPS.API));
+		expect(LOCAL).toContain(`http://${new URL(APPS.API.url).host}`);
+	});
+
+	test('both deployments trust the production app origins', () => {
+		expect(PROD).toContain(APPS.FUJI.url);
+		expect(LOCAL).toContain(APPS.FUJI.url);
+	});
+
+	test('is frozen so Cloudflare isolates cannot accumulate mutations', () => {
+		expect(Object.isFrozen(PROD)).toBe(true);
+		expect(Object.isFrozen(LOCAL)).toBe(true);
+	});
+});

--- a/apps/api/worker/trusted-origins.ts
+++ b/apps/api/worker/trusted-origins.ts
@@ -1,0 +1,87 @@
+import { APPS, localUrl, prodOrigins } from '@epicenter/constants/apps';
+
+/**
+ * Epicenter cloud's trusted-origin set. This lives in `apps/api`, not in the
+ * shared `@epicenter/server` library: it names Epicenter's own app origins and
+ * browser extension, which only the hosted deployment should trust. A
+ * self-host (`apps/team-api`) supplies its own origins instead, so it never
+ * inherits trust in epicenter.so domains it has no relationship with.
+ */
+
+/**
+ * Pinned Chrome extension origin for the tab-manager.
+ *
+ * Stable across all installs because `apps/tab-manager/wxt.config.ts`
+ * pins the manifest `key`. Allowlisting this exact origin replaces an
+ * earlier `chrome-extension://*` wildcard that defeated CSRF protection.
+ */
+const TAB_MANAGER_CHROME_EXTENSION_ORIGIN =
+	'chrome-extension://mkbnicfhpacdofmoocppnjjmdfmkkgda';
+
+/**
+ * Production origins trusted on every Epicenter cloud deployment: each app's
+ * canonical origin (and aliases), the pinned browser extension, and the Tauri
+ * webview origin.
+ *
+ * Adding an app to `APPS` auto-extends this. Browser extensions are added
+ * explicitly with their pinned origin: Chrome via the WXT `key`, Firefox via
+ * `browser_specific_settings.gecko.id` plus AMO signing (required, no
+ * exceptions; self-distributed XPIs get a random per-install UUID).
+ */
+const PRODUCTION_TRUSTED_ORIGINS: readonly string[] = [
+	'tauri://localhost',
+	TAB_MANAGER_CHROME_EXTENSION_ORIGIN,
+	...Object.values(APPS).flatMap(prodOrigins),
+];
+
+/**
+ * Development-only origins: each app's `localhost:<port>` dev server plus the
+ * plain-HTTP API host that `wrangler dev` serves the custom domain over.
+ *
+ * These are trusted ONLY on a local deployment (see
+ * {@link buildEpicenterTrustedOrigins}). A production isolate must not trust
+ * `localhost`: `trustedOrigins` gates not just cookie CSRF but Better Auth's
+ * `callbackURL` / `redirectTo` open-redirect allow-list, so a permanent
+ * localhost entry needlessly widens the production surface. Local iteration
+ * against the deployed API still works because a developer runs the API
+ * locally too.
+ */
+const DEVELOPMENT_TRUSTED_ORIGINS: readonly string[] = [
+	...Object.values(APPS).map((app) => localUrl(app)),
+	`http://${new URL(APPS.API.url).host}`,
+];
+
+function isLocalDeployment(baseURL: string): boolean {
+	try {
+		const { hostname } = new URL(baseURL);
+		return (
+			hostname === 'localhost' ||
+			hostname === '127.0.0.1' ||
+			hostname === '[::1]'
+		);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Origins Epicenter cloud permits for CORS, Better Auth CSRF / redirect checks,
+ * and cookie-mutation guards.
+ *
+ * A local deployment additionally trusts the localhost dev origins so a
+ * developer can iterate against a local API; a deployed origin trusts only the
+ * production set. The deployment identity comes from the deployment's own auth
+ * base URL, never the request.
+ *
+ * Frozen so the long-lived Cloudflare isolate cannot accumulate mutations
+ * across requests. Typed `string[]` (not `readonly string[]`) because Better
+ * Auth's `trustedOrigins` is mutable, and the readonly type leaks into its
+ * inferred Auth, breaking the OAuth metadata helpers.
+ */
+export function buildEpicenterTrustedOrigins(baseURL: string): string[] {
+	return Object.freeze(
+		isLocalDeployment(baseURL)
+			? [...PRODUCTION_TRUSTED_ORIGINS, ...DEVELOPMENT_TRUSTED_ORIGINS]
+			: [...PRODUCTION_TRUSTED_ORIGINS],
+	) as string[];
+}

--- a/apps/self-host/worker/index.ts
+++ b/apps/self-host/worker/index.ts
@@ -47,6 +47,16 @@ const ownership = shared({
 // constant, so it is read straight from `c.env`.
 const app = createServerApp({
 	resolveOrigin: (env) => env.API_PUBLIC_ORIGIN,
+	// A self-host trusts its OWN origin and the Tauri desktop client, never
+	// Epicenter cloud's. Add any browser app origins you serve (and the
+	// Epicenter browser-extension origin, if your users point it at this
+	// deployment) here.
+	resolveTrustedOrigins: (baseURL) => [
+		new URL(baseURL).origin,
+		'tauri://localhost',
+	],
+	// No cookieDomain: a single-origin deployment uses host-only cookies scoped
+	// to its own host.
 });
 
 app.get('/', (c) =>

--- a/packages/server/src/auth/cookie-config.test.ts
+++ b/packages/server/src/auth/cookie-config.test.ts
@@ -7,7 +7,10 @@
  *
  * Key behaviors:
  * - Localhost uses host-only, Lax, non-secure cookies
- * - Production uses .epicenter.so, SameSite=None, Secure cookies
+ * - A deployed origin without a cross-subdomain domain uses host-only,
+ *   SameSite=None, Secure cookies (the self-host default)
+ * - A deployed origin given a cross-subdomain domain (Epicenter cloud passes
+ *   .epicenter.so) scopes cookies to that domain
  */
 
 import { expect, test } from 'bun:test';
@@ -16,10 +19,8 @@ import { getCookies } from 'better-auth/cookies';
 import { createCookieAdvancedConfig } from './cookie-config.js';
 
 test('localhost cookies are host-only, Lax, and non-secure', () => {
-	const advanced = createCookieAdvancedConfig('http://localhost:8787');
 	const cookie = sessionTokenCookie('http://localhost:8787');
 
-	expect(advanced.crossSubDomainCookies).toBeUndefined();
 	expect(cookie.name).toBe('better-auth.session_token');
 	expect(cookie.attributes.secure).toBe(false);
 	expect(cookie.attributes.sameSite).toBe('lax');
@@ -27,10 +28,8 @@ test('localhost cookies are host-only, Lax, and non-secure', () => {
 });
 
 test('loopback cookies use localhost-compatible attributes', () => {
-	const advanced = createCookieAdvancedConfig('http://127.0.0.1:8787');
 	const cookie = sessionTokenCookie('http://127.0.0.1:8787');
 
-	expect(advanced.crossSubDomainCookies).toBeUndefined();
 	expect(cookie.name).toBe('better-auth.session_token');
 	expect(cookie.attributes.secure).toBe(false);
 	expect(cookie.attributes.sameSite).toBe('lax');
@@ -38,35 +37,37 @@ test('loopback cookies use localhost-compatible attributes', () => {
 });
 
 test('IPv6 localhost cookies use localhost-compatible attributes', () => {
-	const advanced = createCookieAdvancedConfig('http://[::1]:8787');
 	const cookie = sessionTokenCookie('http://[::1]:8787');
 
-	expect(advanced.crossSubDomainCookies).toBeUndefined();
 	expect(cookie.name).toBe('better-auth.session_token');
 	expect(cookie.attributes.secure).toBe(false);
 	expect(cookie.attributes.sameSite).toBe('lax');
 	expect('domain' in cookie.attributes).toBe(false);
 });
 
-test('production API cookies are cross-subdomain, SameSite=None, and secure', () => {
-	const advanced = createCookieAdvancedConfig('https://api.epicenter.so');
-	const cookie = sessionTokenCookie('https://api.epicenter.so');
+test('a deployed origin without a cross-subdomain domain uses host-only secure cookies', () => {
+	const cookie = sessionTokenCookie('https://team.example.com');
 
-	expect(advanced.crossSubDomainCookies).toEqual({
-		enabled: true,
-		domain: '.epicenter.so',
-	});
+	expect(cookie.name).toBe('__Secure-better-auth.session_token');
+	expect(cookie.attributes.secure).toBe(true);
+	expect(cookie.attributes.sameSite).toBe('none');
+	expect('domain' in cookie.attributes).toBe(false);
+});
+
+test('a deployed origin given a cross-subdomain domain scopes cookies to it', () => {
+	const cookie = sessionTokenCookie('https://api.epicenter.so', '.epicenter.so');
+
 	expect(cookie.name).toBe('__Secure-better-auth.session_token');
 	expect(cookie.attributes.secure).toBe(true);
 	expect(cookie.attributes.sameSite).toBe('none');
 	expect(cookie.attributes.domain).toBe('.epicenter.so');
 });
 
-function sessionTokenCookie(baseURL: string) {
+function sessionTokenCookie(baseURL: string, crossSubDomainDomain?: string) {
 	const options = {
 		baseURL,
 		basePath: '/auth',
-		advanced: createCookieAdvancedConfig(baseURL),
+		advanced: createCookieAdvancedConfig(baseURL, crossSubDomainDomain),
 	} satisfies BetterAuthOptions;
 	return getCookies(options).sessionToken;
 }

--- a/packages/server/src/auth/cookie-config.test.ts
+++ b/packages/server/src/auth/cookie-config.test.ts
@@ -55,7 +55,10 @@ test('a deployed origin without a cross-subdomain domain uses host-only secure c
 });
 
 test('a deployed origin given a cross-subdomain domain scopes cookies to it', () => {
-	const cookie = sessionTokenCookie('https://api.epicenter.so', '.epicenter.so');
+	const cookie = sessionTokenCookie(
+		'https://api.epicenter.so',
+		'.epicenter.so',
+	);
 
 	expect(cookie.name).toBe('__Secure-better-auth.session_token');
 	expect(cookie.attributes.secure).toBe(true);

--- a/packages/server/src/auth/cookie-config.ts
+++ b/packages/server/src/auth/cookie-config.ts
@@ -5,11 +5,21 @@ import type { BetterAuthOptions } from 'better-auth';
  *
  * Use this from the auth server factory, not from client code. Localhost must
  * use host-only, non-secure Lax cookies so the Vite auth proxy can work during
- * development. Deployed API origins must use secure cross-subdomain cookies so
- * browser sign-in survives redirects while keeping app clients on bearer tokens
- * for resource access.
+ * development. Deployed API origins use secure `SameSite=None` cookies so
+ * browser apps can send them cross-origin while app clients stay on bearer
+ * tokens for resource access.
+ *
+ * `crossSubDomainDomain` is the registrable domain a deployment serving
+ * multiple subdomains shares sessions across (Epicenter cloud passes
+ * `.epicenter.so` so `app.` and `api.` share a session). It is supplied by the
+ * deployment, never hardcoded here: a single-origin self-host passes nothing
+ * and gets host-only cookies that actually apply to its own host, instead of
+ * cookies scoped to a domain it does not control.
  */
-export function createCookieAdvancedConfig(baseURL: string) {
+export function createCookieAdvancedConfig(
+	baseURL: string,
+	crossSubDomainDomain?: string,
+) {
 	const { hostname } = new URL(baseURL);
 	if (
 		hostname === 'localhost' ||
@@ -27,10 +37,9 @@ export function createCookieAdvancedConfig(baseURL: string) {
 
 	return {
 		useSecureCookies: true,
-		crossSubDomainCookies: {
-			enabled: true,
-			domain: '.epicenter.so',
-		},
+		...(crossSubDomainDomain && {
+			crossSubDomainCookies: { enabled: true, domain: crossSubDomainDomain },
+		}),
 		defaultCookieAttributes: {
 			sameSite: 'none',
 			secure: true,

--- a/packages/server/src/auth/create-auth.ts
+++ b/packages/server/src/auth/create-auth.ts
@@ -5,7 +5,6 @@ import { eq } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import * as schema from '../db/schema/index.js';
 import { assetKey } from '../owner.js';
-import { buildTrustedOrigins } from '../trusted-origins.js';
 import { BASE_AUTH_CONFIG } from './base-config.js';
 import { createCookieAdvancedConfig } from './cookie-config.js';
 import { authPlugins } from './plugins.js';
@@ -34,10 +33,20 @@ export function createAuth({
 	db,
 	env,
 	baseURL,
+	trustedOrigins,
+	cookieCrossSubDomain,
 }: {
 	db: Db;
 	env: Cloudflare.Env;
 	baseURL: string;
+	/** Deployment-supplied trusted origins (CORS, CSRF, redirect allow-list). */
+	trustedOrigins: string[];
+	/**
+	 * Registrable domain for cross-subdomain session cookies, when the
+	 * deployment shares sessions across subdomains. Omitted for a single-origin
+	 * deployment, which then uses host-only cookies.
+	 */
+	cookieCrossSubDomain?: string;
 }) {
 	return betterAuth({
 		...BASE_AUTH_CONFIG,
@@ -109,7 +118,7 @@ export function createAuth({
 		// time. During OAuth the top-level site changes mid-flow (client to
 		// Google to API callback), so the cookie becomes invisible at the
 		// callback step. Partitioned is for iframes, not redirect OAuth.
-		advanced: createCookieAdvancedConfig(baseURL),
+		advanced: createCookieAdvancedConfig(baseURL, cookieCrossSubDomain),
 		databaseHooks: {
 			user: {
 				delete: {
@@ -141,7 +150,7 @@ export function createAuth({
 				},
 			},
 		},
-		trustedOrigins: buildTrustedOrigins(baseURL),
+		trustedOrigins,
 		// secondaryStorage = Cloudflare KV as a read-through cache.
 		// Postgres (Germany) is always the source of truth. KV avoids the
 		// ~150ms round-trip on repeated session reads from distant edges.

--- a/packages/server/src/auth/oauth-metadata.test.ts
+++ b/packages/server/src/auth/oauth-metadata.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from 'bun:test';
 import {
 	createOAuthIssuerURL,
-	createOAuthJwksURL,
 	OAUTH_AUTHORIZATION_SERVER_METADATA_PATH,
 	OAUTH_OPENID_CONFIGURATION_PATH,
 	OAUTH_PROTECTED_RESOURCE_METADATA_PATH,
@@ -10,9 +9,6 @@ import {
 test('OAuth metadata paths follow Better Auth issuer-path layout', () => {
 	expect(createOAuthIssuerURL('https://api.epicenter.so')).toBe(
 		'https://api.epicenter.so/auth',
-	);
-	expect(createOAuthJwksURL('https://api.epicenter.so')).toBe(
-		'https://api.epicenter.so/auth/jwks',
 	);
 	expect(OAUTH_OPENID_CONFIGURATION_PATH).toBe(
 		'/auth/.well-known/openid-configuration',

--- a/packages/server/src/auth/oauth-metadata.ts
+++ b/packages/server/src/auth/oauth-metadata.ts
@@ -11,17 +11,6 @@ export function createOAuthIssuerURL(baseURL: string) {
 	return `${baseURL.replace(/\/+$/, '')}${AUTH_BASE_PATH}`;
 }
 
-/**
- * Return the JWKS URL paired with {@link createOAuthIssuerURL}.
- *
- * Resource servers use this URL with the issuer and audience checks. Keeping it
- * derived from the same base URL prevents metadata routes and token verifiers
- * from drifting apart when the API origin changes.
- */
-export function createOAuthJwksURL(baseURL: string) {
-	return `${createOAuthIssuerURL(baseURL)}/jwks`;
-}
-
 // AUTH_BASE_PATH is hardcoded to '/auth'. The OpenID configuration sits
 // beneath that path; the auth-server metadata sits at the root with the
 // basepath as a trailing segment (RFC 8414 §3.1).

--- a/packages/server/src/middleware/cors.ts
+++ b/packages/server/src/middleware/cors.ts
@@ -2,20 +2,19 @@
  * CORS middleware.
  *
  * Skips WebSocket upgrades because the 101 response headers are
- * immutable. Trusted origins come from {@link buildTrustedOrigins} scoped to
- * this deployment's `authBaseURL`, and are shared with Better Auth so CORS and
- * CSRF agree on the allow-list.
+ * immutable. Trusted origins are the deployment-supplied `c.var.trustedOrigins`
+ * (set in `createServerApp`), shared with Better Auth and the cookie-CSRF guard
+ * so all three agree on one allow-list.
  */
 
 import { cors } from 'hono/cors';
 import { createMiddleware } from 'hono/factory';
 import { isWebSocketUpgrade } from '../is-websocket-upgrade.js';
-import { buildTrustedOrigins } from '../trusted-origins.js';
 import type { Env } from '../types.js';
 
 export const corsMiddleware = createMiddleware<Env>(async (c, next) => {
 	if (isWebSocketUpgrade(c)) return next();
-	const trustedOrigins = buildTrustedOrigins(c.var.authBaseURL);
+	const { trustedOrigins } = c.var;
 	return cors({
 		origin: (origin) =>
 			origin && trustedOrigins.includes(origin) ? origin : undefined,

--- a/packages/server/src/middleware/require-auth.test.ts
+++ b/packages/server/src/middleware/require-auth.test.ts
@@ -2,11 +2,14 @@
  * Bearer auth middleware integration tests.
  *
  * Drives `requireBearerUser` through a real Hono app with a real Better Auth
- * server hosted on Bun.serve. Covers the three production paths:
+ * server hosted on Bun.serve. Covers the production paths:
  *
  * - valid token resolves to the calling user on `c.var.user`
- * - token issued for the wrong audience returns 401 InvalidToken
- * - token whose user no longer exists returns 401 InvalidToken
+ * - verification reads the signing keys in-process, with no network hop
+ * - a malformed (non-JWT) bearer returns 401 InvalidToken
+ * - a token issued for the wrong audience returns 401 InvalidToken
+ * - a token whose user no longer exists returns 401 InvalidToken
+ * - a failure reading the signing keys returns 503 ServerError, not 401
  *
  * Header parsing for the bearer scheme lives in `auth/parse-bearer.test.ts`.
  * HTTP and WebSocket failure response shape lives in `auth/oauth-resource.test.ts`.
@@ -14,6 +17,7 @@
 
 import { expect, test } from 'bun:test';
 import { oauthProvider } from '@better-auth/oauth-provider';
+import { JWT_SIGNING_ALG } from '@epicenter/constants/auth';
 import { EPICENTER_OAUTH_SCOPES } from '@epicenter/constants/oauth';
 import { betterAuth } from 'better-auth';
 import { type MemoryDB, memoryAdapter } from 'better-auth/adapters/memory';
@@ -47,6 +51,51 @@ test('requireBearerUser resolves a valid API-audience token to c.var.user', asyn
 			id: expect.any(String),
 			email: 'middleware-test@example.com',
 		});
+	} finally {
+		setup.server.stop(true);
+	}
+});
+
+test('requireBearerUser verifies a valid token in-process, with no network hop', async () => {
+	const setup = createMiddlewareTestServer();
+	try {
+		const { accessToken } = await issueOAuthTokens(setup, {
+			clientName: 'Bearer Middleware Test',
+			email: 'middleware-test@example.com',
+			name: 'Middleware Test',
+		});
+		// Stopping the auth server proves verification never round-trips to
+		// `/auth/jwks`: the signing keys are read in-process from `c.var.auth`.
+		setup.server.stop(true);
+
+		const response = await setup.app.request('/protected', {
+			headers: { authorization: `Bearer ${accessToken}` },
+		});
+
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { id: string; email: string };
+		expect(body).toEqual({
+			id: expect.any(String),
+			email: 'middleware-test@example.com',
+		});
+	} finally {
+		setup.server.stop(true);
+	}
+});
+
+test('requireBearerUser rejects a malformed (non-JWT) bearer with 401 InvalidToken', async () => {
+	const setup = createMiddlewareTestServer();
+	try {
+		const response = await setup.app.request('/protected', {
+			headers: { authorization: 'Bearer not-a-real-jwt' },
+		});
+
+		expect(response.status).toBe(401);
+		expect(response.headers.get('WWW-Authenticate')).toBe(
+			'Bearer error="invalid_token"',
+		);
+		const body = (await response.json()) as { name: string };
+		expect(body.name).toBe('InvalidToken');
 	} finally {
 		setup.server.stop(true);
 	}
@@ -99,6 +148,76 @@ test('requireBearerUser rejects tokens whose user no longer exists with 401 Inva
 	}
 });
 
+test('requireBearerUser returns 503 ServerError when the signing keys cannot be read', async () => {
+	const setup = createMiddlewareTestServer();
+	try {
+		const { accessToken } = await issueOAuthTokens(setup, {
+			clientName: 'Bearer Middleware Test',
+			email: 'middleware-test@example.com',
+			name: 'Middleware Test',
+		});
+
+		// Same valid token, but the signing-key read fails. The token decodes far
+		// enough to need a key, so verification reaches the failing read: that
+		// means the token was never checked, so the client must retry (503), not
+		// discard and refresh a token that may be fine (401). No
+		// `WWW-Authenticate` challenge belongs on an infrastructure fault.
+		const app = new Hono<Env>()
+			.use('*', async (c, next) => {
+				c.set('db', createFakeDb(setup.db));
+				c.set('authBaseURL', setup.baseURL);
+				c.set('auth', {
+					api: {
+						getJwks: async () => {
+							throw new Error('signing keys unreadable');
+						},
+					},
+				} as unknown as Env['Variables']['auth']);
+				await next();
+			})
+			.get('/protected', requireBearerUser, (c) => c.json(c.var.user));
+
+		const response = await app.request('/protected', {
+			headers: { authorization: `Bearer ${accessToken}` },
+		});
+
+		expect(response.status).toBe(503);
+		expect(response.headers.get('WWW-Authenticate')).toBeNull();
+		const body = (await response.json()) as { name: string };
+		expect(body.name).toBe('ServerError');
+	} finally {
+		setup.server.stop(true);
+	}
+});
+
+test('requireBearerUser does not read signing keys for a non-JWT bearer', async () => {
+	// A non-JWT never decodes far enough to need a key, so verification fails
+	// before `jwksFetch` runs: a garbage bearer costs no database read, and the
+	// failure is a 401, not an infrastructure 503.
+	let getJwksCalls = 0;
+	const app = new Hono<Env>()
+		.use('*', async (c, next) => {
+			c.set('authBaseURL', 'http://localhost');
+			c.set('auth', {
+				api: {
+					getJwks: async () => {
+						getJwksCalls += 1;
+						return { keys: [] };
+					},
+				},
+			} as unknown as Env['Variables']['auth']);
+			await next();
+		})
+		.get('/protected', requireBearerUser, (c) => c.json(c.var.user));
+
+	const response = await app.request('/protected', {
+		headers: { authorization: 'Bearer not-a-real-jwt' },
+	});
+
+	expect(response.status).toBe(401);
+	expect(getJwksCalls).toBe(0);
+});
+
 function createMiddlewareTestServer() {
 	const db = createOAuthTestDb();
 
@@ -113,7 +232,7 @@ function createMiddlewareTestServer() {
 			baseURL,
 			secret: 'test-secret-test-secret-test-secret',
 			plugins: [
-				jwt(),
+				jwt({ jwks: { keyPairConfig: { alg: JWT_SIGNING_ALG } } }),
 				oauthProvider({
 					loginPage: '/sign-in',
 					consentPage: '/consent',
@@ -135,6 +254,7 @@ function createMiddlewareTestServer() {
 			const app = new Hono<Env>()
 				.use('*', async (c, next) => {
 					c.set('db', createFakeDb(db));
+					c.set('auth', auth as unknown as Env['Variables']['auth']);
 					c.set('authBaseURL', baseURL);
 					await next();
 				})
@@ -157,7 +277,8 @@ function createMiddlewareTestServer() {
  * Tests issue exactly one user per setup, so the stub returns the lone row
  * (or null when the test mutates `db.user = []`). The `where` clause is
  * ignored, which is fine: a missing-user assertion only needs the empty
- * branch.
+ * branch. The signing keys are read separately through `c.var.auth.api`, so
+ * the stub does not model the `jwks` table.
  */
 function createFakeDb(memoryDb: MemoryDB) {
 	return {

--- a/packages/server/src/middleware/require-auth.ts
+++ b/packages/server/src/middleware/require-auth.ts
@@ -18,29 +18,46 @@
  * bearer is a JWT verified against JWKS by {@link resolveRequestOAuthUser}.
  */
 
-import { oauthProviderResourceClient } from '@better-auth/oauth-provider/resource-client';
 import { AuthUser } from '@epicenter/auth';
 import { OAuthError } from '@epicenter/constants/oauth-errors';
+import { verifyJwsAccessToken } from 'better-auth/oauth2';
 import { eq } from 'drizzle-orm';
 import type { Context } from 'hono';
 import { createMiddleware } from 'hono/factory';
 import { Ok, type Result } from 'wellcrafted/result';
-import {
-	createOAuthIssuerURL,
-	createOAuthJwksURL,
-} from '../auth/oauth-metadata.js';
+import { createOAuthIssuerURL } from '../auth/oauth-metadata.js';
 import { createOAuthUnauthorizedResourceResponse } from '../auth/oauth-resource.js';
 import { parseBearer } from '../auth/parse-bearer.js';
 import * as schema from '../db/schema/index.js';
 import type { Env } from '../types.js';
 
-// `verifyAccessToken` carries no per-request state (`audience`, `issuer`,
-// `jwksUrl` are passed per call), so resolve it once at module load.
-const verifyAccessToken =
-	oauthProviderResourceClient().getActions().verifyAccessToken;
-
 /**
  * Resolve the OAuth bearer on the current request to the calling user.
+ *
+ * Both infrastructure reads (the signing keys and the user row) mean the token
+ * could not be CHECKED, not that it is bad, so the HTTP status is decided by
+ * WHICH step failed, not by inspecting error internals:
+ *
+ *   1. Verify the token against the signing keys. The keys come from
+ *      `auth.api.getJwks()` (Better Auth's own JWKS projection, read from the
+ *      same database in-process, with no HTTP hop to our own `/auth/jwks`,
+ *      which loops back and fails inside a Cloudflare Worker). It is passed as
+ *      `jwksFetch` rather than pre-fetched so Better Auth's module-level JWKS
+ *      cache serves it: a token whose `kid` is already cached, or a non-JWT
+ *      that never decodes far enough to need a key, costs no database read.
+ *      `keysUnreadable` carries a key-read failure across that callback
+ *      boundary. A verification failure with `keysUnreadable` set is a
+ *      retryable 503 (the keys were unreachable, so the token was never
+ *      checked); any other verification failure (bad signature, wrong
+ *      audience/issuer, expired, malformed, unknown `kid`) is a 401.
+ *
+ *   2. Look up the subject. A database failure here is again infrastructure
+ *      (a retryable 503); a successful query that finds no row is a genuine
+ *      401 (the subject was deleted).
+ *
+ * A 503 matters because returning 401 on an infrastructure fault would make
+ * the client discard and refresh a token that may be perfectly good, and pause
+ * network auth over a transient server blip.
  *
  * The API origin (`c.var.authBaseURL`) is the resource audience; the same
  * origin plus `/auth` is the issuer. Cheap by design: skips owner keyring
@@ -54,52 +71,40 @@ async function resolveRequestOAuthUser(
 	if (!accessToken) return OAuthError.InvalidToken();
 
 	const audience = c.var.authBaseURL;
-	let payload: Awaited<ReturnType<typeof verifyAccessToken>>;
+	let keysUnreadable = false;
+	let payload: Awaited<ReturnType<typeof verifyJwsAccessToken>>;
 	try {
-		payload = await verifyAccessToken(accessToken, {
+		payload = await verifyJwsAccessToken(accessToken, {
+			jwksFetch: async () => {
+				try {
+					return await c.var.auth.api.getJwks();
+				} catch {
+					keysUnreadable = true;
+					return undefined;
+				}
+			},
 			verifyOptions: { audience, issuer: createOAuthIssuerURL(audience) },
-			jwksUrl: createOAuthJwksURL(audience),
 		});
-	} catch (error) {
-		// Separate "the token is bad" from "we could not reach the signing keys".
-		// The former is a real 401; the latter (a JWKS fetch failure) must be a
-		// retryable 503, or the client would discard and refresh a good token and
-		// pause network auth over a transient server fault. See
-		// {@link isTokenVerificationError}.
-		return isTokenVerificationError(error)
-			? OAuthError.InvalidToken()
-			: OAuthError.ServerError();
+	} catch {
+		return keysUnreadable
+			? OAuthError.ServerError()
+			: OAuthError.InvalidToken();
 	}
+
 	const userId = typeof payload?.sub === 'string' ? payload.sub : null;
 	if (!userId) return OAuthError.InvalidToken();
 
-	const user = await c.var.db.query.user.findFirst({
-		where: eq(schema.user.id, userId),
-	});
+	let user: Awaited<ReturnType<typeof c.var.db.query.user.findFirst>>;
+	try {
+		user = await c.var.db.query.user.findFirst({
+			where: eq(schema.user.id, userId),
+		});
+	} catch {
+		return OAuthError.ServerError();
+	}
 	if (!user) return OAuthError.InvalidToken();
 
 	return Ok(AuthUser.assert(user));
-}
-
-/**
- * Distinguish a token-verification failure (expired, wrong audience/issuer,
- * bad signature, malformed) from an infrastructure failure (the JWKS endpoint
- * was unreachable so the token could not be checked at all).
- *
- * `jose` tags every token, claim, and signature failure with a stable `code`
- * that starts with `ERR_J` (e.g. `ERR_JWT_EXPIRED`,
- * `ERR_JWT_CLAIM_VALIDATION_FAILED`, `ERR_JWS_SIGNATURE_VERIFICATION_FAILED`,
- * `ERR_JWKS_NO_MATCHING_KEY`), and Better Auth maps expired/invalid tokens to
- * an `UNAUTHORIZED` API error. A JWKS fetch failure is a plain `Error` with
- * neither marker, so it falls through to `ServerError`. If Better Auth ever
- * changes those internals this degrades safely back to the old behavior (treat
- * the failure as an invalid token).
- */
-function isTokenVerificationError(error: unknown): boolean {
-	if (typeof error !== 'object' || error === null) return false;
-	if ((error as { status?: unknown }).status === 'UNAUTHORIZED') return true;
-	const code = (error as { code?: unknown }).code;
-	return typeof code === 'string' && code.startsWith('ERR_J');
 }
 
 export const requireCookieOrBearerUser = createMiddleware<Env>(

--- a/packages/server/src/middleware/require-origin-for-cookie-mutations.test.ts
+++ b/packages/server/src/middleware/require-origin-for-cookie-mutations.test.ts
@@ -83,11 +83,11 @@ test('CSRF guard admits GET regardless of origin', async () => {
 
 function createCsrfTestApp() {
 	const app = new Hono<Env>();
-	// The guard scopes its allow-list to the deployment's authBaseURL. Run the
-	// test as a local deployment so the localhost dev origin under test
-	// (localUrl(APPS.API)) is trusted, mirroring `dev`.
+	// The guard checks `c.var.trustedOrigins`, supplied by the deployment. Trust
+	// the origin under test (localUrl(APPS.API)) so it is admitted while
+	// `https://evil.example` is rejected.
 	app.use('/api/*', async (c, next) => {
-		c.set('authBaseURL', localUrl(APPS.API));
+		c.set('trustedOrigins', [TRUSTED_ORIGIN]);
 		await next();
 	});
 	app.use('/api/*', requireOriginForCookieMutations);

--- a/packages/server/src/middleware/require-origin-for-cookie-mutations.ts
+++ b/packages/server/src/middleware/require-origin-for-cookie-mutations.ts
@@ -1,7 +1,6 @@
 import { RequestGuardError } from '@epicenter/constants/request-guard-errors';
 import { createMiddleware } from 'hono/factory';
 import { parseBearer } from '../auth/parse-bearer.js';
-import { buildTrustedOrigins } from '../trusted-origins.js';
 import type { Env } from '../types.js';
 
 /**
@@ -12,8 +11,8 @@ import type { Env } from '../types.js';
  * so they skip the check.
  *
  * Cookie-auth state-changers must carry an `Origin` header in the deployment's
- * trusted-origin allow-list ({@link buildTrustedOrigins}, scoped to
- * `authBaseURL`). The CORS layer in `app.ts` already restricts `Origin` to the
+ * trusted-origin allow-list (`c.var.trustedOrigins`, supplied by the
+ * deployment). The CORS layer in `app.ts` already restricts `Origin` to the
  * same allow-list for credentialed cross-origin requests; this guard defends
  * the missing-`Origin` case (e.g. an HTML form POST that is a "simple request"
  * per the CORS spec and would not be preflighted).
@@ -26,7 +25,7 @@ export const requireOriginForCookieMutations = createMiddleware<Env>(
 		}
 		if (parseBearer(c.req.header('authorization') ?? null)) return next();
 		const origin = c.req.header('origin');
-		if (!origin || !buildTrustedOrigins(c.var.authBaseURL).includes(origin)) {
+		if (!origin || !c.var.trustedOrigins.includes(origin)) {
 			const err = RequestGuardError.ForbiddenOrigin();
 			return c.json(err, err.error.status);
 		}

--- a/packages/server/src/room/backends/cloudflare/durable-object.test.ts
+++ b/packages/server/src/room/backends/cloudflare/durable-object.test.ts
@@ -700,6 +700,51 @@ describe('Room dispatch: relay round trip', () => {
 			result: { data: 'pong', error: null },
 		});
 	});
+
+	test('dispatch_response from a non-recipient socket is ignored', async () => {
+		const { room } = await makeRoom();
+		const callerWs = await upgrade(room, 'caller');
+		const recipientWs = await upgrade(room, 'recipient');
+		const impostorWs = await upgrade(room, 'impostor');
+
+		await room.webSocketMessage(
+			callerWs,
+			JSON.stringify({
+				type: 'dispatch_request',
+				id: 'd3',
+				to: 'recipient',
+				action: 'noop_ping',
+			}),
+		);
+		// A peer that is not the dispatch target cannot forge the result, even
+		// if it learns the id.
+		await room.webSocketMessage(
+			impostorWs,
+			JSON.stringify({
+				type: 'dispatch_response',
+				id: 'd3',
+				result: { data: 'spoofed', error: null },
+			}),
+		);
+		expect(jsonFrames(callerWs, 'dispatch_result')).toHaveLength(0);
+
+		// The real recipient still resolves it: the pending entry survived the
+		// impostor.
+		await room.webSocketMessage(
+			recipientWs,
+			JSON.stringify({
+				type: 'dispatch_response',
+				id: 'd3',
+				result: { data: 'pong', error: null },
+			}),
+		);
+		const results = jsonFrames(callerWs, 'dispatch_result');
+		expect(results).toHaveLength(1);
+		expect(results[0]).toMatchObject({
+			id: 'd3',
+			result: { data: 'pong', error: null },
+		});
+	});
 });
 
 describe('Room dispatch: recipient offline', () => {

--- a/packages/server/src/room/core.ts
+++ b/packages/server/src/room/core.ts
@@ -389,16 +389,22 @@ export function createRoomCore({ updateLog }: { updateLog: RoomUpdateLog }) {
 	 * matching pending entry is a late reply (the caller already gave up,
 	 * or the entry was lost to hibernation) and is dropped.
 	 *
+	 * Only the socket the dispatch was actually sent to may answer it. In a
+	 * team room a different member's socket cannot forge a result for a
+	 * dispatch id it does not own, even if it learns the id. The id is unicast
+	 * to the recipient, so this is defense in depth, not the only barrier.
+	 *
 	 * The TypeBox validator guarantees `frame.result` is a well-formed
 	 * `Result<unknown, ActionResponseError>`. The relay still forwards the
 	 * error side opaquely; the caller's own validator narrows it again to
 	 * `DispatchErrorWire` (which adds `RecipientOffline` to the union).
 	 */
-	function handleDispatchResponse(frame: unknown): void {
+	function handleDispatchResponse(responderWs: RoomSocket, frame: unknown): void {
 		if (!checkDispatchResponseFrame.Check(frame)) return;
 
 		const pending = pendingDispatches.get(frame.id);
 		if (!pending) return;
+		if (pending.recipientWs !== responderWs) return;
 
 		clearTimeout(pending.timeout);
 		pendingDispatches.delete(frame.id);
@@ -477,7 +483,7 @@ export function createRoomCore({ updateLog }: { updateLog: RoomUpdateLog }) {
 				handleDispatchRequest(ws, parsed);
 				return;
 			case 'dispatch_response':
-				handleDispatchResponse(parsed);
+				handleDispatchResponse(ws, parsed);
 				return;
 			case 'presence_publish':
 				handlePresencePublish(ws, parsed);

--- a/packages/server/src/room/core.ts
+++ b/packages/server/src/room/core.ts
@@ -399,7 +399,10 @@ export function createRoomCore({ updateLog }: { updateLog: RoomUpdateLog }) {
 	 * error side opaquely; the caller's own validator narrows it again to
 	 * `DispatchErrorWire` (which adds `RecipientOffline` to the union).
 	 */
-	function handleDispatchResponse(responderWs: RoomSocket, frame: unknown): void {
+	function handleDispatchResponse(
+		responderWs: RoomSocket,
+		frame: unknown,
+	): void {
 		if (!checkDispatchResponseFrame.Check(frame)) return;
 
 		const pending = pendingDispatches.get(frame.id);

--- a/packages/server/src/server-app.ts
+++ b/packages/server/src/server-app.ts
@@ -47,19 +47,39 @@ type CreateServerAppOptions = {
 	 * operator-set `env.API_PUBLIC_ORIGIN`.
 	 */
 	resolveOrigin: (env: Cloudflare.Env) => string;
+	/**
+	 * The origins this deployment trusts for CORS, cookie-mutation CSRF, and
+	 * Better Auth's redirect allow-list. The library hardcodes none: `apps/api`
+	 * supplies the Epicenter app origins, a self-host supplies its own. Receives
+	 * the resolved `baseURL` so a deployment can include its own origin without
+	 * restating it.
+	 */
+	resolveTrustedOrigins: (baseURL: string) => string[];
+	/**
+	 * Registrable domain for cross-subdomain session cookies, when the
+	 * deployment shares sessions across subdomains (Epicenter cloud passes
+	 * `.epicenter.so`). Omit for a single-origin deployment, which then uses
+	 * host-only cookies scoped to its own host.
+	 */
+	cookieDomain?: string;
 };
 
 export function createServerApp({
 	resolveOrigin,
+	resolveTrustedOrigins,
+	cookieDomain,
 }: CreateServerAppOptions): Hono<Env> {
 	const app = new Hono<Env>();
 
-	// 0. Deployment auth origin. Resolved first (a pure read of the env binding,
-	// no DB) so downstream middleware, including CORS and the cookie-CSRF guard,
-	// can scope the trusted-origin allow-list to this deployment. See note 3 for
-	// why the origin is supplied explicitly and never inferred from the request.
+	// 0. Deployment auth origin and trust set. Resolved first (a pure read of
+	// the env binding, no DB) so downstream middleware, including CORS and the
+	// cookie-CSRF guard, can scope the trusted-origin allow-list to this
+	// deployment. See note 3 for why the origin is supplied explicitly and never
+	// inferred from the request.
 	app.use('*', async (c, next) => {
-		c.set('authBaseURL', resolveOrigin(c.env));
+		const baseURL = resolveOrigin(c.env);
+		c.set('authBaseURL', baseURL);
+		c.set('trustedOrigins', resolveTrustedOrigins(baseURL));
 		await next();
 	});
 
@@ -103,6 +123,8 @@ export function createServerApp({
 				db: c.var.db,
 				env: c.env,
 				baseURL: c.var.authBaseURL,
+				trustedOrigins: c.var.trustedOrigins,
+				cookieCrossSubDomain: cookieDomain,
 			}),
 		);
 		await next();

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -64,6 +64,13 @@ export type Env = {
 		db: NodePgDatabase<typeof schema>;
 		auth: ReturnType<typeof createAuth>;
 		authBaseURL: string;
+		/**
+		 * Origins this deployment trusts for CORS, cookie-mutation CSRF, and
+		 * Better Auth's redirect allow-list. Supplied by the deployment
+		 * (`createServerApp`'s `resolveTrustedOrigins`), never hardcoded in the
+		 * library: a self-host trusts its own origins, not Epicenter cloud's.
+		 */
+		trustedOrigins: string[];
 		user: AuthUser;
 		/**
 		 * Resolved owner partition for this request. Populated by the


### PR DESCRIPTION
Bearer-token verification in `require-auth` returns 503 inside Cloudflare for otherwise-valid tokens, because it verifies them by fetching the Worker's own `/auth/jwks` endpoint, a same-origin loopback subrequest that does not resolve in the Workers runtime. This still reproduces on `main`. This branch verifies tokens in-process against Better Auth's own JWKS projection (`auth.api.getJwks()` fed to `verifyJwsAccessToken` as a cached `jwksFetch`), so there is no network hop; a cached key, or a non-JWT bearer that never decodes far enough to need a key, costs no database read. The 401-vs-503 distinction becomes structural rather than a matter of inspecting error internals: a key-read or user-lookup failure is infrastructure (a retryable 503, the token was never checked), while a genuine verification failure is a 401.

Alongside that, it closes two self-host gaps and a relay-integrity gap. The shared library hardcoded Epicenter cloud origins for every deployment (and a self-host did not trust its own origin) and pinned the session cookie to `.epicenter.so`, so a self-hosted deployment trusted the wrong origins and set cookies for a domain it does not control. Trusted origins and the cookie domain are now deployment-supplied: the Epicenter set lives in `apps/api`, and a self-host trusts only its own origin under host-only cookies. Separately, `dispatch_response` frames are now bound to the recipient socket, so a peer in a shared room cannot forge another device's action result for a dispatch id it does not own.

The AI-route admission gap this work originally also addressed already landed independently on `main` (#1874), so it is not duplicated here. Supersedes #1877, which was built on the pre-rename `team` vocabulary.

## Changelog
- Fixed OAuth bearer authentication intermittently failing with a 503; token verification no longer makes a loopback request to the auth server's JWKS endpoint.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782939896&installation_id=128463665&pr_number=1880&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1880&signature=43aea38776669413f6b84ed69dd00a423659492f9eed14bf8f1cd9754b15fe1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->