### PR TITLE
refactor(whispering): drop recorder status channel, propagate cancel failures

### DIFF
--- a/apps/whispering/src/lib/operations/recording.ts
+++ b/apps/whispering/src/lib/operations/recording.ts
@@ -57,9 +57,7 @@ export async function startManualRecording() {
 		description: 'Setting up your recording environment...',
 	});
 
-	const { data: outcome, error } = await manualRecorder.startRecording({
-		sendStatus: loading.update,
-	});
+	const { data: outcome, error } = await manualRecorder.startRecording();
 
 	if (error) {
 		loading.reject({ cause: error });
@@ -87,9 +85,7 @@ export async function stopManualRecording() {
 		description: 'Finalizing your audio capture...',
 	});
 
-	const { data: source, error } = await manualRecorder.stopRecording({
-		sendStatus: loading.update,
-	});
+	const { data: source, error } = await manualRecorder.stopRecording();
 
 	if (error) {
 		loading.reject({ cause: error });
@@ -133,9 +129,7 @@ export async function cancelManualRecording() {
 		description: 'Cleaning up recording session...',
 	});
 
-	const { data, error } = await manualRecorder.cancelRecording({
-		sendStatus: loading.update,
-	});
+	const { data, error } = await manualRecorder.cancelRecording();
 
 	if (error) {
 		loading.reject({ cause: error });
@@ -172,7 +166,6 @@ export async function startVadRecording() {
 	});
 
 	const { data: outcome, error } = await vadRecorder.startActiveListening({
-		sendStatus: loading.update,
 		onSpeechStart: () => {
 			report.success({
 				title: '🎙️ Speech started',

--- a/apps/whispering/src/lib/report/index.ts
+++ b/apps/whispering/src/lib/report/index.ts
@@ -51,8 +51,6 @@ export const report = {
 			resolve: (r: Notice) => emit('success', r, id),
 			/** Resolve the loading notice as an error notice. */
 			reject: (r: Problem) => emit('error', r, id),
-			/** Replace the displayed loading notice content. */
-			update: (r: Notice) => emit('loading', r, id),
 		};
 	},
 };

--- a/apps/whispering/src/lib/services/README.md
+++ b/apps/whispering/src/lib/services/README.md
@@ -261,10 +261,9 @@ export function createManualRecorderService() {
 	return {
 		startRecording: async (
 			recordingSettings,
-			{ sendStatus },
 		): Promise<Result<DeviceAcquisitionOutcome, RecorderError>> => {
 			const { data: streamResult, error: acquireStreamError } =
-				await getRecordingStream(selectedDeviceId, sendStatus);
+				await getRecordingStream({ selectedDeviceId });
 
 			if (acquireStreamError) {
 				return RecorderError.StreamAcquisition({

--- a/apps/whispering/src/lib/services/device-stream.ts
+++ b/apps/whispering/src/lib/services/device-stream.ts
@@ -9,7 +9,6 @@ import type {
 	Device,
 	DeviceAcquisitionOutcome,
 	DeviceIdentifier,
-	UpdateStatusMessageFn,
 } from '$lib/services/recorder/types';
 import { asDeviceIdentifier } from '$lib/services/recorder/types';
 
@@ -131,10 +130,8 @@ async function getStreamForDeviceIdentifier(
 
 export async function getRecordingStream({
 	selectedDeviceId,
-	sendStatus,
 }: {
 	selectedDeviceId: DeviceIdentifier | null;
-	sendStatus: UpdateStatusMessageFn;
 }): Promise<
 	Result<
 		{ stream: MediaStream; deviceOutcome: DeviceAcquisitionOutcome },
@@ -142,20 +139,7 @@ export async function getRecordingStream({
 	>
 > {
 	// Try preferred device first if specified
-	if (!selectedDeviceId) {
-		// No device selected
-		sendStatus({
-			title: '🔍 No Device Selected',
-			description:
-				"No worries! We'll find the best microphone for you automatically...",
-		});
-	} else {
-		sendStatus({
-			title: '🎯 Connecting Device',
-			description:
-				'Almost there! Just need your permission to use the microphone...',
-		});
-
+	if (selectedDeviceId) {
 		const { data: preferredStream, error: getPreferredStreamError } =
 			await getStreamForDeviceIdentifier(selectedDeviceId);
 
@@ -166,12 +150,8 @@ export async function getRecordingStream({
 			});
 		}
 
-		// We reach here if the preferred device failed, so we'll fall back to the first available device
-		sendStatus({
-			title: '⚠️ Finding a New Microphone',
-			description:
-				"That microphone isn't working. Let's try finding another one...",
-		});
+		// We reach here if the preferred device failed, so we'll fall back to
+		// the first available device.
 	}
 
 	// Try to get any available device as fallback

--- a/apps/whispering/src/lib/services/recorder/index.browser.ts
+++ b/apps/whispering/src/lib/services/recorder/index.browser.ts
@@ -56,12 +56,7 @@ function createNavigatorRecorder() {
 		const recordingSession = {
 			recordingId,
 
-			stop: async ({ sendStatus }) => {
-				sendStatus({
-					title: '⏸️ Finishing Recording',
-					description: 'Saving your audio...',
-				});
-
+			stop: async () => {
 				const { data: blob, error: stopError } = await tryAsync({
 					try: () =>
 						new Promise<Blob>((resolve) => {
@@ -82,26 +77,12 @@ function createNavigatorRecorder() {
 
 				if (stopError) return Err(stopError);
 
-				sendStatus({
-					title: '✅ Recording Saved',
-					description: 'Your recording is ready for transcription!',
-				});
 				return Ok({ kind: 'blob', blob, recordingId, durationMs });
 			},
 
-			cancel: async ({ sendStatus }) => {
-				sendStatus({
-					title: '🛑 Cancelling',
-					description: 'Discarding your recording...',
-				});
-
+			cancel: async () => {
 				mediaRecorder.stop();
 				teardown();
-
-				sendStatus({
-					title: '✨ Cancelled',
-					description: 'Recording discarded successfully!',
-				});
 
 				return Ok({ status: 'cancelled' });
 			},
@@ -137,17 +118,13 @@ function createNavigatorRecorder() {
 			return Ok(devices);
 		},
 
-		startRecording: async (
-			{ selectedDeviceId, recordingId, bitrateKbps }: NavigatorRecordingParams,
-			{ sendStatus },
-		) => {
-			sendStatus({
-				title: '🎙️ Starting Recording',
-				description: 'Setting up your microphone...',
-			});
-
+		startRecording: async ({
+			selectedDeviceId,
+			recordingId,
+			bitrateKbps,
+		}: NavigatorRecordingParams) => {
 			const { data: streamResult, error: acquireStreamError } =
-				await getRecordingStream({ selectedDeviceId, sendStatus });
+				await getRecordingStream({ selectedDeviceId });
 			if (acquireStreamError) {
 				return (
 					categorizeRecorderError(acquireStreamError) ??

--- a/apps/whispering/src/lib/services/recorder/index.tauri.ts
+++ b/apps/whispering/src/lib/services/recorder/index.tauri.ts
@@ -154,11 +154,7 @@ function createCpalRecorder() {
 		const session = {
 			recordingId,
 
-			stop: async ({ sendStatus }) => {
-				sendStatus({
-					title: '⏸️ Saving recording',
-					description: 'Writing the WAV artifact to disk...',
-				});
+			stop: async () => {
 				const { data: artifact, error: stopRecordingError } =
 					await commands.stopRecording();
 				if (stopRecordingError !== null) {
@@ -173,10 +169,6 @@ function createCpalRecorder() {
 				// not close the worker; we still own the cpal stream and the
 				// worker thread. Send `close_recording_session` so Rust can
 				// join the worker and free the stream.
-				sendStatus({
-					title: '🔄 Closing Session',
-					description: 'Cleaning up recording resources...',
-				});
 				const { error: closeError } = await commands.closeRecordingSession();
 				if (closeError !== null)
 					log.error(RecorderError.StopFailed({ cause: closeError }));
@@ -185,25 +177,18 @@ function createCpalRecorder() {
 				return Ok({ kind: 'artifact', artifact });
 			},
 
-			cancel: async ({ sendStatus }) => {
-				sendStatus({
-					title: '🛑 Cancelling',
-					description:
-						'Safely stopping your recording and cleaning up resources...',
-				});
-
+			cancel: async () => {
 				// cancel_recording on the Rust side discards the in-flight
 				// samples and tears down the session worker. One round trip.
 				const { error: cancelError } = await commands.cancelRecording();
-				if (cancelError !== null) {
-					sendStatus({
-						title: '❌ Cancel Failed',
-						description:
-							'We hit a problem cancelling; continuing cleanup anyway...',
-					});
-				}
 
+				// Tear down unconditionally first so the JS-side state can never
+				// wedge in RECORDING, even when the Rust cancel failed.
 				teardown(session);
+
+				if (cancelError !== null) {
+					return RecorderError.CancelFailed({ cause: cancelError });
+				}
 				return Ok({ status: 'cancelled' });
 			},
 
@@ -244,14 +229,11 @@ function createCpalRecorder() {
 
 		enumerateDevices,
 
-		startRecording: async (
-			{ selectedDeviceId, recordingId, sampleRate }: CpalRecordingParams,
-			{ sendStatus },
-		) => {
-			sendStatus({
-				title: '🎙️ Checking microphone access',
-				description: 'Your system may ask you to allow microphone access.',
-			});
+		startRecording: async ({
+			selectedDeviceId,
+			recordingId,
+			sampleRate,
+		}: CpalRecordingParams) => {
 			const { error: permissionError } = await requestMicrophonePermission();
 			if (permissionError) return Err(permissionError);
 
@@ -270,11 +252,6 @@ function createCpalRecorder() {
 
 			const deviceOutcome: DeviceAcquisitionOutcome = (() => {
 				if (!selectedDeviceId) {
-					sendStatus({
-						title: '🔍 No Device Selected',
-						description:
-							"No worries! We'll find the best microphone for you automatically...",
-					});
 					return {
 						outcome: 'fallback',
 						reason: 'no-device-selected',
@@ -286,11 +263,6 @@ function createCpalRecorder() {
 					return { outcome: 'success', deviceId: selectedDeviceId };
 				}
 
-				sendStatus({
-					title: '⚠️ Finding a New Microphone',
-					description:
-						"That microphone isn't available. Let's try finding another one...",
-				});
 				return {
 					outcome: 'fallback',
 					reason: 'preferred-device-unavailable',
@@ -299,12 +271,6 @@ function createCpalRecorder() {
 			})();
 
 			const deviceIdentifier = deviceOutcome.deviceId;
-
-			sendStatus({
-				title: '🎤 Setting Up',
-				description:
-					'Initializing your recording session and checking microphone access...',
-			});
 
 			const sampleRateNum = sampleRate ? Number.parseInt(sampleRate, 10) : null;
 
@@ -322,11 +288,6 @@ function createCpalRecorder() {
 					})
 				);
 
-			sendStatus({
-				title: '🎙️ Starting Recording',
-				description:
-					'Recording session initialized, now starting to capture audio...',
-			});
 			const { error: startRecordingError } = await commands.startRecording();
 			if (startRecordingError !== null)
 				return (

--- a/apps/whispering/src/lib/services/recorder/types.ts
+++ b/apps/whispering/src/lib/services/recorder/types.ts
@@ -13,43 +13,12 @@ export type CancelRecordingResult =
 	| { status: 'no-recording' };
 
 /**
- * Callback function for providing real-time status updates during multi-step recording operations.
- * These status messages become user-facing toast notifications that provide encouraging progress
- * feedback during recording workflows. The messages are displayed as loading toasts in the UI,
- * helping users understand what's happening during potentially long-running operations.
- *
- * @example
- * ```typescript
- * // Good: User-friendly with emoji and encouraging tone
- * sendStatus({
- *   title: '🎙️ Starting Recording',
- *   description: 'Setting up your microphone...'
- * });
- *
- * sendStatus({
- *   title: '✅ Recording Saved',
- *   description: 'Your recording is ready for transcription!'
- * });
- *
- * // Bad: Technical language, no emoji, not encouraging
- * sendStatus({
- *   title: 'Initializing MediaStream',
- *   description: 'getUserMedia() call in progress'
- * });
- * ```
- */
-export type UpdateStatusMessageFn = (args: {
-	title: string;
-	description: string;
-}) => void;
-
-/**
  * Device acquisition outcome after attempting to connect to a recording device.
  *
  * This type represents the result of device selection during recording startup.
- * All outcomes include the deviceId that was ultimately used for recording.
- * When the outcome is 'fallback', appropriate status messages are automatically
- * sent via UpdateStatusMessageFn to inform users about device switching.
+ * All outcomes include the deviceId that was ultimately used for recording. The
+ * outcome is returned to the caller as a structured fact; `operations/recording.ts`
+ * is the single owner of the user-facing copy that explains a fallback.
  *
  * @example
  * ```typescript
@@ -57,7 +26,6 @@ export type UpdateStatusMessageFn = (args: {
  * { outcome: 'success', deviceId: 'preferred-device-id' as DeviceIdentifier }
  *
  * // Fallback: No device selected, used default
- * // Status message: "🔍 No Device Selected" -> "Using your default microphone instead"
  * {
  *   outcome: 'fallback',
  *   reason: 'no-device-selected',
@@ -65,7 +33,6 @@ export type UpdateStatusMessageFn = (args: {
  * }
  *
  * // Fallback: Preferred device unavailable, used alternative
- * // Status message: "⚠️ Finding a New Microphone" -> "Using MacBook Pro Microphone instead"
  * {
  *   outcome: 'fallback',
  *   reason: 'preferred-device-unavailable',
@@ -179,6 +146,10 @@ export const RecorderError = defineErrors({
 		message: `Failed to stop recording: ${extractErrorMessage(cause)}`,
 		cause,
 	}),
+	CancelFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to cancel recording: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
 	StreamAcquisition: ({ cause }: { cause: unknown }) => ({
 		message: `Failed to acquire recording stream: ${extractErrorMessage(cause)}`,
 		cause,
@@ -264,12 +235,8 @@ export type RecorderStopResult =
  */
 export type RecordingSession = {
 	readonly recordingId: string;
-	stop(callbacks: {
-		sendStatus: UpdateStatusMessageFn;
-	}): Promise<Result<RecorderStopResult, RecorderError>>;
-	cancel(callbacks: {
-		sendStatus: UpdateStatusMessageFn;
-	}): Promise<Result<CancelRecordingResult, RecorderError>>;
+	stop(): Promise<Result<RecorderStopResult, RecorderError>>;
+	cancel(): Promise<Result<CancelRecordingResult, RecorderError>>;
 	subscribe(handler: (state: WhisperingRecordingState) => void): () => void;
 };
 
@@ -301,12 +268,7 @@ export type RecorderService<RecordingParams extends BaseRecordingParams> = {
 	 * with the device acquisition outcome. The caller holds the RecordingSession
 	 * and uses its `stop`/`cancel`/`subscribe` for the rest of the session.
 	 */
-	startRecording(
-		params: RecordingParams,
-		callbacks: {
-			sendStatus: UpdateStatusMessageFn;
-		},
-	): Promise<
+	startRecording(params: RecordingParams): Promise<
 		Result<
 			{
 				session: RecordingSession;

--- a/apps/whispering/src/lib/state/manual-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/manual-recorder.svelte.ts
@@ -6,10 +6,9 @@ import { manualRecorderConfig } from '#platform/manual-recorder-config';
 import { ManualRecorderLive } from '#platform/recorder';
 import type { WhisperingRecordingState } from '$lib/constants/audio';
 import { defineQuery } from '$lib/rpc/client';
-import {
-	type RecorderError,
-	type RecordingSession,
-	type UpdateStatusMessageFn,
+import type {
+	RecorderError,
+	RecordingSession,
 } from '$lib/services/recorder/types';
 
 const ManualRecorderError = defineErrors({
@@ -37,7 +36,7 @@ const manualRecorderKeys = defineKeys({
  * reactivity. Mirrors the shape of `vadRecorder` in `vad-recorder.svelte.ts`:
  *
  * - Reactive access: `manualRecorder.state` (triggers effects on change)
- * - Operations: `manualRecorder.startRecording({ sendStatus })` etc.
+ * - Operations: `manualRecorder.startRecording()` etc.
  * - Device enumeration as a TanStack Query for loading states in selectors
  *
  * Each recording is a `RecordingSession` object returned by the implementation
@@ -112,17 +111,13 @@ function createManualRecorder() {
 			},
 		}),
 
-		async startRecording({
-			sendStatus,
-		}: {
-			sendStatus: UpdateStatusMessageFn;
-		}) {
+		async startRecording() {
 			const { error: bootstrapError } = await ensureBootstrapped();
 			if (bootstrapError) return Err(bootstrapError);
 			if (_current) return ManualRecorderError.AlreadyRecording();
 			const params = manualRecorderConfig.resolveStartParams(nanoid());
 			const { data, error: startRecordingError } =
-				await ManualRecorderLive.startRecording(params, { sendStatus });
+				await ManualRecorderLive.startRecording(params);
 
 			if (startRecordingError) return Err(startRecordingError);
 
@@ -130,22 +125,18 @@ function createManualRecorder() {
 			return Ok(data.deviceAcquisition);
 		},
 
-		async stopRecording({ sendStatus }: { sendStatus: UpdateStatusMessageFn }) {
+		async stopRecording() {
 			const { error: bootstrapError } = await ensureBootstrapped();
 			if (bootstrapError) return Err(bootstrapError);
 			if (!_current) return ManualRecorderError.NoActiveRecording();
-			return _current.stop({ sendStatus });
+			return _current.stop();
 		},
 
-		async cancelRecording({
-			sendStatus,
-		}: {
-			sendStatus: UpdateStatusMessageFn;
-		}) {
+		async cancelRecording() {
 			const { error: bootstrapError } = await ensureBootstrapped();
 			if (bootstrapError) return Err(bootstrapError);
 			if (!_current) return Ok({ status: 'no-recording' as const });
-			return _current.cancel({ sendStatus });
+			return _current.cancel();
 		},
 	};
 }

--- a/apps/whispering/src/lib/state/vad-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/vad-recorder.svelte.ts
@@ -13,10 +13,7 @@ import {
 	enumerateDevices,
 	getRecordingStream,
 } from '$lib/services/device-stream';
-import {
-	asDeviceIdentifier,
-	type UpdateStatusMessageFn,
-} from '$lib/services/recorder/types';
+import { asDeviceIdentifier } from '$lib/services/recorder/types';
 import { deviceConfig } from '$lib/state/device-config.svelte';
 
 const VadRecorderError = defineErrors({
@@ -108,14 +105,10 @@ function createVadRecorder() {
 			onSpeechStart,
 			onSpeechEnd,
 			onVADMisfire,
-			onSpeechRealStart,
-			sendStatus,
 		}: {
 			onSpeechStart: () => void;
 			onSpeechEnd: (blob: Blob) => void;
 			onVADMisfire?: () => void;
-			onSpeechRealStart?: () => void;
-			sendStatus: UpdateStatusMessageFn;
 		}) {
 			// Prevent starting if already active
 			if (_session) return VadRecorderError.AlreadyActive();
@@ -132,7 +125,6 @@ function createVadRecorder() {
 			const { data: streamResult, error: streamError } =
 				await getRecordingStream({
 					selectedDeviceId: deviceId,
-					sendStatus,
 				});
 
 			if (streamError) return Err(streamError);
@@ -158,9 +150,6 @@ function createVadRecorder() {
 						onVADMisfire: () => {
 							if (_session) _session.state = 'LISTENING';
 							onVADMisfire?.();
-						},
-						onSpeechRealStart: () => {
-							onSpeechRealStart?.();
 						},
 						model: 'v5',
 					}),


### PR DESCRIPTION
Re-implements the intent of #1836 against main's current `#platform/recorder` boundary. That branch predated main's platform-DI migration and file-inlining rewrites (it still edited the since-deleted `cpal.tauri.ts` / `navigator.ts` / `report/types.ts`), so it could not be merged cleanly. This is the same intent cut fresh against today's structure.

## What this does

The recorder service threaded a `sendStatus` callback through the `RecorderService` contract, the per-session `stop`/`cancel` handlers, `getRecordingStream`, the manual + VAD recorders, and the operations layer. Its only job was to flash rapid-fire intermediate toasts the user never had time to read; each backend also re-authored its own "no device selected" copy.

This removes the mid-operation status channel entirely. The service boundary now emits structured facts only; `operations/recording.ts` stays the single owner of user-facing copy, mapping the structured `DeviceAcquisitionOutcome` to a resolution toast in one place.

```
BEFORE                                  AFTER
══════                                  ═════
operations/recording.ts                 operations/recording.ts
   │  loading.update ◄──┐                  │  (sole owner of toast copy)
   ▼                    │                  ▼
manualRecorder ─ sendStatus ┤            service.startRecording(params)
   ▼                    │                session.stop() / .cancel()
RecorderService ─ sendStatus┤               │
   ├ navigator ─ sendStatus ┤               ▼
   ├ device-stream sendStatus┘            structured returns:
   └ cpal ─ sendStatus                      { deviceAcquisition }, { kind }, { status }
```

## What dies

- `UpdateStatusMessageFn` (the callback type plus its emoji/tone docblock)
- the `sendStatus` parameter on `RecorderService.startRecording`, `RecordingSession.stop` / `.cancel`, `getRecordingStream`, `manualRecorder.*`, and `vadRecorder.startActiveListening`
- every `sendStatus({ title, description })` call inside the cpal/navigator backends and `device-stream.ts`
- `report.loading().update` (its only consumer was `sendStatus`)
- the unused `onSpeechRealStart` VAD callback that no caller ever passed

## Two behavior fixes

- **Cancel no longer lies.** The cpal cancel path used to swallow `commands.cancelRecording()` errors, log them, and still return `Ok({ status: 'cancelled' })`, so the user saw "All Done!" even when Rust failed to tear down. It now tears down unconditionally first (JS state can never wedge in `RECORDING`) and then returns `RecorderError.CancelFailed`, so the loading toast rejects and the user actually knows.
- **Dead VAD callback removed.** `onSpeechRealStart` forwarded the MicVAD event to nothing.

Closes #1836 (superseded by this branch).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782941718&installation_id=128463665&pr_number=1881&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1881&signature=847f99378a1707fe260283524d9306582a4dd29c5852265df09331e89be7ac62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->