### PR TITLE
ci: exempt packages/sync room-route from the hardcoded-path gate

### DIFF
--- a/.github/workflows/ci.format.yml
+++ b/.github/workflows/ci.format.yml
@@ -58,7 +58,7 @@ jobs:
               --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.wrangler --exclude-dir=.next \
               "['\"\`]/api/(session|owners|ai)([^a-z]|$)|['\"\`]/auth/(oauth2/[a-z]+|cli-callback)" \
               packages apps \
-              | grep -vE "packages/constants/src/(api|oauth)-routes\.ts|packages/server/src/auth-pages/scripts/" \
+              | grep -vE "packages/constants/src/(api|oauth)-routes\.ts|packages/sync/src/room-route\.ts|packages/server/src/auth-pages/scripts/" \
               | grep -vE "^[^:]+:[0-9]+:[[:space:]]*(\*|//|/\*)" ; then
             echo "::error::Hardcoded API path literal found. Use API_ROUTES.* from @epicenter/constants/api-routes or OAUTH_ROUTES.* from @epicenter/constants/oauth-routes instead."
             exit 1


### PR DESCRIPTION
The `quality` workflow's "Reject hardcoded API path literals" gate fails on every PR and on `main` itself, because its allowlist omits `packages/sync/src/room-route.ts`. That file holds the canonical `ROOM_ROUTE` definition (`/api/owners/:ownerId/rooms/...`), which is the same category of source-of-truth file the gate already exempts for `packages/constants/src/api-routes.ts`; it just lives in `packages/sync` instead of `packages/constants`. Adding it to the allowlist lets PRs go green again without weakening the rule for genuine offenders.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782943624&installation_id=128463665&pr_number=1882&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1882&signature=421659d27d0ebb5657d2c75df78ace5d13bb63d174ab53cde1bb0ae03af809f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->