### PR TITLE
fix(server): verify bearer tokens in-process via Better Auth JWKS

### DIFF
--- a/packages/server/src/auth/oauth-metadata.test.ts
+++ b/packages/server/src/auth/oauth-metadata.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from 'bun:test';
 import {
 	createOAuthIssuerURL,
-	createOAuthJwksURL,
 	OAUTH_AUTHORIZATION_SERVER_METADATA_PATH,
 	OAUTH_OPENID_CONFIGURATION_PATH,
 	OAUTH_PROTECTED_RESOURCE_METADATA_PATH,
@@ -10,9 +9,6 @@ import {
 test('OAuth metadata paths follow Better Auth issuer-path layout', () => {
 	expect(createOAuthIssuerURL('https://api.epicenter.so')).toBe(
 		'https://api.epicenter.so/auth',
-	);
-	expect(createOAuthJwksURL('https://api.epicenter.so')).toBe(
-		'https://api.epicenter.so/auth/jwks',
 	);
 	expect(OAUTH_OPENID_CONFIGURATION_PATH).toBe(
 		'/auth/.well-known/openid-configuration',

--- a/packages/server/src/auth/oauth-metadata.ts
+++ b/packages/server/src/auth/oauth-metadata.ts
@@ -11,17 +11,6 @@ export function createOAuthIssuerURL(baseURL: string) {
 	return `${baseURL.replace(/\/+$/, '')}${AUTH_BASE_PATH}`;
 }
 
-/**
- * Return the JWKS URL paired with {@link createOAuthIssuerURL}.
- *
- * Resource servers use this URL with the issuer and audience checks. Keeping it
- * derived from the same base URL prevents metadata routes and token verifiers
- * from drifting apart when the API origin changes.
- */
-export function createOAuthJwksURL(baseURL: string) {
-	return `${createOAuthIssuerURL(baseURL)}/jwks`;
-}
-
 // AUTH_BASE_PATH is hardcoded to '/auth'. The OpenID configuration sits
 // beneath that path; the auth-server metadata sits at the root with the
 // basepath as a trailing segment (RFC 8414 §3.1).

--- a/packages/server/src/middleware/require-auth.test.ts
+++ b/packages/server/src/middleware/require-auth.test.ts
@@ -2,11 +2,12 @@
  * Bearer auth middleware integration tests.
  *
  * Drives `requireBearerUser` through a real Hono app with a real Better Auth
- * server hosted on Bun.serve. Covers the three production paths:
+ * server hosted on Bun.serve. Covers the production paths:
  *
  * - valid token resolves to the calling user on `c.var.user`
  * - token issued for the wrong audience returns 401 InvalidToken
  * - token whose user no longer exists returns 401 InvalidToken
+ * - signing keys unreachable returns 503 ServerError (retryable, not a 401)
  *
  * Header parsing for the bearer scheme lives in `auth/parse-bearer.test.ts`.
  * HTTP and WebSocket failure response shape lives in `auth/oauth-resource.test.ts`.
@@ -99,6 +100,28 @@ test('requireBearerUser rejects tokens whose user no longer exists with 401 Inva
 	}
 });
 
+test('requireBearerUser returns 503 ServerError when the signing keys are unreachable', async () => {
+	const setup = createMiddlewareTestServer();
+	try {
+		const { accessToken } = await issueOAuthTokens(setup, {
+			clientName: 'Bearer Middleware Test',
+			email: 'middleware-test@example.com',
+			name: 'Middleware Test',
+		});
+
+		const response = await setup.app.request('/keys-unreadable', {
+			headers: { authorization: `Bearer ${accessToken}` },
+		});
+
+		expect(response.status).toBe(503);
+		expect(response.headers.get('WWW-Authenticate')).toBeNull();
+		const body = (await response.json()) as { name: string };
+		expect(body.name).toBe('ServerError');
+	} finally {
+		setup.server.stop(true);
+	}
+});
+
 function createMiddlewareTestServer() {
 	const db = createOAuthTestDb();
 
@@ -136,9 +159,28 @@ function createMiddlewareTestServer() {
 				.use('*', async (c, next) => {
 					c.set('db', createFakeDb(db));
 					c.set('authBaseURL', baseURL);
+					// The test's minimal Better Auth instance is shaped narrower than
+					// the production `Env` auth; the bearer path only reaches
+					// `auth.api.getJwks()`, which it provides.
+					c.set('auth', auth as unknown as Env['Variables']['auth']);
 					await next();
 				})
-				.get('/protected', requireBearerUser, (c) => c.json(c.var.user));
+				.get('/protected', requireBearerUser, (c) => c.json(c.var.user))
+				.get(
+					'/keys-unreadable',
+					async (c, next) => {
+						c.set('auth', {
+							api: {
+								getJwks: async () => {
+									throw new Error('jwks store unreachable');
+								},
+							},
+						} as unknown as Env['Variables']['auth']);
+						await next();
+					},
+					requireBearerUser,
+					(c) => c.json(c.var.user),
+				);
 
 			return { auth, baseURL, db, server, wrongAudience, app };
 		} catch (error) {

--- a/packages/server/src/middleware/require-auth.ts
+++ b/packages/server/src/middleware/require-auth.ts
@@ -18,34 +18,30 @@
  * bearer is a JWT verified against JWKS by {@link resolveRequestOAuthUser}.
  */
 
-import { oauthProviderResourceClient } from '@better-auth/oauth-provider/resource-client';
 import { AuthUser } from '@epicenter/auth';
 import { OAuthError } from '@epicenter/constants/oauth-errors';
+import { verifyJwsAccessToken } from 'better-auth/oauth2';
 import { eq } from 'drizzle-orm';
 import type { Context } from 'hono';
 import { createMiddleware } from 'hono/factory';
 import { Ok, type Result } from 'wellcrafted/result';
-import {
-	createOAuthIssuerURL,
-	createOAuthJwksURL,
-} from '../auth/oauth-metadata.js';
+import { createOAuthIssuerURL } from '../auth/oauth-metadata.js';
 import { createOAuthUnauthorizedResourceResponse } from '../auth/oauth-resource.js';
 import { parseBearer } from '../auth/parse-bearer.js';
 import * as schema from '../db/schema/index.js';
 import type { Env } from '../types.js';
 
-// `verifyAccessToken` carries no per-request state (`audience`, `issuer`,
-// `jwksUrl` are passed per call), so resolve it once at module load.
-const verifyAccessToken =
-	oauthProviderResourceClient().getActions().verifyAccessToken;
-
 /**
- * Resolve the OAuth bearer on the current request to the calling user.
+ * Resolve an OAuth bearer token to the calling user.
  *
- * The API origin (`c.var.authBaseURL`) is the resource audience; the same
- * origin plus `/auth` is the issuer. Cheap by design: skips owner keyring
- * derivation, since only the calling user is needed once the token proves
- * issuer, audience, signature, expiration, and subject.
+ * The signing keys are read in-process through `jwksFetch` (Better Auth's own
+ * JWKS projection), not by fetching our own `/auth/jwks`, whose same-zone
+ * loopback does not resolve inside a Cloudflare Worker. Passing a callback lets
+ * Better Auth's module cache satisfy a known `kid` with no database read.
+ *
+ * A failed key read or subject lookup is retryable infrastructure (503); a bad
+ * token and a missing subject are client auth failures (401). The split is
+ * observable: 503 tells the client to retry, 401 to discard and refresh.
  */
 async function resolveRequestOAuthUser(
 	c: Context<Env>,
@@ -54,52 +50,42 @@ async function resolveRequestOAuthUser(
 	if (!accessToken) return OAuthError.InvalidToken();
 
 	const audience = c.var.authBaseURL;
-	let payload: Awaited<ReturnType<typeof verifyAccessToken>>;
+	// Thrown by the key-read callback and matched by identity after verification
+	// fails, so "keys unreachable" (503) is told apart from "token bad" (401)
+	// without sniffing the verifier's error internals.
+	const keysUnreadable = new Error('JWKS read failed');
+	let payload: Awaited<ReturnType<typeof verifyJwsAccessToken>>;
 	try {
-		payload = await verifyAccessToken(accessToken, {
+		payload = await verifyJwsAccessToken(accessToken, {
+			jwksFetch: async () => {
+				try {
+					return await c.var.auth.api.getJwks();
+				} catch {
+					throw keysUnreadable;
+				}
+			},
 			verifyOptions: { audience, issuer: createOAuthIssuerURL(audience) },
-			jwksUrl: createOAuthJwksURL(audience),
 		});
 	} catch (error) {
-		// Separate "the token is bad" from "we could not reach the signing keys".
-		// The former is a real 401; the latter (a JWKS fetch failure) must be a
-		// retryable 503, or the client would discard and refresh a good token and
-		// pause network auth over a transient server fault. See
-		// {@link isTokenVerificationError}.
-		return isTokenVerificationError(error)
-			? OAuthError.InvalidToken()
-			: OAuthError.ServerError();
+		return error === keysUnreadable
+			? OAuthError.ServerError()
+			: OAuthError.InvalidToken();
 	}
+
 	const userId = typeof payload?.sub === 'string' ? payload.sub : null;
 	if (!userId) return OAuthError.InvalidToken();
 
-	const user = await c.var.db.query.user.findFirst({
-		where: eq(schema.user.id, userId),
-	});
+	let user: Awaited<ReturnType<typeof c.var.db.query.user.findFirst>>;
+	try {
+		user = await c.var.db.query.user.findFirst({
+			where: eq(schema.user.id, userId),
+		});
+	} catch {
+		return OAuthError.ServerError();
+	}
 	if (!user) return OAuthError.InvalidToken();
 
 	return Ok(AuthUser.assert(user));
-}
-
-/**
- * Distinguish a token-verification failure (expired, wrong audience/issuer,
- * bad signature, malformed) from an infrastructure failure (the JWKS endpoint
- * was unreachable so the token could not be checked at all).
- *
- * `jose` tags every token, claim, and signature failure with a stable `code`
- * that starts with `ERR_J` (e.g. `ERR_JWT_EXPIRED`,
- * `ERR_JWT_CLAIM_VALIDATION_FAILED`, `ERR_JWS_SIGNATURE_VERIFICATION_FAILED`,
- * `ERR_JWKS_NO_MATCHING_KEY`), and Better Auth maps expired/invalid tokens to
- * an `UNAUTHORIZED` API error. A JWKS fetch failure is a plain `Error` with
- * neither marker, so it falls through to `ServerError`. If Better Auth ever
- * changes those internals this degrades safely back to the old behavior (treat
- * the failure as an invalid token).
- */
-function isTokenVerificationError(error: unknown): boolean {
-	if (typeof error !== 'object' || error === null) return false;
-	if ((error as { status?: unknown }).status === 'UNAUTHORIZED') return true;
-	const code = (error as { code?: unknown }).code;
-	return typeof code === 'string' && code.startsWith('ERR_J');
 }
 
 export const requireCookieOrBearerUser = createMiddleware<Env>(


### PR DESCRIPTION
## What

Bearer-token auth on the hosted Cloudflare Worker verified each JWT by **fetching the Worker's own `/auth/jwks` over HTTP**. Inside a Worker, a same-zone subrequest to itself does not resolve (loopback restriction), so the JWKS read failed and the request fell back to a retryable **503**. Net effect: bearer auth for external clients (CLI, Tauri, browser extension) was degraded to **503-and-retry** in production.

This switches verification to read the signing keys **in-process** via `auth.api.getJwks()` (Better Auth's own JWKS projection over the same database), removing the HTTP hop entirely.

```
            BEFORE                                   AFTER
  verify    HTTP fetch → own /auth/jwks    →   in-process auth.api.getJwks()
            (loopback fails in CF Worker)        (no network hop)
  401/503   sniff jose ERR_J error codes   →   sentinel matched by identity
  db read   uncaught → 500                 →   try/catch → 503 (infra, not bad token)
```

## Why it is not over-engineered

This change was adversarially grilled twice (the second pass specifically to cut cleverness). What survived and why:

- **In-process `getJwks()` is the fix, not a refactor.** It removes a layer (the `oauthProviderResourceClient` wrapper) rather than adding one. Net: fewer moving parts than before.
- **The 401-vs-503 split is load-bearing, not decoration.** `oauth-resource.ts` maps `ServerError → 503` (client retries) and `InvalidToken → 401` (client discards + refreshes the token). Collapsing them would make a client throw away a good token on a transient server blip.
- **The key-read failure is signalled by a sentinel thrown from the `jwksFetch` callback and matched by identity**, replacing the previous brittle heuristic that string-matched `jose` `ERR_J*` error codes. Traced through better-auth: `getJwks` does not wrap the callback, and `verifyJwsAccessToken` re-throws an `Error` by reference, so identity holds. Throwing (rather than returning `undefined`) also avoids nulling better-auth's module JWKS cache on a transient failure, a subtle bug the flag version had.
- **Keys pass as a callback, not pre-fetched**, so better-auth's module cache serves a known `kid` (and a non-JWT) with **zero database reads**. Intentional perf property.
- **The DB `try/catch` keeps the function's contract**: `resolveRequestOAuthUser` returns OAuth resource errors, so a thrown subject lookup becomes an observable 503 instead of punching through as an uncaught 500.

## Removed (dead after the change)

- `createOAuthJwksURL` helper (its only caller was the loopback)
- `isTokenVerificationError` jose-code heuristic
- the `oauthProviderResourceClient` import in this file (still used in `routes/auth.ts`)

## Notes

Re-implemented fresh on current `main` rather than cherry-picked: the closed #1877 carried this fix bundled with unrelated server work, and `main` has since reworked `require-auth`. This is the single, isolated bearer-verification fix. Verified: `tsc --noEmit` clean; full `packages/server` suite green (99 tests), including a new test asserting keys-unreachable returns 503 (not 401).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782967896&installation_id=128463665&pr_number=1883&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1883&signature=92a2734b98cc3e9635a7bd892fdcb239c617e4fa591e308d3f372cf0eda00d83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->