### PR TITLE
fix(server): bind dispatch_response to the recipient socket

### DIFF
--- a/packages/server/src/room/backends/cloudflare/durable-object.test.ts
+++ b/packages/server/src/room/backends/cloudflare/durable-object.test.ts
@@ -700,6 +700,51 @@ describe('Room dispatch: relay round trip', () => {
 			result: { data: 'pong', error: null },
 		});
 	});
+
+	test('a dispatch_response from a non-recipient socket is dropped; the real recipient still resolves', async () => {
+		const { room } = await makeRoom();
+		const callerWs = await upgrade(room, 'caller');
+		const recipientWs = await upgrade(room, 'recipient');
+		const impostorWs = await upgrade(room, 'impostor');
+
+		await room.webSocketMessage(
+			callerWs,
+			JSON.stringify({
+				type: 'dispatch_request',
+				id: 'd2b',
+				to: 'recipient',
+				action: 'noop_ping',
+			}),
+		);
+
+		// A different member forges a reply for the caller's dispatch id.
+		await room.webSocketMessage(
+			impostorWs,
+			JSON.stringify({
+				type: 'dispatch_response',
+				id: 'd2b',
+				result: { data: 'forged', error: null },
+			}),
+		);
+		expect(jsonFrames(callerWs, 'dispatch_result')).toHaveLength(0);
+
+		// The real recipient's reply still resolves the dispatch.
+		await room.webSocketMessage(
+			recipientWs,
+			JSON.stringify({
+				type: 'dispatch_response',
+				id: 'd2b',
+				result: { data: 'pong', error: null },
+			}),
+		);
+
+		const results = jsonFrames(callerWs, 'dispatch_result');
+		expect(results).toHaveLength(1);
+		expect(results[0]).toMatchObject({
+			id: 'd2b',
+			result: { data: 'pong', error: null },
+		});
+	});
 });
 
 describe('Room dispatch: recipient offline', () => {

--- a/packages/server/src/room/core.ts
+++ b/packages/server/src/room/core.ts
@@ -389,16 +389,22 @@ export function createRoomCore({ updateLog }: { updateLog: RoomUpdateLog }) {
 	 * matching pending entry is a late reply (the caller already gave up,
 	 * or the entry was lost to hibernation) and is dropped.
 	 *
+	 * Only the socket the dispatch was sent to may answer it: in a team room a
+	 * different member's socket cannot resolve a dispatch id it does not own,
+	 * even if it learns the id. The id is unicast to the recipient, so this is
+	 * defense in depth, not the only barrier.
+	 *
 	 * The TypeBox validator guarantees `frame.result` is a well-formed
 	 * `Result<unknown, ActionResponseError>`. The relay still forwards the
 	 * error side opaquely; the caller's own validator narrows it again to
 	 * `DispatchErrorWire` (which adds `RecipientOffline` to the union).
 	 */
-	function handleDispatchResponse(frame: unknown): void {
+	function handleDispatchResponse(responderWs: RoomSocket, frame: unknown): void {
 		if (!checkDispatchResponseFrame.Check(frame)) return;
 
 		const pending = pendingDispatches.get(frame.id);
 		if (!pending) return;
+		if (pending.recipientWs !== responderWs) return;
 
 		clearTimeout(pending.timeout);
 		pendingDispatches.delete(frame.id);
@@ -477,7 +483,7 @@ export function createRoomCore({ updateLog }: { updateLog: RoomUpdateLog }) {
 				handleDispatchRequest(ws, parsed);
 				return;
 			case 'dispatch_response':
-				handleDispatchResponse(parsed);
+				handleDispatchResponse(ws, parsed);
 				return;
 			case 'presence_publish':
 				handlePresencePublish(ws, parsed);


### PR DESCRIPTION
## What

In a team room, a caller dispatches an action to a recipient device over WebSocket; the relay tracks the in-flight dispatch by a caller-minted id and routes the reply back. `handleDispatchResponse` matched the reply by **id alone** and never checked that it came from the socket the dispatch was actually sent to.

This adds the missing binding: the reply must arrive from the recipient socket the relay already recorded.

```diff
- function handleDispatchResponse(frame: unknown): void {
+ function handleDispatchResponse(responderWs: RoomSocket, frame: unknown): void {
    if (!checkDispatchResponseFrame.Check(frame)) return;
    const pending = pendingDispatches.get(frame.id);
    if (!pending) return;
+   if (pending.recipientWs !== responderWs) return;
    ...
- case 'dispatch_response': handleDispatchResponse(parsed);
+ case 'dispatch_response': handleDispatchResponse(ws, parsed);
```

## Why it is not over-engineered

- **It is three lines and adds no new state.** `PendingDispatch` already stores `recipientWs` (set in `handleDispatchRequest`, and already used by the socket-close cleanup path). The guard just reads what the relay was already tracking.
- **It expresses a real invariant**: only the socket a dispatch was sent to may answer it. Without it, any member of a team room who learns a dispatch id could resolve another member's call.
- **Honestly scoped as defense in depth, not oversold.** The id is a unicast `crypto.randomUUID()` sent only to the recipient, so forging a reply already requires guessing a secret. The code comment and the PR say exactly that rather than dressing it up as a critical hole.
- **No behavior change on the happy path.** The legitimate recipient's reply still resolves the dispatch; the regression test asserts both halves (impostor reply dropped, real recipient still works).

## Notes

Extracted as a standalone change from the closed #1877 (which bundled it with unrelated bearer-auth and trust-boundary work) and re-verified against current `main`. `tsc --noEmit` clean; `packages/server` room suite green (28 tests) including the new regression.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782968060&installation_id=128463665&pr_number=1884&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1884&signature=6d5ffc1c512613daedac9d1b6cab23920f8a914adc1223a49c7b205e44263a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->