### PR TITLE
docs(api): fix stale apps/team-api reference in trusted-origins comment

### DIFF
--- a/apps/api/worker/trusted-origins.ts
+++ b/apps/api/worker/trusted-origins.ts
@@ -4,7 +4,7 @@ import { APPS, localUrl, prodOrigins } from '@epicenter/constants/apps';
  * Epicenter cloud's trusted-origin set. This lives in `apps/api`, not in the
  * shared `@epicenter/server` library: it names Epicenter's own app origins and
  * browser extension, which only the hosted deployment should trust. A
- * self-host (`apps/team-api`) supplies its own origins instead, so it never
+ * self-host (`apps/self-host`) supplies its own origins instead, so it never
  * inherits trust in epicenter.so domains it has no relationship with.
  */
 


### PR DESCRIPTION
`apps/team-api` was renamed to `apps/self-host` in #1874, but the trust-boundary refactor (b3239f917) later added an `apps/api/worker/trusted-origins.ts` comment that still used the old name. This corrects it.

This PR originally also deleted the orphaned `packages/server/src/trusted-origins.ts` module, but #1885 landed that same deletion first, so this is now rebased down to just the one-line comment fix.