### PR TITLE
refactor(whispering): recorder hygiene + concurrent-start guard

### DIFF
--- a/apps/whispering/src/lib/constants/README.md
+++ b/apps/whispering/src/lib/constants/README.md
@@ -9,7 +9,7 @@ This directory holds immutable, cross-cutting values that more than one part of 
 A constant lives with the code that owns its meaning. Only put something here when it is **pure data** and **shared across modules** with no natural home. Everything else lives next to its owner:
 
 - **Logic and functions** (formatters, guards, validators, normalizers) live in `$lib/utils` or `$lib/services`, never here. Example: keyboard display formatting and the supported-key guard live in `$lib/utils/keyboard.ts`.
-- **Types owned by one module** live in that module. Example: `CancelRecordingResult` lives in `$lib/services/recorder/types.ts`.
+- **Types owned by one module** live in that module. Example: `DeviceAcquisitionOutcome` lives in `$lib/services/recorder/types.ts`.
 - **Registries with behavior** live next to their service. The transcription and inference registries stay here only because their service-ID enums are shared vocabulary the workspace schema validates against.
 - **Build-target values** (platform identity) live behind the `#platform/*` seam (see below).
 

--- a/apps/whispering/src/lib/services/device-stream.ts
+++ b/apps/whispering/src/lib/services/device-stream.ts
@@ -43,54 +43,29 @@ const DeviceStreamError = defineErrors({
 });
 type DeviceStreamError = InferErrors<typeof DeviceStreamError>;
 
-/**
- * Check if we already have microphone permissions granted.
- * Uses Permissions API if available, otherwise returns false to trigger proper permission flow.
- */
-async function hasExistingAudioPermission(): Promise<boolean> {
-	// Try the Permissions API first (not all browsers support it)
-	if ('permissions' in navigator) {
-		const { data: permissionStatus, error } = await tryAsync({
-			try: async () => {
-				const permissionStatus = await navigator.permissions.query({
-					name: 'microphone',
-				});
-				return permissionStatus;
-			},
-			catch: (error) => DeviceStreamError.PermissionDenied({ cause: error }),
-		});
-		if (!error) return permissionStatus.state === 'granted';
-	}
-
-	// Return false to let the actual getUserMedia call handle permissions
-	// This avoids unnecessary stream creation just for checking
-	return false;
-}
-
 export async function enumerateDevices(): Promise<
 	Result<Device[], DeviceStreamError>
 > {
-	const hasPermission = await hasExistingAudioPermission();
-	if (!hasPermission) {
-		// extension.openWhisperingTab({});
-	}
 	return tryAsync({
 		try: async () => {
-			const allAudioDevicesStream = await navigator.mediaDevices.getUserMedia({
+			// Acquiring a stream is what prompts the permission grant and unlocks
+			// device labels; we only need it long enough to enumerate, so stop it
+			// in `finally` even when enumeration throws.
+			const stream = await navigator.mediaDevices.getUserMedia({
 				audio: WHISPER_RECOMMENDED_MEDIA_TRACK_CONSTRAINTS,
 			});
-			const devices = await navigator.mediaDevices.enumerateDevices();
-			for (const track of allAudioDevicesStream.getTracks()) {
-				track.stop();
+			try {
+				const devices = await navigator.mediaDevices.enumerateDevices();
+				// On Web: Return Device objects with both ID and label
+				return devices
+					.filter((device) => device.kind === 'audioinput')
+					.map((device) => ({
+						id: asDeviceIdentifier(device.deviceId),
+						label: device.label,
+					}));
+			} finally {
+				for (const track of stream.getTracks()) track.stop();
 			}
-			const audioInputDevices = devices.filter(
-				(device) => device.kind === 'audioinput',
-			);
-			// On Web: Return Device objects with both ID and label
-			return audioInputDevices.map((device) => ({
-				id: asDeviceIdentifier(device.deviceId),
-				label: device.label,
-			}));
 		},
 		catch: (error) => DeviceStreamError.PermissionDenied({ cause: error }),
 	});
@@ -105,10 +80,6 @@ export async function enumerateDevices(): Promise<
 async function getStreamForDeviceIdentifier(
 	deviceIdentifier: DeviceIdentifier,
 ) {
-	const hasPermission = await hasExistingAudioPermission();
-	if (!hasPermission) {
-		// extension.openWhisperingTab({});
-	}
 	return tryAsync({
 		try: async () => {
 			// On Web: deviceIdentifier IS the deviceId, use it directly

--- a/apps/whispering/src/lib/services/device-stream.ts
+++ b/apps/whispering/src/lib/services/device-stream.ts
@@ -3,7 +3,7 @@ import {
 	extractErrorMessage,
 	type InferErrors,
 } from 'wellcrafted/error';
-import { Ok, type Result, tryAsync } from 'wellcrafted/result';
+import { Err, Ok, type Result, tryAsync } from 'wellcrafted/result';
 import { WHISPER_RECOMMENDED_MEDIA_TRACK_CONSTRAINTS } from '$lib/constants/audio';
 import type {
 	Device,
@@ -27,10 +27,6 @@ const DeviceStreamError = defineErrors({
 		message: `Unable to connect to the selected microphone. This could be because the device is already in use by another application, has been disconnected, or lacks proper permissions. ${extractErrorMessage(cause)}`,
 		deviceId,
 		cause,
-	}),
-	EnumerationFailed: () => ({
-		message:
-			'Error enumerating recording devices. Please make sure you have given permission to access your audio devices.',
 	}),
 	NoDevicesFound: () => ({
 		message:
@@ -109,71 +105,58 @@ export async function getRecordingStream({
 		DeviceStreamError
 	>
 > {
-	// Try preferred device first if specified
+	// `exact` is the only deviceId constraint that guarantees the requested
+	// microphone (or a clean rejection). `ideal` is browser-overridable
+	// (Chrome 130+ lets the permission-bubble choice win, Firefox <90 had
+	// quirks), so an exact attempt is what lets us report 'success' honestly.
 	if (selectedDeviceId) {
-		const { data: preferredStream, error: getPreferredStreamError } =
+		const { data: stream, error } =
 			await getStreamForDeviceIdentifier(selectedDeviceId);
-
-		if (!getPreferredStreamError) {
+		if (!error) {
 			return Ok({
-				stream: preferredStream,
+				stream,
 				deviceOutcome: { outcome: 'success', deviceId: selectedDeviceId },
 			});
 		}
-
-		// We reach here if the preferred device failed, so we'll fall back to
-		// the first available device.
+		// Preferred device unavailable; fall through to the system default.
 	}
 
-	// Try to get any available device as fallback
-	const getFirstAvailableStream = async (): Promise<
-		Result<
-			{ stream: MediaStream; deviceId: DeviceIdentifier },
-			DeviceStreamError
-		>
-	> => {
-		const { data: devices, error: enumerateDevicesError } =
-			await enumerateDevices();
-		if (enumerateDevicesError) return DeviceStreamError.EnumerationFailed();
-
-		for (const device of devices) {
-			const { data: stream, error } = await getStreamForDeviceIdentifier(
-				device.id,
-			);
-			if (!error) {
-				return Ok({ stream, deviceId: device.id });
+	// Fall back to whatever the browser picks for the default audio input. One
+	// `getUserMedia` replaces enumerate-and-try-each: it resolves to a working
+	// device and rejects only when none exists (or permission is denied), so we
+	// categorize that rejection instead of masking every failure as "no
+	// devices" (a denied prompt now surfaces as a permission error, not a
+	// missing-microphone one).
+	const { data: stream, error } = await tryAsync({
+		try: () =>
+			navigator.mediaDevices.getUserMedia({
+				audio: WHISPER_RECOMMENDED_MEDIA_TRACK_CONSTRAINTS,
+			}),
+		catch: (error) => {
+			const name = error instanceof DOMException ? error.name : '';
+			if (name === 'NotAllowedError' || name === 'SecurityError') {
+				return DeviceStreamError.PermissionDenied({ cause: error });
 			}
-		}
+			return selectedDeviceId
+				? DeviceStreamError.PreferredDeviceUnavailable()
+				: DeviceStreamError.NoDevicesFound();
+		},
+	});
+	if (error) return Err(error);
 
-		return DeviceStreamError.NoDevicesFound();
-	};
+	// Read back which device the browser actually granted so the outcome
+	// records it for next time.
+	const grantedDeviceId =
+		stream.getAudioTracks()[0]?.getSettings().deviceId ?? '';
 
-	// Get fallback stream
-	const { data: fallbackStreamData, error: getFallbackStreamError } =
-		await getFirstAvailableStream();
-	if (getFallbackStreamError) {
-		return selectedDeviceId
-			? DeviceStreamError.PreferredDeviceUnavailable()
-			: DeviceStreamError.NoDevicesFound();
-	}
-
-	// Return the stream with appropriate device outcome
-	if (!selectedDeviceId) {
-		return Ok({
-			stream: fallbackStreamData.stream,
-			deviceOutcome: {
-				outcome: 'fallback',
-				reason: 'no-device-selected',
-				deviceId: fallbackStreamData.deviceId,
-			},
-		});
-	}
 	return Ok({
-		stream: fallbackStreamData.stream,
+		stream,
 		deviceOutcome: {
 			outcome: 'fallback',
-			reason: 'preferred-device-unavailable',
-			deviceId: fallbackStreamData.deviceId,
+			reason: selectedDeviceId
+				? 'preferred-device-unavailable'
+				: 'no-device-selected',
+			deviceId: asDeviceIdentifier(grantedDeviceId),
 		},
 	});
 }

--- a/apps/whispering/src/lib/services/recorder/types.ts
+++ b/apps/whispering/src/lib/services/recorder/types.ts
@@ -8,15 +8,6 @@ import type { Result } from 'wellcrafted/result';
 import type { WhisperingRecordingState } from '$lib/constants/audio';
 
 /**
- * The outcome of asking the manual recorder to cancel. A live `RecordingSession`
- * can only ever report `cancelled`; the `no-recording` arm exists solely because
- * the manual-recorder state wrapper may be asked to cancel when nothing is live.
- */
-export type CancelRecordingResult =
-	| { status: 'cancelled' }
-	| { status: 'no-recording' };
-
-/**
  * Device acquisition outcome after attempting to connect to a recording device.
  *
  * This type represents the result of device selection during recording startup.

--- a/apps/whispering/src/lib/services/recorder/types.ts
+++ b/apps/whispering/src/lib/services/recorder/types.ts
@@ -7,7 +7,11 @@ import {
 import type { Result } from 'wellcrafted/result';
 import type { WhisperingRecordingState } from '$lib/constants/audio';
 
-/** The outcome of cancelling a recording. */
+/**
+ * The outcome of asking the manual recorder to cancel. A live `RecordingSession`
+ * can only ever report `cancelled`; the `no-recording` arm exists solely because
+ * the manual-recorder state wrapper may be asked to cancel when nothing is live.
+ */
 export type CancelRecordingResult =
 	| { status: 'cancelled' }
 	| { status: 'no-recording' };
@@ -236,7 +240,7 @@ export type RecorderStopResult =
 export type RecordingSession = {
 	readonly recordingId: string;
 	stop(): Promise<Result<RecorderStopResult, RecorderError>>;
-	cancel(): Promise<Result<CancelRecordingResult, RecorderError>>;
+	cancel(): Promise<Result<{ status: 'cancelled' }, RecorderError>>;
 	subscribe(handler: (state: WhisperingRecordingState) => void): () => void;
 };
 

--- a/apps/whispering/src/lib/state/manual-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/manual-recorder.svelte.ts
@@ -55,6 +55,11 @@ function createManualRecorder() {
 	let _state = $state<WhisperingRecordingState>('IDLE');
 	let _current: RecordingSession | null = null;
 	let _unsubscribe: (() => void) | null = null;
+	// Synchronous in-flight guard for start. `_current` is not set until after
+	// two awaits (bootstrap + the service start), so without this a second
+	// start firing in that window (e.g. a global shortcut pressed twice) would
+	// pass the `_current` check and orphan a second recording.
+	let _starting = false;
 
 	function attach(session: RecordingSession) {
 		_unsubscribe?.();
@@ -112,17 +117,25 @@ function createManualRecorder() {
 		}),
 
 		async startRecording() {
-			const { error: bootstrapError } = await ensureBootstrapped();
-			if (bootstrapError) return Err(bootstrapError);
-			if (_current) return ManualRecorderError.AlreadyRecording();
-			const params = manualRecorderConfig.resolveStartParams(nanoid());
-			const { data, error: startRecordingError } =
-				await ManualRecorderLive.startRecording(params);
+			if (_starting) return ManualRecorderError.AlreadyRecording();
+			_starting = true;
+			try {
+				// Bootstrap may rehydrate a CPAL session that outlived a reload,
+				// so the `_current` check has to come after it.
+				const { error: bootstrapError } = await ensureBootstrapped();
+				if (bootstrapError) return Err(bootstrapError);
+				if (_current) return ManualRecorderError.AlreadyRecording();
+				const params = manualRecorderConfig.resolveStartParams(nanoid());
+				const { data, error: startRecordingError } =
+					await ManualRecorderLive.startRecording(params);
 
-			if (startRecordingError) return Err(startRecordingError);
+				if (startRecordingError) return Err(startRecordingError);
 
-			attach(data.session);
-			return Ok(data.deviceAcquisition);
+				attach(data.session);
+				return Ok(data.deviceAcquisition);
+			} finally {
+				_starting = false;
+			}
 		},
 
 		async stopRecording() {


### PR DESCRIPTION
A grilling + collapse pass over the recorder subsystem, cross-checked with an independent codex review and a citation-backed Navigator-API research pass. The headline: the subsystem is **not** meaningfully overengineered, so this only lands the genuine wins (hygiene, correctness, and one well-grounded collapse), and explicitly **leaves alone** the things that earn their keep.

## Hygiene + correctness
1. **Drop dead mic-permission probe + fix a stream leak** (`device-stream.ts`). `hasExistingAudioPermission()` did a real `navigator.permissions.query` round-trip and both callers discarded the result into an empty `if` guarding a commented-out feature. Deleted. `enumerateDevices` also leaked its temp stream if enumeration threw, now stopped in `finally`.
2. **Narrow `RecordingSession.cancel()`** to its only real outcome `{ status: 'cancelled' }` (a live session can't be `no-recording`), then **delete the now-orphaned `CancelRecordingResult`** type and let the wrapper's outcome infer.
3. **Guard the manual recorder against concurrent starts.** The `_current` check sat behind two awaits, so two rapid `toggleManualRecording()` calls (a global shortcut pressed twice) both passed it and started two recordings, orphaning a stream. Added a synchronous `_starting` flag.

## The one collapse worth doing (`device-stream.ts`)
`getRecordingStream` tried the selected device with `exact`, then on failure **enumerated every device and looped** `getUserMedia` on each. That whole loop collapses into a single default `getUserMedia` call: the browser resolves to a working input and rejects only when none exists.

- The **`exact`-first attempt stays** (the only constraint that guarantees the requested mic or a clean rejection, so `success` is still honest). `ideal` was researched and **rejected**: Chrome 130+ lets the permission-bubble choice override `ideal` deviceId, and Firefox <90 mis-resolved it, which would silently record from the wrong device.
- The single fallback call also lets us **categorize its rejection** instead of masking every failure as "no devices": a denied prompt now surfaces as a **permission error** rather than a missing-microphone one (this was a previously-deferred greenfield item).

> **Risk note for reviewers:** the deleted loop tried every device, so the rare "default input broken but another mic works" case is no longer auto-retried. Grounded in MDN / WebRTC constraint docs but **not yet exercised at runtime** across Chrome/Firefox/Safari/Tauri WebView.

## Explicitly left alone (verified by me + codex)
The two `#platform` seams (the config seam has 4 consumers), the generic `RecorderService<P>`, `ensureBootstrapped`, the `resumeActiveSession` asymmetry (web returns a *correct* `Ok(null)`), the `artifact|blob` union, and a proposed manual-config shared factory (it would fight the platform shims' readability for trivial DRY). The types are already minimal discriminated unions.