### PR TITLE
refactor(whispering): recorder types greenfield + dead-code/doc scrub

### DIFF
--- a/apps/whispering/src/lib/report/index.ts
+++ b/apps/whispering/src/lib/report/index.ts
@@ -78,7 +78,7 @@ export const log = {
  * Fan a notice out to the console, toast, and OS-notification surfaces.
  *
  * `id` is the sonner toast correlation id: pass it from the loading family so
- * resolve/reject/update can target the same toast. Omit it for one-shot
+ * resolve/reject can target the same toast. Omit it for one-shot
  * error/success/info reports.
  */
 function emit(level: Level, notice: Notice, id?: string): void {

--- a/apps/whispering/src/lib/services/README.md
+++ b/apps/whispering/src/lib/services/README.md
@@ -412,7 +412,7 @@ The services barrel (`src/lib/services/index.ts`) imports the platform-split ser
 - `recorder/index.tauri.ts` - Desktop manual recording through the native CPAL backend
 - `recorder/index.browser.ts` - Web manual recording through MediaRecorder
 - `recorder/types.ts` - Shared `RecorderService` interface, error types, params
-- `device-stream.ts` - `getRecordingStream` and `enumerateDevices` shared by recorder backends
+- `device-stream.ts` - `getRecordingStream` and `enumerateDevices` used by the navigator recorder and VAD (CPAL records natively through Rust)
 - `local-shortcut-manager.ts` - In-window keyboard shortcuts
 - `text/` - Clipboard operations
 - `blob-store/` - Audio blob persistence (IndexedDB on web, fs on desktop)

--- a/apps/whispering/src/lib/services/device-stream.ts
+++ b/apps/whispering/src/lib/services/device-stream.ts
@@ -67,34 +67,6 @@ export async function enumerateDevices(): Promise<
 	});
 }
 
-/**
- * Get a media stream for a specific device identifier
- * @param deviceIdentifier - The device identifier
- *   - On Web: This is the deviceId (unique identifier)
- *   - On Desktop: This is the device name
- */
-async function getStreamForDeviceIdentifier(
-	deviceIdentifier: DeviceIdentifier,
-) {
-	return tryAsync({
-		try: async () => {
-			// On Web: deviceIdentifier IS the deviceId, use it directly
-			const stream = await navigator.mediaDevices.getUserMedia({
-				audio: {
-					...WHISPER_RECOMMENDED_MEDIA_TRACK_CONSTRAINTS,
-					deviceId: { exact: deviceIdentifier },
-				},
-			});
-			return stream;
-		},
-		catch: (error) =>
-			DeviceStreamError.DeviceConnectionFailed({
-				deviceId: deviceIdentifier,
-				cause: error,
-			}),
-	});
-}
-
 export async function getRecordingStream({
 	selectedDeviceId,
 }: {
@@ -110,8 +82,20 @@ export async function getRecordingStream({
 	// (Chrome 130+ lets the permission-bubble choice win, Firefox <90 had
 	// quirks), so an exact attempt is what lets us report 'success' honestly.
 	if (selectedDeviceId) {
-		const { data: stream, error } =
-			await getStreamForDeviceIdentifier(selectedDeviceId);
+		const { data: stream, error } = await tryAsync({
+			try: () =>
+				navigator.mediaDevices.getUserMedia({
+					audio: {
+						...WHISPER_RECOMMENDED_MEDIA_TRACK_CONSTRAINTS,
+						deviceId: { exact: selectedDeviceId },
+					},
+				}),
+			catch: (error) =>
+				DeviceStreamError.DeviceConnectionFailed({
+					deviceId: selectedDeviceId,
+					cause: error,
+				}),
+		});
 		if (!error) {
 			return Ok({
 				stream,

--- a/apps/whispering/src/lib/services/recorder/index.browser.ts
+++ b/apps/whispering/src/lib/services/recorder/index.browser.ts
@@ -84,7 +84,7 @@ function createNavigatorRecorder() {
 				mediaRecorder.stop();
 				teardown();
 
-				return Ok({ status: 'cancelled' });
+				return Ok(undefined);
 			},
 
 			subscribe(handler) {

--- a/apps/whispering/src/lib/services/recorder/index.tauri.ts
+++ b/apps/whispering/src/lib/services/recorder/index.tauri.ts
@@ -32,22 +32,22 @@ async function getMicrophonePermissionStatus(): Promise<
 }
 
 async function requireMicrophonePermission(): Promise<
-	Result<true, RecorderError>
+	Result<void, RecorderError>
 > {
 	const { data: granted, error } = await getMicrophonePermissionStatus();
 	if (error) return Err(error);
-	if (granted) return Ok(true);
+	if (granted) return Ok(undefined);
 
 	return RecorderError.MicrophonePermissionDenied();
 }
 
 async function requestMicrophonePermission(): Promise<
-	Result<true, RecorderError>
+	Result<void, RecorderError>
 > {
 	const { data: alreadyGranted, error: checkError } =
 		await getMicrophonePermissionStatus();
 	if (checkError) return Err(checkError);
-	if (alreadyGranted) return Ok(true);
+	if (alreadyGranted) return Ok(undefined);
 
 	const { error: requestError } =
 		await tauriOnly.permissions.microphone.request();
@@ -60,7 +60,7 @@ async function requestMicrophonePermission(): Promise<
 	if (recheckError) return Err(recheckError);
 	if (!grantedAfterRequest) return RecorderError.MicrophonePermissionDenied();
 
-	return Ok(true);
+	return Ok(undefined);
 }
 
 /**
@@ -189,7 +189,7 @@ function createCpalRecorder() {
 				if (cancelError !== null) {
 					return RecorderError.CancelFailed({ cause: cancelError });
 				}
-				return Ok({ status: 'cancelled' });
+				return Ok(undefined);
 			},
 
 			subscribe(handler) {
@@ -289,11 +289,18 @@ function createCpalRecorder() {
 				);
 
 			const { error: startRecordingError } = await commands.startRecording();
-			if (startRecordingError !== null)
+			if (startRecordingError !== null) {
+				// The session was initialized but never started; close it so the
+				// Rust worker and cpal stream don't outlive this failed start
+				// (mirrors the stop-error cleanup above).
+				const { error: closeError } = await commands.closeRecordingSession();
+				if (closeError !== null)
+					log.error(RecorderError.StartFailed({ cause: closeError }));
 				return (
 					categorizeRecorderError(startRecordingError) ??
 					RecorderError.StartFailed({ cause: startRecordingError })
 				);
+			}
 
 			const session = buildSession(recordingId);
 			activeSession = session;

--- a/apps/whispering/src/lib/services/recorder/types.ts
+++ b/apps/whispering/src/lib/services/recorder/types.ts
@@ -103,8 +103,8 @@ export type Device = {
 };
 
 /**
- * Type guard to convert a string to DeviceIdentifier
- * Use this when receiving device identifiers from external sources
+ * Cast a string to the branded `DeviceIdentifier` type. Use this when adopting
+ * device identifiers from external sources (settings, the Navigator API, Rust).
  * @see DeviceIdentifier
  */
 export function asDeviceIdentifier(value: string): DeviceIdentifier {
@@ -178,15 +178,10 @@ export type NavigatorRecordingParams = BaseRecordingParams & {
 	bitrateKbps: string;
 };
 
-/**
- * Re-exported from the tauri-specta boundary so this module's
- * `RecorderStopResult` is structurally identical to what `commands.stopRecording`
- * returns. The Rust `RecordingArtifact` struct is the single source of truth;
- * the boundary file generates the TS shape for CPAL-written manual recording
- * artifacts.
- */
-export type { RecordingArtifact } from '$lib/tauri/commands';
-
+// Imported from the tauri-specta boundary so `RecorderStopResult` is
+// structurally identical to what `commands.stopRecording` returns. The Rust
+// `RecordingArtifact` struct is the single source of truth; consumers that need
+// the type import it from `$lib/tauri/commands` directly.
 import type { RecordingArtifact } from '$lib/tauri/commands';
 
 /**
@@ -231,7 +226,12 @@ export type RecorderStopResult =
 export type RecordingSession = {
 	readonly recordingId: string;
 	stop(): Promise<Result<RecorderStopResult, RecorderError>>;
-	cancel(): Promise<Result<{ status: 'cancelled' }, RecorderError>>;
+	/**
+	 * Cancel the in-flight recording and discard it. Success carries no payload
+	 * (a live session can only resolve to "cancelled"); the manual-recorder
+	 * wrapper is where the `cancelled` vs `no-recording` distinction is made.
+	 */
+	cancel(): Promise<Result<void, RecorderError>>;
 	subscribe(handler: (state: WhisperingRecordingState) => void): () => void;
 };
 

--- a/apps/whispering/src/lib/state/manual-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/manual-recorder.svelte.ts
@@ -149,7 +149,9 @@ function createManualRecorder() {
 			const { error: bootstrapError } = await ensureBootstrapped();
 			if (bootstrapError) return Err(bootstrapError);
 			if (!_current) return Ok({ status: 'no-recording' as const });
-			return _current.cancel();
+			const { error } = await _current.cancel();
+			if (error) return Err(error);
+			return Ok({ status: 'cancelled' as const });
 		},
 	};
 }

--- a/apps/whispering/src/lib/state/vad-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/vad-recorder.svelte.ts
@@ -40,7 +40,7 @@ const VadRecorderError = defineErrors({
 });
 type VadRecorderError = InferErrors<typeof VadRecorderError>;
 
-export const vadKeys = defineKeys({
+const vadKeys = defineKeys({
 	devices: ['vad', 'devices'],
 });
 

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
@@ -134,8 +134,7 @@
 					</Alert.Title>
 					<Alert.Description>
 						VAD mode uses the browser's Web Audio API for real-time voice
-						detection and records via the browser's MediaRecorder API. Audio is
-						encoded to uncompressed WAV format.
+						detection. Captured speech is encoded to uncompressed WAV format.
 					</Alert.Description>
 				</Alert.Root>
 			{/if}


### PR DESCRIPTION
A relentless greenfield + dead-code pass over the recorder subsystem, cross-checked with an independent codex hunt and a docs-straggler subagent. Stacks on the prior recorder PRs.

## The headline: `cancel()` returned a constant
`RecordingSession.cancel()` was typed `Promise<Result<{ status: 'cancelled' }, RecorderError>>` — but the success payload is a **constant** (a live session can only resolve to "cancelled"), so the field carried zero information the `Result` didn't already. Now `Result<void, RecorderError>`, with the manual-recorder wrapper synthesizing the real `cancelled` vs `no-recording` distinction (the only place it exists). The same smell hit `requireMicrophonePermission` / `requestMicrophonePermission` (`Result<true>` → `Result<void>`).

## Also in this pass
- **Inlined `getStreamForDeviceIdentifier`** — after the earlier fallback collapse it had exactly one caller; `getRecordingStream` is now the single self-contained acquisition function.
- **Dead-code scrub:** dropped the dead `RecordingArtifact` re-export from `recorder/types` (real consumers import from `$lib/tauri/commands`), un-exported `vadKeys` (used only in its own module).
- **Doc/JSDoc stragglers:** `asDeviceIdentifier` JSDoc called a brand cast a "type guard"; `report.loading()` JSDoc still listed the removed `update`; services/README called `device-stream` "shared by recorder backends" (CPAL records via Rust); VAD settings copy claimed it "records via MediaRecorder" (it encodes WAV from MicVAD frames).

## The one behavior change (flagged for review)
cpal `startRecording` now **closes the Rust session if `commands.startRecording()` fails** after a successful `initRecordingSession`. Previously it returned `StartFailed` and left the worker thread + cpal stream alive (a leak, and reload-recovery could reattach to a non-recording session). Mirrors the existing stop-error cleanup. It's a rare error path and **not runtime-tested** — worth a look.

## Explicitly left alone
`RecorderStopResult` (artifact/blob are real physical shapes), `resumeActiveSession`'s `null` (a real "no resumable session" state), the generic `RecorderService<P>`, the two `#platform` seams, `DeviceConnectionFailed` (kept — deleting it would force an uglier throwaway-error in the inline catch), `DeviceAcquisitionOutcome.success.deviceId` (redundant-with-caller but not a pure constant), and `NoticeAction`/`Problem` exports (foundational `report/` public surface). The 3 `.agents/skills/` reference docs that cite removed recorder symbols (`sendStatus`, `resolveServiceForStart`) are flagged separately — they teach patterns that need a pedagogy refresh, not a mechanical scrub, so I did not bundle them here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782972817&installation_id=128463665&pr_number=1889&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1889&signature=caee4acefefe8188d26e81261eacc734f82a1283ebeb0b4cba78aa90bc7a9a31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->