### PR TITLE
feat(wiki): wiki core + user-defined types vertical slice

### DIFF
--- a/apps/wiki/package.json
+++ b/apps/wiki/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "@epicenter/wiki",
+	"description": "Local-first curated knowledge base: pages with a worldview-neutral core plus user-defined schema-bearing types",
+	"private": true,
+	"version": "0.0.1",
+	"type": "module",
+	"exports": {
+		".": "./src/lib/workspace/index.ts"
+	},
+	"scripts": {
+		"test": "bun test",
+		"typecheck": "tsc --noEmit"
+	},
+	"devDependencies": {
+		"@types/bun": "catalog:",
+		"typescript": "catalog:"
+	},
+	"dependencies": {
+		"@epicenter/workspace": "workspace:*",
+		"typebox": "catalog:",
+		"wellcrafted": "catalog:",
+		"yjs": "catalog:"
+	},
+	"license": "AGPL-3.0-or-later"
+}

--- a/apps/wiki/src/lib/workspace/index.ts
+++ b/apps/wiki/src/lib/workspace/index.ts
@@ -1,0 +1,194 @@
+/**
+ * Wiki workspace contract: id, the two tables, the runtime "define a type" /
+ * "create a page" actions, and the workspace factory.
+ *
+ * Isomorphic, mirroring fuji's `src/lib/workspace/index.ts`: this file imports
+ * only isomorphic dependencies (`@epicenter/workspace`, `typebox`,
+ * `wellcrafted`). Filesystem wiring (the markdown vault) lives in
+ * `./markdown.ts`; the per-type SQLite index lives in `./projection.ts`.
+ *
+ * `body` is a row column for this slice (see `./schema.ts`), so there is no
+ * per-page content doc to open here; the markdown codec routes it to the file
+ * body. Promote it to a child `Y.Doc` when collaborative body editing is real.
+ */
+
+import {
+	createWorkspace,
+	DateTimeString,
+	defineActions,
+	defineMutation,
+	defineQuery,
+	defineWorkspace,
+	generateId,
+	type Keyring,
+} from '@epicenter/workspace';
+import { Type } from 'typebox';
+import { defineErrors, type InferErrors } from 'wellcrafted/error';
+import { Ok, type Result } from 'wellcrafted/result';
+import {
+	isTSchemaObject,
+	type PageId,
+	type PageTypeValues,
+	TYPE_ID_PATTERN,
+	type TypeId,
+	type WikiType,
+	wikiTableDefinitions,
+} from './schema';
+
+export const WIKI_ID = 'epicenter-wiki';
+
+export const WikiActionError = defineErrors({
+	/** A type id is not a stable slug ([a-z0-9_]+); it also names a SQL table. */
+	InvalidTypeId: ({ typeId }: { typeId: string }) => ({
+		message: `Type id "${typeId}" must be a slug matching ${TYPE_ID_PATTERN}`,
+		typeId,
+	}),
+	/** A type definition carries a column whose `schema` is not a TSchema object. */
+	InvalidColumnSchema: ({
+		typeId,
+		columnId,
+	}: {
+		typeId: string;
+		columnId: string;
+	}) => ({
+		message: `Type "${typeId}" column "${columnId}" schema must be a TSchema object (a column.* result)`,
+		typeId,
+		columnId,
+	}),
+});
+export type WikiActionError = InferErrors<typeof WikiActionError>;
+
+const columnSpecInput = Type.Object({
+	id: Type.String(),
+	name: Type.String(),
+	schema: Type.Unknown({
+		description: 'A column.* result (a TypeBox TSchema)',
+	}),
+});
+
+const typeValuesInput = Type.Record(
+	Type.String(),
+	Type.Record(Type.String(), Type.Unknown()),
+);
+
+/**
+ * Build a Wiki workspace: `{ ydoc, tables, kv, actions }`.
+ *
+ * `keyring` is optional (the headless slice runs without encryption); real
+ * runtimes pass one, exactly as fuji does.
+ */
+export function createWiki(opts?: { keyring?: () => Keyring }) {
+	const workspace = createWorkspace({
+		id: WIKI_ID,
+		keyring: opts?.keyring,
+		tables: wikiTableDefinitions,
+		kv: {},
+	});
+	const { tables } = workspace;
+
+	const actions = defineActions({
+		types_define: defineMutation({
+			title: 'Define Type',
+			description:
+				'Register a user-defined type (a Tana supertag) with a column schema.',
+			input: Type.Object({
+				id: Type.String({ description: 'Stable slug, e.g. youtube_video' }),
+				name: Type.String({ description: 'Display name' }),
+				icon: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+				columns: Type.Array(columnSpecInput),
+			}),
+			handler: ({
+				id,
+				name,
+				icon,
+				columns,
+			}): Result<{ id: TypeId }, WikiActionError> => {
+				// Validate the id at definition time, where the cause is visible.
+				// The same slug rule is re-checked in projection (it names a SQL
+				// table) as defense in depth, but this is the gate that fails early.
+				if (!TYPE_ID_PATTERN.test(id)) {
+					return WikiActionError.InvalidTypeId({ typeId: id });
+				}
+				// A type whose column schema is not a TSchema object is not worth
+				// storing; it would only fail validation and projection later.
+				for (const spec of columns) {
+					if (!isTSchemaObject(spec.schema)) {
+						return WikiActionError.InvalidColumnSchema({
+							typeId: id,
+							columnId: spec.id,
+						});
+					}
+				}
+				const now = DateTimeString.now();
+				tables.types.set({
+					id: id as TypeId,
+					name,
+					icon: icon ?? null,
+					columns: columns as unknown as WikiType['columns'],
+					createdAt: now,
+					updatedAt: now,
+				});
+				return Ok({ id: id as TypeId });
+			},
+		}),
+
+		pages_create: defineMutation({
+			title: 'Create Page',
+			description:
+				'Create a wiki page with core fields, an optional body, and optional type values.',
+			input: Type.Object({
+				title: Type.Optional(Type.String()),
+				description: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+				tags: Type.Optional(Type.Array(Type.String())),
+				source: Type.Optional(Type.Array(Type.String())),
+				types: Type.Optional(typeValuesInput),
+				body: Type.Optional(Type.String()),
+			}),
+			handler: ({ title, description, tags, source, types, body }) => {
+				const id = generateId<PageId>();
+				const now = DateTimeString.now();
+				tables.pages.set({
+					id,
+					title: title ?? '',
+					description: description ?? null,
+					tags: tags ?? [],
+					source: source ?? [],
+					types: (types ?? {}) as PageTypeValues,
+					body: body ?? '',
+					createdAt: now,
+					updatedAt: now,
+				});
+				return { id };
+			},
+		}),
+
+		pages_get: defineQuery({
+			title: 'Get Page',
+			description: 'Read one page by id.',
+			input: Type.Object({ id: Type.String() }),
+			handler: ({ id }) => tables.pages.get(id),
+		}),
+
+		pages_get_all: defineQuery({
+			title: 'List Pages',
+			description: 'Read every valid page.',
+			handler: () => tables.pages.getAllValid(),
+		}),
+
+		types_get_all: defineQuery({
+			title: 'List Types',
+			description: 'Read every user-defined type.',
+			handler: () => tables.types.getAllValid(),
+		}),
+	});
+
+	return defineWorkspace({
+		...workspace,
+		actions,
+		[Symbol.dispose]() {
+			workspace[Symbol.dispose]();
+		},
+	});
+}
+
+export type WikiWorkspace = ReturnType<typeof createWiki>;

--- a/apps/wiki/src/lib/workspace/lens.ts
+++ b/apps/wiki/src/lib/workspace/lens.ts
@@ -1,0 +1,87 @@
+/**
+ * Schema-on-read: a type's `columns` are a LENS over a page's stored values,
+ * never a gate or a migration.
+ *
+ * Changing a type's schema does not rewrite any page. Instead, at read time we
+ * line a page's stored `types[typeId]` values up against the type's CURRENT
+ * columns and bucket each property:
+ *
+ *   match    in data AND in schema   render typed (with a validity flag)
+ *   excess   in data, not in schema  kept verbatim; offer to remove
+ *   missing  in schema, not in data  show empty / a "fill me" prompt
+ *
+ * Pure: it reads, it never writes. The durable Yjs/markdown data is untouched;
+ * only the rendered view reflects the current schema.
+ */
+
+import { Value } from 'typebox/value';
+import type { JsonValue } from 'wellcrafted/json';
+import type { ColumnSpec } from './schema';
+
+/** A property present in both the data and the current schema. */
+export type LensMatch = {
+	id: string;
+	name: string;
+	value: JsonValue;
+	/**
+	 * Whether `value` satisfies the column's current schema. `false` is a soft
+	 * signal (the schema widened/changed under stored data), not a drop:
+	 * schema-on-read never deletes durable values.
+	 */
+	valid: boolean;
+};
+
+/** A property the schema declares but the page has no value for. */
+export type LensMissing = { id: string; name: string };
+
+/** A stored value with no matching column in the current schema. */
+export type LensExcess = { id: string; value: JsonValue };
+
+export type TypeLens = {
+	typeId: string;
+	match: LensMatch[];
+	missing: LensMissing[];
+	excess: LensExcess[];
+};
+
+/**
+ * Project one page's values for one type through that type's current columns.
+ *
+ * `data` is the page's `types[typeId]` cell (or `undefined` when the page does
+ * not carry the type, in which case every column reads as missing).
+ */
+export function viewThroughType({
+	typeId,
+	columns,
+	data,
+}: {
+	typeId: string;
+	columns: ColumnSpec[];
+	data: Record<string, JsonValue> | undefined;
+}): TypeLens {
+	const values = data ?? {};
+	const schemaIds = new Set(columns.map((c) => c.id));
+
+	const match: LensMatch[] = [];
+	const missing: LensMissing[] = [];
+	for (const spec of columns) {
+		if (!Object.hasOwn(values, spec.id)) {
+			missing.push({ id: spec.id, name: spec.name });
+			continue;
+		}
+		const value = values[spec.id]!;
+		match.push({
+			id: spec.id,
+			name: spec.name,
+			value,
+			valid: Value.Check(spec.schema, value),
+		});
+	}
+
+	const excess: LensExcess[] = [];
+	for (const [id, value] of Object.entries(values)) {
+		if (!schemaIds.has(id)) excess.push({ id, value });
+	}
+
+	return { typeId, match, missing, excess };
+}

--- a/apps/wiki/src/lib/workspace/markdown.ts
+++ b/apps/wiki/src/lib/workspace/markdown.ts
@@ -1,0 +1,89 @@
+/**
+ * Wiki markdown vault: the bidirectional desktop projection.
+ *
+ *   pages/<id>.md   frontmatter IS the page row (core columns + the nested
+ *                   `types` cell); the file body IS the page `body` column,
+ *                   routed out of frontmatter by the codec below.
+ *   types/<id>.md   frontmatter IS the type registry row, including `columns`
+ *                   whose `schema` is the TypeBox schema as JSON.
+ *
+ * Wiring lives here (filesystem-facing) rather than in the isomorphic factory,
+ * mirroring how fuji keeps `index.ts` pure and composes IO in `browser.ts`.
+ * The `markdown_push` action is the disk-to-Yjs reconcile ("markdown apply"):
+ * it reads the files, parses frontmatter, validates against the table schema,
+ * and writes rows back into Yjs.
+ */
+
+import { attachMarkdownMaterializer } from '@epicenter/workspace/document/materializer/markdown';
+import type { WikiWorkspace } from './index';
+import { asPageId, isTSchemaObject, type Page, type WikiType } from './schema';
+
+/**
+ * Attach the markdown vault to a wiki workspace. Returns the materializer so a
+ * caller can `await whenFlushed` and invoke `actions.markdown_push` to reconcile
+ * disk edits back into Yjs.
+ */
+export function attachWikiVault(
+	wiki: WikiWorkspace,
+	{ dir }: { dir: string | (() => string | Promise<string>) },
+) {
+	return attachMarkdownMaterializer(
+		{ ydoc: wiki.ydoc, tables: wiki.tables },
+		{
+			dir,
+			perTable: {
+				types: {
+					// Default frontmatter codec, plus a decode gate: a hand-edited
+					// type file whose column `schema` is not a JSON object is rejected
+					// at import, matching the `types_define` action's own check rather
+					// than silently degrading later in projection/lens.
+					fromMarkdown: (parsed) => {
+						const row = parsed.frontmatter as WikiType;
+						for (const spec of row.columns) {
+							if (!isTSchemaObject(spec.schema)) {
+								throw new Error(
+									`type "${row.id}" column "${spec.id}" schema must be a TSchema object`,
+								);
+							}
+						}
+						return row;
+					},
+				},
+				pages: {
+					// `body` is a row column but belongs in the file body, never in
+					// frontmatter; route it across in both directions.
+					toMarkdown: (page) => ({
+						frontmatter: {
+							id: page.id,
+							title: page.title,
+							description: page.description,
+							tags: page.tags,
+							source: page.source,
+							types: page.types,
+							createdAt: page.createdAt,
+							updatedAt: page.updatedAt,
+						},
+						body: page.body.length > 0 ? page.body : undefined,
+					}),
+					fromMarkdown: (parsed) => {
+						const fm = parsed.frontmatter;
+						const page: Page = {
+							id: asPageId(String(fm.id)),
+							title: String(fm.title ?? ''),
+							description: (fm.description ?? null) as Page['description'],
+							tags: (fm.tags ?? []) as string[],
+							source: (fm.source ?? []) as string[],
+							types: (fm.types ?? {}) as Page['types'],
+							body: parsed.body ?? '',
+							createdAt: fm.createdAt as Page['createdAt'],
+							updatedAt: fm.updatedAt as Page['updatedAt'],
+						};
+						return page;
+					},
+				},
+			},
+		},
+	);
+}
+
+export type WikiVault = ReturnType<typeof attachWikiVault>;

--- a/apps/wiki/src/lib/workspace/projection.ts
+++ b/apps/wiki/src/lib/workspace/projection.ts
@@ -1,0 +1,185 @@
+/**
+ * Per-type SQLite projection: the derived, disposable query index.
+ *
+ * SQLite is never truth. It is re-projected from the CURRENT type schemas, so
+ * it is always safe to drop and rebuild. The shape:
+ *
+ *   wiki_pages(id PK, title, description, tags, source, created, updated)
+ *   wiki_page_types(page_id, type_id)                  -- membership edge
+ *   wiki_type_<typeId>(page_id PK, c_<colId> ...)      -- one per type
+ *
+ * Two consequences fall straight out of this layout:
+ *
+ *   - A column's physical id is `c_<colId>`, and `colId` never changes on a
+ *     display rename, so a rename emits NO DDL (`projectWiki` returns the same
+ *     DDL string). Adding a column changes the DDL, so it re-projects.
+ *   - Projection is schema-on-read: only columns in the CURRENT schema become
+ *     physical columns; excess stored values are simply not projected (they
+ *     survive in Yjs, see `./lens.ts`).
+ */
+
+import type { Database } from 'bun:sqlite';
+import type { TSchema } from 'typebox';
+import type { JsonValue } from 'wellcrafted/json';
+import { type Page, typeColumns, type WikiType } from './schema';
+
+/** Result of one projection run: the DDL emitted per type table. */
+export type ProjectionResult = {
+	/** `typeId -> CREATE TABLE` for that type's side table. */
+	typeTableDdl: Record<string, string>;
+};
+
+/**
+ * Drop and rebuild the entire derived index from the current registry + pages.
+ * Idempotent and disposable: call it again after any schema or data change.
+ */
+export function projectWiki(
+	db: Database,
+	{ types, pages }: { types: WikiType[]; pages: Page[] },
+): ProjectionResult {
+	dropProjectedTables(db);
+
+	db.run(
+		`CREATE TABLE ${q('wiki_pages')} (` +
+			`${q('id')} TEXT PRIMARY KEY, ${q('title')} TEXT NOT NULL, ` +
+			`${q('description')} TEXT, ${q('tags')} TEXT NOT NULL, ` +
+			`${q('source')} TEXT NOT NULL, ${q('created')} TEXT NOT NULL, ` +
+			`${q('updated')} TEXT NOT NULL)`,
+	);
+	db.run(
+		`CREATE TABLE ${q('wiki_page_types')} (` +
+			`${q('page_id')} TEXT NOT NULL, ${q('type_id')} TEXT NOT NULL, ` +
+			`PRIMARY KEY (${q('page_id')}, ${q('type_id')}))`,
+	);
+
+	const insertPage = db.prepare(
+		`INSERT INTO ${q('wiki_pages')} ` +
+			`(${q('id')}, ${q('title')}, ${q('description')}, ${q('tags')}, ${q('source')}, ${q('created')}, ${q('updated')}) ` +
+			'VALUES (?, ?, ?, ?, ?, ?, ?)',
+	);
+	const insertMembership = db.prepare(
+		`INSERT INTO ${q('wiki_page_types')} (${q('page_id')}, ${q('type_id')}) VALUES (?, ?)`,
+	);
+	for (const page of pages) {
+		insertPage.run(
+			page.id,
+			page.title,
+			page.description,
+			JSON.stringify(page.tags),
+			JSON.stringify(page.source),
+			page.createdAt,
+			page.updatedAt,
+		);
+		for (const typeId of Object.keys(page.types)) {
+			insertMembership.run(page.id, typeId);
+		}
+	}
+
+	const typeTableDdl: Record<string, string> = {};
+	for (const type of types) {
+		typeTableDdl[type.id] = projectTypeTable(db, type, pages);
+	}
+
+	return { typeTableDdl };
+}
+
+/**
+ * Build and populate one `wiki_type_<typeId>` side table from the type's
+ * CURRENT columns. Returns the `CREATE TABLE` statement so callers can prove a
+ * rename emits identical DDL while an add does not.
+ */
+function projectTypeTable(db: Database, type: WikiType, pages: Page[]): string {
+	const tableName = `wiki_type_${assertSafeSlug(type.id)}`;
+
+	const columnDefs: string[] = [`${q('page_id')} TEXT PRIMARY KEY`];
+	const projected: { colId: string; physical: string }[] = [];
+	for (const spec of typeColumns(type)) {
+		const physical = `c_${spec.id}`;
+		columnDefs.push(`${q(physical)} ${deriveStorage(spec.schema)}`);
+		projected.push({ colId: spec.id, physical });
+	}
+
+	const ddl = `CREATE TABLE ${q(tableName)} (${columnDefs.join(', ')})`;
+	db.run(ddl);
+
+	const columns = [q('page_id'), ...projected.map((p) => q(p.physical))];
+	const placeholders = columns.map(() => '?').join(', ');
+	const insert = db.prepare(
+		`INSERT INTO ${q(tableName)} (${columns.join(', ')}) VALUES (${placeholders})`,
+	);
+	for (const page of pages) {
+		const data = page.types[type.id];
+		if (data === undefined) continue; // page does not carry this type
+		const values = projected.map((p) => serializeValue(data[p.colId]));
+		insert.run(page.id, ...values);
+	}
+
+	return ddl;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// SQLITE HELPERS (self-contained; the workspace internals are not public)
+// ════════════════════════════════════════════════════════════════════════════
+
+/** Drop every wiki-projected table so the next projection is a clean rebuild. */
+function dropProjectedTables(db: Database): void {
+	const rows = db
+		.query<{ name: string }, []>(
+			"SELECT name FROM sqlite_master WHERE type = 'table' " +
+				"AND (name = 'wiki_pages' OR name = 'wiki_page_types' OR name LIKE 'wiki_type_%')",
+		)
+		.all();
+	for (const { name } of rows) db.run(`DROP TABLE IF EXISTS ${q(name)}`);
+}
+
+/** Double-quote a SQL identifier, escaping embedded quotes. */
+function q(identifier: string): string {
+	return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+/** Type ids become physical table-name segments, so keep them slug-shaped. */
+function assertSafeSlug(value: string): string {
+	if (!/^[a-z0-9_]+$/.test(value)) {
+		throw new Error(
+			`type id "${value}" is not a safe table-name segment (expected [a-z0-9_]+)`,
+		);
+	}
+	return value;
+}
+
+type SchemaShape = { type?: string; const?: unknown; anyOf?: TSchema[] };
+
+/**
+ * SQLite storage class for a column schema. Mirrors the workspace materializer's
+ * `deriveStorage` (which is not exported from the package), including the
+ * `const`/literal branch, so a `column.literal(5)` column derives INTEGER like
+ * the real one rather than silently falling through to TEXT.
+ */
+function deriveStorage(schema: TSchema): 'TEXT' | 'INTEGER' | 'REAL' {
+	const s = schema as SchemaShape;
+	if (s.type === 'integer' || s.type === 'boolean') return 'INTEGER';
+	if (s.type === 'number') return 'REAL';
+	if (s.type === 'string' || s.type === 'array' || s.type === 'object') {
+		return 'TEXT';
+	}
+	if (s.const !== undefined) {
+		return typeof s.const === 'number' && Number.isInteger(s.const)
+			? 'INTEGER'
+			: 'TEXT';
+	}
+	if (s.anyOf) {
+		const nonNull = s.anyOf.filter(
+			(branch) => (branch as SchemaShape).type !== 'null',
+		);
+		if (nonNull.length === 1 && nonNull[0]) return deriveStorage(nonNull[0]);
+	}
+	return 'TEXT';
+}
+
+/** Convert a stored JSON value into a SQLite binding. */
+function serializeValue(value: JsonValue | undefined): string | number | null {
+	if (value === null || value === undefined) return null;
+	if (typeof value === 'boolean') return value ? 1 : 0;
+	if (typeof value === 'object') return JSON.stringify(value);
+	return value;
+}

--- a/apps/wiki/src/lib/workspace/schema.ts
+++ b/apps/wiki/src/lib/workspace/schema.ts
@@ -1,0 +1,139 @@
+/**
+ * Wiki schema: the two first-party tables and the shared types.
+ *
+ * The whole model is two ordinary `defineTable` schemas:
+ *
+ *   types   a registry of user-defined types. Each row IS a type: a stable id,
+ *           a display name, an optional icon, and `columns` (the user's schema,
+ *           stored as ColumnSpec[]). Materialized to `types/<id>.md`.
+ *
+ *   pages   the unit of the wiki. A worldview-neutral core (id, title,
+ *           description?, tags[], source[], timestamps) plus ONE nested json
+ *           cell `types` holding membership + values, keyed by type id, plus a
+ *           `body` (the markdown body of the file). Membership IS key presence:
+ *           a page is a `youtube_video` iff its `types` cell has that key.
+ *
+ * `body` is a plain string column on the row for this slice (routed to the
+ * markdown file's body section by `./markdown.ts`, never into frontmatter). It
+ * shares the row's whole-row LWW, the same trade every page already accepts.
+ * Promote it to a per-row content `Y.Doc` (fuji's entry-body pattern) when
+ * collaborative or independently-syncing body editing is real.
+ */
+
+import { column, defineTable, type InferTableRow } from '@epicenter/workspace';
+import { type TSchema, Type } from 'typebox';
+import type { Brand } from 'wellcrafted/brand';
+import type { JsonObject, JsonValue } from 'wellcrafted/json';
+
+/** Stable id of a wiki page (the markdown file stem, the row key). */
+export type PageId = string & Brand<'PageId'>;
+/** Stable id of a user-defined type (a slug like `youtube_video`). */
+export type TypeId = string & Brand<'TypeId'>;
+
+export const asPageId = (value: string): PageId => value as PageId;
+
+/** A type id is a stable slug; it also becomes a SQL table-name segment. */
+export const TYPE_ID_PATTERN = /^[a-z0-9_]+$/;
+
+/** A column.* result is a non-null JSON object; a string/array/primitive is not. */
+export function isTSchemaObject(value: unknown): boolean {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * One column of a user-defined type.
+ *
+ * - `id` is the stable physical id. A rename never touches it, which is what
+ *   makes a display rename metadata-only (no SQL DDL).
+ * - `name` is the display name; free to change.
+ * - `schema` is the column's TypeBox schema, authored with the real `column.*`
+ *   builders (`column.url()`, `column.nullable(column.number())`) so call sites
+ *   get autocomplete and type-checking. A `TSchema` IS JSON Schema, so it is
+ *   stored verbatim and re-validated with `Value.Check` after the Yjs/JSON
+ *   round-trip (this TypeBox validates on plain JSON Schema, no `[Kind]`
+ *   symbols, so a round-tripped schema validates identically). NO eval, NO
+ *   codegen, NO interpreter.
+ */
+export type ColumnSpec = {
+	id: string;
+	name: string;
+	schema: TSchema;
+};
+
+/**
+ * The `types.columns` cell.
+ *
+ * A `TSchema` IS a JSON object at runtime, but TypeBox's `TSchema` static type
+ * is not seen as `JsonValue`, so `defineTable`'s SQLite-safe gate would reject a
+ * `schema: TSchema` field. The cell therefore stores `schema` as a JSON object
+ * and `typeColumns()` reads it back as a `ColumnSpec` (schema as `TSchema`).
+ * The runtime value is the same object either way.
+ */
+type StoredColumnSpec = { id: string; name: string; schema: JsonObject };
+
+const columnsCell = Type.Unsafe<StoredColumnSpec[]>(
+	Type.Array(
+		Type.Object({
+			id: Type.String(),
+			name: Type.String(),
+			schema: Type.Unknown(),
+		}),
+	),
+);
+
+/**
+ * The `pages.types` cell: membership + values, keyed by type id then column id.
+ *
+ *   { youtube_video: { url: "https://...", duration: 1240 } }
+ *
+ * Like `columnsCell`, this uses `Type.Unsafe` rather than `column.json`: the
+ * exact `Record<string, Record<string, JsonValue>>` static carries through while
+ * the runtime schema stays an `object` the SQLite layer maps to a TEXT cell. Do
+ * not "simplify" it back to `column.json`; the nested-record static does not
+ * survive that gate.
+ */
+export type PageTypeValues = Record<string, Record<string, JsonValue>>;
+
+const pageTypeValuesCell = Type.Unsafe<PageTypeValues>(
+	Type.Record(Type.String(), Type.Record(Type.String(), Type.Unknown())),
+);
+
+/** The types registry: one row per user-defined type. */
+export const typesTable = defineTable({
+	id: column.string<TypeId>(),
+	name: column.string(),
+	icon: column.nullable(column.string()),
+	columns: columnsCell,
+	createdAt: column.dateTime(),
+	updatedAt: column.dateTime(),
+});
+
+/** The pages table: worldview-neutral core + the nested `types` cell + body. */
+export const pagesTable = defineTable({
+	id: column.string<PageId>(),
+	title: column.string(),
+	description: column.nullable(column.string()),
+	tags: column.json(Type.Array(Type.String())),
+	source: column.json(Type.Array(Type.String())),
+	types: pageTypeValuesCell,
+	body: column.string(),
+	createdAt: column.dateTime(),
+	updatedAt: column.dateTime(),
+});
+
+export type WikiType = InferTableRow<typeof typesTable>;
+export type Page = InferTableRow<typeof pagesTable>;
+
+/**
+ * Read a registry row's columns as authoring `ColumnSpec[]` (each `schema` a
+ * `TSchema`). The single boundary where the stored JSON-object schema is read
+ * back as a TypeBox schema; the runtime value is unchanged.
+ */
+export function typeColumns(type: WikiType): ColumnSpec[] {
+	return type.columns as unknown as ColumnSpec[];
+}
+
+export const wikiTableDefinitions = {
+	types: typesTable,
+	pages: pagesTable,
+};

--- a/apps/wiki/src/lib/workspace/wiki.test.ts
+++ b/apps/wiki/src/lib/workspace/wiki.test.ts
@@ -1,0 +1,217 @@
+/**
+ * The wiki vertical slice, end to end. One test walks the eight milestone
+ * steps: define a type at runtime, create a page in it, materialize it to
+ * `<id>.md`, edit the file, reconcile it back into Yjs, project a per-type
+ * SQLite side table, answer a typed query, and prove a rename is metadata-only
+ * while an add re-projects. Two focused tests cover the schema-on-read lens and
+ * the rename-vs-add DDL distinction.
+ *
+ * If this loop holds, the architecture is real.
+ */
+
+import { Database } from 'bun:sqlite';
+import { expect, test } from 'bun:test';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { column } from '@epicenter/workspace';
+import {
+	assembleMarkdown,
+	parseMarkdownFile,
+} from '@epicenter/workspace/markdown';
+import { createWiki } from './index';
+import { viewThroughType } from './lens';
+import { attachWikiVault } from './markdown';
+import { projectWiki } from './projection';
+import type { ColumnSpec, Page } from './schema';
+
+const youtubeColumns: ColumnSpec[] = [
+	{ id: 'url', name: 'URL', schema: column.url() },
+	{
+		id: 'duration',
+		name: 'Duration',
+		schema: column.nullable(column.number()),
+	},
+];
+
+test('round-trips a typed page Yjs <-> markdown <-> Yjs and answers a typed SQLite query', async () => {
+	const dir = await mkdtemp(join(tmpdir(), 'wiki-vault-'));
+	const wiki = createWiki();
+	try {
+		// 1 + 3. Define the youtube_video type at runtime (real column.* calls).
+		const defined = wiki.actions.types_define({
+			id: 'youtube_video',
+			name: 'YouTube Video',
+			columns: youtubeColumns,
+		});
+		expect(defined.error).toBeNull();
+
+		// 4. Create a page carrying that type, with a body and epicenter:// source.
+		const created = wiki.actions.pages_create({
+			title: 'Great talk',
+			source: ['epicenter://whispering/recordings/rec_123'],
+			types: { youtube_video: { url: 'https://youtu.be/abc', duration: 1240 } },
+			body: 'Notes about the talk.',
+		});
+		const pageId = created.id;
+
+		// Materialize through the vault.
+		const vault = attachWikiVault(wiki, { dir });
+		await vault.whenFlushed;
+
+		const pagePath = join(dir, 'pages', `${pageId}.md`);
+		const pageMd = await readFile(pagePath, 'utf-8');
+		expect(pageMd).toContain('https://youtu.be/abc');
+		expect(pageMd).toContain('duration: 1240');
+		expect(pageMd).toContain('Notes about the talk.');
+		expect(pageMd).toContain('epicenter://whispering/recordings/rec_123');
+
+		// types/<id>.md carries the column schema as JSON.
+		const typeMd = await readFile(
+			join(dir, 'types', 'youtube_video.md'),
+			'utf-8',
+		);
+		expect(typeMd).toContain('format: uri'); // column.url()
+
+		// 5. Edit the .md as a text editor would, then reconcile (markdown apply).
+		const parsed = parseMarkdownFile(pageMd)!;
+		(parsed.frontmatter.types as Page['types']).youtube_video!.duration = 999;
+		await writeFile(
+			pagePath,
+			assembleMarkdown(parsed.frontmatter, 'Edited notes.'),
+		);
+
+		const push = await vault.actions.markdown_push();
+		expect(push.errored).toBe(0);
+
+		const after = wiki.actions.pages_get({ id: pageId }).data!;
+		expect(after.types.youtube_video!.duration).toBe(999);
+		expect(after.types.youtube_video!.url).toBe('https://youtu.be/abc');
+		expect(after.body).toBe('Edited notes.');
+
+		// 6 + 7. Project per-type SQLite and answer a typed query.
+		const db = new Database(':memory:');
+		try {
+			projectWiki(db, {
+				types: wiki.actions.types_get_all(),
+				pages: wiki.actions.pages_get_all(),
+			});
+			const rows = db
+				.query<{ title: string; d: number }, [number]>(
+					'SELECT p.title, yv.c_duration AS d ' +
+						'FROM wiki_pages p ' +
+						'JOIN wiki_type_youtube_video yv ON yv.page_id = p.id ' +
+						'WHERE yv.c_duration > ?',
+				)
+				.all(500);
+			expect(rows).toHaveLength(1);
+			expect(rows[0]!.title).toBe('Great talk');
+			expect(rows[0]!.d).toBe(999);
+		} finally {
+			db.close();
+		}
+	} finally {
+		wiki[Symbol.dispose]();
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test('schema-on-read lens buckets match / excess / missing', () => {
+	// Current schema declares url, duration, rating; the stored data has url,
+	// a malformed duration, and an unknown `channel`.
+	const columns: ColumnSpec[] = [
+		...youtubeColumns,
+		{ id: 'rating', name: 'Rating', schema: column.number() },
+	];
+	const data = {
+		url: 'https://youtu.be/abc',
+		duration: 'not-a-number',
+		channel: 'Veritasium',
+	};
+
+	const lens = viewThroughType({ typeId: 'youtube_video', columns, data });
+
+	const matchById = Object.fromEntries(lens.match.map((m) => [m.id, m]));
+	expect(lens.match.map((m) => m.id).sort()).toEqual(['duration', 'url']);
+	expect(matchById.url!.valid).toBe(true);
+	// Stored but invalid under the current schema: surfaced, never dropped.
+	expect(matchById.duration!.valid).toBe(false);
+	expect(lens.missing.map((m) => m.id)).toEqual(['rating']);
+	expect(lens.excess.map((e) => e.id)).toEqual(['channel']);
+	expect(lens.excess[0]!.value).toBe('Veritasium');
+});
+
+test('types_define rejects a non-slug type id at definition time', () => {
+	const wiki = createWiki();
+	try {
+		const result = wiki.actions.types_define({
+			id: 'Not A Slug',
+			name: 'Bad',
+			columns: [{ id: 'x', name: 'X', schema: column.string() }],
+		});
+		expect(result.error?.name).toBe('InvalidTypeId');
+		expect(wiki.actions.types_get_all()).toHaveLength(0);
+	} finally {
+		wiki[Symbol.dispose]();
+	}
+});
+
+test('column rename is metadata-only; adding a column re-projects', () => {
+	const wiki = createWiki();
+	const db = new Database(':memory:');
+	try {
+		wiki.actions.types_define({
+			id: 'youtube_video',
+			name: 'YouTube Video',
+			columns: youtubeColumns,
+		});
+		wiki.actions.pages_create({
+			title: 'clip',
+			types: { youtube_video: { url: 'https://youtu.be/abc', duration: 10 } },
+		});
+
+		const project = () =>
+			projectWiki(db, {
+				types: wiki.actions.types_get_all(),
+				pages: wiki.actions.pages_get_all(),
+			}).typeTableDdl.youtube_video;
+
+		const ddlBefore = project();
+
+		// Rename display names only; the stable column ids never change.
+		wiki.actions.types_define({
+			id: 'youtube_video',
+			name: 'YouTube Video',
+			columns: [
+				{ id: 'url', name: 'Link', schema: column.url() },
+				{
+					id: 'duration',
+					name: 'Length',
+					schema: column.nullable(column.number()),
+				},
+			],
+		});
+		expect(project()).toBe(ddlBefore); // no DDL: a rename is metadata-only
+
+		// Add a column: the physical shape changes, so projection emits new DDL.
+		wiki.actions.types_define({
+			id: 'youtube_video',
+			name: 'YouTube Video',
+			columns: [
+				{ id: 'url', name: 'Link', schema: column.url() },
+				{
+					id: 'duration',
+					name: 'Length',
+					schema: column.nullable(column.number()),
+				},
+				{ id: 'rating', name: 'Rating', schema: column.number() },
+			],
+		});
+		const ddlAfterAdd = project();
+		expect(ddlAfterAdd).not.toBe(ddlBefore);
+		expect(ddlAfterAdd).toContain('"c_rating"');
+	} finally {
+		db.close();
+		wiki[Symbol.dispose]();
+	}
+});

--- a/apps/wiki/tsconfig.json
+++ b/apps/wiki/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"types": ["bun"],
+		"noUnusedLocals": true,
+		"noUnusedParameters": true
+	}
+}

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",
@@ -460,6 +459,20 @@
         "vite": "catalog:",
         "vite-plugin-devtools-json": "^1.0.0",
         "wrangler": "catalog:",
+      },
+    },
+    "apps/wiki": {
+      "name": "@epicenter/wiki",
+      "version": "0.0.1",
+      "dependencies": {
+        "@epicenter/workspace": "workspace:*",
+        "typebox": "catalog:",
+        "wellcrafted": "catalog:",
+        "yjs": "catalog:",
+      },
+      "devDependencies": {
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
       },
     },
     "apps/zhongwen": {
@@ -1142,6 +1155,8 @@
     "@epicenter/util": ["@epicenter/util@workspace:packages/util"],
 
     "@epicenter/whispering": ["@epicenter/whispering@workspace:apps/whispering"],
+
+    "@epicenter/wiki": ["@epicenter/wiki@workspace:apps/wiki"],
 
     "@epicenter/workspace": ["@epicenter/workspace@workspace:packages/workspace"],
 

--- a/packages/workspace/src/document/column/sugar.ts
+++ b/packages/workspace/src/document/column/sugar.ts
@@ -84,6 +84,17 @@ function string<T extends string = string>(
 			: never;
 }
 
+/**
+ * URL string column. A `TString` carrying `format: 'uri'` as a hint, so the
+ * schema is self-describing and editor tooling can surface it. Static type is
+ * `string` (no brand): callers store and read plain strings. When the `uri`
+ * format is not registered with the runtime validator, `Value.Check` treats it
+ * as a pass, so this never rejects a value the rest of the system would accept.
+ */
+function url(opts?: TStringOptions): TString {
+	return Type.String({ format: 'uri', ...opts });
+}
+
 /** Pass-through to `Type.Number`, exposed as `column.number`. */
 const number = Type.Number;
 
@@ -209,6 +220,7 @@ function ianaTimeZone(opts?: TSchemaOptions): TUnsafe<IanaTimeZone> {
  */
 export const column = {
 	string,
+	url,
 	number,
 	integer,
 	boolean,

--- a/specs/20260601T120000-creative-os-stack-naming-and-drop-serialization.md
+++ b/specs/20260601T120000-creative-os-stack-naming-and-drop-serialization.md
@@ -10,6 +10,8 @@
 - `docs/articles/20260525T120000-epicenter-local-first-creative-operating-system.md`
 
 > Revised 2026-06-01: extended with destinations taxonomy, Ship adapter architecture, slug-by-convention identity, storage index, and composing (round 2 design panel).
+>
+> Superseded in part 2026-06-02: the universal-core schema here (`stage`, `visibility`, and a singular `type` on every drop) is REVISED by [20260602T120000-wiki-core-collections-traits-and-curation.md](20260602T120000-wiki-core-collections-traits-and-curation.md), which shrinks the core to worldview-neutral fields plus loose `tags` and moves stage/visibility/type into opt-in `types` (Tana supertags).
 
 ## Overview
 

--- a/specs/20260601T120000-creative-os-stack-naming-and-drop-serialization.md
+++ b/specs/20260601T120000-creative-os-stack-naming-and-drop-serialization.md
@@ -1,0 +1,554 @@
+# Creative OS Stack Naming and Drop Serialization
+
+**Date**: 2026-06-01
+**Status**: Draft
+**Author**: Epicenter
+**Related**:
+
+- `specs/20260525T130000-creative-os-composition-map.md`
+- `specs/20260518T160639-theark-marp-shortform-content-engine.md`
+- `docs/articles/20260525T120000-epicenter-local-first-creative-operating-system.md`
+
+> Revised 2026-06-01: extended with destinations taxonomy, Ship adapter architecture, slug-by-convention identity, storage index, and composing (round 2 design panel).
+
+## Overview
+
+Epicenter is a local-first creative OS whose apps are named by legible action, whose public destination is The Ark, and whose unit of work is a "drop": one markdown file carrying four orthogonal metadata axes.
+
+This spec settles two things the composition map left open: what the apps are called, and how a single piece of work serializes to disk. It takes the four-compose-apps insight from the composition map to its conclusion (one editor) and pins the on-disk shape of a drop.
+
+```txt
+One sentence:
+  A drop is one markdown file. Frontmatter is its identity.
+  The body is its content and its relationships. Everything
+  else (folders, ledgers, projections) is derived.
+```
+
+## Motivation
+
+### Current State
+
+The composition map names apps by their legacy product identities, and several of them overlap.
+
+```txt
+Compose (today)
+  Honeycrisp    rich-text notes
+  Fuji          rich-text CMS entries
+  Opensidian    rich-text vault
+  Open City     rich-text public spaces
+
+  -> four apps whose only real difference is metadata defaults
+```
+
+Problems this leaves open:
+
+1. **Naming has no law**: some names are places (The Ark), some are actions (Polish, Whispering), some are fruit (Honeycrisp, Fuji). A reader cannot predict what a name means.
+2. **Four editors, one job**: Honeycrisp, Fuji, Opensidian, and Open City are the same editor wearing different metadata costumes.
+3. **The unit of work is undefined**: the map talks about transcripts, notes, entries, and artifacts as if they were different kinds of thing. On disk they are all one markdown file.
+4. **No serialization ruling**: nobody has said whether metadata is flat keys, sectioned YAML, or an external sidecar, and whether folders or frontmatter is the source of truth.
+
+### Desired State
+
+A naming law, a named stack, one editor, and one serialized unit.
+
+```txt
+Naming law:
+  PLATFORM / DESTINATION  -> place / metaphor   (Epicenter, The Ark)
+  TOOLS                   -> legible action      (Whispering, Polish, Clip, Draft, Ship)
+
+Unit of work:
+  drop = one markdown file (YAML frontmatter + body)
+  body IS the content; body holds relationships as [[wikilinks]]
+  frontmatter holds identity across four orthogonal axes
+```
+
+## The Naming Law
+
+Two layers, one rule each.
+
+```txt
+Layer            Naming rule            Examples
+---------------  ---------------------  ----------------------------
+platform /       place or metaphor      Epicenter (the OS)
+destination                             The Ark   (public network)
+
+tool             legible action verb    Whispering (voice capture)
+                                        Polish     (refine)
+                                        Clip       (web capture)
+                                        Draft      (compose)
+                                        Ship       (publish)
+```
+
+Gold standard already shipping: Whispering (voice capture) and Polish (refine). They are verbs you can act out. New tool names inherit that test: if you cannot say "I am going to X this," it is not a tool name.
+
+## The Named Stack
+
+Epicenter is the umbrella (private, local-first). Inside it: The Brain (the substrate), The Workshop (private tools), and a bridge to The Ark (public). Tools live under Epicenter, not under The Ark. The Ark is a destination sibling.
+
+```txt
+EPICENTER  -- ecosystem / local-first creative OS (umbrella, private side)
+|
++-- THE BRAIN      a folder of markdown files on disk (the substrate)
+|
++-- THE WORKSHOP   private tools that read and promote drops
+|     |
+|     +-- Flow        home: the stage board; the brain made visible
+|     +-- Whispering  voice -> drops          (keep; gold-standard name)
+|     +-- Clip        web/tabs -> drops       (replaces "Tab Manager")
+|     +-- Polish      refine drops            (keep)
+|     +-- Draft       THE editor              (one app; presets are saved views)
+|     +-- Ship        the membrane: publish/syndicate a drop outward
+|
++== bridge ==> THE ARK   public, server-authoritative network
+                         Ship's native 1:1 destination
+                         Ship also fans out to Substack, Medium, X, short-video
+```
+
+Ship is the only tool that touches both the private side and the public side, which is exactly why it is its own named tool: it is the membrane.
+
+### Apps That Die
+
+The collapse is the point. Differences between the old compose apps were metadata defaults, not different programs.
+
+```txt
+Honeycrisp ---+
+Fuji ---------+--> Draft   (one editor; old apps become saved facet/stage views)
+Opensidian ---+
+Open City ----+
+
+Tab Manager -----> Clip
+```
+
+The four-compose-apps observation from the composition map is taken to its conclusion: one editor named Draft. A "Fuji view" or "Honeycrisp view" is now a saved view inside Draft (a stage filter plus a type default), not a separate application.
+
+## The Drop: Four Orthogonal Axes
+
+A drop is one markdown file: YAML frontmatter plus body. The body IS the content. The frontmatter carries exactly four metadata axes. Each axis answers a different question, and none constrains the others. This is a coordinate system, not a backbone.
+
+| Axis | Field(s) | Question | Cardinality |
+| --- | --- | --- | --- |
+| classification | `type` (one) + `tags` (many) | what is this / what is it about | 1 + many |
+| lifecycle | `stage` | where is it in its life | one |
+| provenance | `source` | where did it come from | one, nullable |
+| release | `destinations` | where has it been released | many |
+
+Rulings:
+
+- **"facets" is deleted, not renamed.** `type` is load-bearing because it is singular (what a thing is). `tags` is load-bearing because it is open and plural (what it is about). They answer different questions; do not collapse them back into one "facets" bag.
+- **`source` is a provenance list (ids or URLs), never a navigation graph.** It is a bill of materials (what this drop was made from), not a hyperlink map: directional, acyclic, set-valued, closed at promote (see the Composing section). Associative links live in the body as `[[wikilinks]]`. Frontmatter is the drop's identity; the body is its relationships.
+- **Serialization is flat top-level keys.** Sectioned YAML is rejected as premature namespace engineering. A minimal-core-with-external-sidecar is rejected because it breaks portability and self-containment, which is the whole point of markdown-as-truth.
+
+### Canonical Frontmatter
+
+```yaml
+---
+# identity
+id: 01J8X7K9P2QW                              # ULID; content identity survives rename
+slug: offset-market-runs-on-vibes            # human handle, unique, the Ship slug and the
+                                             #   vocabulary-resolution key; stable, never re-derived from title
+title: The Offset Market Runs on Vibes
+description: Why carbon credits run on confidence, not proof.
+# classification
+type: essay                                  # singular; resolves (optionally) to drops/types/essay.md
+tags: [climate, pricing]                     # opaque slugs; each resolves (optionally) to drops/tags/<slug>.md
+# lifecycle
+stage: compose            # capture | refine | compose | done
+# provenance (bill of materials, array of upstream parents; not a graph)
+source:
+  - 01J8-walk-memo
+# release (intent; receipts live in Ship's ledger, not here)
+destinations: [ark, substack]                # opaque slugs; each resolves (optionally) to drops/destinations/<slug>.md
+# daemon-maintained, never hand-edited
+created: 2026-06-01T09:14:00Z
+updated: 2026-06-03T11:00:00Z
+---
+Every carbon credit rests on a promise no one checks...
+```
+
+## Folders Are a Derived Projection
+
+The canonical store is flat by id (`drops/<id>.md`). That is what the CRDT syncs, and it is fully portable. The daemon materializes read-only projections (`by-stage/`, `by-type/`) as symlinks so a human can browse them in Finder.
+
+```txt
+You author by frontmatter.
+You browse by projection.
+
+A Finder move means nothing.
+Stage changes only by editing  stage: .
+```
+
+On disk:
+
+```txt
+vault/
+  .epicenter/ship.json                       # Ship's ledger (receipts)
+  drops/                                      # canonical truth: flat, id-named
+    01J8X7K9P2QW.md
+  by-stage/  capture/ refine/ compose/ done/  # derived projection (symlinks)
+  by-type/   essays/ notes/ transcripts/      # derived projection (symlinks)
+```
+
+Rejected: folders-as-type and folders-as-stage. A file move would silently mutate a CRDT field, and hierarchy is single-parent so it cannot represent four orthogonal axes at once. The projection is one-way: frontmatter writes the tree; the tree never writes frontmatter.
+
+## Evergreen: Visibility Is Orthogonal to Stage
+
+`done` means released or finished, not public. Where a drop went lives in `destinations`, not in `stage`. There is no fifth "kept" or "lake" lane.
+
+```txt
+stage axis        capture -> refine -> compose -> done
+                                                   ^
+                                                   |  done = finished,
+                                                   |  not public
+
+visibility axis   destinations: [library]   private / evergreen lake
+                  destinations: [ark, ...]   public
+```
+
+Evergreen reference material (contacts, API keys, notes you reread) is `stage: done, destinations: [library]`: released privately to your own library. Born finished is allowed; you can enter directly at `done`.
+
+The terminal stage is named `done`, not `publish`, on purpose. "Publish" stays a pure destination action and never reads as "make public". `destinations: [library]` is the private evergreen lake; `[ark, substack]` is public release.
+
+## Ship: One Publishable, Two Kinds of Adapter
+
+Every destination projects from one canonical content shape. `description` is the universal subtitle, kicker, or hook.
+
+```ts
+type Publishable = {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;   // Ark subtitle | Substack subtitle | Medium kicker | video hook caption
+  body: string;          // markdown, canonical content
+  cover?: Asset;
+  tags: string[];
+  canonical?: string;
+};
+```
+
+Key insight: text destinations are projections (lossy, synchronous); short-video is a render (async, asset-producing). That asymmetry is honest, so Ship has two adapter kinds rather than one forced interface.
+
+```ts
+type TextAdapter<P> = (drop: Publishable, ctx: ShipContext) => {
+  payload: P;
+  warnings: string[];
+};
+
+type RenderAdapter<In, Out> = (drop: Publishable, ctx: ShipContext) => Promise<{
+  input: In;
+  output: Out;
+  warnings: string[];
+}>;
+
+const toArk: TextAdapter<ArkPayload>;
+const toSubstack: TextAdapter<SubstackPayload>;
+const toMedium: TextAdapter<MediumPayload>;
+const toTwitterThread: TextAdapter<TwitterThreadPayload>;
+
+const toShortVideo: RenderAdapter<ShortVideoRenderInput, ShortVideoRenderOutput>;
+```
+
+### Destination Mapping
+
+One Publishable, projected per destination. The same fields land in different slots.
+
+| Publishable field | The Ark | Substack | Medium | X (thread) | Short-video |
+| --- | --- | --- | --- | --- | --- |
+| `title` | post title | post title | post title | first-tweet lead | title card text |
+| `description` | subtitle | subtitle | kicker | hook tweet | hook caption (slide 0) |
+| `body` | post body | post body | post body | split into tweets | one idea per slide |
+| `cover` | hero image | header image | featured image | first-tweet media | poster + title card |
+| `tags` | tags | tags | tags | trailing hashtags | metadata only |
+
+### Short-Video Render Plan
+
+This ties to the existing short-form content engine spec. The render adapter input is concrete.
+
+```ts
+type ShortVideoRenderInput = {
+  renderer: 'marp' | 'remotion';
+  aspect: '9:16';
+  hook: string;                              // from Publishable.description
+  hookClip: { src: string; durationSec: 2 }; // the 2-second face/pull intro
+  voiceover: { src: string; transcript: Segment[] };
+  slides: VideoSlide[];                      // body -> one idea per slide
+  captions: ForcedAlignmentCaption[];        // force-aligned, burned in
+  render: { fps: 30; width: 1080; height: 1920 };
+};
+
+type ShortVideoRenderOutput = {
+  video: Asset;
+  poster: Asset;
+  captionsVtt: string; // captions.vtt
+};
+```
+
+### Receipts vs Intent
+
+The split is deliberate. Intent travels with the drop; operational state does not.
+
+```txt
+intent      destinations: [ark, substack]   -> lives in the drop's frontmatter
+                                                portable, durable, hand-editable
+
+receipts    urls, timestamps, hashes,       -> live in Ship's ledger
+            retries, status                     .epicenter/ship.json, keyed by drop id
+                                                operational, not durable markdown
+```
+
+The `.epicenter/ship.json` ledger:
+
+```yaml
+01J8X7K9P2QW:
+  ark:
+    status: live
+    url: https://theark.so/p/offset-market-vibes
+    contentHash: sha256-9f2c...
+    publishedAt: 2026-06-03T11:04:00Z
+    retries: 0
+  substack:
+    status: failed
+    error: rate_limited
+    retries: 2
+    lastAttemptAt: 2026-06-03T11:06:30Z
+```
+
+Operational state (urls, hashes, retry counts, failure reasons) does not belong in the durable markdown. The drop declares where it should go; the ledger records what actually happened.
+
+## Design Decisions
+
+| Decision | Class | Choice | Rationale |
+| --- | --- | --- | --- |
+| Naming law, two layers | 3 taste | Places/metaphors for platform and destination; action verbs for tools | A reader can predict what a name means; Whispering and Polish already prove the verb test. |
+| Tools under Epicenter, not The Ark | 2 coherence | Tools live in The Workshop under Epicenter; The Ark is a destination sibling | Tools are private and local-first; The Ark is public and server-authoritative. Different ownership, different home. |
+| Ship as the membrane | 2 coherence | One named tool spans private and public | Only Ship touches both sides, so it earns its own name and its own ledger. |
+| Collapse four compose apps into Draft | 2 coherence | One editor; old apps become saved views | Honeycrisp, Fuji, Opensidian, and Open City differed only by metadata defaults. |
+| Four orthogonal axes | 2 coherence | classification, lifecycle, provenance, release as independent fields | Each answers a different question; none constrains the others. A coordinate system, not a backbone. |
+| Delete "facets" | 2 coherence | Split into `type` (one) + `tags` (many); do not keep "facets" | Singular identity and open description are different questions and need different cardinality. |
+| `source` is lineage, not a graph | 2 coherence | One nullable pointer in frontmatter; associative links in body `[[wikilinks]]` | Frontmatter is identity; the body is relationships. A graph in frontmatter is the wrong layer. |
+| Flat serialization | 3 taste | Flat top-level YAML keys | Sectioned YAML is premature namespace engineering; an external sidecar breaks portability. |
+| Folders as derived projection | 2 coherence | Canonical flat `drops/<id>.md`; `by-stage/` and `by-type/` are read-only symlinks | A file move must never mutate a CRDT field; hierarchy is single-parent and cannot hold four axes. |
+| Terminal stage named "done" | 3 taste | `done`, not `publish` | Keeps "publish" a pure destination action so it never reads as "make public". |
+| Visibility orthogonal to stage | 2 coherence | Where it went lives in `destinations`; no fifth "kept" lane | `done` means finished; `[library]` vs `[ark]` decides private vs public. |
+| One Publishable, two adapter kinds | 2 coherence | `TextAdapter` (sync projection) + `RenderAdapter` (async render) | Text destinations are lossy projections; short-video is an asset-producing render. The asymmetry is real. |
+| Receipts in Ship ledger, not frontmatter | 2 coherence | `destinations:` intent in the drop; urls/hashes/retries in `.epicenter/ship.json` | Operational state is not durable markdown; intent is portable, receipts are not. |
+| `type` cardinality | 2 coherence | Singular | `destinations` already owns one-to-many outputs; a type array double-counts the need it already holds. |
+| Identity model | 2 coherence | Slug-by-convention with two-tier identity | Content identity is a ULID (survives rename); vocabulary identity is a slug (the name is the meaning). |
+| `source` cardinality | 2 coherence | Array | A composed drop genuinely has N parents; `source[]` is a provenance bill of materials, not a navigation graph. |
+| No `related:` field | 2 coherence | Deliberate non-addition | Avoids a hand-authored truth-layer graph that drifts, cycles, and grows without bound. Associations stay `[[wikilinks]]` in the body. |
+| User `publish()` | 2 coherence | Refused | A user-authored `publish()` is SSRF-with-a-vault. The escape hatch is a PR or self-host, not a credential-bearing user verb. |
+| Storage | 2 coherence | Reuse existing SQLite materializer; add derived edge tables; no graph store | The derived-index pipeline already ships; edges are triggers over existing primitives, not a parallel index with its own rebuild. |
+
+## Destination Taxonomy
+
+Memo 1 proposed seven kinds. Three of them (`forum`, `chat-message`, `issue`) are the same animal wearing different collars: host markdown, optionally footer a canonical. Collapse them. Five kinds, not seven.
+
+| Kind | Hosts body? | Needs canonical first? | Brands |
+| --- | --- | --- | --- |
+| hosted-article | yes (full) | no (it mints it) | own blog, Epicenter blog, Medium, Substack |
+| hosted-post | yes (subset) | no (optional footer) | Reddit self-post, Discord, GitHub Issue |
+| link-submission | no | YES (hard gate) | HN, Reddit-link, Product Hunt, Bookface |
+| microblog-thread | yes (chunked) | no (links back) | X/Twitter |
+| vertical-video | yes (MP4) | no (independent) | TikTok, IG Reels, YT Shorts |
+
+The collapse: `forum`, `chat-message`, and `issue` all have the identical adapter contract, take `title` plus a lossy `body` subset plus an optional `canonical` footer, post it, get a `Receipt`. The only difference is a config field (`subreddit` / `channelId` / `repo+labels`). That is a connection-row config value, not a kind. Three kinds that differ only by a config string are one kind: "host a markdown post with optional canonical attribution." One sentence, one kind.
+
+`microblog-thread` and `vertical-video` stay separate because they genuinely differ in operation shape: a thread is a chunking projection (split at 280, sequence matters), and video is an async render, not a synchronous projection. Different verbs, different shapes. Honest asymmetry.
+
+### Ship's two-wave ordering
+
+```txt
+WAVE 1  canonical-hosting (mints the URL)
+  hosted-article (ONE designated primary) --> sets Publishable.canonical
+  + other hosted-article / hosted-post set canonicalUrl --> primary (SEO rel)
+
+        | canonical now resolved
+        v
+WAVE 2  link-submission  (HARD precondition: canonical != null)
+  HN . Reddit-link . Product Hunt . Bookface
+  + microblog-thread (links back to canonical)
+
+INDEPENDENT (no canonical edge, runs parallel to Wave 1)
+  vertical-video   (async render, self-hosting asset)
+```
+
+Four ordering rules, enforced by the Ship engine, not by convention:
+
+1. Exactly one Wave-1 destination is `primary`; its returned `url` becomes `Publishable.canonical`. Every other hosted destination sets `canonicalUrl -> primary`.
+2. Ship REFUSES to dispatch any `link-submission` while `canonical == null`. Hard precondition, surfaced as an error, never a silent skip.
+3. Selecting only `link-submission` destinations with no host is an invalid plan. Error: "no canonical host selected." Never fabricate a URL.
+4. `vertical-video` schedules in parallel with Wave 1 (no canonical dependency).
+
+`link-submission` is not a special adapter type. It is a `hosted=false` adapter with `requiresCanonical: true`. The ordering gate lives in the Ship engine reading that flag, not in a parallel interface hierarchy.
+
+## Ship Adapter Architecture (three layers)
+
+The verdict first: a user-authored `publish()` is SSRF-as-a-service with a credential vault attached. Do not build it. Ship the safe layers, refuse the dangerous verb.
+
+```txt
+                    +-------------------------------------+
+ Drop --Publishable-->|           SHIP ENGINE             |
+                    |  (first-party; OWNS vault + fetch)  |
+                    +--------------+----------------------+
+                                   | resolves
+      +----------------------------+----------------------------+
+      v (3) DATA ROW                v (1) BUILT-IN        (2) USER v
+ connection table              first-party TS         pure project() only
+ id, kind, label,              substack/reddit/ark    no creds, no network,
+ vaultRef (token id),          full PublishContext    runs in no-I/O isolate
+ config(JSON)                  (real authed fetch)    paired w/ HTTP recipe
+```
+
+Layer 1, built-in adapters (first-party TS). The only code that touches the vault and the network. Two shapes, not one with a `mode` discriminator: text is a synchronous `project`, video is an async `render`.
+
+```ts
+export type Publishable = {
+  id: string; slug: string; title: string; description: string;
+  body: string; cover?: { url: string; alt: string };
+  tags: string[]; canonical?: string;
+};
+
+export type TextAdapter<Payload> = {
+  kind: DestinationKind;
+  requiresCanonical?: boolean;                 // the ordering gate (link-submission = true)
+  project(input: Publishable): Payload;         // PURE. no creds, no network, no clock.
+  publish(p: Payload, creds: Credentials, ctx: PublishContext): Promise<Receipt>;
+};
+
+export type RenderAdapter<Payload> = {
+  kind: DestinationKind;                         // vertical-video only
+  render(input: Publishable, ctx: RenderContext): Promise<Payload>; // async artifact
+  publish(p: Payload, creds: Credentials, ctx: PublishContext): Promise<Receipt>;
+};
+```
+
+`PublishContext` is the only capability surface the effectful half gets: a host-allowlisted `fetch`, a structured `log`, and an `idempotencyKey` derived from `(drop id, kind, content hash)`.
+
+Layer 2, user scripting. Open the door exactly this far and no further. A user authors a pure `project(Publishable) -> Payload` only: it runs in a V8 isolate with ZERO host bindings (no `fetch`, no creds, no env, CPU-capped, output size-capped), paired with a first-party declarative `HttpRecipe` for the authed POST. A user-authored `publish()` is REFUSED. The escape hatch is one of: open a PR to a first-party adapter, point an `HttpRecipe` at your own server, or (self-hoster) cross the trust boundary in your own Worker.
+
+Layer 3, connection rows (data). Plain workspace data on the existing `defineTable`/`column` primitive. The token is NEVER in the row; the row holds a `vaultRef`. This is non-negotiable: row values sync as plaintext through the relay (the body-encryption-gap finding), so a raw token in a column leaks.
+
+```ts
+export const connectionsTable = defineTable({
+  id:        column.string<ConnectionId>(),
+  kind:      column.string(),                  // 'hosted-article' | 'link-submission' | ...
+  brand:     column.string(),                  // 'substack' | 'reddit' | 'hackernews'
+  label:     column.string(),                  // "My newsletter", "r/selfhosted"
+  vaultRef:  column.nullable(column.string()), // pointer into the vault, NOT the secret
+  config:    column.json(),                    // { subreddit } | { repo, labels } | { publicationUrl }
+  createdAt: column.number(),
+});
+```
+
+## Identity: Slug-by-Convention
+
+Two-tier identity is law. Content drops use a ULID (identity survives rename). Vocabulary (type, tag, destination) uses a human slug (the name is the meaning). A frontmatter `slug` stores a plain string that OPTIONALLY resolves, by path convention, to a vocabulary drop carrying its metadata.
+
+```txt
+drops/types/essay.md          template + default destinations + description
+drops/tags/climate.md         tag page + backlinks + aliases
+drops/destinations/substack.md  adapter / connection config
+
+PRESENT  -> behavior
+ABSENT   -> plain label, always valid
+```
+
+Three laws make it a system, not a vibe:
+
+1. Two-tier identity. Content is a ULID; vocabulary is a slug. You never hand-type a ULID into `tags:`, and you never let a slug's meaning drift silently.
+2. Resolution is opt-in and lazy. A slug with no page is a label, not a dangling pointer. Absence is always valid.
+3. Rename and merge via an `aliases:` list on the vocabulary drop, folded by the indexer at read time. Content drops are never rewritten to rename a tag.
+
+| Property | Opaque | Slug-by-convention | Full-reference |
+| --- | --- | --- | --- |
+| markdown portability | perfect | near-perfect | BROKEN (cat useless) |
+| grep-as-query | yes | yes | no |
+| attach metadata | impossible | yes (term is a drop) | yes |
+| rename / merge | manual | lazy aliases, no rewrite | clean but needs DB |
+| manage a graph | immune | opt-in edges only | maximal |
+
+Full-reference is disqualified: storing `tags: [01J8TAG-CLIMATE]` means you cannot `cat` or `grep` a drop without a database, which violates markdown-as-truth. Slug-by-convention keeps every opaque win (content drops stay byte-identical) and adds every full-reference win (metadata, lazy rename) without the portability catastrophe.
+
+This collapses view, template, and type-page into one mechanism: a Draft view (`type: view`), a template (`type: template`), and the `essay` type page (`type: type`) are the same thing. Vocabulary is just drops keyed by slug.
+
+## Storage and Query Index
+
+SQLite (recursive CTEs plus FTS5) is sufficient; a graph or triple store is not warranted. The entire derived-index pipeline already exists and ships in three apps. The recommendation is to configure existing primitives in `packages/workspace`, not build infrastructure.
+
+```txt
+Yjs Y.Doc (TRUTH)
+  |- attachBunSqliteMaterializer --> SQLite mirror (DERIVED, disposable)
+  |     observe() debounced UPSERT . sqlite_rebuild . FTS5 triggers
+  |- attachMarkdownMaterializer --> {slug}-{id}.md  (markdown_push/pull/rebuild)
+  +- openSqliteReader --> read-only WAL handle for peers/scripts
+```
+
+Key reconciliation: SQLite is NEVER rebuilt from markdown directly. Both markdown and SQLite are siblings derived from the Yjs Y.Doc (the truth).
+
+```txt
+disk .md --markdown_push--> Yjs rows --observe()--> SQLite mirror (auto UPSERT + FTS)
+  (truth)    parse+validate    (truth)    debounced
+```
+
+What is missing today: edges. The materializer mirrors rows 1:1; `source` is a scalar and `tags`/`destinations` are JSON arrays (queryable, not joinable). The fix stays in the grain of the existing system: derived edge tables populated by triggers, modeled on `fts.ts`'s `setupForBulkLoad` precedent. No new public primitive.
+
+```sql
+drop_provenance(child_id, parent_id)    -- explode source[]; recursive CTE for lineage
+drop_tags(drop_id, tag)                 -- explode tags[]
+drop_destinations(drop_id, destination) -- explode destinations[]
+drop_links(from_id, to_id)              -- [[wikilink]] extraction; reverse lookup = backlinks
+```
+
+Provenance lineage and backlinks are recursive CTEs over indexed edge tables: textbook SQLite at personal-brain scale, not graph-DB territory. Verdict: no graph or triple store. It would be a parallel index with its own rebuild, its own Yjs reconciliation, and no FTS integration: pure cost.
+
+## Composing
+
+`source` is an ARRAY: `SourceRef[]` where `SourceRef = DropId | URL`. Empty means born original; one element is the refine case; N means composed. It stays provenance, never navigation, because of four constraints:
+
+```txt
+DIRECTIONAL  always upstream (made-from)         not bidirectional "see also"
+ACYCLIC      can't be made from your descendant  no cycles
+SET          order-free, dedup, no edge metadata not weighted/typed edges
+CLOSED       written once at promote             not an open editing surface
+```
+
+Three relationships live in three layers; do not conflate them.
+
+| Relationship | Where | Syntax | Semantics | Renders? |
+| --- | --- | --- | --- | --- |
+| PROVENANCE | frontmatter | `source: [id]` | made from (lineage) | no (metadata) |
+| TRANSCLUSION | body | `![[id]]` | embed X's content | yes, inline live |
+| REFERENCE | body | `[[id]]` | mention / jump to X | yes, as a link |
+
+Two rules keep `source[]` from rotting into a hairball:
+
+```txt
+RULE A  source[] grows ONLY when you PULL material into the body.
+        A mere [[mention]] does NOT add to source[]. Made-from requires taking.
+RULE B  source[] is CLOSED at promote. New associations go in the body as
+        [[wikilinks]], never back into frontmatter.
+```
+
+NO `related:` field. A `related:` array is open, bidirectional, grows forever, and begs for edge types: the graph-DB-in-YAML hairball. Provenance is recorded as a byproduct of authoring: Draft unions the dragged-from id into `source[]` when you pull a passage. You never type an id into `source:`. `type` carries an optional template (a `type: template, for: essay` skeleton drop Draft clones on "New essay").
+
+## Open Questions
+
+1. **Does Whispering stay a standalone named app or fold into a generic capture inbox?**
+   - Recommendation: stays standalone. It is shipping brand equity, and "voice -> drop" is a legible action worth its own name.
+
+2. **How far does the adapter-power door open?**
+   - The fork is a declarative `HttpRecipe` (no user code in the egress path) versus a sandboxed imperative user `publish()` with host-injected opaque creds. The pure-`project()` isolate plus `HttpRecipe` is the safe near-term answer; whether to ever cross into sandboxed imperative egress is undecided.
+
+3. **What does the `type` narrowing migration look like in practice?**
+   - Narrowing `apps/fuji/src/lib/workspace/index.ts` `type` from a JSON array to `column.string()` is a sync-wire-contract change. It requires a real migration, not a silent edit. The migration shape is open.
+
+4. **Does `library` (the private destination) need sync to The Ark servers, or stay purely local?**
+   - Staying local keeps evergreen reference material private by construction. Syncing would enable cross-device private access but reintroduces a server dependency for non-public drops. Undecided.
+
+5. **Which Ship destination ships first?**
+   - Recommendation: Markdown export or The Ark native, before fragile third-party APIs. Both avoid OAuth and rate-limit failure modes while proving the Publishable contract.
+
+## References
+
+- `specs/20260525T130000-creative-os-composition-map.md` - the Capture/Refine/Compose/Publish map this spec refines into named tools and one editor.
+- `specs/20260518T160639-theark-marp-shortform-content-engine.md` - the short-video render pipeline that `toShortVideo` targets.
+- `docs/articles/20260525T120000-epicenter-local-first-creative-operating-system.md` - vision article for the local-first creative OS.

--- a/specs/20260602T120000-wiki-core-collections-traits-and-curation.md
+++ b/specs/20260602T120000-wiki-core-collections-traits-and-curation.md
@@ -1,0 +1,381 @@
+# Wiki Core, Collections, Types, and Curation
+
+**Date**: 2026-06-02
+**Status**: Draft
+**Author**: Epicenter
+**Related**:
+
+- [20260601T120000-creative-os-stack-naming-and-drop-serialization.md](20260601T120000-creative-os-stack-naming-and-drop-serialization.md): the four-axis drop model this spec revises; a drop becomes a Wiki Page, and `stage` / `visibility` / `destinations` / singular `type` leave the universal core and become an opt-in `type`.
+- [20260525T130000-creative-os-composition-map.md](20260525T130000-creative-os-composition-map.md): the capture / refine / compose / publish map, typed integrations, and `epicenter://` links; the capture-to-curation bridge here REALIZES that typed-integration direction.
+- [20260220T195900-clean-markdown-yaml-frontmatter-export.md](20260220T195900-clean-markdown-yaml-frontmatter-export.md): the markdown vault, frontmatter-is-the-row, disk-to-Yjs reconcile this spec's storage model builds on.
+- [20260518T160639-theark-marp-shortform-content-engine.md](20260518T160639-theark-marp-shortform-content-engine.md): The Ark, the public render target a `publishing` type ships a Page toward.
+- [packages/workspace/src/document/column/sugar.ts](../packages/workspace/src/document/column/sugar.ts): the `column.*` DSL; each helper returns a vanilla TypeBox `TSchema` that is at once JSON Schema, validator input, and static-type carrier.
+- [packages/workspace/src/document/define-table.ts](../packages/workspace/src/document/define-table.ts): `defineTable`, the `FlatJsonTSchema` SQLite-safe constraint, and the positional `_v` + `.migrate()` versioning a type schema reuses.
+- [packages/workspace/src/document/table.ts](../packages/workspace/src/document/table.ts): the `YKeyValueLww` storage primitive (whole-row last-write-wins) and `Value.Check` row validation the concurrency rulings rest on.
+- [packages/workspace/src/links.ts](../packages/workspace/src/links.ts): `EpicenterLink` and the `epicenter://{workspace}/{table}/{id}` scheme the curation bridge resolves through.
+
+## Overview
+
+The Epicenter Wiki is a curated, local-first peer namespace whose unit is a Page with a minimal worldview-neutral core, loose `tags`, and any number of opt-in schema-bearing `types` (Tana supertags), with publishing modeled as a type and user-defined type schemas authored in the `column.*` DSL.
+
+This spec supersedes the trait-based draft that preceded it. The earlier draft split "what kind of thing is this" into a single-value Collection and "what else is this" into many Traits. That split was one concept too many. This rewrite collapses both into one idea, the `type` (Tana's supertag): a Page can carry several types, and each type contributes its own typed properties. A Collection is no longer a second kind of thing; it is just the table VIEW of every Page that shares a type.
+
+```txt
+One sentence:
+  A Wiki Page has a tiny worldview-neutral core (id, title,
+  description?, tags[], source[], timestamps) plus a body. It
+  opts into any number of TYPES, each a named identity that
+  contributes typed properties. The VIEW of all Pages sharing a
+  type is a COLLECTION. Publishing is just one of those types.
+```
+
+## Motivation
+
+### Current State
+
+The owner's real store lives at `~/Code/epicenter-md` (outside this repo; cited as evidence, not as a repo file): roughly fifteen thousand markdown files under a single forced nullable schema in `epicenter.config.md.ts`. One `pages` table, one shape, applied to everything. The shape failed in five concrete ways.
+
+```txt
+FAILURE 1  type[] became folksonomy
+  `type` was a free multiSelect. It exploded into 770 directory
+  combinations; 558 of them hold a single file. A schema that
+  collapses into 558 one-off folders is not a schema, it is tag soup.
+
+FAILURE 2  status meant four unrelated things at once
+  workflow    Needs Scaffolding   x4433
+  provenance  Imported from Todoist   x449
+  audience    Family   x238
+  junk        miscellaneous garbage values
+  One column, four orthogonal meanings, zero of them clean.
+
+FAILURE 3  visibility leaked foreign vocabulary
+  values like `Mild`, `Commune` (not a visibility at all)
+
+FAILURE 4  optional fields were mostly empty
+  resonance   blank x1513
+  url         present on only 461 of ~15,000
+
+FAILURE 5  body lived in two places
+  some kinds put text in `content`, others in `content_draft` (x863)
+
+PLUS one telling misfile
+  a note ABOUT a campus talk was filed as `Recipe`.
+```
+
+The `status` overload (workflow plus provenance plus audience plus junk in one column) is the cautionary tale this spec keeps pointing back to: an ordered workflow state and a loose label do not belong in the same field.
+
+The store ALREADY discovered the alternative. The owner's own `clippings/` folder is not one forced schema; it is clean per-type collections:
+
+```txt
+clippings/articles      domain, word_count, quality
+clippings/recipes       servings, prep, cook
+clippings/github_repos  owner/repo, stars, language
+clippings/essays        resonance
+```
+
+And `Needs Scaffolding x4433` literally means "captured, not yet curated." The capture-versus-curation split was staring back from the data the whole time.
+
+### Desired State
+
+Stop forcing one schema onto BOTH raw capture and curated knowledge. That is the root error. The fix is a core that imposes no worldview, plus a single opt-in mechanism that is multi-valued and schema-bearing: the `type`.
+
+```txt
+CORE (every Page, worldview-neutral)
+  id, title, description?, tags[], source[], created, updated   + body
+
+TYPES (0..many, opt-in, schema-bearing)
+  named identities a Page has; each contributes typed properties
+  (Tana supertag / a Notion database treated as a Page identity)
+
+the VIEW of all Pages sharing a type
+  is a COLLECTION (the table view). "Collection" names the VIEW,
+  "type" names the page-level IDENTITY.
+```
+
+The earlier creative-OS core (see [20260601T120000](20260601T120000-creative-os-stack-naming-and-drop-serialization.md)) tried to put singular `type`, `stage`, `visibility`, and `destinations` on every drop. This spec already removed those from the universal core under greenfield scrutiny, and the rename here is consistent with that removal: a `type` is opt-in, multi, and schema-bearing, NOT a forced singular core label. CORE is the minimum that lets a user EXPRESS any methodology (PARA, Zettelkasten, GTD, CRM) without IMPOSING one. `tags` is the single worldview-neutral facet; `id`, `title`, and timestamps are mechanical; `source[]` is method-neutral provenance; `description` is an optional universal summary, never required.
+
+## The Model: Three Layers
+
+Read it top to bottom: worldview-neutral core, then any number of opt-in typed identities, then the table view that each type induces.
+
+```txt
+                 +-------------------------------------------------+
+  CORE           | id  title  description?  tags[]  source[]        |   every Page
+  (worldview-    | created  updated                       + body   |   has exactly this
+   neutral)      +-------------------------------------------------+
+                              |
+                 +------------+-------------------------------------+
+  TYPES          | 0..N opt-in schema-bearing identities            |   "what is this,
+  (Tana          |   youtube_video { url, duration }                |    what else is it"
+   supertag)     |   gift_idea     { recipient, budget, priority }  |   multi-value
+                 +------------+-------------------------------------+
+                              |
+                 +------------+-------------------------------------+
+  COLLECTION     | the table VIEW of every Page sharing a type      |   "type" = identity
+  (the view)     |   the youtube_video collection = all such Pages  |   "collection" = view
+                 +-------------------------------------------------+
+```
+
+Naming rulings: the page-level identity is a `type` (a Page can have several); the table view of all Pages of a type is a `collection`. Loose `tags` stay separate as zero-ceremony labels. "Supertag" is acceptable UI copy for `type`.
+
+## Two Tables (defineTable)
+
+There are exactly two first-party tables: a registry of user-defined types, and the Pages table. Both are ordinary [`defineTable`](../packages/workspace/src/document/define-table.ts) schemas.
+
+```ts
+// the TYPES REGISTRY: a system table (fixed first-party schema). Each row is one
+// user-defined type; its schema is DATA (an array of ColumnSpec), materialized to
+// types/<id>.md so it is editable in VSCode.
+const types = defineTable({
+  id:        column.string(),                 // "youtube_video" (stable slug; the key)
+  name:      column.string(),                 // "YouTube Video" (display; rename is free)
+  icon:      column.nullable(column.string()),
+  columns:   column.json(/* schema for ColumnSpec[] */),  // the user schema, stored as JSON
+  createdAt: column.dateTime(),
+  updatedAt: column.dateTime(),
+});
+
+// PAGES: core columns + ONE json column `types` holding membership + values,
+// nested by type id.
+const pages = defineTable({
+  id:          column.string(),
+  title:       column.string(),
+  description: column.nullable(column.string()),  // optional summary
+  tags:        column.json(/* string[] */),        // loose labels; default []
+  source:      column.json(/* string[] */),        // provenance (paths | urls | epicenter:// links); default []
+  createdAt:   column.dateTime(),
+  updatedAt:   column.dateTime(),
+  types:       column.json(/* Record<typeId, Record<propName, unknown>> */),  // { youtube_video: { url, duration } }
+});
+// body = the per-row content doc (markdown), not a frontmatter column
+// (per the existing fuji entryBody pattern).
+```
+
+Membership IS key presence: a Page belongs to the `youtube_video` type iff `types` contains the `youtube_video` key. There is no separate membership flag.
+
+## ColumnSpec and column.* (verified against the codebase)
+
+Every `column.*` helper RETURNS a TypeBox `TSchema`. The [sugar.ts](../packages/workspace/src/document/column/sugar.ts) header states it precisely: "`column.X(opts)` returns a vanilla TypeBox `TSchema`; each schema IS the JSON Schema, the validator input, and the static-type carrier." [`defineTable`](../packages/workspace/src/document/define-table.ts) takes a `Record<name, TSchema>` with each column constrained by `FlatJsonTSchema`, which rejects any TypeBox kind that cannot map 1:1 to a SQLite column. So a user type schema is built out of the same vocabulary as a first-party table.
+
+```ts
+type ColumnSpec = {
+  id: string;        // stable column id; rename touches `name`, never this -> rename is metadata-only
+  name: string;      // display name
+  schema: TSchema;   // a column.* result: column.url() | column.nullable(column.number())
+                     //   | column.enum([...]) | ... constrained to FlatJsonTSchema (SQLite-safe).
+                     //   It IS JSON Schema, so it serializes.
+};
+
+// a type's `columns` is ColumnSpec[]. Stored via column.json (a TSchema is a JSON
+// object, so it round-trips).
+//
+// runtime validation of a Page's `types.<id>` values uses TypeBox Value.Check
+// against the stored schema. NO eval, NO codegen.
+//
+// schema versioning reuses defineTable's positional `_v` + `.migrate()`; user
+// edits emit declarative ops (rename / add / remove / widen).
+```
+
+Make it explicit: there is no separate "ColumnSpec parser." `column.*` is the AUTHORING DSL, its output `TSchema` is the stored data, and `Value.Check` (already used in [table.ts](../packages/workspace/src/document/table.ts) for row validation) is the validator. Storing a user type schema is storing JSON (the `column.*` `TSchema` output), not storing or evaluating TypeScript.
+
+## Nullability Rulings
+
+- `description`: nullable (`column.nullable(column.string())`), an optional summary.
+- `icon` (types): nullable; genuinely absent for most types.
+- `tags`, `source`, `types` (on pages) and `columns` (on types): NOT nullable; default to EMPTY (`[]` / `{}`).
+- `body`: the page content; an empty body is the empty string, never null. In practice body is the per-row content doc, not a column.
+
+Rule: prefer EMPTY over NULL for collections so there is no null-check on the common path; reserve `nullable` for genuinely-absent scalars (`description`, `icon`).
+
+## Storage and Concurrency (grounded in the real primitives)
+
+A [`defineTable`](../packages/workspace/src/document/define-table.ts) row is stored in a `YKeyValueLww` (see [table.ts](../packages/workspace/src/document/table.ts)): a `Y.Array` of `{ key, val, ts }` entries where the WHOLE row is one plain-object `val`, reconciled by whole-row last-write-wins on a timestamp. `column.*` create NO Yjs nodes; there is no per-column merge; `update()` is a read-modify-write of the entire row.
+
+```txt
+YKeyValueLww  Y.Array of { key, val, ts }
+   key = page id
+   val = the WHOLE row (core columns + the nested `types` json cell)
+   ts  = the LWW timestamp; the higher ts wins the whole val
+```
+
+Therefore the nested `types` json column is a single LWW cell. Two devices editing different properties on the SAME Page concurrently while offline reconcile to one whole row; the other device's edit is dropped.
+
+Rulings:
+
+1. This is the EXISTING contract for every Page already, not new behavior introduced here.
+2. It is acceptable for a personal wiki (the offline-concurrent-same-page danger window is narrow).
+3. The recovery net is `attachGitAutosave` git history on the vault: a dropped edit is a previous commit, not a lost edit.
+4. Add conflict VISIBILITY before going collaborative.
+5. Finer-grained merge, if ever needed, is NEW work, ranked: (a) a real nested-`Y.Map` column type; then (b) an EAV truth table `(pageId, typeId, propId) -> value` (the one place EAV is justified, TRUTH only, with SQLite staying the typed projection); then (c) per-type physical columns (a bad fit because types are runtime-defined).
+
+## Schema-on-Read (a type schema is a LENS, not a gate)
+
+Changing a type's schema does NOT migrate Page data. At read time the schema is applied per type:
+
+```txt
+match     in data AND in schema             show normally
+excess    in data, NOT in current schema    survives while membership exists; offer to remove
+missing   in schema, NOT in data            show empty / a red "fill me" prompt
+```
+
+The TYPED SQLite index is RE-PROJECTED from the current schema (disposable, rebuildable); the durable markdown/Yjs data is never migrated. A type change is a display mismatch plus an optional bulk-fix, never a forced destructive migration. Removing a type key from a Page deletes that type's nested values: membership and type-scoped values are coupled, so dropping the identity drops its properties.
+
+## Capture vs Curation: Peer Namespaces and the Bridge
+
+The Wiki is NOT the universal substrate. It is a PEER top-level namespace alongside `apps/whispering` (voice capture) and `apps/tab-manager` (web / reddit-save capture), which own their raw native data in their own Yjs workspaces and docs. Raw capture does NOT auto-materialize into the Wiki; an item enters only through deliberate curation. This realizes the typed-integration direction of the [composition map](20260525T130000-creative-os-composition-map.md): tools integrate through explicit `epicenter://` references, not a shared substrate every tool writes into.
+
+```txt
+                 CAPTURE (own raw native data, own Yjs workspace/docs)
+   +-------------------+   +-------------------+
+   | apps/whispering   |   | apps/tab-manager  |
+   | recordings,       |   | saved tabs,       |
+   | transcripts       |   | reddit/tweet saves|
+   +---------+---------+   +---------+---------+
+             |  curateToWiki(...)     |  curateToWiki(...)
+             |  (deliberate, manual)  |  (deliberate, manual)
+             v                        v
+        +-------------------------------------------+
+        | THE WIKI  (curation / compose namespace)  |
+        |  Pages: core + types (0..N)               |
+        |  raw capture does NOT auto-materialize    |
+        +----------------------+--------------------+
+                               |  Ship (publishing type)
+                               v
+                          THE ARK (public)
+```
+
+The bridge is one explicit call:
+
+```ts
+curateToWiki({
+  from: "epicenter://whispering/recordings/rec_123",
+  create: {
+    types: ["note"],
+    bodyMode: "copy",     // default: a durable artifact, not a live pinned view
+  },
+});
+```
+
+The resulting Page's `source[]` retains the `epicenter://` provenance link; the capture item is NOT deleted. The default `bodyMode` is `copy`: curation produces a durable artifact decoupled from the capture item's future edits, because a curated Page is meant to outlive and diverge from its raw source. Transclusion (a live, block-level embed) is an explicit option, not the default.
+
+Cross-namespace `epicenter://` resolves through the existing [links.ts](../packages/workspace/src/links.ts), which ships `epicenter://{workspace}/{table}/{id}` and parses it into a structured `EpicenterLink`. The bridge uses the `{workspace}` segment as the namespace authority (Open Question: is a capture app a "workspace" for this addressing).
+
+## Publishing Is a Type, Not Core, Not a Per-Type Field
+
+`publishing` is a type that carries `stage`, `visibility`, and `destinations`. It is not in the core (most Pages are never published) and it is not redefined per type (then every type would re-declare `stage` and the publishing board would fracture). Modeling publishing as a type is the direct consequence of the rename: anything that is "an identity some Pages also have" is a type.
+
+```ts
+// publishing as a user-defined type (one ColumnSpec[] in the types registry)
+{
+  id: "publishing",
+  name: "Publishing",
+  columns: [
+    { id: "stage",        name: "Stage",        schema: column.enum(["inbox","drafting","editing","scheduled","published","archived"]) },
+    { id: "visibility",   name: "Visibility",   schema: column.enum(["private","unlisted","public"]) },
+    { id: "destinations", name: "Destinations", schema: column.json(/* string[] */) },
+    { id: "publishAt",    name: "Publish at",   schema: column.nullable(column.dateTime()) },
+    { id: "publishedAt",  name: "Published at", schema: column.nullable(column.dateTime()) },
+  ],
+}
+```
+
+The Flow board is then "every Page carrying the `publishing` type, across all collections," shipping toward [The Ark](20260518T160639-theark-marp-shortform-content-engine.md). One type, one board, one definition of `stage`.
+
+```sql
+-- Flow board: every publishing Page, any collection, not yet archived
+SELECT p.id, p.title, pub.c_stage, pub.c_visibility, pub.c_publish_at
+FROM wiki_type_publishing pub
+JOIN wiki_pages p ON p.id = pub.page_id
+WHERE pub.c_stage != 'archived'
+ORDER BY pub.c_stage, p.updated DESC;
+```
+
+`stage` is NOT a tag. A tag is an open, unordered, worldview-neutral label; `stage` is an ordered workflow state with board semantics (column order, transitions, a terminal `archived`). The `epicenter-md` `status` overload is exactly what happens when an ordered state and a loose label share a field. Keep them apart.
+
+## SQLite Projection (per type)
+
+Each type materializes a 1:1 side table with stable physical ids, a join table projects membership, and core columns live on `wiki_pages`. The display name is metadata, so a rename never issues DDL.
+
+```sql
+wiki_pages(id PK, title, description, tags, source, created, updated)  -- core columns
+wiki_page_types(page_id, type_id)                                      -- membership edge
+wiki_type_<stableId>(page_id PK, c_<colId> ...)                        -- one per type; props as columns
+```
+
+DDL is generated from the current `columns` schema and re-projected on schema change. Because physical column ids are stable, a display rename is metadata-only (no `ALTER`).
+
+```sql
+-- a Page with the youtube_video type carrying the gift_idea type:
+-- its values live in two side tables, joined to the core by id.
+SELECT p.id, p.title, yv.c_url, yv.c_duration, gi.c_recipient, gi.c_budget
+FROM wiki_pages p
+LEFT JOIN wiki_type_youtube_video yv ON yv.page_id = p.id
+LEFT JOIN wiki_type_gift_idea     gi ON gi.page_id = p.id
+WHERE p.id = ?;
+```
+
+## Storage and Truth
+
+Truth and projections carry forward from the [markdown vault model](20260220T195900-clean-markdown-yaml-frontmatter-export.md) (frontmatter-is-the-row).
+
+```txt
+Yjs Y.Doc            TRUTH (browser + desktop), CRDT-synced via YKeyValueLww
+   |
+   |  bidirectional desktop projection (disk-to-Yjs reconcile, "markdown_apply")
+   v
+markdown vault       <id>.md, frontmatter IS the core row; types/<id>.md IS each type schema
+   |
+   |  derived, disposable query index (re-projected from current schemas)
+   v
+SQLite               wiki_pages + wiki_page_types + wiki_type_<id> side tables
+```
+
+- Yjs is truth in the browser and on desktop.
+- The markdown vault is a bidirectional desktop projection: `<id>.md` (frontmatter is the row), and `types/<id>.md` (each user type schema as editable data).
+- SQLite is a derived query index: one side table per type plus the membership join and the core table. It is disposable and rebuildable, never the source of truth.
+
+## Design Decisions
+
+| Decision | Class | Choice | Rationale |
+| --- | --- | --- | --- |
+| Minimal worldview-neutral core | 2 coherence | id, title, description?, tags[], source[], created, updated, body | The smallest set that lets any methodology be EXPRESSED without one being IMPOSED. |
+| Types replace the Collection/Trait split | 3 taste | One concept: a multi, opt-in, schema-bearing `type` (Tana supertag) | The earlier draft's single-Collection plus many-Traits was one concept too many; a type covers both. |
+| "type" names the identity, "collection" names the view | 2 coherence | A Page HAS types; the table of all Pages of a type IS a collection | Two words for two things (page-level identity vs the view), no overlap. |
+| Loose tags kept separate | 3 taste | `tags` stays a zero-ceremony loose facet, not folded into types | Matches Obsidian's single default property; everything more opinionated is opt-in. |
+| ColumnSpec = { id, name, schema: TSchema } | 2 coherence | Schema authored via `column.*` (returns `TSchema`), stored as JSON, validated via `Value.Check` | `column.*` IS the DSL, its `TSchema` output IS the stored data; no eval, no separate parser. |
+| Two tables | 2 coherence | A types registry + a pages table | The registry holds schemas as DATA; pages hold core columns plus the nested `types` cell. |
+| Types as ONE nested json column | 2 coherence | `types: Record<typeId, Record<prop, unknown>>`; membership = key presence | One cell, no per-type physical column on pages; membership and values stay coupled. |
+| Whole-row LWW accepted | 1 evidence | `YKeyValueLww` whole-row last-write-wins, recovered by git autosave | This is the EXISTING contract; the danger window is narrow for a personal wiki. |
+| Schema-on-read lens | 2 coherence | match / excess / missing at read time; never a destructive migration | The typed SQLite index is re-projected; durable data is never migrated. |
+| SQLite re-projected with stable physical ids | 2 coherence | `wiki_type_<id>(page_id, c_<colId>)` + a membership join | Display rename is metadata-only (no DDL); the index is disposable. |
+| description / icon nullable, collections default-empty | 2 coherence | `nullable` for absent scalars; `[]` / `{}` for collections | No null-check on the common path; null reserved for genuinely-absent scalars. |
+| Publishing is a type | 2 coherence | `publishing` carries stage / visibility / destinations | One type keeps `stage` defined once and the Flow board whole across collections. |
+| Wiki as a curated peer namespace | 3 taste | A peer of whispering / tab-manager, not the universal substrate | Forcing one schema on raw capture AND curated knowledge is the root error; separate the spaces. |
+| curateToWiki bridge with epicenter:// provenance | 2 coherence | Explicit call, copy-by-default, `source: [epicenter://...]`, original retained | Curation is a deliberate durable artifact, not an auto-materialized live mirror. |
+| Trait arrival timing | Deferred | (now moot: types are the single concept; ship core + first types) | See Open Questions for which types ship first. |
+| epicenter:// namespace authority | Deferred | Reconcile a capture-app authority with the shipped `{workspace}` segment | The addressing for a capture app is unsettled (see Open Questions). |
+
+## Open Questions
+
+1. **Is a capture app a "workspace" for `epicenter://` addressing?** [links.ts](../packages/workspace/src/links.ts) uses `{workspace}/{table}/{id}`. The bridge needs the `{workspace}` segment to name a capture app like `whispering`; confirm a capture app registers as a resolvable workspace authority.
+
+2. **Store `columns` as raw `TSchema` JSON, or a compact `{ kind }` ColumnSpec?** Raw `TSchema` JSON round-trips with zero interpreter but is verbose to hand-edit in `types/<id>.md`; a compact `{ kind }` form is terser but needs an interpreter to rebuild the `TSchema`. Decide for VSCode-editability of `types/<id>.md`.
+
+3. **Finer-grained per-property merge.** Build a nested-`Y.Map` column type (real per-property CRDT merge), or accept whole-row LWW plus git recovery indefinitely? The trigger is going collaborative; for a personal wiki, whole-row LWW stands.
+
+4. **Unify loose `tags` into `types` later (full Tana), or keep them separate?** Current ruling: separate. Revisit only if the loose/typed boundary proves to be friction in practice.
+
+5. **Which types ship first?** Real data suggests `note`, `clipped-web`, `saved-social`, `recipe`, `essay`. Pick the one or two that prove the core-plus-types shape before scaling the registry.
+
+## References
+
+- [20260601T120000-creative-os-stack-naming-and-drop-serialization.md](20260601T120000-creative-os-stack-naming-and-drop-serialization.md): the four-axis drop model this spec revises; a drop becomes a Wiki Page, and stage / visibility / destinations / singular type leave the core and become the `publishing` type.
+- [20260525T130000-creative-os-composition-map.md](20260525T130000-creative-os-composition-map.md): the capture / refine / compose / publish map, typed integrations, and `epicenter://` links that the curation bridge realizes.
+- [20260220T195900-clean-markdown-yaml-frontmatter-export.md](20260220T195900-clean-markdown-yaml-frontmatter-export.md): the markdown vault and frontmatter-is-the-row projection this spec's storage model builds on.
+- [20260518T160639-theark-marp-shortform-content-engine.md](20260518T160639-theark-marp-shortform-content-engine.md): The Ark, the public render target the `publishing` type ships a Page toward.
+- [packages/workspace/src/document/column/sugar.ts](../packages/workspace/src/document/column/sugar.ts): the `column.*` DSL; each helper returns a vanilla TypeBox `TSchema` that is JSON Schema, validator input, and static-type carrier at once.
+- [packages/workspace/src/document/define-table.ts](../packages/workspace/src/document/define-table.ts): `defineTable`, the `FlatJsonTSchema` SQLite-safe constraint, and the positional `_v` + `.migrate()` versioning a type schema reuses.
+- [packages/workspace/src/document/table.ts](../packages/workspace/src/document/table.ts): the `YKeyValueLww` whole-row last-write-wins storage primitive and `Value.Check` row validation the concurrency and validation rulings rest on.
+- [packages/workspace/src/links.ts](../packages/workspace/src/links.ts): `EpicenterLink` and the `epicenter://{workspace}/{table}/{id}` scheme the curation bridge resolves through.
+- `~/Code/epicenter-md/epicenter.config.md.ts`: empirical evidence (outside this repo): the single forced nullable `pages` schema whose failure motivates the three-layer model.
+- `~/Code/epicenter-md/clippings/`: empirical evidence (outside this repo): the clean per-type collections (articles, recipes, github_repos, essays) the owner already discovered.

--- a/specs/20260602T120000-wiki-core-collections-traits-and-curation.md
+++ b/specs/20260602T120000-wiki-core-collections-traits-and-curation.md
@@ -153,6 +153,8 @@ const pages = defineTable({
 
 Membership IS key presence: a Page belongs to the `youtube_video` type iff `types` contains the `youtube_video` key. There is no separate membership flag.
 
+IMPLEMENTATION NOTE (slice): `apps/wiki` stores `body` as a plain `column.string()` on the page row, and the markdown codec routes it to the file's body section (never into frontmatter). It shares the row's whole-row LWW (the same trade the `types` cell already accepts) and round-trips through `<id>.md`. The per-row content `Y.Doc` (fuji's entry-body pattern, for independently-syncing/collaborative bodies) is the documented promotion path, deferred until collaborative body editing is real.
+
 ## ColumnSpec and column.* (verified against the codebase)
 
 Every `column.*` helper RETURNS a TypeBox `TSchema`. The [sugar.ts](../packages/workspace/src/document/column/sugar.ts) header states it precisely: "`column.X(opts)` returns a vanilla TypeBox `TSchema`; each schema IS the JSON Schema, the validator input, and the static-type carrier." [`defineTable`](../packages/workspace/src/document/define-table.ts) takes a `Record<name, TSchema>` with each column constrained by `FlatJsonTSchema`, which rejects any TypeBox kind that cannot map 1:1 to a SQLite column. So a user type schema is built out of the same vocabulary as a first-party table.
@@ -161,22 +163,35 @@ Every `column.*` helper RETURNS a TypeBox `TSchema`. The [sugar.ts](../packages/
 type ColumnSpec = {
   id: string;        // stable column id; rename touches `name`, never this -> rename is metadata-only
   name: string;      // display name
-  schema: TSchema;   // a column.* result: column.url() | column.nullable(column.number())
-                     //   | column.enum([...]) | ... constrained to FlatJsonTSchema (SQLite-safe).
-                     //   It IS JSON Schema, so it serializes.
+  schema: TSchema;   // the column.* result itself: column.url() | column.nullable(column.number())
+                     //   | column.enum([...]). A TSchema IS JSON Schema, so it is stored verbatim.
 };
 
-// a type's `columns` is ColumnSpec[]. Stored via column.json (a TSchema is a JSON
-// object, so it round-trips).
+// a type's `columns` is ColumnSpec[], stored as JSON. A TSchema's static type is
+// not seen as JsonValue, so the registry cell stores `schema` as a JSON object
+// and a single typed boundary (`typeColumns`) reads it back as a TSchema.
 //
 // runtime validation of a Page's `types.<id>` values uses TypeBox Value.Check
-// against the stored schema. NO eval, NO codegen.
+// against the STORED schema directly. NO eval, NO codegen, NO interpreter.
 //
 // schema versioning reuses defineTable's positional `_v` + `.migrate()`; user
 // edits emit declarative ops (rename / add / remove / widen).
 ```
 
-Make it explicit: there is no separate "ColumnSpec parser." `column.*` is the AUTHORING DSL, its output `TSchema` is the stored data, and `Value.Check` (already used in [table.ts](../packages/workspace/src/document/table.ts) for row validation) is the validator. Storing a user type schema is storing JSON (the `column.*` `TSchema` output), not storing or evaluating TypeScript.
+IMPLEMENTATION RESOLUTION (see Open Question 2). The slice in `apps/wiki` stores
+each column's schema as the `TSchema` the `column.*` call returns, NOT as a
+`column.*` string. The two principled choices are "store the call" or "store the
+output"; an intermediary `{ kind }` object is rejected as a third form. "Store the
+output" wins because (a) defining a type IN CODE uses the real `column.*` builder
+with full autocomplete and type-checking, (b) a `TSchema` is already JSON, so the
+`decode()` boundary collapses to identity (no parser, no injection surface, ~320
+fewer lines than the abandoned restricted reader), and (c) it was verified that
+this repo's TypeBox validates on PLAIN JSON Schema (no `[Kind]` symbols), so a
+schema that round-trips through the Yjs/JSON boundary still validates identically
+with `Value.Check`. The trade given up is pretty `types/<id>.md` files: a column
+schema renders as `{type: string, format: uri}`, not `column.url()`. Acceptable
+because type definitions are few and usually authored via the API, not hand-typed
+in the vault.
 
 ## Nullability Rulings
 
@@ -359,7 +374,7 @@ SQLite               wiki_pages + wiki_page_types + wiki_type_<id> side tables
 
 1. **Is a capture app a "workspace" for `epicenter://` addressing?** [links.ts](../packages/workspace/src/links.ts) uses `{workspace}/{table}/{id}`. The bridge needs the `{workspace}` segment to name a capture app like `whispering`; confirm a capture app registers as a resolvable workspace authority.
 
-2. **Store `columns` as raw `TSchema` JSON, or a compact `{ kind }` ColumnSpec?** Raw `TSchema` JSON round-trips with zero interpreter but is verbose to hand-edit in `types/<id>.md`; a compact `{ kind }` form is terser but needs an interpreter to rebuild the `TSchema`. Decide for VSCode-editability of `types/<id>.md`.
+2. **Store `columns` as raw `TSchema` JSON, or a compact `{ kind }` ColumnSpec?** RESOLVED (slice): raw `TSchema` (the output of calling `column.*`). The compact `{ kind }` middle form is rejected; the only principled choices were "store the call (string)" or "store the output (TSchema)", and the output wins on code-authoring ergonomics (real builder = autocomplete), zero interpreter/injection surface, and a verified-safe Yjs/JSON round-trip (this TypeBox validates on plain JSON Schema). See the ColumnSpec section above. The earlier author-string codec was built and then deleted. Remaining sub-question: a richer `types/<id>.md` editing experience (the stored form is JSON Schema, which is verbose to hand-edit) is a product-polish concern, not a storage decision.
 
 3. **Finer-grained per-property merge.** Build a nested-`Y.Map` column type (real per-property CRDT merge), or accept whole-row LWW plus git recovery indefinitely? The trigger is going collaborative; for a personal wiki, whole-row LWW stands.
 


### PR DESCRIPTION
A first working slice of the Epicenter **Wiki** (`apps/wiki`, headless/iso, no UI): a page has a worldview-neutral core plus any number of opt-in, schema-bearing **types** (Tana supertags). Implements spec `20260602T120000`.

## The model

```
CORE (every page)   id, title, description?, tags[], source[], timestamps, body
TYPES (0..N)        opt-in, schema-bearing identities; membership IS key presence
                      types: { youtube_video: { url, duration } }
COLLECTION          the table VIEW of all pages sharing a type
```

Two ordinary `defineTable` tables: a `types` registry (one row per user-defined type) and a `pages` table with a nested `types` cell.

## What the slice proves (end to end, in tests)

```
define a type at runtime ─▶ create a page in it ─▶ materialize to <id>.md
        ▲                                                      │
        └──────── markdown_push (disk → Yjs reconcile) ◀───── edit the file
                                   │
        project per-type SQLite ───┴──▶ typed query ("youtube_videos, duration > N")
        schema-on-read lens ──▶ match / excess / missing
        rename a column = metadata-only (no DDL); add a column = re-project
```

## Key decisions

- **A type's column schema is the `TSchema` that `column.*` returns, stored verbatim.** No string codec, no interpreter, no `eval`. Defining a type in code uses the real builder (autocomplete). Verified this repo's TypeBox validates on **plain JSON Schema** (no `[Kind]` symbols), so a schema survives the Yjs/JSON round-trip and `Value.Check` behaves identically.
- **Body is a row column** routed to the file body by the vault codec (never frontmatter). The per-row content `Y.Doc` (fuji's pattern) is the documented promotion path for collaborative body editing.
- **SQLite is a derived, disposable index.** `wiki_type_<id>(page_id, c_<colId>)` side tables + a membership join, re-projected from current schemas. Physical ids are `c_<colId>`, so a display rename emits no DDL.
- **Schema-on-read is a lens, not a migration.** Changing a type never rewrites page data; excess values survive, missing ones prompt.

## Layout

```
apps/wiki/src/lib/workspace/
  schema.ts       two tables, brands, ColumnSpec, typeColumns boundary
  index.ts        createWiki + actions (types_define / pages_create / reads)
  markdown.ts     attachWikiVault (bidirectional vault codec)
  projection.ts   projectWiki (per-type SQLite)
  lens.ts         viewThroughType (match / excess / missing)
  wiki.test.ts    4 integration tests
packages/workspace/.../column/sugar.ts   + column.url()
```

## Deferred (called out, not built)
`curateToWiki` capture bridge, the publishing-type board, UI, and per-property CRDT merge (the nested `types` cell shares the existing whole-row LWW; git autosave is the recovery net).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783020903&installation_id=128463665&pr_number=1893&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1893&signature=ab53c35e15ebb2db59ee42eaf0853688e867e394e8053c7a8fa54250bcd62af9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->