### PR TITLE
docs(skills): a few transferable PR-writing patterns

### DIFF
--- a/.agents/skills/pull-request/references/pull-request-guidelines.md
+++ b/.agents/skills/pull-request/references/pull-request-guidelines.md
@@ -112,6 +112,8 @@ Use before/after snippets when:
 
 Use ASCII diagrams liberally to communicate complex ideas. They're more scannable than prose and show relationships at a glance.
 
+Default to the lightest diagram that carries the relationship: two annotated columns, an indented tree, or a small before/after block. Reserve full box-drawing for genuine multi-box architecture. A heavy box around what is really a two-column mapping costs the reader more than it gives.
+
 #### Journey/Evolution Diagrams
 
 For PRs that iterate on previous work, show the evolution:
@@ -359,6 +361,10 @@ State the simplest possible description of what the old system accomplished, the
 **Bad**: "The encryption system was complex and needed simplification." (no contrast, no specifics)
 
 The fix then lands with zero effort—the reader is already rooting for it.
+
+##### Name the One Regression
+
+If a change trades something away, name it and quantify it with the payoff attached, before the reviewer finds it in the diff and reads it as an oversight. A scoped, quantified regression reads as judgment; an unmentioned one reads as a miss.
 
 ##### Lead with What Dies (API-collapse PRs)
 

--- a/.agents/skills/writing-voice/SKILL.md
+++ b/.agents/skills/writing-voice/SKILL.md
@@ -12,6 +12,8 @@ metadata:
 
 For technical explanations where the user is trying to understand a system, combine this voice with [notebook-explanation](../notebook-explanation/SKILL.md): short working notes, code blocks, tiny definitions, ASCII diagrams, and durable rules.
 
+For PR and commit text, combine this voice with [pull-request](../pull-request/SKILL.md): the voice rules here still apply, but the product and personal-voice sections further down (landing-page framing, "end with an invitation", first-person story openers) are for marketing and community writing, not for a reviewer-facing PR.
+
 ## When to Apply This Skill
 
 Use this pattern when you need to:


### PR DESCRIPTION
The skill is already comprehensive, so this stays small and resists turning one good PR into a rulebook.

Three changes. A "lightest diagram first" default at the top of the ASCII section, because it currently shows five heavy box-drawing examples before the lightweight one, so readers copy the first thing they see. A two-sentence "Name the One Regression" entry, the one instruction the catalog genuinely lacked: state and quantify what a change trades away before the reviewer finds it in the diff. And a one-sentence pointer so an agent drafting a PR reaches for this skill's structure instead of writing-voice's landing-page framing.

An earlier draft added more, all of it mined from a single PR. That was overfit and got cut back to what generalizes.