### PR TITLE
feat(wiki): runtime-typed pages-and-tags engine over Yjs truth

### DIFF
--- a/apps/wiki/src/lib/workspace/index.ts
+++ b/apps/wiki/src/lib/workspace/index.ts
@@ -111,15 +111,12 @@ type TagsRegistry = {
  *
  * Typing `#newidea` (assigning a tag that was never defined) upserts
  * `{ id, name: id, columns: [], description: null }`. Capture stays instant;
- * promote later by adding columns. Both the assign path and `markdown_push`
+ * promote later by adding columns. `pages_create` and `pages_assign_tag` both
  * call this, so `page_tags` always resolves to a real row. Invalid slugs are
  * skipped (the caller validates them where the cause is visible); a valid but
- * unwanted slug is acceptable junk, same risk as today's free `string[]` tags.
+ * unwanted slug is acceptable junk, same risk as a free-text tag.
  */
-export function mintMissingTags(
-	tables: TagsRegistry,
-	tagIds: Iterable<string>,
-): void {
+function mintMissingTags(tables: TagsRegistry, tagIds: Iterable<string>): void {
 	const now = DateTimeString.now();
 	for (const tagId of tagIds) {
 		if (!TAG_ID_PATTERN.test(tagId) || tagId === RESERVED_TAG_ID) continue;

--- a/apps/wiki/src/lib/workspace/index.ts
+++ b/apps/wiki/src/lib/workspace/index.ts
@@ -27,6 +27,7 @@ import { defineErrors, type InferErrors } from 'wellcrafted/error';
 import { Ok, type Result } from 'wellcrafted/result';
 import {
 	isTSchemaObject,
+	type Page,
 	type PageId,
 	type PageTypeValues,
 	TYPE_ID_PATTERN,
@@ -54,6 +55,23 @@ export const WikiActionError = defineErrors({
 		message: `Type "${typeId}" column "${columnId}" schema must be a TSchema object (a column.* result)`,
 		typeId,
 		columnId,
+	}),
+	/** A body write named a page id that has no row. */
+	PageNotFound: ({ id }: { id: string }) => ({
+		message: `No page with id "${id}"`,
+		id,
+	}),
+	/** A body_patch anchor (the exact text to replace) was not present in the body. */
+	AnchorNotFound: ({ id, old }: { id: string; old: string }) => ({
+		message: `Anchor not found in page "${id}": the exact text to replace is not present in the body`,
+		id,
+		old,
+	}),
+	/** A body_patch anchor appears more than once, so the target is ambiguous. */
+	AnchorAmbiguous: ({ id, old }: { id: string; old: string }) => ({
+		message: `Anchor is ambiguous in page "${id}": the text to replace appears more than once; include more surrounding context`,
+		id,
+		old,
 	}),
 });
 export type WikiActionError = InferErrors<typeof WikiActionError>;
@@ -159,6 +177,70 @@ export function createWiki(opts?: { keyring?: () => Keyring }) {
 					updatedAt: now,
 				});
 				return { id };
+			},
+		}),
+
+		pages_set_body: defineMutation({
+			title: 'Set Page Body',
+			description:
+				'Overwrite a page body with new markdown (the whole-rewrite shape). Returns the updated page so the caller never has to re-read the file.',
+			input: Type.Object({
+				id: Type.String(),
+				body: Type.String({ description: 'The full new markdown body' }),
+			}),
+			/**
+			 * The agent-path body write: text in, whole-row LWW write out. There is
+			 * no codec and no round-trip; the body is a plain string column, so the
+			 * materialized markdown is this value verbatim. Promote to a `Y.Text`
+			 * child doc with a positional diff only when concurrent body editing is
+			 * real (see `./schema.ts`).
+			 */
+			handler: ({ id, body }): Result<Page, WikiActionError> => {
+				const { data: page } = tables.pages.get(id);
+				if (!page) return WikiActionError.PageNotFound({ id });
+				const updated = { ...page, body, updatedAt: DateTimeString.now() };
+				tables.pages.set(updated);
+				return Ok(updated);
+			},
+		}),
+
+		pages_patch_body: defineMutation({
+			title: 'Patch Page Body',
+			description:
+				'Anchored search/replace on a page body, mirroring a coding agent str_replace. Fails loud if the anchor is missing or appears more than once.',
+			input: Type.Object({
+				id: Type.String(),
+				old: Type.String({
+					description: 'Exact existing substring to replace; must be unique',
+				}),
+				new: Type.String({ description: 'Replacement text' }),
+			}),
+			/**
+			 * `slice` splice, not `String.replace`: a string `replace` hits only the
+			 * first match and interprets `$` sequences in the replacement, both silent
+			 * bugs. We locate the single occurrence, reject zero or multiple matches,
+			 * and splice exactly that range. The anchor check doubles as a staleness
+			 * guard: a stale read fails here instead of corrupting the body.
+			 */
+			handler: ({
+				id,
+				old,
+				new: replacement,
+			}): Result<Page, WikiActionError> => {
+				const { data: page } = tables.pages.get(id);
+				if (!page) return WikiActionError.PageNotFound({ id });
+				const at = page.body.indexOf(old);
+				if (at < 0) return WikiActionError.AnchorNotFound({ id, old });
+				if (page.body.indexOf(old, at + old.length) >= 0) {
+					return WikiActionError.AnchorAmbiguous({ id, old });
+				}
+				const body =
+					page.body.slice(0, at) +
+					replacement +
+					page.body.slice(at + old.length);
+				const updated = { ...page, body, updatedAt: DateTimeString.now() };
+				tables.pages.set(updated);
+				return Ok(updated);
 			},
 		}),
 

--- a/apps/wiki/src/lib/workspace/index.ts
+++ b/apps/wiki/src/lib/workspace/index.ts
@@ -45,7 +45,7 @@ export const WikiActionError = defineErrors({
 		message: `Tag id "${tagId}" must be a slug matching ${TAG_ID_PATTERN}`,
 		tagId,
 	}),
-	/** The reserved tag id `columns` (collides with the tag_columns projection table). */
+	/** The reserved tag id `columns` (kept clear of an internal-sounding name). */
 	ReservedTagId: ({ tagId }: { tagId: string }) => ({
 		message: `Tag id "${tagId}" is reserved`,
 		tagId,

--- a/apps/wiki/src/lib/workspace/index.ts
+++ b/apps/wiki/src/lib/workspace/index.ts
@@ -24,14 +24,18 @@ import {
 } from '@epicenter/workspace';
 import { Type } from 'typebox';
 import { defineErrors, type InferErrors } from 'wellcrafted/error';
-import { Ok, type Result } from 'wellcrafted/result';
+import { Err, Ok, type Result } from 'wellcrafted/result';
 import {
-	isTSchemaObject,
+	buildColumnSchema,
+	COLUMN_ID_PATTERN,
+	type ColumnInput,
+	type ColumnSpec,
 	type Page,
 	type PageId,
 	type PageTagValues,
 	RESERVED_TAG_ID,
 	type TagId,
+	tagColumns,
 	TAG_ID_PATTERN,
 	type WikiTag,
 	wikiTableDefinitions,
@@ -50,16 +54,19 @@ export const WikiActionError = defineErrors({
 		message: `Tag id "${tagId}" is reserved`,
 		tagId,
 	}),
-	/** A tag definition carries a column whose `schema` is not a TSchema object. */
-	InvalidColumnSchema: ({
+	/** A tag edit named a tag id with no registry row. */
+	TagNotFound: ({ tagId }: { tagId: string }) => ({
+		message: `No tag with id "${tagId}"`,
 		tagId,
+	}),
+	/** A column id is not a stable slug ([a-z][a-z0-9_]*) or collides with the page_id PK. */
+	InvalidColumnId: ({ columnId }: { columnId: string }) => ({
+		message: `Column id "${columnId}" must be a slug matching ${COLUMN_ID_PATTERN} and not "page_id"`,
 		columnId,
-	}: {
-		tagId: string;
-		columnId: string;
-	}) => ({
-		message: `Tag "${tagId}" column "${columnId}" schema must be a TSchema object (a column.* result)`,
-		tagId,
+	}),
+	/** An `enum` column was authored with no allowed values. */
+	EnumValuesRequired: ({ columnId }: { columnId: string }) => ({
+		message: `Column "${columnId}" is an enum and needs at least one value`,
 		columnId,
 	}),
 	/** A body write or tag assignment named a page id that has no row. */
@@ -82,13 +89,54 @@ export const WikiActionError = defineErrors({
 });
 export type WikiActionError = InferErrors<typeof WikiActionError>;
 
-const columnSpecInput = Type.Object({
-	id: Type.String(),
-	name: Type.String(),
-	schema: Type.Unknown({
-		description: 'A column.* result (a TypeBox TSchema)',
-	}),
+/**
+ * The column authoring descriptor (see `ColumnInput`). `kind` is a closed
+ * literal union, so `invokeAction`'s input validation rejects an unknown kind
+ * before the handler runs: an agent picks from a menu, never hand-writes JSON
+ * Schema, and no junk schema can be stored.
+ */
+const columnInputSchema = Type.Object({
+	id: Type.String({ description: 'Stable column slug, e.g. duration' }),
+	name: Type.String({ description: 'Display name' }),
+	kind: Type.Union(
+		[
+			Type.Literal('string'),
+			Type.Literal('number'),
+			Type.Literal('integer'),
+			Type.Literal('boolean'),
+			Type.Literal('datetime'),
+			Type.Literal('url'),
+			Type.Literal('enum'),
+		],
+		{
+			description:
+				'Column kind (closed set). A reference is just a string holding an epicenter:// URN, found by value.',
+		},
+	),
+	nullable: Type.Optional(Type.Boolean({ description: 'Allow null' })),
+	array: Type.Optional(Type.Boolean({ description: 'A list of the kind' })),
+	enumValues: Type.Optional(
+		Type.Array(Type.String(), {
+			description: 'Allowed values; required when kind is enum',
+		}),
+	),
 });
+
+/**
+ * Validate one authoring descriptor and compile it to a stored `ColumnSpec`. The
+ * `kind` is already validated by the action input layer; this catches the two
+ * domain rules that layer cannot: the column id must be a slug (it becomes a
+ * bare SQL column name) and an `enum` must carry values.
+ */
+function compileColumn(input: ColumnInput): Result<ColumnSpec, WikiActionError> {
+	if (!COLUMN_ID_PATTERN.test(input.id) || input.id === 'page_id') {
+		return WikiActionError.InvalidColumnId({ columnId: input.id });
+	}
+	if (input.kind === 'enum' && !(input.enumValues && input.enumValues.length)) {
+		return WikiActionError.EnumValuesRequired({ columnId: input.id });
+	}
+	return Ok({ id: input.id, name: input.name, schema: buildColumnSchema(input) });
+}
 
 const tagValuesInput = Type.Record(
 	Type.String(),
@@ -157,7 +205,7 @@ export function createWiki(opts?: { keyring?: () => Keyring }) {
 				id: Type.String({ description: 'Stable slug, e.g. youtube_video' }),
 				name: Type.String({ description: 'Display name' }),
 				icon: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-				columns: Type.Array(columnSpecInput),
+				columns: Type.Array(columnInputSchema),
 				description: Type.Optional(Type.Union([Type.String(), Type.Null()])),
 			}),
 			handler: ({
@@ -176,27 +224,78 @@ export function createWiki(opts?: { keyring?: () => Keyring }) {
 				if (id === RESERVED_TAG_ID) {
 					return WikiActionError.ReservedTagId({ tagId: id });
 				}
-				// A tag whose column schema is not a TSchema object is not worth
-				// storing; it would only fail validation and projection later.
-				for (const spec of columns) {
-					if (!isTSchemaObject(spec.schema)) {
-						return WikiActionError.InvalidColumnSchema({
-							tagId: id,
-							columnId: spec.id,
-						});
-					}
+				// Compile each descriptor to its stored schema, bailing on the first
+				// bad column (a non-slug id, or an enum with no values).
+				const specs: ColumnSpec[] = [];
+				for (const col of columns) {
+					const { data: spec, error } = compileColumn(col);
+					if (error) return Err(error);
+					specs.push(spec!);
 				}
 				const now = DateTimeString.now();
 				tables.tags.set({
 					id: id as TagId,
 					name,
 					icon: icon ?? null,
-					columns: columns as unknown as WikiTag['columns'],
+					columns: specs as unknown as WikiTag['columns'],
 					description: description ?? null,
 					createdAt: now,
 					updatedAt: now,
 				});
 				return Ok({ id: id as TagId });
+			},
+		}),
+
+		tags_set_column: defineMutation({
+			title: 'Set Tag Column',
+			description:
+				'Add or change one typed column on an existing tag (upsert by column id). Rename = same id with a new name (no DDL); retype = same id with a new kind. The agent picks a kind from a closed menu; it never writes a schema by hand.',
+			input: Type.Object({
+				tagId: Type.String({ description: 'The tag to edit' }),
+				column: columnInputSchema,
+			}),
+			handler: ({
+				tagId,
+				column,
+			}): Result<{ tagId: string; columnId: string }, WikiActionError> => {
+				const { data: tag } = tables.tags.get(tagId);
+				if (!tag) return WikiActionError.TagNotFound({ tagId });
+				const { data: spec, error } = compileColumn(column);
+				if (error) return Err(error);
+				const existing = tagColumns(tag);
+				const next = existing.some((c) => c.id === spec!.id)
+					? existing.map((c) => (c.id === spec!.id ? spec! : c))
+					: [...existing, spec!];
+				tables.tags.set({
+					...tag,
+					columns: next as unknown as WikiTag['columns'],
+					updatedAt: DateTimeString.now(),
+				});
+				return Ok({ tagId, columnId: spec!.id });
+			},
+		}),
+
+		tags_remove_column: defineMutation({
+			title: 'Remove Tag Column',
+			description:
+				'Drop one column from a tag by id (a no-op if the column is absent). Stored page values for it survive in Yjs; they just stop projecting.',
+			input: Type.Object({
+				tagId: Type.String(),
+				columnId: Type.String(),
+			}),
+			handler: ({
+				tagId,
+				columnId,
+			}): Result<{ tagId: string }, WikiActionError> => {
+				const { data: tag } = tables.tags.get(tagId);
+				if (!tag) return WikiActionError.TagNotFound({ tagId });
+				const next = tagColumns(tag).filter((c) => c.id !== columnId);
+				tables.tags.set({
+					...tag,
+					columns: next as unknown as WikiTag['columns'],
+					updatedAt: DateTimeString.now(),
+				});
+				return Ok({ tagId });
 			},
 		}),
 

--- a/apps/wiki/src/lib/workspace/index.ts
+++ b/apps/wiki/src/lib/workspace/index.ts
@@ -241,8 +241,9 @@ export function createWiki(opts?: { keyring?: () => Keyring }) {
 			}),
 			/**
 			 * Auto-mint at the write boundary so `page_tags` always resolves, and
-			 * never block on a dangling `column.ref()` value: references may dangle
-			 * (wiki red-link behavior), discoverable later as an `edges` LEFT JOIN.
+			 * never block on a dangling `epicenter://` reference value: references
+			 * may dangle (wiki red-link behavior), discoverable later as an `edges`
+			 * LEFT JOIN.
 			 */
 			handler: ({ id, tagId, values }): Result<Page, WikiActionError> => {
 				if (!TAG_ID_PATTERN.test(tagId)) {

--- a/apps/wiki/src/lib/workspace/index.ts
+++ b/apps/wiki/src/lib/workspace/index.ts
@@ -1,11 +1,11 @@
 /**
- * Wiki workspace contract: id, the two tables, the runtime "define a type" /
- * "create a page" actions, and the workspace factory.
+ * Wiki workspace contract: id, the two tables, the runtime "define a tag" /
+ * "create a page" / "assign a tag" actions, and the workspace factory.
  *
  * Isomorphic, mirroring fuji's `src/lib/workspace/index.ts`: this file imports
  * only isomorphic dependencies (`@epicenter/workspace`, `typebox`,
  * `wellcrafted`). Filesystem wiring (the markdown vault) lives in
- * `./markdown.ts`; the per-type SQLite index lives in `./projection.ts`.
+ * `./markdown.ts`; the SQLite projection lives in `./projection.ts`.
  *
  * `body` is a row column for this slice (see `./schema.ts`), so there is no
  * per-page content doc to open here; the markdown codec routes it to the file
@@ -29,34 +29,40 @@ import {
 	isTSchemaObject,
 	type Page,
 	type PageId,
-	type PageTypeValues,
-	TYPE_ID_PATTERN,
-	type TypeId,
-	type WikiType,
+	type PageTagValues,
+	RESERVED_TAG_ID,
+	type TagId,
+	TAG_ID_PATTERN,
+	type WikiTag,
 	wikiTableDefinitions,
 } from './schema';
 
 export const WIKI_ID = 'epicenter-wiki';
 
 export const WikiActionError = defineErrors({
-	/** A type id is not a stable slug ([a-z0-9_]+); it also names a SQL table. */
-	InvalidTypeId: ({ typeId }: { typeId: string }) => ({
-		message: `Type id "${typeId}" must be a slug matching ${TYPE_ID_PATTERN}`,
-		typeId,
+	/** A tag id is not a stable slug ([a-z][a-z0-9_]*); it also names a SQL table. */
+	InvalidTagId: ({ tagId }: { tagId: string }) => ({
+		message: `Tag id "${tagId}" must be a slug matching ${TAG_ID_PATTERN}`,
+		tagId,
 	}),
-	/** A type definition carries a column whose `schema` is not a TSchema object. */
+	/** The reserved tag id `columns` (collides with the tag_columns projection table). */
+	ReservedTagId: ({ tagId }: { tagId: string }) => ({
+		message: `Tag id "${tagId}" is reserved`,
+		tagId,
+	}),
+	/** A tag definition carries a column whose `schema` is not a TSchema object. */
 	InvalidColumnSchema: ({
-		typeId,
+		tagId,
 		columnId,
 	}: {
-		typeId: string;
+		tagId: string;
 		columnId: string;
 	}) => ({
-		message: `Type "${typeId}" column "${columnId}" schema must be a TSchema object (a column.* result)`,
-		typeId,
+		message: `Tag "${tagId}" column "${columnId}" schema must be a TSchema object (a column.* result)`,
+		tagId,
 		columnId,
 	}),
-	/** A body write named a page id that has no row. */
+	/** A body write or tag assignment named a page id that has no row. */
 	PageNotFound: ({ id }: { id: string }) => ({
 		message: `No page with id "${id}"`,
 		id,
@@ -84,10 +90,51 @@ const columnSpecInput = Type.Object({
 	}),
 });
 
-const typeValuesInput = Type.Record(
+const tagValuesInput = Type.Record(
 	Type.String(),
 	Type.Record(Type.String(), Type.Unknown()),
 );
+
+/**
+ * The slice of the wiki tables handle the auto-mint helper needs: just enough
+ * of the `tags` table to look a row up and upsert a bare one.
+ */
+type TagsRegistry = {
+	tags: {
+		get(id: string): { data: WikiTag | null };
+		set(row: WikiTag): void;
+	};
+};
+
+/**
+ * Auto-mint a bare tag definition for every assigned tag with no registry row.
+ *
+ * Typing `#newidea` (assigning a tag that was never defined) upserts
+ * `{ id, name: id, columns: [], description: null }`. Capture stays instant;
+ * promote later by adding columns. Both the assign path and `markdown_push`
+ * call this, so `page_tags` always resolves to a real row. Invalid slugs are
+ * skipped (the caller validates them where the cause is visible); a valid but
+ * unwanted slug is acceptable junk, same risk as today's free `string[]` tags.
+ */
+export function mintMissingTags(
+	tables: TagsRegistry,
+	tagIds: Iterable<string>,
+): void {
+	const now = DateTimeString.now();
+	for (const tagId of tagIds) {
+		if (!TAG_ID_PATTERN.test(tagId) || tagId === RESERVED_TAG_ID) continue;
+		if (tables.tags.get(tagId).data) continue;
+		tables.tags.set({
+			id: tagId as TagId,
+			name: tagId,
+			icon: null,
+			columns: [],
+			description: null,
+			createdAt: now,
+			updatedAt: now,
+		});
+	}
+}
 
 /**
  * Build a Wiki workspace: `{ ydoc, tables, kv, actions }`.
@@ -105,78 +152,118 @@ export function createWiki(opts?: { keyring?: () => Keyring }) {
 	const { tables } = workspace;
 
 	const actions = defineActions({
-		types_define: defineMutation({
-			title: 'Define Type',
+		tags_define: defineMutation({
+			title: 'Define Tag',
 			description:
-				'Register a user-defined type (a Tana supertag) with a column schema.',
+				'Register a tag (a reusable annotation / schema facet). Empty columns = a plain tag; columns make it a structured tag with its own SQLite table.',
 			input: Type.Object({
 				id: Type.String({ description: 'Stable slug, e.g. youtube_video' }),
 				name: Type.String({ description: 'Display name' }),
 				icon: Type.Optional(Type.Union([Type.String(), Type.Null()])),
 				columns: Type.Array(columnSpecInput),
+				description: Type.Optional(Type.Union([Type.String(), Type.Null()])),
 			}),
 			handler: ({
 				id,
 				name,
 				icon,
 				columns,
-			}): Result<{ id: TypeId }, WikiActionError> => {
+				description,
+			}): Result<{ id: TagId }, WikiActionError> => {
 				// Validate the id at definition time, where the cause is visible.
 				// The same slug rule is re-checked in projection (it names a SQL
 				// table) as defense in depth, but this is the gate that fails early.
-				if (!TYPE_ID_PATTERN.test(id)) {
-					return WikiActionError.InvalidTypeId({ typeId: id });
+				if (!TAG_ID_PATTERN.test(id)) {
+					return WikiActionError.InvalidTagId({ tagId: id });
 				}
-				// A type whose column schema is not a TSchema object is not worth
+				if (id === RESERVED_TAG_ID) {
+					return WikiActionError.ReservedTagId({ tagId: id });
+				}
+				// A tag whose column schema is not a TSchema object is not worth
 				// storing; it would only fail validation and projection later.
 				for (const spec of columns) {
 					if (!isTSchemaObject(spec.schema)) {
 						return WikiActionError.InvalidColumnSchema({
-							typeId: id,
+							tagId: id,
 							columnId: spec.id,
 						});
 					}
 				}
 				const now = DateTimeString.now();
-				tables.types.set({
-					id: id as TypeId,
+				tables.tags.set({
+					id: id as TagId,
 					name,
 					icon: icon ?? null,
-					columns: columns as unknown as WikiType['columns'],
+					columns: columns as unknown as WikiTag['columns'],
+					description: description ?? null,
 					createdAt: now,
 					updatedAt: now,
 				});
-				return Ok({ id: id as TypeId });
+				return Ok({ id: id as TagId });
 			},
 		}),
 
 		pages_create: defineMutation({
 			title: 'Create Page',
 			description:
-				'Create a wiki page with core fields, an optional body, and optional type values.',
+				'Create a wiki page with a title, an optional body, and an optional tags map. Unknown tags auto-mint a bare definition.',
 			input: Type.Object({
 				title: Type.Optional(Type.String()),
-				description: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-				tags: Type.Optional(Type.Array(Type.String())),
-				source: Type.Optional(Type.Array(Type.String())),
-				types: Type.Optional(typeValuesInput),
+				tags: Type.Optional(tagValuesInput),
 				body: Type.Optional(Type.String()),
 			}),
-			handler: ({ title, description, tags, source, types, body }) => {
+			handler: ({ title, tags, body }) => {
 				const id = generateId<PageId>();
 				const now = DateTimeString.now();
+				const tagValues = (tags ?? {}) as PageTagValues;
+				// Assigning a tag at creation mints it, same as the assign action.
+				mintMissingTags(tables, Object.keys(tagValues));
 				tables.pages.set({
 					id,
 					title: title ?? '',
-					description: description ?? null,
-					tags: tags ?? [],
-					source: source ?? [],
-					types: (types ?? {}) as PageTypeValues,
 					body: body ?? '',
+					tags: tagValues,
 					createdAt: now,
 					updatedAt: now,
 				});
 				return { id };
+			},
+		}),
+
+		pages_assign_tag: defineMutation({
+			title: 'Assign Tag',
+			description:
+				'Wear a tag on a page, with optional column values. An unknown tag auto-mints a bare definition. A page wears each tag at most once; re-assigning overwrites the values.',
+			input: Type.Object({
+				id: Type.String({ description: 'The page id' }),
+				tagId: Type.String({ description: 'The tag slug to wear' }),
+				values: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+			}),
+			/**
+			 * Auto-mint at the write boundary so `page_tags` always resolves, and
+			 * never block on a dangling `column.ref()` value: references may dangle
+			 * (wiki red-link behavior), discoverable later as an `edges` LEFT JOIN.
+			 */
+			handler: ({ id, tagId, values }): Result<Page, WikiActionError> => {
+				if (!TAG_ID_PATTERN.test(tagId)) {
+					return WikiActionError.InvalidTagId({ tagId });
+				}
+				if (tagId === RESERVED_TAG_ID) {
+					return WikiActionError.ReservedTagId({ tagId });
+				}
+				const { data: page } = tables.pages.get(id);
+				if (!page) return WikiActionError.PageNotFound({ id });
+				mintMissingTags(tables, [tagId]);
+				const updated: Page = {
+					...page,
+					tags: {
+						...page.tags,
+						[tagId]: (values ?? {}) as unknown as PageTagValues[string],
+					},
+					updatedAt: DateTimeString.now(),
+				};
+				tables.pages.set(updated);
+				return Ok(updated);
 			},
 		}),
 
@@ -257,10 +344,10 @@ export function createWiki(opts?: { keyring?: () => Keyring }) {
 			handler: () => tables.pages.getAllValid(),
 		}),
 
-		types_get_all: defineQuery({
-			title: 'List Types',
-			description: 'Read every user-defined type.',
-			handler: () => tables.types.getAllValid(),
+		tags_get_all: defineQuery({
+			title: 'List Tags',
+			description: 'Read every tag definition.',
+			handler: () => tables.tags.getAllValid(),
 		}),
 	});
 

--- a/apps/wiki/src/lib/workspace/lens.ts
+++ b/apps/wiki/src/lib/workspace/lens.ts
@@ -1,9 +1,9 @@
 /**
- * Schema-on-read: a type's `columns` are a LENS over a page's stored values,
+ * Schema-on-read: a tag's `columns` are a LENS over a page's stored values,
  * never a gate or a migration.
  *
- * Changing a type's schema does not rewrite any page. Instead, at read time we
- * line a page's stored `types[typeId]` values up against the type's CURRENT
+ * Changing a tag's schema does not rewrite any page. Instead, at read time we
+ * line a page's stored `tags[tagId]` values up against the tag's CURRENT
  * columns and bucket each property:
  *
  *   match    in data AND in schema   render typed (with a validity flag)
@@ -37,28 +37,28 @@ export type LensMissing = { id: string; name: string };
 /** A stored value with no matching column in the current schema. */
 export type LensExcess = { id: string; value: JsonValue };
 
-export type TypeLens = {
-	typeId: string;
+export type TagLens = {
+	tagId: string;
 	match: LensMatch[];
 	missing: LensMissing[];
 	excess: LensExcess[];
 };
 
 /**
- * Project one page's values for one type through that type's current columns.
+ * Project one page's values for one tag through that tag's current columns.
  *
- * `data` is the page's `types[typeId]` cell (or `undefined` when the page does
- * not carry the type, in which case every column reads as missing).
+ * `data` is the page's `tags[tagId]` cell (or `undefined` when the page does
+ * not carry the tag, in which case every column reads as missing).
  */
-export function viewThroughType({
-	typeId,
+export function viewThroughTag({
+	tagId,
 	columns,
 	data,
 }: {
-	typeId: string;
+	tagId: string;
 	columns: ColumnSpec[];
 	data: Record<string, JsonValue> | undefined;
-}): TypeLens {
+}): TagLens {
 	const values = data ?? {};
 	const schemaIds = new Set(columns.map((c) => c.id));
 
@@ -83,5 +83,5 @@ export function viewThroughType({
 		if (!schemaIds.has(id)) excess.push({ id, value });
 	}
 
-	return { typeId, match, missing, excess };
+	return { tagId, match, missing, excess };
 }

--- a/apps/wiki/src/lib/workspace/markdown.ts
+++ b/apps/wiki/src/lib/workspace/markdown.ts
@@ -1,89 +1,175 @@
 /**
- * Wiki markdown vault: the bidirectional desktop projection.
+ * Wiki markdown vault: the browse projection plus a disk-to-Yjs reconcile.
  *
- *   pages/<id>.md   frontmatter IS the page row (core columns + the nested
- *                   `types` cell); the file body IS the page `body` column,
+ *   pages/<id>.md   frontmatter = the page core (id, title, the nested `tags`
+ *                   cell, timestamps); the file body IS the page `body` column,
  *                   routed out of frontmatter by the codec below.
- *   types/<id>.md   frontmatter IS the type registry row, including `columns`
- *                   whose `schema` is the TypeBox schema as JSON.
+ *   tags/<id>.md    frontmatter = the tag registry row (columns schema as JSON,
+ *                   description).
  *
- * Wiring lives here (filesystem-facing) rather than in the isomorphic factory,
- * mirroring how fuji keeps `index.ts` pure and composes IO in `browser.ts`.
- * The `markdown_push` action is the disk-to-Yjs reconcile ("markdown apply"):
- * it reads the files, parses frontmatter, validates against the table schema,
- * and writes rows back into Yjs.
+ * The Yjs -> disk direction is the package's read-only `attachMarkdownExport`:
+ * a continuously-materialized, one-way projection. The disk -> Yjs direction is
+ * `markdown_push` below, a deliberate reconcile a human triggers after editing
+ * files in the vault (not a live two-way binding). It parses each file,
+ * validates it against the table shape, auto-mints any unknown tag the page
+ * wears, and writes rows back into Yjs. Wiring lives here (filesystem-facing)
+ * rather than in the isomorphic factory, mirroring how fuji keeps `index.ts`
+ * pure and composes IO in `browser.ts`.
  */
 
-import { attachMarkdownMaterializer } from '@epicenter/workspace/document/materializer/markdown';
-import type { WikiWorkspace } from './index';
-import { asPageId, isTSchemaObject, type Page, type WikiType } from './schema';
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { attachMarkdownExport } from '@epicenter/workspace/document/materializer/markdown';
+import { parseMarkdownFile } from '@epicenter/workspace/markdown';
+import { createLogger } from 'wellcrafted/logger';
+import { type WikiWorkspace, mintMissingTags } from './index';
+import {
+	asPageId,
+	asTagId,
+	isTSchemaObject,
+	type Page,
+	type WikiTag,
+} from './schema';
+
+/** Outcome of one `markdown_push`: rows written back and files that failed. */
+type MarkdownPushResult = { pushed: number; errored: number };
 
 /**
- * Attach the markdown vault to a wiki workspace. Returns the materializer so a
- * caller can `await whenFlushed` and invoke `actions.markdown_push` to reconcile
- * disk edits back into Yjs.
+ * Attach the markdown vault to a wiki workspace. Returns `whenFlushed` (the
+ * initial Yjs -> disk flush) plus the `markdown_push` reconcile and the
+ * export's destructive `markdown_rebuild`.
  */
 export function attachWikiVault(
 	wiki: WikiWorkspace,
 	{ dir }: { dir: string | (() => string | Promise<string>) },
 ) {
-	return attachMarkdownMaterializer(
+	const log = createLogger('wiki-vault');
+	const resolveDir = async () =>
+		typeof dir === 'function' ? await dir() : dir;
+
+	const exported = attachMarkdownExport(
 		{ ydoc: wiki.ydoc, tables: wiki.tables },
 		{
 			dir,
-			perTable: {
-				types: {
-					// Default frontmatter codec, plus a decode gate: a hand-edited
-					// type file whose column `schema` is not a JSON object is rejected
-					// at import, matching the `types_define` action's own check rather
-					// than silently degrading later in projection/lens.
-					fromMarkdown: (parsed) => {
-						const row = parsed.frontmatter as WikiType;
-						for (const spec of row.columns) {
-							if (!isTSchemaObject(spec.schema)) {
-								throw new Error(
-									`type "${row.id}" column "${spec.id}" schema must be a TSchema object`,
-								);
-							}
-						}
-						return row;
-					},
-				},
+			tables: {
+				// Default whole-row frontmatter: the registry row, columns schema and
+				// description included.
+				tags: {},
 				pages: {
 					// `body` is a row column but belongs in the file body, never in
-					// frontmatter; route it across in both directions.
+					// frontmatter; route it across.
 					toMarkdown: (page) => ({
 						frontmatter: {
 							id: page.id,
 							title: page.title,
-							description: page.description,
 							tags: page.tags,
-							source: page.source,
-							types: page.types,
 							createdAt: page.createdAt,
 							updatedAt: page.updatedAt,
 						},
 						body: page.body.length > 0 ? page.body : undefined,
 					}),
-					fromMarkdown: (parsed) => {
-						const fm = parsed.frontmatter;
-						const page: Page = {
-							id: asPageId(String(fm.id)),
-							title: String(fm.title ?? ''),
-							description: (fm.description ?? null) as Page['description'],
-							tags: (fm.tags ?? []) as string[],
-							source: (fm.source ?? []) as string[],
-							types: (fm.types ?? {}) as Page['types'],
-							body: parsed.body ?? '',
-							createdAt: fm.createdAt as Page['createdAt'],
-							updatedAt: fm.updatedAt as Page['updatedAt'],
-						};
-						return page;
-					},
 				},
 			},
 		},
 	);
+
+	/**
+	 * Read every `<subdir>/*.md`, returning each parsed file. A missing directory
+	 * (nothing materialized yet) reads as empty; a non-`.md` entry is skipped.
+	 */
+	async function readVaultDir(
+		subdir: string,
+	): Promise<{ frontmatter: Record<string, unknown>; body: string | undefined }[]> {
+		const baseDir = await resolveDir();
+		const fullDir = join(baseDir, subdir);
+		let entries: string[];
+		try {
+			entries = await readdir(fullDir);
+		} catch {
+			return [];
+		}
+		const parsed: {
+			frontmatter: Record<string, unknown>;
+			body: string | undefined;
+		}[] = [];
+		for (const entry of entries) {
+			if (!entry.endsWith('.md')) continue;
+			const content = await readFile(join(fullDir, entry), 'utf-8');
+			const file = parseMarkdownFile(content);
+			if (file === null) {
+				log.info(`skipping ${subdir}/${entry}: no frontmatter`);
+				continue;
+			}
+			parsed.push(file);
+		}
+		return parsed;
+	}
+
+	/**
+	 * Disk -> Yjs reconcile. Tags push first so their definitions exist, then
+	 * pages; any tag a page wears without a registry row auto-mints a bare
+	 * definition (the same mint the assign action does), so `page_tags` always
+	 * resolves after a push.
+	 */
+	async function markdownPush(): Promise<MarkdownPushResult> {
+		let pushed = 0;
+		let errored = 0;
+
+		for (const file of await readVaultDir('tags')) {
+			const row = file.frontmatter as unknown as WikiTag;
+			const columns = row.columns ?? [];
+			// Match the define action's gate: a hand-edited column schema that is
+			// not a JSON object is rejected at import rather than silently degrading
+			// in projection / lens.
+			const badColumn = columns.find((spec) => !isTSchemaObject(spec.schema));
+			if (badColumn) {
+				log.info(
+					`tag "${row.id}" column "${badColumn.id}" schema is not a TSchema object; skipping`,
+				);
+				errored++;
+				continue;
+			}
+			wiki.tables.tags.set({
+				id: asTagId(String(row.id)),
+				name: String(row.name ?? row.id),
+				icon: (row.icon ?? null) as WikiTag['icon'],
+				columns: row.columns,
+				description: (row.description ?? null) as WikiTag['description'],
+				createdAt: row.createdAt,
+				updatedAt: row.updatedAt,
+			});
+			pushed++;
+		}
+
+		const wornTagIds = new Set<string>();
+		for (const file of await readVaultDir('pages')) {
+			const fm = file.frontmatter;
+			const tags = (fm.tags ?? {}) as Page['tags'];
+			for (const tagId of Object.keys(tags)) wornTagIds.add(tagId);
+			wiki.tables.pages.set({
+				id: asPageId(String(fm.id)),
+				title: String(fm.title ?? ''),
+				body: file.body ?? '',
+				tags,
+				createdAt: fm.createdAt as Page['createdAt'],
+				updatedAt: fm.updatedAt as Page['updatedAt'],
+			});
+			pushed++;
+		}
+
+		// Mint any worn-but-undefined tag, so membership always resolves.
+		mintMissingTags(wiki.tables, wornTagIds);
+
+		return { pushed, errored };
+	}
+
+	return {
+		whenFlushed: exported.whenFlushed,
+		actions: {
+			markdown_rebuild: exported.actions.markdown_rebuild,
+			markdown_push: markdownPush,
+		},
+	};
 }
 
 export type WikiVault = ReturnType<typeof attachWikiVault>;

--- a/apps/wiki/src/lib/workspace/markdown.ts
+++ b/apps/wiki/src/lib/workspace/markdown.ts
@@ -1,5 +1,5 @@
 /**
- * Wiki markdown vault: the browse projection plus a disk-to-Yjs reconcile.
+ * Wiki markdown vault: the one-way browse projection.
  *
  *   pages/<id>.md   frontmatter = the page core (id, title, the nested `tags`
  *                   cell, timestamps); the file body IS the page `body` column,
@@ -7,47 +7,28 @@
  *   tags/<id>.md    frontmatter = the tag registry row (columns schema as JSON,
  *                   description).
  *
- * The Yjs -> disk direction is the package's read-only `attachMarkdownExport`:
- * a continuously-materialized, one-way projection. The disk -> Yjs direction is
- * `markdown_push` below, a deliberate reconcile a human triggers after editing
- * files in the vault (not a live two-way binding). It parses each file,
- * validates it against the table shape, auto-mints any unknown tag the page
- * wears, and writes rows back into Yjs. Wiring lives here (filesystem-facing)
- * rather than in the isomorphic factory, mirroring how fuji keeps `index.ts`
- * pure and composes IO in `browser.ts`.
+ * This is a ONE-WAY read projection of the Yjs truth (the package's
+ * `attachMarkdownExport`): Yjs continuously materializes to disk, and the files
+ * are never read back. All writes go through validated actions (`pages_create`,
+ * `pages_assign_tag`, `pages_set_body`, ...), never by editing a `.md`, the same
+ * read-projection contract the rest of Epicenter settled on. Wiring lives here
+ * (filesystem-facing) rather than in the isomorphic factory, mirroring how fuji
+ * keeps `index.ts` pure and composes IO in `browser.ts`.
  */
 
-import { readdir, readFile } from 'node:fs/promises';
-import { join } from 'node:path';
 import { attachMarkdownExport } from '@epicenter/workspace/document/materializer/markdown';
-import { parseMarkdownFile } from '@epicenter/workspace/markdown';
-import { createLogger } from 'wellcrafted/logger';
-import { type WikiWorkspace, mintMissingTags } from './index';
-import {
-	asPageId,
-	asTagId,
-	isTSchemaObject,
-	type Page,
-	type WikiTag,
-} from './schema';
-
-/** Outcome of one `markdown_push`: rows written back and files that failed. */
-type MarkdownPushResult = { pushed: number; errored: number };
+import type { WikiWorkspace } from './index';
 
 /**
- * Attach the markdown vault to a wiki workspace. Returns `whenFlushed` (the
- * initial Yjs -> disk flush) plus the `markdown_push` reconcile and the
- * export's destructive `markdown_rebuild`.
+ * Attach the read-only markdown export to a wiki workspace. Returns the export
+ * handle: `whenFlushed` (the initial Yjs -> disk flush) and `markdown_rebuild`
+ * (a destructive full re-export for orphan cleanup after a layout change).
  */
 export function attachWikiVault(
 	wiki: WikiWorkspace,
 	{ dir }: { dir: string | (() => string | Promise<string>) },
 ) {
-	const log = createLogger('wiki-vault');
-	const resolveDir = async () =>
-		typeof dir === 'function' ? await dir() : dir;
-
-	const exported = attachMarkdownExport(
+	return attachMarkdownExport(
 		{ ydoc: wiki.ydoc, tables: wiki.tables },
 		{
 			dir,
@@ -72,104 +53,6 @@ export function attachWikiVault(
 			},
 		},
 	);
-
-	/**
-	 * Read every `<subdir>/*.md`, returning each parsed file. A missing directory
-	 * (nothing materialized yet) reads as empty; a non-`.md` entry is skipped.
-	 */
-	async function readVaultDir(
-		subdir: string,
-	): Promise<{ frontmatter: Record<string, unknown>; body: string | undefined }[]> {
-		const baseDir = await resolveDir();
-		const fullDir = join(baseDir, subdir);
-		let entries: string[];
-		try {
-			entries = await readdir(fullDir);
-		} catch {
-			return [];
-		}
-		const parsed: {
-			frontmatter: Record<string, unknown>;
-			body: string | undefined;
-		}[] = [];
-		for (const entry of entries) {
-			if (!entry.endsWith('.md')) continue;
-			const content = await readFile(join(fullDir, entry), 'utf-8');
-			const file = parseMarkdownFile(content);
-			if (file === null) {
-				log.info(`skipping ${subdir}/${entry}: no frontmatter`);
-				continue;
-			}
-			parsed.push(file);
-		}
-		return parsed;
-	}
-
-	/**
-	 * Disk -> Yjs reconcile. Tags push first so their definitions exist, then
-	 * pages; any tag a page wears without a registry row auto-mints a bare
-	 * definition (the same mint the assign action does), so `page_tags` always
-	 * resolves after a push.
-	 */
-	async function markdownPush(): Promise<MarkdownPushResult> {
-		let pushed = 0;
-		let errored = 0;
-
-		for (const file of await readVaultDir('tags')) {
-			const row = file.frontmatter as unknown as WikiTag;
-			const columns = row.columns ?? [];
-			// Match the define action's gate: a hand-edited column schema that is
-			// not a JSON object is rejected at import rather than silently degrading
-			// in projection / lens.
-			const badColumn = columns.find((spec) => !isTSchemaObject(spec.schema));
-			if (badColumn) {
-				log.info(
-					`tag "${row.id}" column "${badColumn.id}" schema is not a TSchema object; skipping`,
-				);
-				errored++;
-				continue;
-			}
-			wiki.tables.tags.set({
-				id: asTagId(String(row.id)),
-				name: String(row.name ?? row.id),
-				icon: (row.icon ?? null) as WikiTag['icon'],
-				columns: row.columns,
-				description: (row.description ?? null) as WikiTag['description'],
-				createdAt: row.createdAt,
-				updatedAt: row.updatedAt,
-			});
-			pushed++;
-		}
-
-		const wornTagIds = new Set<string>();
-		for (const file of await readVaultDir('pages')) {
-			const fm = file.frontmatter;
-			const tags = (fm.tags ?? {}) as Page['tags'];
-			for (const tagId of Object.keys(tags)) wornTagIds.add(tagId);
-			wiki.tables.pages.set({
-				id: asPageId(String(fm.id)),
-				title: String(fm.title ?? ''),
-				body: file.body ?? '',
-				tags,
-				createdAt: fm.createdAt as Page['createdAt'],
-				updatedAt: fm.updatedAt as Page['updatedAt'],
-			});
-			pushed++;
-		}
-
-		// Mint any worn-but-undefined tag, so membership always resolves.
-		mintMissingTags(wiki.tables, wornTagIds);
-
-		return { pushed, errored };
-	}
-
-	return {
-		whenFlushed: exported.whenFlushed,
-		actions: {
-			markdown_rebuild: exported.actions.markdown_rebuild,
-			markdown_push: markdownPush,
-		},
-	};
 }
 
 export type WikiVault = ReturnType<typeof attachWikiVault>;

--- a/apps/wiki/src/lib/workspace/page-body-actions.test.ts
+++ b/apps/wiki/src/lib/workspace/page-body-actions.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The page body write actions, in isolation from the vault/projection.
+ *
+ * `pages_set_body` (whole rewrite) and `pages_patch_body` (anchored str_replace)
+ * are the agent-path write surface from
+ * `specs/20260603T164627-agents-read-projection-write-actions.md`: an agent reads
+ * the read-only markdown projection, then mutates only through these actions.
+ * These tests touch only `createWiki` (isomorphic), never the markdown vault, so
+ * they exercise the actions without the filesystem materializer.
+ */
+
+import { expect, test } from 'bun:test';
+import { createWiki } from './index';
+
+test('pages_set_body overwrites the body and returns the updated page', () => {
+	const wiki = createWiki();
+	try {
+		const { id } = wiki.actions.pages_create({ title: 'Draft', body: 'first' });
+
+		const set = wiki.actions.pages_set_body({ id, body: 'second' });
+		expect(set.error).toBeNull();
+		expect(set.data!.body).toBe('second');
+		// Read-your-writes: the store reflects it without re-reading the file.
+		expect(wiki.actions.pages_get({ id }).data!.body).toBe('second');
+	} finally {
+		wiki[Symbol.dispose]();
+	}
+});
+
+test('pages_patch_body splices a unique anchor; rejects missing and ambiguous ones', () => {
+	const wiki = createWiki();
+	try {
+		const { id } = wiki.actions.pages_create({
+			title: 'Draft',
+			body: 'alpha beta gamma',
+		});
+
+		// Surgical replace of a single unique anchor.
+		const patched = wiki.actions.pages_patch_body({
+			id,
+			old: 'beta',
+			new: 'BETA',
+		});
+		expect(patched.error).toBeNull();
+		expect(patched.data!.body).toBe('alpha BETA gamma');
+
+		// A missing anchor fails loud and leaves the body untouched.
+		const missing = wiki.actions.pages_patch_body({ id, old: 'delta', new: 'x' });
+		expect(missing.error?.name).toBe('AnchorNotFound');
+		expect(wiki.actions.pages_get({ id }).data!.body).toBe('alpha BETA gamma');
+
+		// An ambiguous anchor (two occurrences) fails loud and leaves it untouched.
+		wiki.actions.pages_set_body({ id, body: 'one one' });
+		const ambiguous = wiki.actions.pages_patch_body({ id, old: 'one', new: 'two' });
+		expect(ambiguous.error?.name).toBe('AnchorAmbiguous');
+		expect(wiki.actions.pages_get({ id }).data!.body).toBe('one one');
+	} finally {
+		wiki[Symbol.dispose]();
+	}
+});
+
+test('pages_patch_body uses a literal splice, not String.replace ($ is not special)', () => {
+	const wiki = createWiki();
+	try {
+		const { id } = wiki.actions.pages_create({
+			title: 'Draft',
+			body: 'a TOKEN b',
+		});
+		// `$&` in a String.replace replacement would re-insert the match; a literal
+		// splice writes it verbatim.
+		const patched = wiki.actions.pages_patch_body({
+			id,
+			old: 'TOKEN',
+			new: '$& and $1',
+		});
+		expect(patched.data!.body).toBe('a $& and $1 b');
+	} finally {
+		wiki[Symbol.dispose]();
+	}
+});
+
+test('pages_set_body rejects an unknown page id', () => {
+	const wiki = createWiki();
+	try {
+		const result = wiki.actions.pages_set_body({ id: 'nope', body: 'x' });
+		expect(result.error?.name).toBe('PageNotFound');
+	} finally {
+		wiki[Symbol.dispose]();
+	}
+});

--- a/apps/wiki/src/lib/workspace/projection.ts
+++ b/apps/wiki/src/lib/workspace/projection.ts
@@ -26,15 +26,16 @@
  *     constraint. The durable value survives in Yjs; the on-read lens
  *     (`./lens.ts`) is what surfaces invalid / excess values for a page.
  *   - `edges` is rebuilt every run from body `[[id]]` wikilinks (source_kind
- *     `body_wikilink`) and every `column.ref()` value (source_kind
- *     `structured_field`); a `column.array(column.ref())` emits one row per
- *     element. Dangling targets are allowed (no FK): find them with a LEFT JOIN
- *     to `pages`.
+ *     `body_wikilink`) and every cell value that is an `epicenter://` URN
+ *     (source_kind `structured_field`); a list of URNs emits one row per
+ *     element. References are recognized from the VALUE (the URN scheme), never
+ *     a schema marker, exactly like `[[id]]` is recognized in body prose.
+ *     Dangling targets are allowed (no FK): find them with a LEFT JOIN to
+ *     `pages`.
  */
 
 import type { Database } from 'bun:sqlite';
-import { deriveStorage, EPICENTER_REF_KEYWORD } from '@epicenter/workspace';
-import type { TSchema } from 'typebox';
+import { deriveStorage } from '@epicenter/workspace';
 import { Value } from 'typebox/value';
 import type { JsonValue } from 'wellcrafted/json';
 import {
@@ -50,9 +51,6 @@ type ProjectionResult = {
 	/** `tagId -> CREATE TABLE` for that structured tag's side table. */
 	tagTableDdl: Record<string, string>;
 };
-
-/** A reference column's value shape, recognized from its `x-epicenter-ref` keyword. */
-type RefKind = 'ref' | 'ref_array';
 
 /**
  * Drop and rebuild the entire derived index from the current registry + pages.
@@ -75,7 +73,7 @@ export function projectWiki(
 		tagTableDdl[tag.id] = projectStructuredTag(db, tag, pages);
 	}
 
-	insertEdges(db, tags, pages);
+	insertEdges(db, pages);
 
 	return { tagTableDdl };
 }
@@ -202,13 +200,12 @@ function projectStructuredTag(
 // EDGES (provenance-aware; rebuilt every run, dangling targets allowed)
 // ════════════════════════════════════════════════════════════════════════════
 
-function insertEdges(db: Database, tags: WikiTag[], pages: Page[]): void {
+function insertEdges(db: Database, pages: Page[]): void {
 	const insert = db.prepare(
 		`INSERT INTO ${q('edges')} ` +
 			`(${q('source_id')}, ${q('rel')}, ${q('target_id')}, ${q('source_kind')}, ${q('field_id')}) ` +
 			'VALUES (?, ?, ?, ?, ?)',
 	);
-	const byId = new Map<string, WikiTag>(tags.map((tag) => [tag.id, tag]));
 
 	for (const page of pages) {
 		// Body wikilinks: [[id]] (or [[id|Title]]) become a body_wikilink edge.
@@ -216,18 +213,15 @@ function insertEdges(db: Database, tags: WikiTag[], pages: Page[]): void {
 			insert.run(page.id, 'links_to', targetId, 'body_wikilink', null);
 		}
 
-		// Structured-field references: each column.ref() / column.array(column.ref())
-		// value names a target. The relationship is the tag id; the field is the
-		// column. An array expands to one row per element.
+		// Structured-field references: any cell value that is an `epicenter://`
+		// URN (or a list of them) names a target. References are recognized from
+		// the VALUE, never a schema marker, exactly like `[[id]]` in the body: the
+		// URN scheme is self-describing. The relationship is the tag id; the field
+		// is the column. A list expands to one row per URN element.
 		for (const [tagId, data] of Object.entries(page.tags)) {
-			const tag = byId.get(tagId);
-			if (tag === undefined) continue;
-			for (const spec of tagColumns(tag)) {
-				if (!Object.hasOwn(data, spec.id)) continue;
-				const kind = refKind(spec.schema);
-				if (kind === null) continue;
-				for (const targetId of refTargets(kind, data[spec.id])) {
-					insert.run(page.id, tagId, targetId, 'structured_field', spec.id);
+			for (const [fieldId, value] of Object.entries(data)) {
+				for (const targetId of refUrns(value)) {
+					insert.run(page.id, tagId, targetId, 'structured_field', fieldId);
 				}
 			}
 		}
@@ -245,28 +239,18 @@ function parseWikilinks(body: string): string[] {
 	return targets;
 }
 
-type SchemaShape = {
-	type?: string;
-	[EPICENTER_REF_KEYWORD]?: unknown;
-	items?: TSchema & SchemaShape;
-};
+/** The `epicenter://` URN scheme that self-identifies a value as a cross-entity reference. */
+const REF_URN_PREFIX = 'epicenter://';
 
-const isRefString = (s: SchemaShape): boolean =>
-	s.type === 'string' && s[EPICENTER_REF_KEYWORD] === true;
+const isRefUrn = (value: JsonValue): value is string =>
+	typeof value === 'string' && value.startsWith(REF_URN_PREFIX);
 
-/** Whether a column schema is a reference (`column.ref`) or a list of references. */
-function refKind(schema: TSchema): RefKind | null {
-	const s = schema as SchemaShape;
-	if (isRefString(s)) return 'ref';
-	if (s.type === 'array' && s.items && isRefString(s.items)) return 'ref_array';
-	return null;
-}
-
-/** Extract the target id(s) of a stored reference value (one for `ref`, N for `ref_array`). */
-function refTargets(kind: RefKind, value: JsonValue | undefined): string[] {
-	if (kind === 'ref') return typeof value === 'string' ? [value] : [];
-	if (!Array.isArray(value)) return [];
-	return value.filter((element): element is string => typeof element === 'string');
+/** Reference targets in a stored cell value: the value itself if a URN, or every URN element of a list. */
+function refUrns(value: JsonValue | undefined): string[] {
+	if (value === undefined) return [];
+	if (isRefUrn(value)) return [value];
+	if (Array.isArray(value)) return value.filter(isRefUrn);
+	return [];
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/apps/wiki/src/lib/workspace/projection.ts
+++ b/apps/wiki/src/lib/workspace/projection.ts
@@ -7,7 +7,6 @@
  * bare, typed column names (no `c_` prefix). The shape:
  *
  *   pages (id PK, title, body, created_at, updated_at)            WITHOUT ROWID
- *   tags  (id PK, name, icon, description, created_at, updated_at) WITHOUT ROWID
  *   page_tags (page_id, tag_id)            -- THE membership owner (every tag)
  *   tag_<slug> (page_id PK, <col> <storage>, ...)  STRICT, WITHOUT ROWID
  *                                          -- ONLY for tags with >= 1 column
@@ -64,7 +63,6 @@ export function projectWiki(
 	createFixedTables(db);
 
 	insertPages(db, pages);
-	insertTags(db, tags);
 	insertMembership(db, pages);
 
 	const tagTableDdl: Record<string, string> = {};
@@ -90,12 +88,6 @@ function createFixedTables(db: Database): void {
 			`${q('updated_at')} TEXT NOT NULL) WITHOUT ROWID`,
 	);
 	db.run(
-		`CREATE TABLE ${q('tags')} (` +
-			`${q('id')} TEXT PRIMARY KEY, ${q('name')} TEXT NOT NULL, ` +
-			`${q('icon')} TEXT, ${q('description')} TEXT, ` +
-			`${q('created_at')} TEXT NOT NULL, ${q('updated_at')} TEXT NOT NULL) WITHOUT ROWID`,
-	);
-	db.run(
 		`CREATE TABLE ${q('page_tags')} (` +
 			`${q('page_id')} TEXT NOT NULL, ${q('tag_id')} TEXT NOT NULL, ` +
 			`PRIMARY KEY (${q('page_id')}, ${q('tag_id')})) WITHOUT ROWID`,
@@ -116,24 +108,6 @@ function insertPages(db: Database, pages: Page[]): void {
 	);
 	for (const page of pages) {
 		insert.run(page.id, page.title, page.body, page.createdAt, page.updatedAt);
-	}
-}
-
-function insertTags(db: Database, tags: WikiTag[]): void {
-	const insertTag = db.prepare(
-		`INSERT INTO ${q('tags')} ` +
-			`(${q('id')}, ${q('name')}, ${q('icon')}, ${q('description')}, ${q('created_at')}, ${q('updated_at')}) ` +
-			'VALUES (?, ?, ?, ?, ?, ?)',
-	);
-	for (const tag of tags) {
-		insertTag.run(
-			tag.id,
-			tag.name,
-			tag.icon,
-			tag.description,
-			tag.createdAt,
-			tag.updatedAt,
-		);
 	}
 }
 
@@ -258,7 +232,7 @@ function refUrns(value: JsonValue | undefined): string[] {
 // ════════════════════════════════════════════════════════════════════════════
 
 /** The fixed (non-`tag_<slug>`) tables this projection owns. */
-const FIXED_TABLES = new Set(['pages', 'tags', 'page_tags', 'edges']);
+const FIXED_TABLES = new Set(['pages', 'page_tags', 'edges']);
 
 /**
  * Drop every projected table so the next projection is a clean rebuild: the

--- a/apps/wiki/src/lib/workspace/projection.ts
+++ b/apps/wiki/src/lib/workspace/projection.ts
@@ -1,33 +1,60 @@
 /**
- * Per-type SQLite projection: the derived, disposable query index.
+ * The wiki SQLite projection: the derived, disposable query index.
  *
- * SQLite is never truth. It is re-projected from the CURRENT type schemas, so
- * it is always safe to drop and rebuild. The shape:
+ * SQLite is never truth. It is re-projected from the CURRENT tag schemas + the
+ * pages, so it is always safe to drop and rebuild. It lives in its own database
+ * file (no `wiki_` prefix needed, no collision with anything else), and uses
+ * bare, typed column names (no `c_` prefix). The shape:
  *
- *   wiki_pages(id PK, title, description, tags, source, created, updated)
- *   wiki_page_types(page_id, type_id)                  -- membership edge
- *   wiki_type_<typeId>(page_id PK, c_<colId> ...)      -- one per type
+ *   pages (id PK, title, body, created_at, updated_at)            WITHOUT ROWID
+ *   tags  (id PK, name, icon, description, created_at, updated_at) WITHOUT ROWID
+ *   tag_columns (tag_id, column_id, name, schema_json, storage, ordinal)
+ *   page_tags (page_id, tag_id)            -- THE membership owner (every tag)
+ *   tag_<slug> (page_id PK, <col> <storage>, ...)  STRICT, WITHOUT ROWID
+ *                                          -- ONLY for tags with >= 1 column
+ *   edges (source_id, rel, target_id, source_kind, field_id)
+ *                                          -- provenance-aware; derived, never truth
+ *   projection_issues (page_id, tag_id, column_id, kind, value_json, message)
  *
- * Two consequences fall straight out of this layout:
+ * Consequences that fall straight out of this layout:
  *
- *   - A column's physical id is `c_<colId>`, and `colId` never changes on a
- *     display rename, so a rename emits NO DDL (`projectWiki` returns the same
- *     DDL string). Adding a column changes the DDL, so it re-projects.
- *   - Projection is schema-on-read: only columns in the CURRENT schema become
- *     physical columns; excess stored values are simply not projected (they
- *     survive in Yjs, see `./lens.ts`).
+ *   - A structured tag's physical column is its bare `column_id`, which never
+ *     changes on a display rename, so a rename emits NO DDL (`projectWiki`
+ *     returns the same `tag_<slug>` DDL string). Adding a column changes the
+ *     DDL, so it re-projects.
+ *   - Plain tags get NO side table; their membership lives in `page_tags`.
+ *   - TypeBox is the single validator: the projector `Value.Check`s every cell
+ *     and routes failures to `projection_issues` (kind `invalid`), excess
+ *     values (present in data, absent from the current schema) to
+ *     `projection_issues` (kind `excess`), and never emits a `CHECK` constraint.
+ *   - `edges` is rebuilt every run from body `[[id]]` wikilinks (source_kind
+ *     `body_wikilink`) and every `column.ref()` value (source_kind
+ *     `structured_field`); a `column.array(column.ref())` emits one row per
+ *     element. Dangling targets are allowed (no FK): find them with a LEFT JOIN
+ *     to `pages`.
  */
 
 import type { Database } from 'bun:sqlite';
+import { deriveStorage, EPICENTER_REF_KEYWORD } from '@epicenter/workspace';
 import type { TSchema } from 'typebox';
+import { Value } from 'typebox/value';
 import type { JsonValue } from 'wellcrafted/json';
-import { type Page, typeColumns, type WikiType } from './schema';
+import {
+	COLUMN_ID_PATTERN,
+	type Page,
+	type WikiTag,
+	tagColumns,
+	TAG_ID_PATTERN,
+} from './schema';
 
-/** Result of one projection run: the DDL emitted per type table. */
-export type ProjectionResult = {
-	/** `typeId -> CREATE TABLE` for that type's side table. */
-	typeTableDdl: Record<string, string>;
+/** Result of one projection run: the DDL emitted per structured-tag side table. */
+type ProjectionResult = {
+	/** `tagId -> CREATE TABLE` for that structured tag's side table. */
+	tagTableDdl: Record<string, string>;
 };
+
+/** A reference column's value shape, recognized from its `x-epicenter-ref` keyword. */
+type RefKind = 'ref' | 'ref_array';
 
 /**
  * Drop and rebuild the entire derived index from the current registry + pages.
@@ -35,101 +62,297 @@ export type ProjectionResult = {
  */
 export function projectWiki(
 	db: Database,
-	{ types, pages }: { types: WikiType[]; pages: Page[] },
+	{ tags, pages }: { tags: WikiTag[]; pages: Page[] },
 ): ProjectionResult {
 	dropProjectedTables(db);
+	createFixedTables(db);
 
-	db.run(
-		`CREATE TABLE ${q('wiki_pages')} (` +
-			`${q('id')} TEXT PRIMARY KEY, ${q('title')} TEXT NOT NULL, ` +
-			`${q('description')} TEXT, ${q('tags')} TEXT NOT NULL, ` +
-			`${q('source')} TEXT NOT NULL, ${q('created')} TEXT NOT NULL, ` +
-			`${q('updated')} TEXT NOT NULL)`,
-	);
-	db.run(
-		`CREATE TABLE ${q('wiki_page_types')} (` +
-			`${q('page_id')} TEXT NOT NULL, ${q('type_id')} TEXT NOT NULL, ` +
-			`PRIMARY KEY (${q('page_id')}, ${q('type_id')}))`,
-	);
+	insertPages(db, pages);
+	insertTags(db, tags);
+	insertMembership(db, pages);
 
-	const insertPage = db.prepare(
-		`INSERT INTO ${q('wiki_pages')} ` +
-			`(${q('id')}, ${q('title')}, ${q('description')}, ${q('tags')}, ${q('source')}, ${q('created')}, ${q('updated')}) ` +
-			'VALUES (?, ?, ?, ?, ?, ?, ?)',
-	);
-	const insertMembership = db.prepare(
-		`INSERT INTO ${q('wiki_page_types')} (${q('page_id')}, ${q('type_id')}) VALUES (?, ?)`,
-	);
-	for (const page of pages) {
-		insertPage.run(
-			page.id,
-			page.title,
-			page.description,
-			JSON.stringify(page.tags),
-			JSON.stringify(page.source),
-			page.createdAt,
-			page.updatedAt,
-		);
-		for (const typeId of Object.keys(page.types)) {
-			insertMembership.run(page.id, typeId);
-		}
+	const tagTableDdl: Record<string, string> = {};
+	for (const tag of tags) {
+		if (tagColumns(tag).length === 0) continue; // plain tag: no side table
+		tagTableDdl[tag.id] = projectStructuredTag(db, tag, pages);
 	}
 
-	const typeTableDdl: Record<string, string> = {};
-	for (const type of types) {
-		typeTableDdl[type.id] = projectTypeTable(db, type, pages);
-	}
+	insertEdges(db, tags, pages);
 
-	return { typeTableDdl };
+	return { tagTableDdl };
 }
 
-/**
- * Build and populate one `wiki_type_<typeId>` side table from the type's
- * CURRENT columns. Returns the `CREATE TABLE` statement so callers can prove a
- * rename emits identical DDL while an add does not.
- */
-function projectTypeTable(db: Database, type: WikiType, pages: Page[]): string {
-	const tableName = `wiki_type_${assertSafeSlug(type.id)}`;
+// ════════════════════════════════════════════════════════════════════════════
+// FIXED TABLES
+// ════════════════════════════════════════════════════════════════════════════
 
-	const columnDefs: string[] = [`${q('page_id')} TEXT PRIMARY KEY`];
-	const projected: { colId: string; physical: string }[] = [];
-	for (const spec of typeColumns(type)) {
-		const physical = `c_${spec.id}`;
-		columnDefs.push(`${q(physical)} ${deriveStorage(spec.schema)}`);
-		projected.push({ colId: spec.id, physical });
-	}
+function createFixedTables(db: Database): void {
+	db.run(
+		`CREATE TABLE ${q('pages')} (` +
+			`${q('id')} TEXT PRIMARY KEY, ${q('title')} TEXT NOT NULL, ` +
+			`${q('body')} TEXT NOT NULL, ${q('created_at')} TEXT NOT NULL, ` +
+			`${q('updated_at')} TEXT NOT NULL) WITHOUT ROWID`,
+	);
+	db.run(
+		`CREATE TABLE ${q('tags')} (` +
+			`${q('id')} TEXT PRIMARY KEY, ${q('name')} TEXT NOT NULL, ` +
+			`${q('icon')} TEXT, ${q('description')} TEXT, ` +
+			`${q('created_at')} TEXT NOT NULL, ${q('updated_at')} TEXT NOT NULL) WITHOUT ROWID`,
+	);
+	db.run(
+		`CREATE TABLE ${q('tag_columns')} (` +
+			`${q('tag_id')} TEXT NOT NULL, ${q('column_id')} TEXT NOT NULL, ` +
+			`${q('name')} TEXT NOT NULL, ${q('schema_json')} TEXT NOT NULL, ` +
+			`${q('storage')} TEXT NOT NULL, ${q('ordinal')} INTEGER NOT NULL, ` +
+			`PRIMARY KEY (${q('tag_id')}, ${q('column_id')})) WITHOUT ROWID`,
+	);
+	db.run(
+		`CREATE TABLE ${q('page_tags')} (` +
+			`${q('page_id')} TEXT NOT NULL, ${q('tag_id')} TEXT NOT NULL, ` +
+			`PRIMARY KEY (${q('page_id')}, ${q('tag_id')})) WITHOUT ROWID`,
+	);
+	db.run(
+		`CREATE TABLE ${q('edges')} (` +
+			`${q('source_id')} TEXT NOT NULL, ${q('rel')} TEXT NOT NULL, ` +
+			`${q('target_id')} TEXT NOT NULL, ${q('source_kind')} TEXT NOT NULL, ` +
+			`${q('field_id')} TEXT)`,
+	);
+	db.run(
+		`CREATE TABLE ${q('projection_issues')} (` +
+			`${q('page_id')} TEXT NOT NULL, ${q('tag_id')} TEXT NOT NULL, ` +
+			`${q('column_id')} TEXT NOT NULL, ${q('kind')} TEXT NOT NULL, ` +
+			`${q('value_json')} TEXT, ${q('message')} TEXT NOT NULL)`,
+	);
+}
 
-	const ddl = `CREATE TABLE ${q(tableName)} (${columnDefs.join(', ')})`;
-	db.run(ddl);
-
-	const columns = [q('page_id'), ...projected.map((p) => q(p.physical))];
-	const placeholders = columns.map(() => '?').join(', ');
+function insertPages(db: Database, pages: Page[]): void {
 	const insert = db.prepare(
-		`INSERT INTO ${q(tableName)} (${columns.join(', ')}) VALUES (${placeholders})`,
+		`INSERT INTO ${q('pages')} ` +
+			`(${q('id')}, ${q('title')}, ${q('body')}, ${q('created_at')}, ${q('updated_at')}) ` +
+			'VALUES (?, ?, ?, ?, ?)',
 	);
 	for (const page of pages) {
-		const data = page.types[type.id];
-		if (data === undefined) continue; // page does not carry this type
-		const values = projected.map((p) => serializeValue(data[p.colId]));
-		insert.run(page.id, ...values);
+		insert.run(page.id, page.title, page.body, page.createdAt, page.updatedAt);
+	}
+}
+
+function insertTags(db: Database, tags: WikiTag[]): void {
+	const insertTag = db.prepare(
+		`INSERT INTO ${q('tags')} ` +
+			`(${q('id')}, ${q('name')}, ${q('icon')}, ${q('description')}, ${q('created_at')}, ${q('updated_at')}) ` +
+			'VALUES (?, ?, ?, ?, ?, ?)',
+	);
+	const insertColumn = db.prepare(
+		`INSERT INTO ${q('tag_columns')} ` +
+			`(${q('tag_id')}, ${q('column_id')}, ${q('name')}, ${q('schema_json')}, ${q('storage')}, ${q('ordinal')}) ` +
+			'VALUES (?, ?, ?, ?, ?, ?)',
+	);
+	for (const tag of tags) {
+		insertTag.run(
+			tag.id,
+			tag.name,
+			tag.icon,
+			tag.description,
+			tag.createdAt,
+			tag.updatedAt,
+		);
+		tagColumns(tag).forEach((spec, ordinal) => {
+			insertColumn.run(
+				tag.id,
+				spec.id,
+				spec.name,
+				JSON.stringify(spec.schema),
+				deriveStorage(spec.schema),
+				ordinal,
+			);
+		});
+	}
+}
+
+/** Membership owner: one row per (page, tag) for EVERY tag, plain or structured. */
+function insertMembership(db: Database, pages: Page[]): void {
+	const insert = db.prepare(
+		`INSERT INTO ${q('page_tags')} (${q('page_id')}, ${q('tag_id')}) VALUES (?, ?)`,
+	);
+	for (const page of pages) {
+		for (const tagId of Object.keys(page.tags)) insert.run(page.id, tagId);
+	}
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// STRUCTURED TAG SIDE TABLE
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Build and populate one `tag_<slug>` side table from the tag's CURRENT
+ * columns. Returns the `CREATE TABLE` statement so callers can prove a rename
+ * emits identical DDL while an add does not. Each cell is `Value.Check`ed before
+ * insert; failures route to `projection_issues` and store NULL instead.
+ */
+function projectStructuredTag(
+	db: Database,
+	tag: WikiTag,
+	pages: Page[],
+): string {
+	const tableName = `tag_${assertTagSlug(tag.id)}`;
+	const specs = tagColumns(tag);
+
+	const columnDefs: string[] = [`${q('page_id')} TEXT PRIMARY KEY`];
+	for (const spec of specs) {
+		columnDefs.push(`${q(assertColumnId(spec.id))} ${deriveStorage(spec.schema)}`);
+	}
+	const ddl = `CREATE TABLE ${q(tableName)} (${columnDefs.join(', ')}) STRICT, WITHOUT ROWID`;
+	db.run(ddl);
+
+	const physicalCols = [q('page_id'), ...specs.map((s) => q(s.id))];
+	const insert = db.prepare(
+		`INSERT INTO ${q(tableName)} (${physicalCols.join(', ')}) ` +
+			`VALUES (${physicalCols.map(() => '?').join(', ')})`,
+	);
+	const insertIssue = db.prepare(
+		`INSERT INTO ${q('projection_issues')} ` +
+			`(${q('page_id')}, ${q('tag_id')}, ${q('column_id')}, ${q('kind')}, ${q('value_json')}, ${q('message')}) ` +
+			'VALUES (?, ?, ?, ?, ?, ?)',
+	);
+
+	const schemaIds = new Set(specs.map((s) => s.id));
+	for (const page of pages) {
+		const data = page.tags[tag.id];
+		if (data === undefined) continue; // page does not wear this tag
+
+		const cells = specs.map((spec) => {
+			if (!Object.hasOwn(data, spec.id)) return null; // missing is not an issue
+			const value = data[spec.id]!;
+			if (Value.Check(spec.schema, value)) return serializeValue(value);
+			insertIssue.run(
+				page.id,
+				tag.id,
+				spec.id,
+				'invalid',
+				JSON.stringify(value),
+				`value does not satisfy column "${spec.id}" schema`,
+			);
+			return null;
+		});
+		insert.run(page.id, ...cells);
+
+		for (const [columnId, value] of Object.entries(data)) {
+			if (schemaIds.has(columnId)) continue;
+			insertIssue.run(
+				page.id,
+				tag.id,
+				columnId,
+				'excess',
+				JSON.stringify(value),
+				`no column "${columnId}" in the current schema of tag "${tag.id}"`,
+			);
+		}
 	}
 
 	return ddl;
 }
 
 // ════════════════════════════════════════════════════════════════════════════
+// EDGES (provenance-aware; rebuilt every run, dangling targets allowed)
+// ════════════════════════════════════════════════════════════════════════════
+
+function insertEdges(db: Database, tags: WikiTag[], pages: Page[]): void {
+	const insert = db.prepare(
+		`INSERT INTO ${q('edges')} ` +
+			`(${q('source_id')}, ${q('rel')}, ${q('target_id')}, ${q('source_kind')}, ${q('field_id')}) ` +
+			'VALUES (?, ?, ?, ?, ?)',
+	);
+	const byId = new Map<string, WikiTag>(tags.map((tag) => [tag.id, tag]));
+
+	for (const page of pages) {
+		// Body wikilinks: [[id]] (or [[id|Title]]) become a body_wikilink edge.
+		for (const targetId of parseWikilinks(page.body)) {
+			insert.run(page.id, 'links_to', targetId, 'body_wikilink', null);
+		}
+
+		// Structured-field references: each column.ref() / column.array(column.ref())
+		// value names a target. The relationship is the tag id; the field is the
+		// column. An array expands to one row per element.
+		for (const [tagId, data] of Object.entries(page.tags)) {
+			const tag = byId.get(tagId);
+			if (tag === undefined) continue;
+			for (const spec of tagColumns(tag)) {
+				if (!Object.hasOwn(data, spec.id)) continue;
+				const kind = refKind(spec.schema);
+				if (kind === null) continue;
+				for (const targetId of refTargets(kind, data[spec.id])) {
+					insert.run(page.id, tagId, targetId, 'structured_field', spec.id);
+				}
+			}
+		}
+	}
+}
+
+/** Collect `[[id]]` / `[[id|Title]]` targets from a markdown body, in order. */
+function parseWikilinks(body: string): string[] {
+	const targets: string[] = [];
+	const pattern = /\[\[([^[\]|]+?)(?:\|[^[\]]*)?\]\]/g;
+	for (const match of body.matchAll(pattern)) {
+		const id = match[1]?.trim();
+		if (id) targets.push(id);
+	}
+	return targets;
+}
+
+type SchemaShape = {
+	type?: string;
+	[EPICENTER_REF_KEYWORD]?: unknown;
+	items?: TSchema & SchemaShape;
+};
+
+const isRefString = (s: SchemaShape): boolean =>
+	s.type === 'string' && s[EPICENTER_REF_KEYWORD] === true;
+
+/** Whether a column schema is a reference (`column.ref`) or a list of references. */
+function refKind(schema: TSchema): RefKind | null {
+	const s = schema as SchemaShape;
+	if (isRefString(s)) return 'ref';
+	if (s.type === 'array' && s.items && isRefString(s.items)) return 'ref_array';
+	return null;
+}
+
+/** Extract the target id(s) of a stored reference value (one for `ref`, N for `ref_array`). */
+function refTargets(kind: RefKind, value: JsonValue | undefined): string[] {
+	if (kind === 'ref') return typeof value === 'string' ? [value] : [];
+	if (!Array.isArray(value)) return [];
+	return value.filter((element): element is string => typeof element === 'string');
+}
+
+// ════════════════════════════════════════════════════════════════════════════
 // SQLITE HELPERS (self-contained; the workspace internals are not public)
 // ════════════════════════════════════════════════════════════════════════════
 
-/** Drop every wiki-projected table so the next projection is a clean rebuild. */
+/** The fixed (non-`tag_<slug>`) tables this projection owns. */
+const FIXED_TABLES = new Set([
+	'pages',
+	'tags',
+	'tag_columns',
+	'page_tags',
+	'edges',
+	'projection_issues',
+]);
+
+/**
+ * Drop every projected table so the next projection is a clean rebuild: the
+ * fixed set plus every `tag_<slug>` side table (any `tag_*` name, which also
+ * sweeps `tag_columns`, already in the fixed set).
+ */
 function dropProjectedTables(db: Database): void {
 	const rows = db
 		.query<{ name: string }, []>(
-			"SELECT name FROM sqlite_master WHERE type = 'table' " +
-				"AND (name = 'wiki_pages' OR name = 'wiki_page_types' OR name LIKE 'wiki_type_%')",
+			"SELECT name FROM sqlite_master WHERE type = 'table'",
 		)
 		.all();
-	for (const { name } of rows) db.run(`DROP TABLE IF EXISTS ${q(name)}`);
+	for (const { name } of rows) {
+		if (FIXED_TABLES.has(name) || name.startsWith('tag_')) {
+			db.run(`DROP TABLE IF EXISTS ${q(name)}`);
+		}
+	}
 }
 
 /** Double-quote a SQL identifier, escaping embedded quotes. */
@@ -137,43 +360,24 @@ function q(identifier: string): string {
 	return `"${identifier.replaceAll('"', '""')}"`;
 }
 
-/** Type ids become physical table-name segments, so keep them slug-shaped. */
-function assertSafeSlug(value: string): string {
-	if (!/^[a-z0-9_]+$/.test(value)) {
+/** A tag id becomes a physical table-name segment, so keep it slug-shaped. */
+function assertTagSlug(value: string): string {
+	if (!TAG_ID_PATTERN.test(value)) {
 		throw new Error(
-			`type id "${value}" is not a safe table-name segment (expected [a-z0-9_]+)`,
+			`tag id "${value}" is not a safe table-name segment (expected ${TAG_ID_PATTERN})`,
 		);
 	}
 	return value;
 }
 
-type SchemaShape = { type?: string; const?: unknown; anyOf?: TSchema[] };
-
-/**
- * SQLite storage class for a column schema. Mirrors the workspace materializer's
- * `deriveStorage` (which is not exported from the package), including the
- * `const`/literal branch, so a `column.literal(5)` column derives INTEGER like
- * the real one rather than silently falling through to TEXT.
- */
-function deriveStorage(schema: TSchema): 'TEXT' | 'INTEGER' | 'REAL' {
-	const s = schema as SchemaShape;
-	if (s.type === 'integer' || s.type === 'boolean') return 'INTEGER';
-	if (s.type === 'number') return 'REAL';
-	if (s.type === 'string' || s.type === 'array' || s.type === 'object') {
-		return 'TEXT';
-	}
-	if (s.const !== undefined) {
-		return typeof s.const === 'number' && Number.isInteger(s.const)
-			? 'INTEGER'
-			: 'TEXT';
-	}
-	if (s.anyOf) {
-		const nonNull = s.anyOf.filter(
-			(branch) => (branch as SchemaShape).type !== 'null',
+/** A column id becomes a bare physical column name; keep it slug-shaped, never the PK. */
+function assertColumnId(value: string): string {
+	if (!COLUMN_ID_PATTERN.test(value) || value === 'page_id') {
+		throw new Error(
+			`column id "${value}" is not a safe column name (expected ${COLUMN_ID_PATTERN}, not "page_id")`,
 		);
-		if (nonNull.length === 1 && nonNull[0]) return deriveStorage(nonNull[0]);
 	}
-	return 'TEXT';
+	return value;
 }
 
 /** Convert a stored JSON value into a SQLite binding. */

--- a/apps/wiki/src/lib/workspace/projection.ts
+++ b/apps/wiki/src/lib/workspace/projection.ts
@@ -8,13 +8,11 @@
  *
  *   pages (id PK, title, body, created_at, updated_at)            WITHOUT ROWID
  *   tags  (id PK, name, icon, description, created_at, updated_at) WITHOUT ROWID
- *   tag_columns (tag_id, column_id, name, schema_json, storage, ordinal)
  *   page_tags (page_id, tag_id)            -- THE membership owner (every tag)
  *   tag_<slug> (page_id PK, <col> <storage>, ...)  STRICT, WITHOUT ROWID
  *                                          -- ONLY for tags with >= 1 column
  *   edges (source_id, rel, target_id, source_kind, field_id)
  *                                          -- provenance-aware; derived, never truth
- *   projection_issues (page_id, tag_id, column_id, kind, value_json, message)
  *
  * Consequences that fall straight out of this layout:
  *
@@ -24,9 +22,9 @@
  *     DDL, so it re-projects.
  *   - Plain tags get NO side table; their membership lives in `page_tags`.
  *   - TypeBox is the single validator: the projector `Value.Check`s every cell
- *     and routes failures to `projection_issues` (kind `invalid`), excess
- *     values (present in data, absent from the current schema) to
- *     `projection_issues` (kind `excess`), and never emits a `CHECK` constraint.
+ *     before insert and stores NULL on a miss, never a generated `CHECK`
+ *     constraint. The durable value survives in Yjs; the on-read lens
+ *     (`./lens.ts`) is what surfaces invalid / excess values for a page.
  *   - `edges` is rebuilt every run from body `[[id]]` wikilinks (source_kind
  *     `body_wikilink`) and every `column.ref()` value (source_kind
  *     `structured_field`); a `column.array(column.ref())` emits one row per
@@ -100,13 +98,6 @@ function createFixedTables(db: Database): void {
 			`${q('created_at')} TEXT NOT NULL, ${q('updated_at')} TEXT NOT NULL) WITHOUT ROWID`,
 	);
 	db.run(
-		`CREATE TABLE ${q('tag_columns')} (` +
-			`${q('tag_id')} TEXT NOT NULL, ${q('column_id')} TEXT NOT NULL, ` +
-			`${q('name')} TEXT NOT NULL, ${q('schema_json')} TEXT NOT NULL, ` +
-			`${q('storage')} TEXT NOT NULL, ${q('ordinal')} INTEGER NOT NULL, ` +
-			`PRIMARY KEY (${q('tag_id')}, ${q('column_id')})) WITHOUT ROWID`,
-	);
-	db.run(
 		`CREATE TABLE ${q('page_tags')} (` +
 			`${q('page_id')} TEXT NOT NULL, ${q('tag_id')} TEXT NOT NULL, ` +
 			`PRIMARY KEY (${q('page_id')}, ${q('tag_id')})) WITHOUT ROWID`,
@@ -116,12 +107,6 @@ function createFixedTables(db: Database): void {
 			`${q('source_id')} TEXT NOT NULL, ${q('rel')} TEXT NOT NULL, ` +
 			`${q('target_id')} TEXT NOT NULL, ${q('source_kind')} TEXT NOT NULL, ` +
 			`${q('field_id')} TEXT)`,
-	);
-	db.run(
-		`CREATE TABLE ${q('projection_issues')} (` +
-			`${q('page_id')} TEXT NOT NULL, ${q('tag_id')} TEXT NOT NULL, ` +
-			`${q('column_id')} TEXT NOT NULL, ${q('kind')} TEXT NOT NULL, ` +
-			`${q('value_json')} TEXT, ${q('message')} TEXT NOT NULL)`,
 	);
 }
 
@@ -142,11 +127,6 @@ function insertTags(db: Database, tags: WikiTag[]): void {
 			`(${q('id')}, ${q('name')}, ${q('icon')}, ${q('description')}, ${q('created_at')}, ${q('updated_at')}) ` +
 			'VALUES (?, ?, ?, ?, ?, ?)',
 	);
-	const insertColumn = db.prepare(
-		`INSERT INTO ${q('tag_columns')} ` +
-			`(${q('tag_id')}, ${q('column_id')}, ${q('name')}, ${q('schema_json')}, ${q('storage')}, ${q('ordinal')}) ` +
-			'VALUES (?, ?, ?, ?, ?, ?)',
-	);
 	for (const tag of tags) {
 		insertTag.run(
 			tag.id,
@@ -156,16 +136,6 @@ function insertTags(db: Database, tags: WikiTag[]): void {
 			tag.createdAt,
 			tag.updatedAt,
 		);
-		tagColumns(tag).forEach((spec, ordinal) => {
-			insertColumn.run(
-				tag.id,
-				spec.id,
-				spec.name,
-				JSON.stringify(spec.schema),
-				deriveStorage(spec.schema),
-				ordinal,
-			);
-		});
 	}
 }
 
@@ -187,7 +157,10 @@ function insertMembership(db: Database, pages: Page[]): void {
  * Build and populate one `tag_<slug>` side table from the tag's CURRENT
  * columns. Returns the `CREATE TABLE` statement so callers can prove a rename
  * emits identical DDL while an add does not. Each cell is `Value.Check`ed before
- * insert; failures route to `projection_issues` and store NULL instead.
+ * insert; a value that fails its column schema (or is absent) stores NULL. The
+ * durable value survives in Yjs, and the on-read lens (`./lens.ts`) is what
+ * surfaces the mismatch; excess values (no current column) simply do not
+ * project.
  */
 function projectStructuredTag(
 	db: Database,
@@ -209,44 +182,17 @@ function projectStructuredTag(
 		`INSERT INTO ${q(tableName)} (${physicalCols.join(', ')}) ` +
 			`VALUES (${physicalCols.map(() => '?').join(', ')})`,
 	);
-	const insertIssue = db.prepare(
-		`INSERT INTO ${q('projection_issues')} ` +
-			`(${q('page_id')}, ${q('tag_id')}, ${q('column_id')}, ${q('kind')}, ${q('value_json')}, ${q('message')}) ` +
-			'VALUES (?, ?, ?, ?, ?, ?)',
-	);
 
-	const schemaIds = new Set(specs.map((s) => s.id));
 	for (const page of pages) {
 		const data = page.tags[tag.id];
 		if (data === undefined) continue; // page does not wear this tag
 
 		const cells = specs.map((spec) => {
-			if (!Object.hasOwn(data, spec.id)) return null; // missing is not an issue
+			if (!Object.hasOwn(data, spec.id)) return null;
 			const value = data[spec.id]!;
-			if (Value.Check(spec.schema, value)) return serializeValue(value);
-			insertIssue.run(
-				page.id,
-				tag.id,
-				spec.id,
-				'invalid',
-				JSON.stringify(value),
-				`value does not satisfy column "${spec.id}" schema`,
-			);
-			return null;
+			return Value.Check(spec.schema, value) ? serializeValue(value) : null;
 		});
 		insert.run(page.id, ...cells);
-
-		for (const [columnId, value] of Object.entries(data)) {
-			if (schemaIds.has(columnId)) continue;
-			insertIssue.run(
-				page.id,
-				tag.id,
-				columnId,
-				'excess',
-				JSON.stringify(value),
-				`no column "${columnId}" in the current schema of tag "${tag.id}"`,
-			);
-		}
 	}
 
 	return ddl;
@@ -328,19 +274,11 @@ function refTargets(kind: RefKind, value: JsonValue | undefined): string[] {
 // ════════════════════════════════════════════════════════════════════════════
 
 /** The fixed (non-`tag_<slug>`) tables this projection owns. */
-const FIXED_TABLES = new Set([
-	'pages',
-	'tags',
-	'tag_columns',
-	'page_tags',
-	'edges',
-	'projection_issues',
-]);
+const FIXED_TABLES = new Set(['pages', 'tags', 'page_tags', 'edges']);
 
 /**
  * Drop every projected table so the next projection is a clean rebuild: the
- * fixed set plus every `tag_<slug>` side table (any `tag_*` name, which also
- * sweeps `tag_columns`, already in the fixed set).
+ * fixed set plus every `tag_<slug>` side table (any `tag_*` name).
  */
 function dropProjectedTables(db: Database): void {
 	const rows = db

--- a/apps/wiki/src/lib/workspace/schema.ts
+++ b/apps/wiki/src/lib/workspace/schema.ts
@@ -52,32 +52,94 @@ export const RESERVED_TAG_ID = 'columns';
 /** A column id is a stable slug, separate from its display name. */
 export const COLUMN_ID_PATTERN = /^[a-z][a-z0-9_]*$/;
 
-/** A column.* result is a non-null JSON object; a string/array/primitive is not. */
-export function isTSchemaObject(value: unknown): boolean {
-	return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
 /**
- * One column of a structured tag.
+ * One column of a structured tag, AS STORED.
  *
  * - `id` is the stable physical id. A rename never touches it, which is what
  *   makes a display rename metadata-only (no SQL DDL).
  * - `name` is the display name; free to change.
- * - `schema` is the column's TypeBox schema, authored with the real `column.*`
- *   builders (`column.url()`, `column.array(column.string())`) so call sites
- *   get autocomplete and type-checking. A reference is just a `column.string()`
- *   whose value is an `epicenter://` URN; the projector recognizes it by value,
- *   never a schema marker. A `TSchema` IS JSON Schema,
- *   so it is stored verbatim and re-validated with `Value.Check` after the
- *   Yjs/JSON round-trip (this TypeBox validates on plain JSON Schema, no
- *   `[Kind]` symbols, so a round-tripped schema validates identically). NO
- *   eval, NO codegen, NO interpreter.
+ * - `schema` is the column's TypeBox schema. It is never hand-authored: an agent
+ *   passes a `ColumnInput` descriptor and `buildColumnSchema` compiles it. The
+ *   resulting `TSchema` IS JSON Schema, so it is stored verbatim and re-validated
+ *   with `Value.Check` after the Yjs/JSON round-trip (TypeBox validates on plain
+ *   JSON Schema, no `[Kind]` symbols, so a round-tripped schema validates
+ *   identically). NO eval, NO codegen, NO interpreter.
  */
 export type ColumnSpec = {
 	id: string;
 	name: string;
 	schema: TSchema;
 };
+
+/**
+ * The closed set of column kinds an agent can author. Each maps to a `column.*`
+ * builder; the projector derives SQLite storage from the built schema. A
+ * reference is NOT a kind: it is a `string` (or an `array` of strings) whose
+ * value is an `epicenter://` URN, recognized by value, never by the schema.
+ */
+export type ColumnKind =
+	| 'string'
+	| 'number'
+	| 'integer'
+	| 'boolean'
+	| 'datetime'
+	| 'url'
+	| 'enum';
+
+/**
+ * The authoring descriptor for one column: a closed `kind` plus modifiers, never
+ * a hand-written JSON Schema. `buildColumnSchema` compiles it to the stored
+ * `TSchema`. This is the ONLY vocabulary the actions accept, so a stored schema
+ * is always a real `column.*` result (the input layer rejects unknown kinds, so
+ * no junk can land).
+ */
+export type ColumnInput = {
+	id: string;
+	name: string;
+	kind: ColumnKind;
+	/** Wrap the value as `value | null`. */
+	nullable?: boolean;
+	/** A list of the kind ("many of a kind"); each `epicenter://` element is its own edge. */
+	array?: boolean;
+	/** Required when `kind` is `enum`: the allowed literal values. */
+	enumValues?: string[];
+};
+
+/**
+ * Compile an authoring descriptor to the stored `TSchema`, via the `column.*`
+ * builders (no eval, no parser, just a switch). Modifiers compose on the base:
+ * `nullable` wraps the value, `array` wraps a list. Throws on an `enum` with no
+ * values (the action validates that first and returns a clean error).
+ */
+export function buildColumnSchema(input: ColumnInput): TSchema {
+	let schema: TSchema = baseColumnSchema(input);
+	if (input.nullable) schema = column.nullable(schema);
+	if (input.array) schema = column.array(schema);
+	return schema;
+}
+
+function baseColumnSchema(input: ColumnInput): TSchema {
+	switch (input.kind) {
+		case 'string':
+			return column.string();
+		case 'number':
+			return column.number();
+		case 'integer':
+			return column.integer();
+		case 'boolean':
+			return column.boolean();
+		case 'datetime':
+			return column.dateTime();
+		case 'url':
+			return column.url();
+		case 'enum':
+			return column.enum(input.enumValues ?? []);
+		default: {
+			const unreachable: never = input.kind;
+			throw new Error(`unknown column kind: ${String(unreachable)}`);
+		}
+	}
+}
 
 /**
  * The `tags.columns` cell.

--- a/apps/wiki/src/lib/workspace/schema.ts
+++ b/apps/wiki/src/lib/workspace/schema.ts
@@ -16,7 +16,7 @@
  *           plus ONE nested json cell `tags` holding membership + values, keyed
  *           by tag id. A page is a `youtube_video` iff its `tags` cell has that
  *           key; a plain tag is the empty object `{}`. A page wears each tag at
- *           most once (multiplicity lives in a `column.array(column.ref())`
+ *           most once (multiplicity lives in a `column.array(column.string())`
  *           column, never in wearing a tag twice).
  *
  * `body` is a plain string column on the row for this slice (routed to the
@@ -67,8 +67,10 @@ export function isTSchemaObject(value: unknown): boolean {
  *   makes a display rename metadata-only (no SQL DDL).
  * - `name` is the display name; free to change.
  * - `schema` is the column's TypeBox schema, authored with the real `column.*`
- *   builders (`column.url()`, `column.ref()`, `column.array(column.ref())`) so
- *   call sites get autocomplete and type-checking. A `TSchema` IS JSON Schema,
+ *   builders (`column.url()`, `column.array(column.string())`) so call sites
+ *   get autocomplete and type-checking. A reference is just a `column.string()`
+ *   whose value is an `epicenter://` URN; the projector recognizes it by value,
+ *   never a schema marker. A `TSchema` IS JSON Schema,
  *   so it is stored verbatim and re-validated with `Value.Check` after the
  *   Yjs/JSON round-trip (this TypeBox validates on plain JSON Schema, no
  *   `[Kind]` symbols, so a round-tripped schema validates identically). NO

--- a/apps/wiki/src/lib/workspace/schema.ts
+++ b/apps/wiki/src/lib/workspace/schema.ts
@@ -36,9 +36,6 @@ export type PageId = string & Brand<'PageId'>;
 /** Stable id of a tag (a human slug like `youtube_video`); also names a SQL table. */
 export type TagId = string & Brand<'TagId'>;
 
-export const asPageId = (value: string): PageId => value as PageId;
-export const asTagId = (value: string): TagId => value as TagId;
-
 /**
  * A tag id is a stable slug (must start with a letter); it also becomes a SQL
  * table-name segment. No slashes: hierarchy is a future `parent` field, never
@@ -108,12 +105,21 @@ const columnsCell = Type.Unsafe<StoredColumnSpec[]>(
  *
  *   { idea: {}, youtube_video: { url: "https://...", duration: 1240 } }
  *
- * `{}` is a plain tag (membership only). Like `columnsCell`, this uses
- * `Type.Unsafe` rather than `column.json`: the exact
- * `Record<string, Record<string, JsonValue>>` static carries through while the
- * runtime schema stays an `object` the SQLite layer maps to a TEXT cell. Do not
- * "simplify" it back to `column.json`; the nested-record static does not
- * survive that gate.
+ * `{}` is a plain tag (membership only). This schema is a live validator, not a
+ * typing trick: `getAllValid` runs `Value.Check` on it when materializing a
+ * page, so a `tags` cell that is not a map-of-maps is rejected before it can
+ * reach SQLite or any reader. Writes only ever arrive through validated actions
+ * (`pages_create`, `pages_assign_tag`) or a statically-typed `.set`, so that read
+ * gate is defense in depth. The `Unknown` leaf is deliberate: leaf values are
+ * already JSON (every ingress is a JSON round-trip), so re-policing them on every
+ * read would be wasted work.
+ *
+ * It uses raw `Type.Unsafe` rather than `column.json` because `column.json`
+ * derives its static from the schema and gates on `Static<S> extends JsonValue`;
+ * the `Unknown` leaf infers `unknown`, which is not `JsonValue`, so the naive
+ * `column.json(Type.Record(..., Type.Unknown()))` is a compile error.
+ * `Type.Unsafe` pins the precise `PageTagValues` static while the same `object`
+ * runtime schema maps to a TEXT cell. Do not "simplify" it back to `column.json`.
  */
 export type PageTagValues = Record<string, Record<string, JsonValue>>;
 

--- a/apps/wiki/src/lib/workspace/schema.ts
+++ b/apps/wiki/src/lib/workspace/schema.ts
@@ -1,17 +1,23 @@
 /**
  * Wiki schema: the two first-party tables and the shared types.
  *
- * The whole model is two ordinary `defineTable` schemas:
+ * The whole model is two ordinary `defineTable` schemas (an Entity-Component
+ * backbone):
  *
- *   types   a registry of user-defined types. Each row IS a type: a stable id,
- *           a display name, an optional icon, and `columns` (the user's schema,
- *           stored as ColumnSpec[]). Materialized to `types/<id>.md`.
+ *   tags    the registry of reusable annotation / schema facets. Each row IS a
+ *           tag: a stable human slug id, a display name, an optional icon, a
+ *           short `description` (what the tag is for; may embed a `[[id]]`), and
+ *           `columns` (the user's schema, stored as ColumnSpec[]). A tag with
+ *           `columns: []` is a PLAIN tag (membership only); a tag with columns is
+ *           a STRUCTURED tag (a typed component) that projects to its own SQLite
+ *           table. Materialized to `tags/<id>.md`.
  *
- *   pages   the unit of the wiki. A worldview-neutral core (id, title,
- *           description?, tags[], source[], timestamps) plus ONE nested json
- *           cell `types` holding membership + values, keyed by type id, plus a
- *           `body` (the markdown body of the file). Membership IS key presence:
- *           a page is a `youtube_video` iff its `types` cell has that key.
+ *   pages   the knowledge objects. A minimal core (id, title, body, timestamps)
+ *           plus ONE nested json cell `tags` holding membership + values, keyed
+ *           by tag id. A page is a `youtube_video` iff its `tags` cell has that
+ *           key; a plain tag is the empty object `{}`. A page wears each tag at
+ *           most once (multiplicity lives in a `column.array(column.ref())`
+ *           column, never in wearing a tag twice).
  *
  * `body` is a plain string column on the row for this slice (routed to the
  * markdown file's body section by `./markdown.ts`, never into frontmatter). It
@@ -25,15 +31,29 @@ import { type TSchema, Type } from 'typebox';
 import type { Brand } from 'wellcrafted/brand';
 import type { JsonObject, JsonValue } from 'wellcrafted/json';
 
-/** Stable id of a wiki page (the markdown file stem, the row key). */
+/** Stable id of a wiki page (the markdown file stem, the row key). Generated, opaque. */
 export type PageId = string & Brand<'PageId'>;
-/** Stable id of a user-defined type (a slug like `youtube_video`). */
-export type TypeId = string & Brand<'TypeId'>;
+/** Stable id of a tag (a human slug like `youtube_video`); also names a SQL table. */
+export type TagId = string & Brand<'TagId'>;
 
 export const asPageId = (value: string): PageId => value as PageId;
+export const asTagId = (value: string): TagId => value as TagId;
 
-/** A type id is a stable slug; it also becomes a SQL table-name segment. */
-export const TYPE_ID_PATTERN = /^[a-z0-9_]+$/;
+/**
+ * A tag id is a stable slug (must start with a letter); it also becomes a SQL
+ * table-name segment. No slashes: hierarchy is a future `parent` field, never
+ * encoded in the table name.
+ */
+export const TAG_ID_PATTERN = /^[a-z][a-z0-9_]*$/;
+
+/**
+ * `columns` is reserved as a tag id: it would collide with the `tag_columns`
+ * projection table.
+ */
+export const RESERVED_TAG_ID = 'columns';
+
+/** A column id is a stable slug, separate from its display name. */
+export const COLUMN_ID_PATTERN = /^[a-z][a-z0-9_]*$/;
 
 /** A column.* result is a non-null JSON object; a string/array/primitive is not. */
 export function isTSchemaObject(value: unknown): boolean {
@@ -41,18 +61,18 @@ export function isTSchemaObject(value: unknown): boolean {
 }
 
 /**
- * One column of a user-defined type.
+ * One column of a structured tag.
  *
  * - `id` is the stable physical id. A rename never touches it, which is what
  *   makes a display rename metadata-only (no SQL DDL).
  * - `name` is the display name; free to change.
  * - `schema` is the column's TypeBox schema, authored with the real `column.*`
- *   builders (`column.url()`, `column.nullable(column.number())`) so call sites
- *   get autocomplete and type-checking. A `TSchema` IS JSON Schema, so it is
- *   stored verbatim and re-validated with `Value.Check` after the Yjs/JSON
- *   round-trip (this TypeBox validates on plain JSON Schema, no `[Kind]`
- *   symbols, so a round-tripped schema validates identically). NO eval, NO
- *   codegen, NO interpreter.
+ *   builders (`column.url()`, `column.ref()`, `column.array(column.ref())`) so
+ *   call sites get autocomplete and type-checking. A `TSchema` IS JSON Schema,
+ *   so it is stored verbatim and re-validated with `Value.Check` after the
+ *   Yjs/JSON round-trip (this TypeBox validates on plain JSON Schema, no
+ *   `[Kind]` symbols, so a round-tripped schema validates identically). NO
+ *   eval, NO codegen, NO interpreter.
  */
 export type ColumnSpec = {
 	id: string;
@@ -61,12 +81,12 @@ export type ColumnSpec = {
 };
 
 /**
- * The `types.columns` cell.
+ * The `tags.columns` cell.
  *
  * A `TSchema` IS a JSON object at runtime, but TypeBox's `TSchema` static type
  * is not seen as `JsonValue`, so `defineTable`'s SQLite-safe gate would reject a
  * `schema: TSchema` field. The cell therefore stores `schema` as a JSON object
- * and `typeColumns()` reads it back as a `ColumnSpec` (schema as `TSchema`).
+ * and `tagColumns()` reads it back as a `ColumnSpec` (schema as `TSchema`).
  * The runtime value is the same object either way.
  */
 type StoredColumnSpec = { id: string; name: string; schema: JsonObject };
@@ -82,46 +102,45 @@ const columnsCell = Type.Unsafe<StoredColumnSpec[]>(
 );
 
 /**
- * The `pages.types` cell: membership + values, keyed by type id then column id.
+ * The `pages.tags` cell: membership + values, keyed by tag id then column id.
  *
- *   { youtube_video: { url: "https://...", duration: 1240 } }
+ *   { idea: {}, youtube_video: { url: "https://...", duration: 1240 } }
  *
- * Like `columnsCell`, this uses `Type.Unsafe` rather than `column.json`: the
- * exact `Record<string, Record<string, JsonValue>>` static carries through while
- * the runtime schema stays an `object` the SQLite layer maps to a TEXT cell. Do
- * not "simplify" it back to `column.json`; the nested-record static does not
+ * `{}` is a plain tag (membership only). Like `columnsCell`, this uses
+ * `Type.Unsafe` rather than `column.json`: the exact
+ * `Record<string, Record<string, JsonValue>>` static carries through while the
+ * runtime schema stays an `object` the SQLite layer maps to a TEXT cell. Do not
+ * "simplify" it back to `column.json`; the nested-record static does not
  * survive that gate.
  */
-export type PageTypeValues = Record<string, Record<string, JsonValue>>;
+export type PageTagValues = Record<string, Record<string, JsonValue>>;
 
-const pageTypeValuesCell = Type.Unsafe<PageTypeValues>(
+const pageTagsCell = Type.Unsafe<PageTagValues>(
 	Type.Record(Type.String(), Type.Record(Type.String(), Type.Unknown())),
 );
 
-/** The types registry: one row per user-defined type. */
-export const typesTable = defineTable({
-	id: column.string<TypeId>(),
+/** The tags registry: one row per reusable annotation / schema facet. */
+export const tagsTable = defineTable({
+	id: column.string<TagId>(),
 	name: column.string(),
 	icon: column.nullable(column.string()),
 	columns: columnsCell,
+	description: column.nullable(column.string()),
 	createdAt: column.dateTime(),
 	updatedAt: column.dateTime(),
 });
 
-/** The pages table: worldview-neutral core + the nested `types` cell + body. */
+/** The pages table: minimal core + the nested `tags` cell + body. */
 export const pagesTable = defineTable({
 	id: column.string<PageId>(),
 	title: column.string(),
-	description: column.nullable(column.string()),
-	tags: column.json(Type.Array(Type.String())),
-	source: column.json(Type.Array(Type.String())),
-	types: pageTypeValuesCell,
 	body: column.string(),
+	tags: pageTagsCell,
 	createdAt: column.dateTime(),
 	updatedAt: column.dateTime(),
 });
 
-export type WikiType = InferTableRow<typeof typesTable>;
+export type WikiTag = InferTableRow<typeof tagsTable>;
 export type Page = InferTableRow<typeof pagesTable>;
 
 /**
@@ -129,11 +148,11 @@ export type Page = InferTableRow<typeof pagesTable>;
  * `TSchema`). The single boundary where the stored JSON-object schema is read
  * back as a TypeBox schema; the runtime value is unchanged.
  */
-export function typeColumns(type: WikiType): ColumnSpec[] {
-	return type.columns as unknown as ColumnSpec[];
+export function tagColumns(tag: WikiTag): ColumnSpec[] {
+	return tag.columns as unknown as ColumnSpec[];
 }
 
 export const wikiTableDefinitions = {
-	types: typesTable,
+	tags: tagsTable,
 	pages: pagesTable,
 };

--- a/apps/wiki/src/lib/workspace/schema.ts
+++ b/apps/wiki/src/lib/workspace/schema.ts
@@ -47,8 +47,8 @@ export const asTagId = (value: string): TagId => value as TagId;
 export const TAG_ID_PATTERN = /^[a-z][a-z0-9_]*$/;
 
 /**
- * `columns` is reserved as a tag id: it would collide with the `tag_columns`
- * projection table.
+ * `columns` is reserved as a tag id by the wiki normalization rules, keeping the
+ * tag-id namespace clear of an internal-sounding name.
  */
 export const RESERVED_TAG_ID = 'columns';
 

--- a/apps/wiki/src/lib/workspace/wiki.test.ts
+++ b/apps/wiki/src/lib/workspace/wiki.test.ts
@@ -15,20 +15,19 @@ import { expect, test } from 'bun:test';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { column } from '@epicenter/workspace';
 import { createWiki } from './index';
 import { viewThroughTag } from './lens';
 import { attachWikiVault } from './markdown';
 import { projectWiki } from './projection';
-import type { ColumnSpec } from './schema';
+import {
+	buildColumnSchema,
+	type ColumnInput,
+	type ColumnSpec,
+} from './schema';
 
-const youtubeColumns: ColumnSpec[] = [
-	{ id: 'url', name: 'URL', schema: column.url() },
-	{
-		id: 'duration',
-		name: 'Duration',
-		schema: column.nullable(column.number()),
-	},
+const youtubeColumns: ColumnInput[] = [
+	{ id: 'url', name: 'URL', kind: 'url' },
+	{ id: 'duration', name: 'Duration', kind: 'number', nullable: true },
 ];
 
 /** Define the structured tags the spec's example page wears. */
@@ -41,12 +40,12 @@ function defineExampleTags(wiki: ReturnType<typeof createWiki>): void {
 	wiki.actions.tags_define({
 		id: 'publishable',
 		name: 'Publishable',
-		columns: [{ id: 'stage', name: 'Stage', schema: column.string() }],
+		columns: [{ id: 'stage', name: 'Stage', kind: 'string' }],
 	});
 	wiki.actions.tags_define({
 		id: 'whispering_recording',
 		name: 'Whispering Recording',
-		columns: [{ id: 'recording', name: 'Recording', schema: column.string() }],
+		columns: [{ id: 'recording', name: 'Recording', kind: 'string' }],
 		description: 'A page captured from a [[whispering]] recording.',
 	});
 }
@@ -197,10 +196,13 @@ test('materializes the spec example page one-way, writes through an action, answ
 });
 
 test('schema-on-read lens buckets match / excess / missing', () => {
-	const columns: ColumnSpec[] = [
-		...youtubeColumns,
-		{ id: 'rating', name: 'Rating', schema: column.number() },
-	];
+	// The lens reads stored ColumnSpec (TSchema); compile the descriptors to it.
+	const columns: ColumnSpec[] = (
+		[
+			...youtubeColumns,
+			{ id: 'rating', name: 'Rating', kind: 'number' },
+		] satisfies ColumnInput[]
+	).map((c) => ({ id: c.id, name: c.name, schema: buildColumnSchema(c) }));
 	const data = {
 		url: 'https://youtu.be/abc',
 		duration: 'not-a-number',
@@ -225,7 +227,7 @@ test('tags_define rejects a non-slug tag id and the reserved `columns`', () => {
 		const bad = wiki.actions.tags_define({
 			id: 'Not A Slug',
 			name: 'Bad',
-			columns: [{ id: 'x', name: 'X', schema: column.string() }],
+			columns: [{ id: 'x', name: 'X', kind: 'string' }],
 		});
 		expect(bad.error?.name).toBe('InvalidTagId');
 
@@ -269,12 +271,8 @@ test('column rename is metadata-only; adding a column re-projects', () => {
 			id: 'youtube_video',
 			name: 'YouTube Video',
 			columns: [
-				{ id: 'url', name: 'Link', schema: column.url() },
-				{
-					id: 'duration',
-					name: 'Length',
-					schema: column.nullable(column.number()),
-				},
+				{ id: 'url', name: 'Link', kind: 'url' },
+				{ id: 'duration', name: 'Length', kind: 'number', nullable: true },
 			],
 		});
 		expect(project()).toBe(ddlBefore); // no DDL: a rename is metadata-only
@@ -284,13 +282,9 @@ test('column rename is metadata-only; adding a column re-projects', () => {
 			id: 'youtube_video',
 			name: 'YouTube Video',
 			columns: [
-				{ id: 'url', name: 'Link', schema: column.url() },
-				{
-					id: 'duration',
-					name: 'Length',
-					schema: column.nullable(column.number()),
-				},
-				{ id: 'rating', name: 'Rating', schema: column.number() },
+				{ id: 'url', name: 'Link', kind: 'url' },
+				{ id: 'duration', name: 'Length', kind: 'number', nullable: true },
+				{ id: 'rating', name: 'Rating', kind: 'number' },
 			],
 		});
 		const ddlAfterAdd = project();
@@ -329,6 +323,79 @@ test('pages_assign_tag auto-mints an unknown tag and wears it once', () => {
 		// An invalid slug is rejected where the cause is visible.
 		const bad = wiki.actions.pages_assign_tag({ id, tagId: 'Bad Slug' });
 		expect(bad.error?.name).toBe('InvalidTagId');
+	} finally {
+		wiki[Symbol.dispose]();
+	}
+});
+
+test('tags_set_column adds and upserts a typed column from a kind descriptor', () => {
+	const wiki = createWiki();
+	const db = new Database(':memory:');
+	try {
+		wiki.actions.tags_define({ id: 'note', name: 'Note', columns: [] });
+
+		// Add a column to an existing tag. The agent picks a kind, not a schema.
+		const added = wiki.actions.tags_set_column({
+			tagId: 'note',
+			column: { id: 'rating', name: 'Rating', kind: 'integer' },
+		});
+		expect(added.error).toBeNull();
+
+		const noteDdl = () =>
+			projectWiki(db, { tags: wiki.actions.tags_get_all(), pages: [] })
+				.tagTableDdl.note;
+		expect(noteDdl()).toContain('"rating" INTEGER'); // kind -> storage class
+
+		// Upsert by id: retype to an enum (now TEXT) and rename, still one column.
+		wiki.actions.tags_set_column({
+			tagId: 'note',
+			column: { id: 'rating', name: 'Stars', kind: 'enum', enumValues: ['lo', 'hi'] },
+		});
+		const note = wiki.actions.tags_get_all().find((t) => t.id === 'note')!;
+		expect(note.columns).toHaveLength(1); // upsert, not append
+		expect(note.columns[0]!.name).toBe('Stars');
+		expect(noteDdl()).toContain('"rating" TEXT');
+
+		// Remove it: the column is gone, the tag becomes plain again.
+		wiki.actions.tags_remove_column({ tagId: 'note', columnId: 'rating' });
+		expect(
+			wiki.actions.tags_get_all().find((t) => t.id === 'note')!.columns,
+		).toEqual([]);
+	} finally {
+		db.close();
+		wiki[Symbol.dispose]();
+	}
+});
+
+test('the column authoring surface rejects bad input', () => {
+	const wiki = createWiki();
+	try {
+		wiki.actions.tags_define({ id: 'note', name: 'Note', columns: [] });
+
+		const unknownTag = wiki.actions.tags_set_column({
+			tagId: 'nope',
+			column: { id: 'x', name: 'X', kind: 'string' },
+		});
+		expect(unknownTag.error?.name).toBe('TagNotFound');
+
+		const badId = wiki.actions.tags_set_column({
+			tagId: 'note',
+			column: { id: 'Bad Id', name: 'X', kind: 'string' },
+		});
+		expect(badId.error?.name).toBe('InvalidColumnId');
+
+		// A column id colliding with the page_id PK is rejected too.
+		const pkClash = wiki.actions.tags_set_column({
+			tagId: 'note',
+			column: { id: 'page_id', name: 'X', kind: 'string' },
+		});
+		expect(pkClash.error?.name).toBe('InvalidColumnId');
+
+		const emptyEnum = wiki.actions.tags_set_column({
+			tagId: 'note',
+			column: { id: 'x', name: 'X', kind: 'enum' },
+		});
+		expect(emptyEnum.error?.name).toBe('EnumValuesRequired');
 	} finally {
 		wiki[Symbol.dispose]();
 	}

--- a/apps/wiki/src/lib/workspace/wiki.test.ts
+++ b/apps/wiki/src/lib/workspace/wiki.test.ts
@@ -1,12 +1,13 @@
 /**
- * The wiki vertical slice, end to end. One test walks the eight milestone
- * steps: define a type at runtime, create a page in it, materialize it to
- * `<id>.md`, edit the file, reconcile it back into Yjs, project a per-type
- * SQLite side table, answer a typed query, and prove a rename is metadata-only
- * while an add re-projects. Two focused tests cover the schema-on-read lens and
- * the rename-vs-add DDL distinction.
+ * The wiki pages-and-tags model, end to end. The first test walks the spec's
+ * example page: define structured tags at runtime, create a page that wears a
+ * mix of plain and structured tags (auto-minting an unknown one), materialize
+ * it to `pages/<id>.md`, edit the file, reconcile it back into Yjs, project to
+ * SQLite, and answer the typed JOIN. Focused tests cover the schema-on-read
+ * lens, the rename-vs-add DDL distinction, plain-tag membership, the two edge
+ * provenances, and auto-mint.
  *
- * If this loop holds, the architecture is real.
+ * If this loop holds, the Entity-Component architecture is real.
  */
 
 import { Database } from 'bun:sqlite';
@@ -20,7 +21,7 @@ import {
 	parseMarkdownFile,
 } from '@epicenter/workspace/markdown';
 import { createWiki } from './index';
-import { viewThroughType } from './lens';
+import { viewThroughTag } from './lens';
 import { attachWikiVault } from './markdown';
 import { projectWiki } from './projection';
 import type { ColumnSpec, Page } from './schema';
@@ -34,26 +35,53 @@ const youtubeColumns: ColumnSpec[] = [
 	},
 ];
 
-test('round-trips a typed page Yjs <-> markdown <-> Yjs and answers a typed SQLite query', async () => {
+/** Define the structured tags the spec's example page wears. */
+function defineExampleTags(wiki: ReturnType<typeof createWiki>): void {
+	wiki.actions.tags_define({
+		id: 'youtube_video',
+		name: 'YouTube Video',
+		columns: youtubeColumns,
+	});
+	wiki.actions.tags_define({
+		id: 'publishable',
+		name: 'Publishable',
+		columns: [{ id: 'stage', name: 'Stage', schema: column.string() }],
+	});
+	wiki.actions.tags_define({
+		id: 'whispering_recording',
+		name: 'Whispering Recording',
+		columns: [{ id: 'recording', name: 'Recording', schema: column.ref() }],
+		description: 'A page captured from a [[whispering]] recording.',
+	});
+}
+
+test('round-trips the spec example page Yjs <-> markdown <-> Yjs, answers the typed JOIN, and builds both edge kinds', async () => {
 	const dir = await mkdtemp(join(tmpdir(), 'wiki-vault-'));
 	const wiki = createWiki();
 	try {
-		// 1 + 3. Define the youtube_video type at runtime (real column.* calls).
-		const defined = wiki.actions.types_define({
-			id: 'youtube_video',
-			name: 'YouTube Video',
-			columns: youtubeColumns,
-		});
-		expect(defined.error).toBeNull();
+		defineExampleTags(wiki);
 
-		// 4. Create a page carrying that type, with a body and epicenter:// source.
+		// Create the example page. `idea` is never defined: it auto-mints as a
+		// bare plain tag. The recording is a column.ref() to a cross-app source.
 		const created = wiki.actions.pages_create({
 			title: 'Great talk',
-			source: ['epicenter://whispering/recordings/rec_123'],
-			types: { youtube_video: { url: 'https://youtu.be/abc', duration: 1240 } },
-			body: 'Notes about the talk.',
+			tags: {
+				idea: {},
+				youtube_video: { url: 'https://youtu.be/abc', duration: 1240 },
+				publishable: { stage: 'draft' },
+				whispering_recording: {
+					recording: 'epicenter://whispering/recordings/rec_123',
+				},
+			},
+			body: 'Notes about the talk. See also [[page_def]].',
 		});
 		const pageId = created.id;
+
+		// Auto-mint: the unknown `idea` tag now exists as a bare plain definition.
+		const idea = wiki.actions.tags_get_all().find((t) => t.id === 'idea');
+		expect(idea).toBeDefined();
+		expect(idea!.columns).toEqual([]);
+		expect(idea!.description).toBeNull();
 
 		// Materialize through the vault.
 		const vault = attachWikiVault(wiki, { dir });
@@ -64,49 +92,109 @@ test('round-trips a typed page Yjs <-> markdown <-> Yjs and answers a typed SQLi
 		expect(pageMd).toContain('https://youtu.be/abc');
 		expect(pageMd).toContain('duration: 1240');
 		expect(pageMd).toContain('Notes about the talk.');
+		expect(pageMd).toContain('[[page_def]]');
 		expect(pageMd).toContain('epicenter://whispering/recordings/rec_123');
 
-		// types/<id>.md carries the column schema as JSON.
-		const typeMd = await readFile(
-			join(dir, 'types', 'youtube_video.md'),
+		// tags/<id>.md carries the column schema as JSON, plus the description.
+		const tagMd = await readFile(
+			join(dir, 'tags', 'youtube_video.md'),
 			'utf-8',
 		);
-		expect(typeMd).toContain('format: uri'); // column.url()
+		expect(tagMd).toContain('format: uri'); // column.url()
+		const recordingTagMd = await readFile(
+			join(dir, 'tags', 'whispering_recording.md'),
+			'utf-8',
+		);
+		expect(recordingTagMd).toContain('x-epicenter-ref: true'); // column.ref()
+		expect(recordingTagMd).toContain('captured from a [[whispering]]');
 
-		// 5. Edit the .md as a text editor would, then reconcile (markdown apply).
+		// Edit the .md as a text editor would, then reconcile (markdown push).
 		const parsed = parseMarkdownFile(pageMd)!;
-		(parsed.frontmatter.types as Page['types']).youtube_video!.duration = 999;
+		(parsed.frontmatter.tags as Page['tags']).youtube_video!.duration = 999;
 		await writeFile(
 			pagePath,
-			assembleMarkdown(parsed.frontmatter, 'Edited notes.'),
+			assembleMarkdown(parsed.frontmatter, 'Edited notes. See also [[page_def]].'),
 		);
 
 		const push = await vault.actions.markdown_push();
 		expect(push.errored).toBe(0);
 
 		const after = wiki.actions.pages_get({ id: pageId }).data!;
-		expect(after.types.youtube_video!.duration).toBe(999);
-		expect(after.types.youtube_video!.url).toBe('https://youtu.be/abc');
-		expect(after.body).toBe('Edited notes.');
+		expect(after.tags.youtube_video!.duration).toBe(999);
+		expect(after.tags.youtube_video!.url).toBe('https://youtu.be/abc');
+		expect(after.body).toBe('Edited notes. See also [[page_def]].');
 
-		// 6 + 7. Project per-type SQLite and answer a typed query.
+		// Project to SQLite and answer the typed JOIN (bare column names).
 		const db = new Database(':memory:');
 		try {
 			projectWiki(db, {
-				types: wiki.actions.types_get_all(),
+				tags: wiki.actions.tags_get_all(),
 				pages: wiki.actions.pages_get_all(),
 			});
+
 			const rows = db
 				.query<{ title: string; d: number }, [number]>(
-					'SELECT p.title, yv.c_duration AS d ' +
-						'FROM wiki_pages p ' +
-						'JOIN wiki_type_youtube_video yv ON yv.page_id = p.id ' +
-						'WHERE yv.c_duration > ?',
+					'SELECT p.title, yv.duration AS d ' +
+						'FROM pages p ' +
+						'JOIN tag_youtube_video yv ON yv.page_id = p.id ' +
+						'WHERE yv.duration > ?',
 				)
 				.all(500);
 			expect(rows).toHaveLength(1);
 			expect(rows[0]!.title).toBe('Great talk');
 			expect(rows[0]!.d).toBe(999);
+
+			// Plain tag `idea`: membership lives in page_tags, with NO side table.
+			const membership = db
+				.query<{ tag_id: string }, [string]>(
+					'SELECT tag_id FROM page_tags WHERE page_id = ? ORDER BY tag_id',
+				)
+				.all(pageId)
+				.map((r) => r.tag_id);
+			expect(membership).toContain('idea');
+			const ideaTable = db
+				.query<{ name: string }, []>(
+					"SELECT name FROM sqlite_master WHERE type='table' AND name='tag_idea'",
+				)
+				.all();
+			expect(ideaTable).toHaveLength(0);
+
+			// A column.ref() value becomes a structured_field edge.
+			const refEdges = db
+				.query<
+					{ target_id: string; source_kind: string; field_id: string },
+					[string]
+				>(
+					"SELECT target_id, source_kind, field_id FROM edges " +
+						"WHERE source_id = ? AND source_kind = 'structured_field'",
+				)
+				.all(pageId);
+			expect(refEdges).toHaveLength(1);
+			expect(refEdges[0]!.target_id).toBe(
+				'epicenter://whispering/recordings/rec_123',
+			);
+			expect(refEdges[0]!.field_id).toBe('recording');
+
+			// A body [[id]] becomes a DISTINCT edge with a different source_kind.
+			const bodyEdges = db
+				.query<{ target_id: string }, [string]>(
+					"SELECT target_id FROM edges " +
+						"WHERE source_id = ? AND source_kind = 'body_wikilink'",
+				)
+				.all(pageId);
+			expect(bodyEdges).toHaveLength(1);
+			expect(bodyEdges[0]!.target_id).toBe('page_def');
+
+			// `page_def` dangles (no page row); discoverable via LEFT JOIN, never an error.
+			const dangling = db
+				.query<{ target_id: string }, []>(
+					'SELECT e.target_id FROM edges e ' +
+						'LEFT JOIN pages p ON p.id = e.target_id ' +
+						"WHERE p.id IS NULL AND e.source_kind = 'body_wikilink'",
+				)
+				.all()
+				.map((r) => r.target_id);
+			expect(dangling).toContain('page_def');
 		} finally {
 			db.close();
 		}
@@ -117,8 +205,6 @@ test('round-trips a typed page Yjs <-> markdown <-> Yjs and answers a typed SQLi
 });
 
 test('schema-on-read lens buckets match / excess / missing', () => {
-	// Current schema declares url, duration, rating; the stored data has url,
-	// a malformed duration, and an unknown `channel`.
 	const columns: ColumnSpec[] = [
 		...youtubeColumns,
 		{ id: 'rating', name: 'Rating', schema: column.number() },
@@ -129,7 +215,7 @@ test('schema-on-read lens buckets match / excess / missing', () => {
 		channel: 'Veritasium',
 	};
 
-	const lens = viewThroughType({ typeId: 'youtube_video', columns, data });
+	const lens = viewThroughTag({ tagId: 'youtube_video', columns, data });
 
 	const matchById = Object.fromEntries(lens.match.map((m) => [m.id, m]));
 	expect(lens.match.map((m) => m.id).sort()).toEqual(['duration', 'url']);
@@ -141,16 +227,24 @@ test('schema-on-read lens buckets match / excess / missing', () => {
 	expect(lens.excess[0]!.value).toBe('Veritasium');
 });
 
-test('types_define rejects a non-slug type id at definition time', () => {
+test('tags_define rejects a non-slug tag id and the reserved `columns`', () => {
 	const wiki = createWiki();
 	try {
-		const result = wiki.actions.types_define({
+		const bad = wiki.actions.tags_define({
 			id: 'Not A Slug',
 			name: 'Bad',
 			columns: [{ id: 'x', name: 'X', schema: column.string() }],
 		});
-		expect(result.error?.name).toBe('InvalidTypeId');
-		expect(wiki.actions.types_get_all()).toHaveLength(0);
+		expect(bad.error?.name).toBe('InvalidTagId');
+
+		const reserved = wiki.actions.tags_define({
+			id: 'columns',
+			name: 'Reserved',
+			columns: [],
+		});
+		expect(reserved.error?.name).toBe('ReservedTagId');
+
+		expect(wiki.actions.tags_get_all()).toHaveLength(0);
 	} finally {
 		wiki[Symbol.dispose]();
 	}
@@ -160,26 +254,26 @@ test('column rename is metadata-only; adding a column re-projects', () => {
 	const wiki = createWiki();
 	const db = new Database(':memory:');
 	try {
-		wiki.actions.types_define({
+		wiki.actions.tags_define({
 			id: 'youtube_video',
 			name: 'YouTube Video',
 			columns: youtubeColumns,
 		});
 		wiki.actions.pages_create({
 			title: 'clip',
-			types: { youtube_video: { url: 'https://youtu.be/abc', duration: 10 } },
+			tags: { youtube_video: { url: 'https://youtu.be/abc', duration: 10 } },
 		});
 
 		const project = () =>
 			projectWiki(db, {
-				types: wiki.actions.types_get_all(),
+				tags: wiki.actions.tags_get_all(),
 				pages: wiki.actions.pages_get_all(),
-			}).typeTableDdl.youtube_video;
+			}).tagTableDdl.youtube_video;
 
 		const ddlBefore = project();
 
 		// Rename display names only; the stable column ids never change.
-		wiki.actions.types_define({
+		wiki.actions.tags_define({
 			id: 'youtube_video',
 			name: 'YouTube Video',
 			columns: [
@@ -194,7 +288,7 @@ test('column rename is metadata-only; adding a column re-projects', () => {
 		expect(project()).toBe(ddlBefore); // no DDL: a rename is metadata-only
 
 		// Add a column: the physical shape changes, so projection emits new DDL.
-		wiki.actions.types_define({
+		wiki.actions.tags_define({
 			id: 'youtube_video',
 			name: 'YouTube Video',
 			columns: [
@@ -209,9 +303,41 @@ test('column rename is metadata-only; adding a column re-projects', () => {
 		});
 		const ddlAfterAdd = project();
 		expect(ddlAfterAdd).not.toBe(ddlBefore);
-		expect(ddlAfterAdd).toContain('"c_rating"');
+		expect(ddlAfterAdd).toContain('"rating"');
 	} finally {
 		db.close();
+		wiki[Symbol.dispose]();
+	}
+});
+
+test('pages_assign_tag auto-mints an unknown tag and wears it once', () => {
+	const wiki = createWiki();
+	try {
+		const { id } = wiki.actions.pages_create({ title: 'Draft' });
+
+		const assigned = wiki.actions.pages_assign_tag({ id, tagId: 'newidea' });
+		expect(assigned.error).toBeNull();
+		expect(assigned.data!.tags.newidea).toEqual({});
+
+		// The unknown tag minted a bare definition at the write boundary.
+		const minted = wiki.actions.tags_get_all().find((t) => t.id === 'newidea');
+		expect(minted).toBeDefined();
+		expect(minted!.name).toBe('newidea');
+		expect(minted!.columns).toEqual([]);
+
+		// Re-assigning overwrites the values; a page wears each tag at most once.
+		const reassigned = wiki.actions.pages_assign_tag({
+			id,
+			tagId: 'newidea',
+			values: { note: 'now structured-ish' },
+		});
+		expect(reassigned.data!.tags.newidea).toEqual({ note: 'now structured-ish' });
+		expect(Object.keys(reassigned.data!.tags)).toEqual(['newidea']);
+
+		// An invalid slug is rejected where the cause is visible.
+		const bad = wiki.actions.pages_assign_tag({ id, tagId: 'Bad Slug' });
+		expect(bad.error?.name).toBe('InvalidTagId');
+	} finally {
 		wiki[Symbol.dispose]();
 	}
 });

--- a/apps/wiki/src/lib/workspace/wiki.test.ts
+++ b/apps/wiki/src/lib/workspace/wiki.test.ts
@@ -50,7 +50,7 @@ function defineExampleTags(wiki: ReturnType<typeof createWiki>): void {
 	wiki.actions.tags_define({
 		id: 'whispering_recording',
 		name: 'Whispering Recording',
-		columns: [{ id: 'recording', name: 'Recording', schema: column.ref() }],
+		columns: [{ id: 'recording', name: 'Recording', schema: column.string() }],
 		description: 'A page captured from a [[whispering]] recording.',
 	});
 }
@@ -62,7 +62,8 @@ test('round-trips the spec example page Yjs <-> markdown <-> Yjs, answers the ty
 		defineExampleTags(wiki);
 
 		// Create the example page. `idea` is never defined: it auto-mints as a
-		// bare plain tag. The recording is a column.ref() to a cross-app source.
+		// bare plain tag. The recording is an `epicenter://` URN to a cross-app
+		// source (a plain string column; the projector reads the edge by value).
 		const created = wiki.actions.pages_create({
 			title: 'Great talk',
 			tags: {
@@ -105,7 +106,8 @@ test('round-trips the spec example page Yjs <-> markdown <-> Yjs, answers the ty
 			join(dir, 'tags', 'whispering_recording.md'),
 			'utf-8',
 		);
-		expect(recordingTagMd).toContain('x-epicenter-ref: true'); // column.ref()
+		// The recording column is a plain string (no schema marker); references are
+		// recognized from the `epicenter://` URN value, not the schema.
 		expect(recordingTagMd).toContain('captured from a [[whispering]]');
 
 		// Edit the .md as a text editor would, then reconcile (markdown push).
@@ -159,7 +161,8 @@ test('round-trips the spec example page Yjs <-> markdown <-> Yjs, answers the ty
 				.all();
 			expect(ideaTable).toHaveLength(0);
 
-			// A column.ref() value becomes a structured_field edge.
+			// An `epicenter://` URN cell value becomes a structured_field edge,
+			// detected by value (no schema marker).
 			const refEdges = db
 				.query<
 					{ target_id: string; source_kind: string; field_id: string },

--- a/apps/wiki/src/lib/workspace/wiki.test.ts
+++ b/apps/wiki/src/lib/workspace/wiki.test.ts
@@ -2,29 +2,25 @@
  * The wiki pages-and-tags model, end to end. The first test walks the spec's
  * example page: define structured tags at runtime, create a page that wears a
  * mix of plain and structured tags (auto-minting an unknown one), materialize
- * it to `pages/<id>.md`, edit the file, reconcile it back into Yjs, project to
- * SQLite, and answer the typed JOIN. Focused tests cover the schema-on-read
- * lens, the rename-vs-add DDL distinction, plain-tag membership, the two edge
- * provenances, and auto-mint.
+ * it one-way to `pages/<id>.md`, write through an action, project to SQLite, and
+ * answer the typed JOIN. Focused tests cover the schema-on-read lens, the
+ * rename-vs-add DDL distinction, plain-tag membership, the two edge provenances,
+ * and auto-mint.
  *
  * If this loop holds, the Entity-Component architecture is real.
  */
 
 import { Database } from 'bun:sqlite';
 import { expect, test } from 'bun:test';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { column } from '@epicenter/workspace';
-import {
-	assembleMarkdown,
-	parseMarkdownFile,
-} from '@epicenter/workspace/markdown';
 import { createWiki } from './index';
 import { viewThroughTag } from './lens';
 import { attachWikiVault } from './markdown';
 import { projectWiki } from './projection';
-import type { ColumnSpec, Page } from './schema';
+import type { ColumnSpec } from './schema';
 
 const youtubeColumns: ColumnSpec[] = [
 	{ id: 'url', name: 'URL', schema: column.url() },
@@ -55,7 +51,7 @@ function defineExampleTags(wiki: ReturnType<typeof createWiki>): void {
 	});
 }
 
-test('round-trips the spec example page Yjs <-> markdown <-> Yjs, answers the typed JOIN, and builds both edge kinds', async () => {
+test('materializes the spec example page one-way, writes through an action, answers the typed JOIN, and builds both edge kinds', async () => {
 	const dir = await mkdtemp(join(tmpdir(), 'wiki-vault-'));
 	const wiki = createWiki();
 	try {
@@ -110,21 +106,14 @@ test('round-trips the spec example page Yjs <-> markdown <-> Yjs, answers the ty
 		// recognized from the `epicenter://` URN value, not the schema.
 		expect(recordingTagMd).toContain('captured from a [[whispering]]');
 
-		// Edit the .md as a text editor would, then reconcile (markdown push).
-		const parsed = parseMarkdownFile(pageMd)!;
-		(parsed.frontmatter.tags as Page['tags']).youtube_video!.duration = 999;
-		await writeFile(
-			pagePath,
-			assembleMarkdown(parsed.frontmatter, 'Edited notes. See also [[page_def]].'),
-		);
-
-		const push = await vault.actions.markdown_push();
-		expect(push.errored).toBe(0);
-
-		const after = wiki.actions.pages_get({ id: pageId }).data!;
-		expect(after.tags.youtube_video!.duration).toBe(999);
-		expect(after.tags.youtube_video!.url).toBe('https://youtu.be/abc');
-		expect(after.body).toBe('Edited notes. See also [[page_def]].');
+		// Writes go through actions, never by editing the .md (the vault is a
+		// one-way read projection). Re-wearing the tag overwrites its values.
+		const reassigned = wiki.actions.pages_assign_tag({
+			id: pageId,
+			tagId: 'youtube_video',
+			values: { url: 'https://youtu.be/abc', duration: 999 },
+		});
+		expect(reassigned.data!.tags.youtube_video!.duration).toBe(999);
 
 		// Project to SQLite and answer the typed JOIN (bare column names).
 		const db = new Database(':memory:');

--- a/packages/workspace/src/document/column/column.test.ts
+++ b/packages/workspace/src/document/column/column.test.ts
@@ -94,3 +94,64 @@ describe('column.ianaTimeZone', () => {
 		expect(Value.Check(schema, '')).toBe(false);
 	});
 });
+
+describe('column.ref', () => {
+	const schema = column.ref();
+
+	test('validates a reference as a plain string', () => {
+		expect(Value.Check(schema, 'page_abc')).toBe(true);
+		expect(Value.Check(schema, 'epicenter://whispering/recordings/rec_1')).toBe(
+			true,
+		);
+		expect(Value.Check(schema, 42)).toBe(false);
+	});
+
+	test('carries the x-epicenter-ref keyword so a projector can recognize it', () => {
+		expect((schema as unknown as Record<string, unknown>)['x-epicenter-ref']).toBe(
+			true,
+		);
+		// NOT `format`: a ref is a slug or URN, not a URI, and a custom keyword is
+		// never touched by the validator (refs stay free to dangle).
+		expect((schema as { format?: string }).format).toBeUndefined();
+	});
+
+	test('a dangling reference still validates (references may dangle, never block a write)', () => {
+		expect(Value.Check(schema, 'page_does_not_exist_yet')).toBe(true);
+	});
+});
+
+describe('column.array', () => {
+	test('validates a list of the inner schema', () => {
+		const schema = column.array(column.ref());
+		expect(Value.Check(schema, ['page_a', 'page_b'])).toBe(true);
+		expect(Value.Check(schema, [])).toBe(true);
+		expect(Value.Check(schema, [42])).toBe(false);
+		expect(Value.Check(schema, 'page_a')).toBe(false);
+	});
+});
+
+describe('column.ref / column.array survive a JSON / Yjs round-trip', () => {
+	// A ColumnSpec.schema is stored verbatim in Yjs as JSON and re-validated with
+	// Value.Check after the round-trip. These schemas are plain JSON Schema (no
+	// `[Kind]` symbols), so a structured-clone / JSON pass must validate
+	// identically: this is what lets column.ref() and column.array(column.ref())
+	// live inside a tag's stored columns.
+	test('column.ref() round-trips and validates identically', () => {
+		const original = column.ref();
+		const roundTripped = JSON.parse(JSON.stringify(original));
+		expect(roundTripped).toEqual({ type: 'string', 'x-epicenter-ref': true });
+		expect(Value.Check(roundTripped, 'page_abc')).toBe(true);
+		expect(Value.Check(roundTripped, 7)).toBe(false);
+	});
+
+	test('column.array(column.ref()) round-trips and validates identically', () => {
+		const original = column.array(column.ref());
+		const roundTripped = JSON.parse(JSON.stringify(original));
+		expect(roundTripped).toEqual({
+			type: 'array',
+			items: { type: 'string', 'x-epicenter-ref': true },
+		});
+		expect(Value.Check(roundTripped, ['page_a', 'page_b'])).toBe(true);
+		expect(Value.Check(roundTripped, [1, 2])).toBe(false);
+	});
+});

--- a/packages/workspace/src/document/column/column.test.ts
+++ b/packages/workspace/src/document/column/column.test.ts
@@ -95,34 +95,9 @@ describe('column.ianaTimeZone', () => {
 	});
 });
 
-describe('column.ref', () => {
-	const schema = column.ref();
-
-	test('validates a reference as a plain string', () => {
-		expect(Value.Check(schema, 'page_abc')).toBe(true);
-		expect(Value.Check(schema, 'epicenter://whispering/recordings/rec_1')).toBe(
-			true,
-		);
-		expect(Value.Check(schema, 42)).toBe(false);
-	});
-
-	test('carries the x-epicenter-ref keyword so a projector can recognize it', () => {
-		expect((schema as unknown as Record<string, unknown>)['x-epicenter-ref']).toBe(
-			true,
-		);
-		// NOT `format`: a ref is a slug or URN, not a URI, and a custom keyword is
-		// never touched by the validator (refs stay free to dangle).
-		expect((schema as { format?: string }).format).toBeUndefined();
-	});
-
-	test('a dangling reference still validates (references may dangle, never block a write)', () => {
-		expect(Value.Check(schema, 'page_does_not_exist_yet')).toBe(true);
-	});
-});
-
 describe('column.array', () => {
 	test('validates a list of the inner schema', () => {
-		const schema = column.array(column.ref());
+		const schema = column.array(column.string());
 		expect(Value.Check(schema, ['page_a', 'page_b'])).toBe(true);
 		expect(Value.Check(schema, [])).toBe(true);
 		expect(Value.Check(schema, [42])).toBe(false);
@@ -130,26 +105,19 @@ describe('column.array', () => {
 	});
 });
 
-describe('column.ref / column.array survive a JSON / Yjs round-trip', () => {
+describe('column.array survives a JSON / Yjs round-trip', () => {
 	// A ColumnSpec.schema is stored verbatim in Yjs as JSON and re-validated with
 	// Value.Check after the round-trip. These schemas are plain JSON Schema (no
 	// `[Kind]` symbols), so a structured-clone / JSON pass must validate
-	// identically: this is what lets column.ref() and column.array(column.ref())
-	// live inside a tag's stored columns.
-	test('column.ref() round-trips and validates identically', () => {
-		const original = column.ref();
-		const roundTripped = JSON.parse(JSON.stringify(original));
-		expect(roundTripped).toEqual({ type: 'string', 'x-epicenter-ref': true });
-		expect(Value.Check(roundTripped, 'page_abc')).toBe(true);
-		expect(Value.Check(roundTripped, 7)).toBe(false);
-	});
-
-	test('column.array(column.ref()) round-trips and validates identically', () => {
-		const original = column.array(column.ref());
+	// identically: this is what lets column.array(column.string()) live inside a
+	// tag's stored columns. A reference is just a string holding an `epicenter://`
+	// URN; the projector recognizes it by value, never a schema marker.
+	test('column.array(column.string()) round-trips and validates identically', () => {
+		const original = column.array(column.string());
 		const roundTripped = JSON.parse(JSON.stringify(original));
 		expect(roundTripped).toEqual({
 			type: 'array',
-			items: { type: 'string', 'x-epicenter-ref': true },
+			items: { type: 'string' },
 		});
 		expect(Value.Check(roundTripped, ['page_a', 'page_b'])).toBe(true);
 		expect(Value.Check(roundTripped, [1, 2])).toBe(false);

--- a/packages/workspace/src/document/column/index.ts
+++ b/packages/workspace/src/document/column/index.ts
@@ -13,4 +13,4 @@ export {
 	isNullable,
 	type SqliteStorage,
 } from './derive';
-export { column, EPICENTER_REF_KEYWORD, type Infer } from './sugar';
+export { column, type Infer } from './sugar';

--- a/packages/workspace/src/document/column/index.ts
+++ b/packages/workspace/src/document/column/index.ts
@@ -13,4 +13,4 @@ export {
 	isNullable,
 	type SqliteStorage,
 } from './derive';
-export { column, type Infer } from './sugar';
+export { column, EPICENTER_REF_KEYWORD, type Infer } from './sugar';

--- a/packages/workspace/src/document/column/sugar.ts
+++ b/packages/workspace/src/document/column/sugar.ts
@@ -35,6 +35,7 @@
 
 import {
 	type Static,
+	type TArray,
 	type TLiteral,
 	type TLiteralValue,
 	type TNull,
@@ -93,6 +94,49 @@ function string<T extends string = string>(
  */
 function url(opts?: TStringOptions): TString {
 	return Type.String({ format: 'uri', ...opts });
+}
+
+/**
+ * The custom JSON-Schema keyword that marks a string column as an
+ * `epicenter://` reference (see `column.ref`). Shared contract: `column.ref`
+ * writes it, a projector reads it to build link edges. A custom keyword, not
+ * `format`, on purpose (see `ref` below).
+ */
+export const EPICENTER_REF_KEYWORD = 'x-epicenter-ref';
+
+/**
+ * Reference string column: a page id or an `epicenter://` URN naming another
+ * entity. A `TString` carrying the `x-epicenter-ref` keyword as a marker so a
+ * projector can recognize reference columns and build edges from their values.
+ * Static type is `string`: a reference is just a stable name, never "how to
+ * open" (that is a per-platform resolver, not stored data).
+ *
+ * The marker is a CUSTOM KEYWORD, not `format`, on purpose:
+ * - A reference is a slug (`page_abc`) OR an `epicenter://` URN, neither of
+ *   which is a valid URI, so `format: 'uri'` would be a lie and could reject
+ *   real refs if that format were ever registered.
+ * - `Value.Check` never touches unknown keywords, so a reference is always free
+ *   to dangle (wiki red-link behavior) with zero dependence on global validator
+ *   state. A `format` marker only validates-as-pass because nobody registered
+ *   it yet; a keyword can never be hijacked that way.
+ */
+function ref(opts?: TStringOptions): TString {
+	return Type.String({ [EPICENTER_REF_KEYWORD]: true, ...opts });
+}
+
+/**
+ * Array column. Wraps `Type.Array`, exposed as `column.array`. The standard way
+ * to model "many of the same kind": `column.array(column.ref())` is a list of
+ * references (sources, citations), each element its own `edges` row in a
+ * projection.
+ *
+ * This is for DYNAMIC schemas (a structured tag's `ColumnSpec.schema`), where
+ * the value stores JSON-encoded in a single TEXT cell (and a ref-array unnests
+ * into edges). It is NOT a top-level `defineTable` column: `FlatJsonTSchema`
+ * rejects a raw array there and steers you to `column.json` instead.
+ */
+function array<S extends TSchema>(items: S, opts?: TSchemaOptions): TArray<S> {
+	return Type.Array(items, opts);
 }
 
 /** Pass-through to `Type.Number`, exposed as `column.number`. */
@@ -221,6 +265,8 @@ function ianaTimeZone(opts?: TSchemaOptions): TUnsafe<IanaTimeZone> {
 export const column = {
 	string,
 	url,
+	ref,
+	array,
 	number,
 	integer,
 	boolean,

--- a/packages/workspace/src/document/column/sugar.ts
+++ b/packages/workspace/src/document/column/sugar.ts
@@ -97,43 +97,17 @@ function url(opts?: TStringOptions): TString {
 }
 
 /**
- * The custom JSON-Schema keyword that marks a string column as an
- * `epicenter://` reference (see `column.ref`). Shared contract: `column.ref`
- * writes it, a projector reads it to build link edges. A custom keyword, not
- * `format`, on purpose (see `ref` below).
- */
-export const EPICENTER_REF_KEYWORD = 'x-epicenter-ref';
-
-/**
- * Reference string column: a page id or an `epicenter://` URN naming another
- * entity. A `TString` carrying the `x-epicenter-ref` keyword as a marker so a
- * projector can recognize reference columns and build edges from their values.
- * Static type is `string`: a reference is just a stable name, never "how to
- * open" (that is a per-platform resolver, not stored data).
- *
- * The marker is a CUSTOM KEYWORD, not `format`, on purpose:
- * - A reference is a slug (`page_abc`) OR an `epicenter://` URN, neither of
- *   which is a valid URI, so `format: 'uri'` would be a lie and could reject
- *   real refs if that format were ever registered.
- * - `Value.Check` never touches unknown keywords, so a reference is always free
- *   to dangle (wiki red-link behavior) with zero dependence on global validator
- *   state. A `format` marker only validates-as-pass because nobody registered
- *   it yet; a keyword can never be hijacked that way.
- */
-function ref(opts?: TStringOptions): TString {
-	return Type.String({ [EPICENTER_REF_KEYWORD]: true, ...opts });
-}
-
-/**
  * Array column. Wraps `Type.Array`, exposed as `column.array`. The standard way
- * to model "many of the same kind": `column.array(column.ref())` is a list of
- * references (sources, citations), each element its own `edges` row in a
- * projection.
+ * to model "many of the same kind": `column.array(column.string())` is a list of
+ * strings (sources, citations). A reference is just a string whose value is an
+ * `epicenter://` URN; the projector recognizes references from the VALUE (the
+ * URN scheme), never a schema marker, so a list of references is an ordinary
+ * `column.array(column.string())` and each URN element becomes its own edge.
  *
  * This is for DYNAMIC schemas (a structured tag's `ColumnSpec.schema`), where
- * the value stores JSON-encoded in a single TEXT cell (and a ref-array unnests
- * into edges). It is NOT a top-level `defineTable` column: `FlatJsonTSchema`
- * rejects a raw array there and steers you to `column.json` instead.
+ * the value stores JSON-encoded in a single TEXT cell. It is NOT a top-level
+ * `defineTable` column: `FlatJsonTSchema` rejects a raw array there and steers
+ * you to `column.json` instead.
  */
 function array<S extends TSchema>(items: S, opts?: TSchemaOptions): TArray<S> {
 	return Type.Array(items, opts);
@@ -265,7 +239,6 @@ function ianaTimeZone(opts?: TSchemaOptions): TUnsafe<IanaTimeZone> {
 export const column = {
 	string,
 	url,
-	ref,
 	array,
 	number,
 	integer,

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -152,7 +152,6 @@ export {
 	type ColumnError,
 	column,
 	deriveStorage,
-	EPICENTER_REF_KEYWORD,
 	type FlatJsonTSchema,
 	type Infer,
 	type SqliteStorage,

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -151,8 +151,11 @@ export { generateGuid, generateId } from './shared/id';
 export {
 	type ColumnError,
 	column,
+	deriveStorage,
+	EPICENTER_REF_KEYWORD,
 	type FlatJsonTSchema,
 	type Infer,
+	type SqliteStorage,
 } from './document/column/index';
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/specs/20260603T164627-agents-read-projection-write-actions.md
+++ b/specs/20260603T164627-agents-read-projection-write-actions.md
@@ -1,0 +1,336 @@
+# Agents Read the Projection, Write Through Actions
+
+**Date**: 2026-06-03
+**Status**: Draft
+**Owner**: Braden
+**Extends**: `20260602T200000-vault-read-only-projection-agent-mutation.md`
+**Grounded in**: `docs/articles/two-kinds-of-ai-editing.md`, `every-ai-editor-converges-on-str-replace.md`, `every-ai-editor-flattens-the-tree.md`, `liveblocks-flatten-diff-pattern.md`
+
+## How to read this spec
+
+```txt
+Read first:
+  One Sentence
+  The two kinds of AI editing (the frame for everything)
+  Current State
+  Target Shape (The Contract)
+  The Agent Action Surface (catalog)
+  Implementation Plan
+
+Read if changing the design:
+  Design Decisions
+  Body model: Y.Text for the agent path
+  Enforcement layers
+  Open Questions
+
+Skip unless curious:
+  Research Findings
+  Edge Cases
+  Decisions Log
+```
+
+## One Sentence
+
+Coding agents read the read-only materialized markdown projection to orient, and mutate **exclusively** through validated actions: structural changes via named semantic verbs, prose via one text-diff apply engine over `Y.Text` bodies, so there is never a second writer and never a lossy round-trip.
+
+## The two kinds of AI editing (the frame for everything)
+
+This spec governs **one** of two editing contexts, named in `docs/articles/two-kinds-of-ai-editing.md`. Conflating them is what makes body editing look hard. They want opposite storage.
+
+```txt
+INTERACTIVE COPILOT                      EXTERNAL AGENT  <-- THIS SPEC
+─────────────────────────────────       ─────────────────────────────────
+user highlights in a WYSIWYG editor,     Claude Code / Codex reads a file,
+AI rewrites the selection                reasons, writes text back
+frozen snapshot + human-gated merge      LIVE doc, concurrent, no human gate
+flatten-diff against the schema          text diff -> character ops that
+(Liveblocks pattern)                     compose with the CRDT natively
+wants Y.XmlFragment (rich tree)          wants TEXT as source of truth
+lives in honeycrisp / fuji TODAY         lives in the vault / agent world
+```
+
+**Consequence**: body storage is not a platform-global choice. It is a per-app consequence of which context is primary. honeycrisp/fuji are copilot-primary and keep `Y.XmlFragment`. The vault is agent-primary and should use `Y.Text` (see Body model). This spec does not touch the copilot apps.
+
+## Overview
+
+Defines the agent-facing contract for an agent-primary workspace (the vault): which surface an agent reads, which surface it writes through, how that rule is enforced rather than requested, and how an agent edits a prose body without round-tripping a file. Introduces a semantic action vocabulary plus a single text-diff body apply engine (`body_set` / `body_patch`). Does **not** reintroduce the bidirectional disk-to-Yjs subsystem deleted in `20260602T200000`.
+
+## Motivation
+
+### Current State
+
+```txt
+SOURCE OF TRUTH     Yjs CRDT store (tables, KV, body docs)
+      │
+      ▼  one-way, no apply
+PROJECTION          materialized .md files under apps/**
+      │
+      ▼
+AGENT READS         Read / Grep / Glob          (native, read-only)
+AGENT WRITES        epicenter run <mount>.<action>   (validated)
+```
+
+Verified anchors:
+
+- One-way projection, explicitly no apply: `packages/workspace/src/document/materializer/markdown/export.ts:13-21`.
+- Single validated choke point `invokeAction` (returns `result.data`): `packages/workspace/src/shared/actions.ts:417-437` (TypeBox `Value.Check`).
+- CLI `run` already accepts inline JSON, `@file.json`, and **stdin**: `packages/cli/src/commands/run.ts` (`resolveInput`).
+- CLI `list --format json` already exists: `packages/cli/src/commands/list.ts:29-51`.
+- Three consumers already route through the choke point: daemon `action-handler.ts:66`, dispatch `dispatch.ts:290`, AI tool-bridge `ai/tool-bridge.ts:147-151`.
+- Body primitives: `attachRichText` (Y.XmlFragment) `attach-rich-text.ts:30-49`; `attachPlainText` (Y.Text) `attach-plain-text.ts`. Codec: `packages/filesystem/src/formats/markdown.ts:88-106`.
+- Live WYSIWYG editors (copilot context, untouched): `apps/honeycrisp/src/lib/editor/Editor.svelte`, `apps/fuji/src/routes/(signed-in)/components/EntryBodyEditor.svelte`.
+
+Gaps:
+
+1. **The write rule is prompt-only.** `vault/AGENTS.md` says "never hand-edit `apps/**`," but nothing stops an agent's `Write`/`Edit` tool from doing it (then the next rebuild silently overwrites it).
+2. **No clean body-write story.** Small typed fields map to `run <mount>.update`; a prose body does not. This is the pressure that tempts a round-trip back into the design.
+3. **CLI-vs-MCP and the body model keep recirculating.** Settle both.
+
+### Desired State
+
+> Agents read the materialized folder and mutate through `epicenter run <mount>.<action>`: structural fields via named verbs, prose via `body_set`/`body_patch` over `Y.Text`, every `apps/**` file read-only and self-documenting its own mutate command, and the action result is the read-your-writes (no re-grep).
+
+## Research Findings
+
+### Your own articles already decided the body model
+
+| Article | Load-bearing claim |
+| --- | --- |
+| `every-ai-editor-converges-on-str-replace.md` | Every production AI tool converged on text search/replace. "Rich editing is a view on the text, not the source of truth. `readFile()` returns plain text, `writeFile()` applies text diffs." |
+| `every-ai-editor-flattens-the-tree.md` | The tree stays editor-side, text stays AI-side, markdown is the bridge. Sophistication lives in the **apply step**, not the format. |
+| `two-kinds-of-ai-editing.md` | Copilot = flatten-diff on a snapshot. Agent = text diff -> character ops that compose with concurrent CRDT edits. Build for both; do not pretend one solution covers both. |
+| `liveblocks-flatten-diff-pattern.md` | Ask the AI for the whole new version, reconstruct the diff algorithmically. (This is the copilot path, not the agent path.) |
+
+**Key finding**: for the external-agent path, text is the source of truth and the body should be flat markdown the agent reads verbatim. `Y.XmlFragment` forces a lossy serialize/parse and makes `body_patch` a fragment re-derivation (no merge benefit). `Y.Text` makes `body_patch` a true positional delta that composes with concurrent edits, which is exactly what `two-kinds-of-ai-editing.md` prescribes for agents.
+
+**Implication**: use `Y.Text` for vault/agent bodies. The materialized file is the `Y.Text` verbatim, so agent anchors always match.
+
+### CLI versus MCP
+
+| What MCP adds over CLI | CLI status today | Verdict |
+| --- | --- | --- |
+| Schemas pushed to the agent | `list --format json` + one AGENTS.md line (pull) | Covered, cheaply |
+| Structured args, no shell escaping | `run` already takes stdin + `@file.json` | **Already solved** |
+| Works in a shell-less client | CLI needs a shell | **Only real MCP win** |
+
+**Key finding**: MCP is ~90% redundant with the CLI in any shelled environment; the escaping win is already implemented in `run.ts`. MCP earns its keep only for a shell-less client (browser-hosted instance), where it is a fourth thin adapter over `invokeAction`. **Defer it.** This also dodges the fact that Codex lacks Claude Code's per-path deny (see Enforcement).
+
+## Design Decisions
+
+| Decision | Class | Choice | Rationale |
+| --- | --- | --- | --- |
+| Read surface | 2 coherence | Materialized `.md`, read-only | Native agent search idiom; projection exists |
+| Write surface | 2 coherence | `epicenter run <mount>.<action>` only | Single validated choke point; no second writer |
+| Structural writes | 2 coherence | Named semantic verbs (`set_status`, `add_tag`, ...) | Zero ambiguity, no diffing, merge-trivial; the agent states intent |
+| Prose writes | 1 evidence | One text-diff apply engine; `body_set` + `body_patch` shapes | Matches the str_replace convergence in your own articles |
+| **Body model (agent apps)** | **1 evidence** | **`Y.Text` (raw markdown), not `Y.XmlFragment`** | `every-ai-editor-converges-on-str-replace.md`: text is the source of truth; gives surgical, merge-composable patches |
+| Body model (copilot apps) | 2 coherence | Keep `Y.XmlFragment` + flatten-diff | honeycrisp/fuji are copilot-primary; out of scope here |
+| CLI vs MCP | 1 evidence | CLI now; MCP deferred | `run.ts` already does stdin/`@file`; MCP only for shell-less clients |
+| Round-trip / file-edit-then-reconcile | 2 coherence | Rejected | Two writers + lossy parse, deleted in `20260602T200000` |
+| Enforcement scope | 1 evidence | Deny writes to `apps/**` only, not all markdown | Agents must still edit user files (`imessage/`, etc.) |
+| Audit + dry-run | 3 taste | Log `{action,input,ts}`; offer `--dry-run` | The choke point makes mutations observable and previewable |
+| Self-documenting files | 3 taste | Stamp mutate command (agent) + deep link (human) | Read surface hands off to write surface, per audience |
+
+## Target Shape (The Contract)
+
+```txt
+1. ORIENT     Read / Grep the materialized folder            (read-only, native)
+2. MUTATE     epicenter run <mount>.<action> [stdin|@file]   (validated, single writer)
+3. CONFIRM    trust the action's returned data               (read-your-writes; no re-grep)
+```
+
+Honest asymmetry (do not unify behind a "mode" discriminator):
+
+```txt
+ONE write path:  actions via `run`   (structural = verbs, prose = diff engine)
+TWO read paths:  grep files (fuzzy)  +  query action (structured)
+```
+
+## The Agent Action Surface (catalog)
+
+```ts
+// READ (structured complement to grep)
+<mount>.list / get / query                 // --format json
+
+// WRITE structural  (named verbs; agent states intent, no text diff)
+<mount>.set_status   --id X --status published
+<mount>.add_tag      --id X --tag draft
+<mount>.set_destination --id X --to instagram
+<mount>.update       --id X --title "..."   // generic field set for the long tail
+
+// WRITE prose  (ONE text-diff apply engine, TWO input shapes, over Y.Text)
+<mount>.body_set     --id X (stdin|@file)            // whole rewrite; diff + apply char ops
+<mount>.body_patch   --id X --old ".." --new ".."    // anchored str_replace; same engine
+```
+
+### Considered and rejected
+
+| Candidate | Why rejected |
+| --- | --- |
+| Body as `Y.XmlFragment` for agent apps | Lossy serialize/parse; `body_patch` becomes a fragment re-derivation with no merge benefit |
+| Asking the agent to emit CRDT/tree/ProseMirror ops | `every-ai-editor-converges-on-str-replace.md`: LLMs cannot reliably produce structural positions |
+| Generic `workspace.body_set(guid)` | Body-docs clean break refused generic doc verbs; keep app-owned + typed |
+| `epicenter body-edit` top-level CLI verb | `epicenter apply` was removed in favor of `run <mount>.<action>` |
+| Markdown round-trip / `markdown_apply` for bodies | Two writers + lossy parse; deleted in `20260602T200000` |
+| MCP server (now) | Redundant with CLI; only needed for shell-less clients |
+| Deny all markdown edits | Agents must edit user files; scope deny to `apps/**` |
+
+### Self-documenting projection (audience-aware stamp)
+
+```markdown
+---
+id: 9z6dxc2x
+title: My draft
+status: draft
+---
+<!-- generated, read-only. agent: epicenter run pages.set_status --id 9z6dxc2x --status X -->
+<!--                        agent: epicenter run pages.body_set --id 9z6dxc2x  (stdin) -->
+<!--                        human: epicenter://pages/9z6dxc2x  (edit in app) -->
+
+Body the agent reads verbatim (this IS the Y.Text)...
+```
+
+## Body model: Y.Text for the agent path
+
+One apply engine, two input shapes. Both reduce to "produce target text, diff against current `Y.Text`, apply character ops" (the `two-kinds-of-ai-editing.md` agent prescription).
+
+```ts
+// body_set: whole rewrite (LLMs are good at rewriting)
+body_set: defineMutation({
+  input: Type.Object({ id: PageId, markdown: Type.String() }),
+  handler: ({ id, markdown }) => applyTextDiff(bodyText(id), markdown), // Y.Text delete/insert
+}),
+
+// body_patch: anchored str_replace (mirrors Claude Code / Codex edit tools)
+body_patch: defineMutation({
+  input: Type.Object({ id: PageId, old: Type.String(), next: Type.String() }),
+  handler: ({ id, old, next }) => {
+    const text = bodyText(id);                 // Y.Text
+    const i = text.toString().indexOf(old);
+    if (i < 0) throw AnchorNotFound;           // staleness guard, fails loud
+    text.delete(i, old.length);                // surgical, composes with concurrent edits
+    text.insert(i, next);
+  },
+}),
+```
+
+`applyTextDiff` is the engine the articles point at: LCS/char diff of current vs target, emitted as `Y.Text` insert/delete at positions. Insert at 42 and insert at 200 do not conflict; the CRDT merges concurrent edits natively. No `Y.XmlFragment`, no codec, no re-parse.
+
+## Enforcement layers
+
+Soft alone is not enough, but note: the projection is **regenerable** (`markdown_rebuild`), so corruption is recoverable. Enforcement is mostly about *feedback* ("that will not persist, use the action"), not preventing data loss. **Scope every deny to `apps/**`**, never all markdown.
+
+```txt
+1. AGENTS.md rule           soft   agent-agnostic   have it
+2. Claude Code permissions  hard   CC only          deny Write/Edit on apps/**,
+   + PreToolUse hook                                 allow Bash(epicenter run|list:*)
+3. Codex sandbox            hard   Codex            COARSE: sandbox levels, not per-path;
+                                                     use OS read-only or MCP-write-only
+4. chmod -R a-w apps/**      hard   agent-agnostic   blunt backstop; daemon re-locks
+5. MCP = the only write     hard   agent-agnostic   DEFER (shell-less clients)
+   tool (read-only FS)
+```
+
+Claude Code `.claude/settings.json`:
+
+```json
+{ "permissions": {
+    "deny": ["Write(apps/**)", "Edit(apps/**)"],
+    "allow": ["Bash(epicenter run:*)", "Bash(epicenter list:*)", "Read", "Grep"]
+} }
+```
+
+Codex governs writes by sandbox level (`read-only` / `workspace-write` / `danger-full-access`) and approval policy in `~/.codex/config.toml`, **not** per-path tool allow/deny. So `apps/**`-scoped denial is not native there: rely on OS read-only on `apps/**` or the MCP-write-only path. Verify exact Codex keys against the installed version before writing config.
+
+## Vault AGENTS.md good practices
+
+The vault's `AGENTS.md` should tell any coding agent:
+
+1. **`apps/**` is generated and read-only.** Read/grep it freely. Never write it. Everything else (`imessage/`, `pull-request-writing/`) is your normal plain-markdown to edit as files.
+2. **Mutate `apps/**` data only via** `epicenter run <mount>.<action>`. Discover the surface with `epicenter list --format json`.
+3. **Big payloads go through stdin or `@file.json`**, never inline shell JSON.
+4. **Trust the action's returned data** as the new state; do not immediately re-grep a possibly-stale file.
+5. **Structural change = named verb** (`set_status`, `add_tag`). **Prose change = `body_set` / `body_patch`**.
+6. **If you think you corrupted a generated file**, run `markdown_rebuild`; truth lives in the store.
+
+## Implementation Plan
+
+### Phase 0: Decide the body model (prerequisite)
+
+- [ ] **0.1** Confirm vault bodies are `Y.Text` (agent-primary). honeycrisp/fuji keep `Y.XmlFragment`. (Recommendation: yes.)
+
+### Phase 1: The apply engine + body actions
+
+- [ ] **1.1** `applyTextDiff(yText, targetMarkdown)`: char/LCS diff -> `Y.Text` insert/delete.
+- [ ] **1.2** `body_set` (stdin) and `body_patch` (anchored, `AnchorNotFound`/`AnchorAmbiguous`).
+- [ ] **1.3** Verify the loop end to end on one app, then `markdown_rebuild` and re-read.
+
+### Phase 2: Semantic verbs + self-documenting files
+
+- [ ] **2.1** Add the structural verbs the target app actually needs (status/tags/destinations).
+- [ ] **2.2** Stamp the audience-aware mutate commands into `toMarkdown` (HTML comments, never round-tripped).
+- [ ] **2.3** Write the vault `AGENTS.md` good-practices block.
+
+### Phase 3: Enforcement
+
+- [ ] **3.1** Claude Code `settings.json` deny `apps/**` + allow `epicenter`; `PreToolUse` redirect hook.
+- [ ] **3.2** OS read-only backstop for non-Claude-Code harnesses (Codex).
+
+### Deferred
+
+- MCP server over `invokeAction` (OQ3): build at the first shell-less client.
+- Audit log + `--dry-run` (nice-to-have; the choke point makes both cheap later).
+
+## Edge Cases
+
+### Stale read before write
+Single-user sequential is fine; `body_patch` anchor check fails loud if the read was stale; trust the action return rather than re-grepping.
+
+### Anchor not unique / not found
+`body_patch` throws; agent falls back to `body_set`. Never silently corrupt.
+
+### Concurrent body edits (the reason for Y.Text)
+Agent rewrites paragraph 7 while a peer edits paragraph 3. `Y.Text` char ops at disjoint positions merge; both survive. (A whole-fragment overwrite would lose the peer's edit; this is the `two-kinds` concurrent-deletion problem.)
+
+### Rename / identity
+No file rename; `update --id X --title ...`. The slug is projection cosmetics; identity is the row id.
+
+## Open Questions
+
+1. **Vault body model: `Y.Text` confirmed?** Options: (a) `Y.Text` for agent apps [recommended], (b) keep `Y.XmlFragment` everywhere, (c) per-app. Recommendation: (a); leave the copilot apps on `Y.XmlFragment`. Open.
+2. **Ship `body_patch` or `body_set` only first?** Recommendation: both; `body_set` is the safe default, `body_patch` the token-cheap surgical path. Open.
+3. **When does MCP get built?** Recommendation: first shell-less client. Open.
+4. **Diff granularity in `applyTextDiff`** (char vs word vs line LCS)? Recommendation: start line+char hybrid; tune by feel. Open.
+
+## Adjacent Work
+
+- **The post pipeline is the priority, not this.** `draft.md` -> Marp -> carousel never calls `body_set`. Build Phase 1 only when an agent is actually editing bodies, which is after a post ships.
+- **`packages/filesystem` as a live virtual FS** is the eventual read-path unification (no materialization lag). Out of scope; does not change the body model.
+- **Copilot path (honeycrisp/fuji)** keeps flatten-diff over `Y.XmlFragment`; this spec deliberately leaves it alone.
+
+## Decisions Log
+
+- Keep `Y.XmlFragment` in copilot apps while vault uses `Y.Text`: two contexts, two correct answers (`two-kinds-of-ai-editing.md`).
+  Revisit when: a single app needs to be both agent-primary and WYSIWYG-primary on the same body.
+- Keep CLI as the sole write transport (no MCP): every current client has a shell.
+  Revisit when: a browser-hosted / shell-less agent client ships.
+
+## Success Criteria
+
+- [ ] An agent sets a status and rewrites + tweaks a body using only `Read`/`Grep` + `epicenter run`, never writing under `apps/**`.
+- [ ] Vault bodies are `Y.Text`; `body_patch` is a positional delta that survives a concurrent peer edit.
+- [ ] Structural changes use named verbs, not text diffs.
+- [ ] A blocked `Write`/`Edit` on `apps/**` (Claude Code) returns the redirect; edits outside `apps/**` still work.
+- [ ] Each generated file shows its agent command and human deep link.
+- [ ] No markdown-to-store reconcile path exists; the projection stays one-way.
+
+## References
+
+- `docs/articles/two-kinds-of-ai-editing.md`, `every-ai-editor-converges-on-str-replace.md`, `every-ai-editor-flattens-the-tree.md`, `liveblocks-flatten-diff-pattern.md` - the editing-model grounding
+- `packages/workspace/src/shared/actions.ts:417-437` / `:270-301` - `invokeAction`, `defineMutation`
+- `packages/cli/src/commands/run.ts` (`resolveInput`) / `list.ts:29-51` - stdin/`@file`, `--format json`
+- `packages/workspace/src/document/attach-plain-text.ts` - `Y.Text` body primitive (the agent-path choice)
+- `packages/workspace/src/document/attach-rich-text.ts:30-49` - `Y.XmlFragment` (copilot apps)
+- `apps/honeycrisp/src/lib/editor/Editor.svelte`, `apps/fuji/.../EntryBodyEditor.svelte` - copilot editors left untouched
+- `packages/workspace/src/document/materializer/markdown/export.ts:13-21` - one-way projection, no apply
+- `specs/20260602T200000-vault-read-only-projection-agent-mutation.md` - the one-way clean break this extends

--- a/specs/20260603T180000-wiki-pages-and-tags.md
+++ b/specs/20260603T180000-wiki-pages-and-tags.md
@@ -1,0 +1,238 @@
+# Wiki: Pages and Tags (an Entity-Component model)
+
+Date: 20260603T180000
+Status: Draft. Supersedes the tag/type/trait/collection model in
+`20260602T120000-wiki-core-collections-traits-and-curation.md`.
+
+## One sentence
+
+A page is an id, a title, and a body; everything it is, has, or links to is a
+tag; a tag may declare typed columns that project to SQLite; markdown and SQLite
+are disposable projections of the Yjs truth.
+
+## Decision summary
+
+- **Two things, not one.** `pages` and `tags` stay distinct concepts and distinct
+  tables. We REFUSE the Tana/Logseq "a tag is a page" unification (it becomes
+  meta fast: can a tag wear tags, does a tag tag itself, where is its schema
+  edited). The boundary is principled:
+  - `page` = a human-authored knowledge object.
+  - `tag` = a reusable annotation / schema facet a page wears.
+- **Entity-Component backbone.** A page is an entity; a tag is a component. A page
+  composes 0..N tags (composition, not inheritance). A structured tag projects to
+  its own SQLite table, so "pages with tag X where field > N" is an indexed JOIN.
+  This is the model game engines (Flecs) and Tana/Logseq DB converged on.
+- **A plain tag is the empty component.** `{}` = a tag with no columns. Columns
+  (from `column.*` helpers) turn it into a structured tag. One primitive, two ends.
+- **A tag carries a short `description`, not a page.** The only real need is "what
+  is this tag for?", which is one nullable string (tooltip, picker hint). A whole
+  page per tag is overkill and quietly reintroduces the tag/page blur we refuse; a
+  `[[id]]` inside the description covers the rare "see this page" case, so
+  `description` strictly subsumes a `documentationPageId` pointer.
+- **References are names, resolved to locators per platform.** Truth stores a
+  stable id (page) or an `epicenter://` URN (cross-app). Each platform (web,
+  desktop, markdown file) resolves it to a locator at render. The reference never
+  carries "how to open."
+- **Two id kinds for two id uses** (a consequence of rejecting G3): page ids are
+  generated and opaque; tag ids are human slugs. `column.ref()` targets page ids.
+
+## What a "tag" is
+
+```
+ENTITY      page       id + title + body + timestamps
+COMPONENT   tag        a named, composable, optionally-typed facet
+   plain    {}         membership only           (ECS: a zero-data "tag")
+   structured fields   typed columns -> SQLite   (ECS: a "component")
+EDGE        ref        a tag/body value that names another page
+```
+
+The querying power (the whole point) comes from table-per-structured-tag: each
+component is a narrow typed table, and membership is one join away.
+
+## Storage across the three layers
+
+Yjs is the only truth. SQLite and markdown are disposable, always safe to drop
+and reproject.
+
+### 1. Yjs truth (`defineTable`)
+
+```ts
+// pages: the knowledge objects
+export const pagesTable = defineTable({
+  id: column.string<PageId>(),          // generated, opaque (page_abc123)
+  title: column.string(),
+  body: column.string(),                // markdown; promote to Y.Text when concurrent editing is real
+  tags: pageTagsCell,                   // Record<TagId, Record<columnId, JsonValue>>; {} = plain tag
+  createdAt: column.dateTime(),
+  updatedAt: column.dateTime(),
+});
+
+// tags: the reusable annotation / schema facets (the registry)
+export const tagsTable = defineTable({
+  id: column.string<TagId>(),                       // human slug (youtube_video); names a SQL table
+  name: column.string(),                            // display, free to rename
+  icon: column.nullable(column.string()),
+  columns: columnsCell,                             // ColumnSpec[]; [] = plain tag
+  description: column.nullable(column.string()),    // what the tag is for; may embed a [[id]]
+  createdAt: column.dateTime(),
+  updatedAt: column.dateTime(),
+});
+```
+
+`pageTagsCell` and `columnsCell` use `Type.Unsafe` over a nested record / object
+array, exactly as the current branch does for `pages.types` and `types.columns`
+(the nested static does not survive the `column.json` gate). `ColumnSpec.schema`
+stays the raw `column.*` TSchema, stored verbatim, re-validated with `Value.Check`.
+
+`column.ref()` is a new helper: a string id with a marker (`format: 'epicenter-ref'`)
+so the projector can recognize reference columns and build edges. It validates as
+a string; its value is a page id or an `epicenter://` URN.
+
+### 2. SQLite projection (disposable; own database file)
+
+```sql
+pages (id PK, title, body, created_at, updated_at) WITHOUT ROWID;
+
+tags (id PK, name, icon, description, created_at, updated_at) WITHOUT ROWID;
+
+tag_columns (                          -- agent-facing schema catalog (no columns_json blob)
+  tag_id, column_id, name, schema_json, storage, ordinal,
+  PRIMARY KEY (tag_id, column_id)
+) WITHOUT ROWID;
+
+page_tags (page_id, tag_id, PRIMARY KEY (page_id, tag_id)) WITHOUT ROWID;  -- THE membership owner
+
+tag_<id> (                             -- ONLY for tags with >= 1 column
+  page_id PRIMARY KEY,
+  <columnId> <storage>,                -- bare names (duration REAL), not c_duration
+  ...
+) STRICT, WITHOUT ROWID;
+
+edges (                                -- provenance-aware; derived, never truth
+  source_id, rel, target_id,
+  source_kind,                         -- 'body_wikilink' | 'structured_field'
+  field_id                             -- nullable; the column.ref() column for structured edges
+);
+
+projection_issues (                    -- durable values the typed projection refused to place
+  page_id, tag_id, column_id,
+  kind,                                -- 'invalid' | 'excess'   (never 'missing')
+  value_json, message
+);
+```
+
+Projection rules:
+- Plain tags get NO side table; membership lives in `page_tags`.
+- Structured tags get `tag_<slug>` with bare, typed columns. `STRICT` asserts the
+  affinity the projector already derives (catches projector bugs, no drift).
+- `TypeBox is the single validator.` We REFUSE generated `CHECK` constraints: they
+  duplicate the schema, can only express a fraction of it, and are redundant
+  because the projector validates every cell before insert and routes failures to
+  `projection_issues`.
+- `edges` is rebuilt from Yjs each projection by scanning body `[[id]]` links
+  (source_kind = body_wikilink) and every `column.ref()` value (source_kind =
+  structured_field, field_id = the column). Never treat `edges` as truth.
+
+### 3. Markdown vault (the browse projection)
+
+```
+pages/<id>.md   frontmatter = page core + the tags cell; body = markdown (with [[id]] links)
+tags/<id>.md    frontmatter = the tag registry row (columns schema as JSON, description)
+```
+
+Example `pages/page_abc.md`:
+
+```yaml
+---
+id: page_abc
+title: Great talk
+tags:
+  idea: {}
+  youtube_video:
+    url: https://youtu.be/abc
+    duration: 1240
+  publishable:
+    stage: draft
+  whispering_recording:
+    recording: epicenter://whispering/recordings/rec_123   # a column.ref() to a cross-app source
+createdAt: 2026-06-03T19:00:00.000Z
+updatedAt: 2026-06-03T19:00:00.000Z
+---
+Notes about the talk. See also [[page_def]].
+```
+
+References:
+- In truth, a reference is a stable NAME: a bare page id in-wiki, an
+  `epicenter://app/collection/id` URN cross-app. It never says how to open.
+- In markdown it renders as a wikilink `[[id]]` (or `[[id|Title]]` for a readable,
+  rename-safe form). On `markdown_push`, `[[id]]` parses back to the reference.
+- In the web app it resolves to a path (`/whispering/rec_123`); on desktop to
+  in-app navigation. "How to open" is a per-platform resolver, not stored data.
+
+## Asymmetric wins (what we refuse, and why)
+
+- **G3 (a tag is a page).** Refused. A tag's `description` (with an optional
+  `[[id]]`) covers the only real need without the recursion. Trigger to revisit:
+  tags routinely need their own tags, backlinks, and history as first-class.
+- **`source` and `description` as core fields.** Refused.
+  - `source` is a typed edge: model it as a tag with a `column.ref()` field
+    (`whispering_recording: { recording }`), richer than an opaque `string[]`.
+  - `description` decomposes: the preview is derived from `body`; the publish blurb
+    is `publishable.excerpt`. Nothing called "description" remains.
+- **A separate link-graph subsystem.** Refused. Tags-with-ref-columns already are
+  typed edges; `edges` is just their projection.
+- **`CHECK` constraints, the `c_` prefix, `wiki_` prefix, empty per-tag tables.**
+  Refused (see SQLite rules). Bare names on `WITHOUT ROWID` tables, own database,
+  TypeBox as the one validator.
+
+## Normalization rules
+
+```
+tag id        ^[a-z][a-z0-9_]*$  (slug; names a SQL table). NO slashes (hierarchy is a
+              future `extends`/`parent` field, never encoded in the table name).
+              reserved: `columns` (would collide with tag_columns).
+tag name      free text; rename is metadata-only (no DDL).
+tag id change DESTRUCTIVE: a dedicated rename action that rewrites page.tags keys + reprojects.
+column id     ^[a-z][a-z0-9_]*$; reserved: page_id, sqlite_*. Stable, separate from display name.
+              rename name = no DDL; add/remove/id-change = DDL.
+page id       generated, opaque; STABLE bedrock (edges and refs point at it; never renamed).
+```
+
+## Migration from `wiki-page-body-write-actions`
+
+The current branch has `pages.tags: string[]`, `pages.types: Record<typeId, values>`,
+and a `types` table. One-way migration (no live dual-reader):
+
+```
+tags table   = types table renamed; add documentationPageId (null).
+pages.tags{} = { ...fromEntries(oldTags.map(t => [slug(t), {}])), ...oldTypes }
+               (typed values win on key collision; old free tags become slugged
+                tags whose display name preserves the original string).
+markdown     = one-shot vault rewrite: tags: [..] + types: {..} -> tags: {..};
+               types/ dir -> tags/.
+```
+
+## Build order (what's next)
+
+```
+1. Rename types -> tags in schema/index/lens/projection/markdown; pages.types -> pages.tags;
+   fold pages.tags string[] into the map as {} entries. (mechanical; see naming table)
+2. Add column.ref() to the column.* sugar (string + format marker).
+3. Projection: page_tags membership + tag_<slug> structured tables + edges (provenance-aware)
+   + projection_issues. Own database file; bare names; STRICT; WITHOUT ROWID.
+4. documentationPageId on the tags table + markdown round-trip.
+5. Tests: plain-tag membership (no side table); structured typed query; rename-no-DDL vs
+   add-column-DDL; ref column -> edges row; body [[id]] -> edges row (distinct source_kind).
+6. One-way migration script for existing vault data.
+```
+
+## Deferred (with triggers)
+
+- **Tag hierarchy / `extends`** (taxonomy): a nullable `parent`/`extends: TagId`.
+  Trigger: a real need to inherit columns across tags.
+- **`body` as `Y.Text`**: positional-diff collaborative body. Trigger: concurrent
+  body editing, or a second body modality (canvas) that makes body-as-tag earn it.
+- **Title-as-alias resolution** in `[[Title]]` input: store id, display title,
+  support `[[id|Title]]`. Trigger: the wikilink authoring UX is built.
+- **Single id namespace / G3 fold**: only if the two-things boundary ever stops
+  paying for itself.

--- a/specs/20260603T180000-wiki-pages-and-tags.md
+++ b/specs/20260603T180000-wiki-pages-and-tags.md
@@ -36,6 +36,25 @@ are disposable projections of the Yjs truth.
 - **Two id kinds for two id uses** (a consequence of rejecting G3): page ids are
   generated and opaque; tag ids are human slugs. `column.ref()` targets page ids.
 
+## Finalized: capture-cheap and lossless
+
+Three decisions, all chosen to keep capture instant and never lose data:
+
+- **A page wears each tag at most once.** Multiplicity ("two source recordings,
+  three citations") lives in a LIST-valued column, not in wearing a tag twice:
+  `whispering_recording: { recordings: column.array(column.ref()) }`. The `tags`
+  map stays a simple `Record<tagId, values>`; a list-of-refs column expands to
+  multiple `edges` rows (still fully queryable). We REFUSE `Record<tagId, values[]>`
+  (it would push arrays through every projection, query, and markdown shape).
+- **Unknown tags auto-mint a bare definition.** Assigning a tag with no `tags` row
+  (typing `#newidea`) upserts a bare definition `{ id, name: id, columns: [], 
+  description: null }`. Capture stays instant; promote later by adding columns.
+  The assign action and `markdown_push` both mint, so `page_tags` always resolves.
+  Typos mint junk tags, same risk as today's free `string[]` tags; acceptable.
+- **References may dangle.** A `[[id]]` or `column.ref()` to a not-yet-existing page
+  is allowed (wiki red-link behavior). The write never blocks; a dangling ref is
+  discoverable as `edges LEFT JOIN pages WHERE pages.id IS NULL`, never an error.
+
 ## What a "tag" is
 
 ```
@@ -86,7 +105,9 @@ stays the raw `column.*` TSchema, stored verbatim, re-validated with `Value.Chec
 
 `column.ref()` is a new helper: a string id with a marker (`format: 'epicenter-ref'`)
 so the projector can recognize reference columns and build edges. It validates as
-a string; its value is a page id or an `epicenter://` URN.
+a string; its value is a page id or an `epicenter://` URN. `column.array(column.ref())`
+is the list form, the standard way to model "many of the same kind" (sources,
+citations); each element becomes its own `edges` row.
 
 ### 2. SQLite projection (disposable; own database file)
 
@@ -131,7 +152,9 @@ Projection rules:
   `projection_issues`.
 - `edges` is rebuilt from Yjs each projection by scanning body `[[id]]` links
   (source_kind = body_wikilink) and every `column.ref()` value (source_kind =
-  structured_field, field_id = the column). Never treat `edges` as truth.
+  structured_field, field_id = the column). A `column.array(column.ref())` emits
+  one row per element. Dangling targets are allowed (no FK); find them with a
+  LEFT JOIN to `pages`. Never treat `edges` as truth.
 
 ### 3. Markdown vault (the browse projection)
 
@@ -217,10 +240,12 @@ markdown     = one-shot vault rewrite: tags: [..] + types: {..} -> tags: {..};
 ```
 1. Rename types -> tags in schema/index/lens/projection/markdown; pages.types -> pages.tags;
    fold pages.tags string[] into the map as {} entries. (mechanical; see naming table)
-2. Add column.ref() to the column.* sugar (string + format marker).
-3. Projection: page_tags membership + tag_<slug> structured tables + edges (provenance-aware)
-   + projection_issues. Own database file; bare names; STRICT; WITHOUT ROWID.
-4. documentationPageId on the tags table + markdown round-trip.
+   Auto-mint a bare tag definition when an assigned tag has no row.
+2. Add column.ref() (string + format marker) and column.array() to the column.* sugar.
+3. Projection: page_tags membership + tag_<slug> structured tables + edges (provenance-aware,
+   ref[] expands to many rows, dangling allowed) + projection_issues. Own database file;
+   bare names; STRICT; WITHOUT ROWID.
+4. description on the tags table + markdown round-trip.
 5. Tests: plain-tag membership (no side table); structured typed query; rename-no-DDL vs
    add-column-DDL; ref column -> edges row; body [[id]] -> edges row (distinct source_kind).
 6. One-way migration script for existing vault data.

--- a/specs/20260603T180000-wiki-pages-and-tags.md
+++ b/specs/20260603T180000-wiki-pages-and-tags.md
@@ -34,7 +34,9 @@ are disposable projections of the Yjs truth.
   desktop, markdown file) resolves it to a locator at render. The reference never
   carries "how to open."
 - **Two id kinds for two id uses** (a consequence of rejecting G3): page ids are
-  generated and opaque; tag ids are human slugs. `column.ref()` targets page ids.
+  generated and opaque; tag ids are human slugs. A reference is a plain string
+  holding a page id or an `epicenter://` URN; the projector reads edges from the
+  value, not a schema marker.
 
 ## Finalized: capture-cheap and lossless
 
@@ -42,8 +44,8 @@ Three decisions, all chosen to keep capture instant and never lose data:
 
 - **A page wears each tag at most once.** Multiplicity ("two source recordings,
   three citations") lives in a LIST-valued column, not in wearing a tag twice:
-  `whispering_recording: { recordings: column.array(column.ref()) }`. The `tags`
-  map stays a simple `Record<tagId, values>`; a list-of-refs column expands to
+  `whispering_recording: { recordings: column.array(column.string()) }`. The `tags`
+  map stays a simple `Record<tagId, values>`; a list of URN strings expands to
   multiple `edges` rows (still fully queryable). We REFUSE `Record<tagId, values[]>`
   (it would push arrays through every projection, query, and markdown shape).
 - **Unknown tags auto-mint a bare definition.** Assigning a tag with no `tags` row
@@ -51,7 +53,7 @@ Three decisions, all chosen to keep capture instant and never lose data:
   description: null }`. Capture stays instant; promote later by adding columns.
   The assign action and `markdown_push` both mint, so `page_tags` always resolves.
   Typos mint junk tags, same risk as today's free `string[]` tags; acceptable.
-- **References may dangle.** A `[[id]]` or `column.ref()` to a not-yet-existing page
+- **References may dangle.** A `[[id]]` or an `epicenter://` URN to a not-yet-existing page
   is allowed (wiki red-link behavior). The write never blocks; a dangling ref is
   discoverable as `edges LEFT JOIN pages WHERE pages.id IS NULL`, never an error.
 
@@ -103,11 +105,13 @@ array, exactly as the current branch does for `pages.types` and `types.columns`
 (the nested static does not survive the `column.json` gate). `ColumnSpec.schema`
 stays the raw `column.*` TSchema, stored verbatim, re-validated with `Value.Check`.
 
-`column.ref()` is a new helper: a string id with a marker (`format: 'epicenter-ref'`)
-so the projector can recognize reference columns and build edges. It validates as
-a string; its value is a page id or an `epicenter://` URN. `column.array(column.ref())`
-is the list form, the standard way to model "many of the same kind" (sources,
-citations); each element becomes its own `edges` row.
+A reference needs NO new helper. It is a plain `column.string()` whose value is an
+`epicenter://` URN; the projector recognizes it from the value (the URN scheme),
+exactly like it recognizes a `[[id]]` in body prose. No schema marker, so there is
+one reference mechanism for the whole wiki, and a value is free to dangle with zero
+dependence on validator state. `column.array(column.string())` is the list form, the
+standard way to model "many of the same kind" (sources, citations); each URN element
+becomes its own `edges` row.
 
 ### 2. SQLite projection (disposable; own database file)
 
@@ -132,7 +136,7 @@ tag_<id> (                             -- ONLY for tags with >= 1 column
 edges (                                -- provenance-aware; derived, never truth
   source_id, rel, target_id,
   source_kind,                         -- 'body_wikilink' | 'structured_field'
-  field_id                             -- nullable; the column.ref() column for structured edges
+  field_id                             -- nullable; the column id holding the URN, for structured edges
 );
 
 projection_issues (                    -- durable values the typed projection refused to place
@@ -151,10 +155,11 @@ Projection rules:
   because the projector validates every cell before insert and routes failures to
   `projection_issues`.
 - `edges` is rebuilt from Yjs each projection by scanning body `[[id]]` links
-  (source_kind = body_wikilink) and every `column.ref()` value (source_kind =
-  structured_field, field_id = the column). A `column.array(column.ref())` emits
-  one row per element. Dangling targets are allowed (no FK); find them with a
-  LEFT JOIN to `pages`. Never treat `edges` as truth.
+  (source_kind = body_wikilink) and every cell value that is an `epicenter://` URN
+  (source_kind = structured_field, field_id = the column). A list of URNs emits one
+  row per element. Both edge kinds are recognized from the VALUE (the `[[id]]` syntax
+  or the URN scheme), never a schema marker. Dangling targets are allowed (no FK);
+  find them with a LEFT JOIN to `pages`. Never treat `edges` as truth.
 
 ### 3. Markdown vault (the browse projection)
 
@@ -177,7 +182,7 @@ tags:
   publishable:
     stage: draft
   whispering_recording:
-    recording: epicenter://whispering/recordings/rec_123   # a column.ref() to a cross-app source
+    recording: epicenter://whispering/recordings/rec_123   # a plain string URN; edge read by value
 createdAt: 2026-06-03T19:00:00.000Z
 updatedAt: 2026-06-03T19:00:00.000Z
 ---
@@ -198,8 +203,9 @@ References:
   `[[id]]`) covers the only real need without the recursion. Trigger to revisit:
   tags routinely need their own tags, backlinks, and history as first-class.
 - **`source` and `description` as core fields.** Refused.
-  - `source` is a typed edge: model it as a tag with a `column.ref()` field
-    (`whispering_recording: { recording }`), richer than an opaque `string[]`.
+  - `source` is a typed edge: model it as a tag with a `column.string()` field
+    holding an `epicenter://` URN (`whispering_recording: { recording }`), richer
+    than an opaque `string[]`.
   - `description` decomposes: the preview is derived from `body`; the publish blurb
     is `publishable.excerpt`. Nothing called "description" remains.
 - **A separate link-graph subsystem.** Refused. Tags-with-ref-columns already are
@@ -241,13 +247,14 @@ markdown     = one-shot vault rewrite: tags: [..] + types: {..} -> tags: {..};
 1. Rename types -> tags in schema/index/lens/projection/markdown; pages.types -> pages.tags;
    fold pages.tags string[] into the map as {} entries. (mechanical; see naming table)
    Auto-mint a bare tag definition when an assigned tag has no row.
-2. Add column.ref() (string + format marker) and column.array() to the column.* sugar.
+2. Add column.array() to the column.* sugar. References need no helper: a plain
+   column.string() holds an `epicenter://` URN, recognized by value.
 3. Projection: page_tags membership + tag_<slug> structured tables + edges (provenance-aware,
-   ref[] expands to many rows, dangling allowed) + projection_issues. Own database file;
-   bare names; STRICT; WITHOUT ROWID.
+   URN values + URN-list elements expand to many rows, dangling allowed) + projection_issues.
+   Own database file; bare names; STRICT; WITHOUT ROWID.
 4. description on the tags table + markdown round-trip.
 5. Tests: plain-tag membership (no side table); structured typed query; rename-no-DDL vs
-   add-column-DDL; ref column -> edges row; body [[id]] -> edges row (distinct source_kind).
+   add-column-DDL; URN cell value -> edges row; body [[id]] -> edges row (distinct source_kind).
 6. One-way migration script for existing vault data.
 ```
 

--- a/specs/20260603T180000-wiki-pages-and-tags.md
+++ b/specs/20260603T180000-wiki-pages-and-tags.md
@@ -268,3 +268,46 @@ markdown     = one-shot vault rewrite: tags: [..] + types: {..} -> tags: {..};
   support `[[id|Title]]`. Trigger: the wikilink authoring UX is built.
 - **Single id namespace / G3 fold**: only if the two-things boundary ever stops
   paying for itself.
+
+## Amendments (20260603, code is ahead of this draft)
+
+This draft was written before the final refactor wave. The text above is preserved
+as the original record; the items below are current truth where they conflict.
+
+Implemented since the draft:
+
+- **One-way vault.** The markdown vault is a read-only projection of Yjs; there is
+  no `markdown_push` disk-to-Yjs reconcile. Writes happen ONLY through actions, so
+  the `markdown_push` mentions (lines 54, 196) are obsolete: the assign action is
+  the sole minting path.
+- **Typed column authoring via a closed `kind` descriptor.** An agent passes a
+  `ColumnInput` `{ id, name, kind, nullable?, array?, enumValues? }`, never a
+  hand-written schema; `buildColumnSchema` compiles it. The "raw `column.*`
+  TSchema, stored verbatim" language (line 106) describes the OLD path. Junk can no
+  longer be authored: the input `kind` union rejects unknown kinds before the
+  handler runs, which retired the `isTSchemaObject` guard.
+- **Naming.** The tables are `pages` / `tags` (the draft's `pages.types` /
+  `types.columns`, line 104, predates the rename).
+
+New decisions (this review):
+
+- **Deletion (the symmetric closure of create/define).** Add `pages_delete`,
+  `tags_remove`, `pages_remove_tag`. Safe by construction: the model already
+  supports dangling refs (a delete just creates one) and excess values (an orphaned
+  tag's values render as excess through the lens, never lost). Soft-delete / trash
+  deferred; trigger: an undo or trash UX.
+- **Verb symmetry.** Rename `pages_assign_tag` to `pages_set_tag` so the page-tag
+  verbs mirror the tag-column verbs exactly:
+  `tags_set_column` / `tags_remove_column` to `pages_set_tag` / `pages_remove_tag`.
+- **Law: kinds validate leaves, edges are value-detected.** A column `kind`
+  validates a LEAF value (url, datetime, enum). A reference is never a kind; it is
+  an EDGE recognized by its `epicenter://` URN value at projection. The next
+  "special string" follows the law: a leaf format becomes a kind, a cross-entity
+  pointer is value-detected.
+- **Store the descriptor, derive the schema.** Store the `ColumnInput` descriptor
+  and compile the `TSchema` on read. The compiled schema is a pure function of the
+  descriptor (`buildColumnSchema`), so storing it is storing a derived value;
+  storing the descriptor instead deletes the `StoredColumnSpec` / `Type.Unsafe` /
+  `tagColumns`-cast impedance (lines 103-106) and is even more constrained than a
+  raw TSchema (a closed switch, no eval). `pageTagsCell` keeps its `Type.Unsafe`:
+  its leaf values are genuinely arbitrary JSON, the one earned escape hatch.


### PR DESCRIPTION
This branch set out to answer one uncomfortable question: can a person define a *typed* shape at runtime, store it somewhere that merges offline and that agents can mutate without corrupting it, and still walk away with plain markdown they own, all without ever forcing a schema onto anything? The answer turned out to be yes, and this is the ~1600 lines that prove it. It is deliberately small, two tables and a handful of verbs, because the point was never to ship a wiki. The point was to find the smallest engine that makes "store everything, structure it later" actually true.

It opens against `main` as a record, not as a merge. The framing it wears here (a "wiki," one workspace, a knowledge graph) is being replaced by a different one: tenant apps that each materialize into a folder of a vault you already own. But the engine *underneath* that framing is the keeper, and the discussion that reframed it kept re-deriving decisions this branch had already made. So rather than let it rot on a branch or delete it on a whim, this captures what it is and what it taught, so the next pass lifts the proven pieces instead of rediscovering them.

What it is: two ordinary tables:

```
tags  (registry of facets)              pages  (knowledge objects)
  id       youtube_video  (a slug)        id      opaque, == file stem
  name     "YouTube Video"                title
  columns  [ {url}, {duration} ]  <-----  tags    { youtube_video:{url,duration}, idea:{} }
  ...                                     body    (markdown source)

a tag with `columns: []`  is a PLAIN tag      (membership only)
a tag with columns        is a STRUCTURED tag (a typed component -> its own SQLite table)
a page "wears" a tag  iff  its `tags` cell has that key
a page wears a tag at most once; "many of a kind" is an array column, never wearing twice
```

The reason for this shape is:

**1. Truth that merges, output you own.** One authority, two throwaway views.

```
Yjs (Y.Array LWW)   TRUTH      merges offline; agents mutate only via actions
   | one-way
   v
markdown vault      PORTABLE   pages/<id>.md, tags/<id>.md   (read-only)
   | derived
   v
SQLite              QUERY      one table per structured tag   (disposable)

rebuild test:  delete SQLite -> rebuild from Yjs.   delete vault -> rebuild from Yjs.
               delete Yjs    -> nothing rebuilds it.  that is what "truth" means.
```

**2. Types defined at runtime, with no eval and no codegen.** An agent authors a column as a closed `kind`, never a hand-written schema:

```
tags_define({ id: 'youtube_video', columns: [
    { id: 'url',      kind: 'url' },
    { id: 'duration', kind: 'number' } ] })
        |
    buildColumnSchema(kind)        a switch, not an interpreter
        v
    TSchema   (which IS plain JSON Schema)
        |  survives the Yjs / JSON round-trip
        v
    Value.Check still validates it   -> no eval, no parser, no codegen
```

The input layer only accepts the closed `kind` vocabulary, so a stored schema is always a real `column.*` result. Junk can't land.

**3. Changing a type never rewrites your data.** The tag's columns are a lens over the page's stored values, never a gate or a migration (`lens.ts`):

```
page values   { url: "...", duration: 1240, note: "old" }
tag columns   [ url, duration, channel ]
                      |
                viewThroughTag
                      v
    match    url, duration   rendered typed (with a `valid` flag)
    missing  channel         schema has it, page doesn't -> "fill me"
    excess   note            page has it, schema dropped it -> kept verbatim

renaming or reshaping a tag rewrote ZERO pages. the durable data is untouched;
only the rendered view reflects the current schema.
```

**4. The vault is read-only, but the body is writable through verbs.** Agents read `pages/<id>.md` by grepping; they never edit it. Writes go through validated actions: `pages_create`, `pages_assign_tag`, `pages_set_body`, `pages_patch_body`, `tags_define`, `tags_set_column`, `tags_remove_column`. The file is generated; the verbs are the only door.

What already matches where we landed, and what would change:

Already right, and worth lifting forward verbatim:

- tag ids are human slugs (`youtube_video`), so a display rename is metadata-only
- schema lives as *data* (the `tags.columns` cell), authored at runtime
- schema-on-read: loose truth, typed view, lossless type changes
- one-way vault: the markdown is a projection, the actions are the write path

What the reframe changes, and why it's a *next pass* not a fix here:

- the noun: "wiki" becomes the substrate for tenant apps that materialize into a vault's reserved `apps/` folder, browsed alongside your own plain markdown
- `body` is a plain LWW string today; promote it to a per-row `Y.Text` doc once agent / offline body editing is real (the `schema.ts` comment already flags this)
- one workspace today; the tenant model slices into a document per domain (curated notes vs imported messages vs ephemeral tabs) for sync and scale

The implementation works like this:

Start with `schema.ts` (the whole model lives in its doc comment), then `lens.ts` (the one idea that makes loose truth safe), then `markdown.ts` (the projection contract), then `index.ts` (the verbs).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783144757&installation_id=128463665&pr_number=1897&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1897&signature=bbb332a34525dee5d07a161c808cbdbfd02215015d77681a79cc6cb731d57c87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->