### PR TITLE
fix: ignore non-package workspace glob matches

### DIFF
--- a/scripts/clean.ts
+++ b/scripts/clean.ts
@@ -12,7 +12,7 @@
 
 import { rm } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { workspaces } from '../package.json';
 
 const isNuke = process.argv.includes('--nuke');
@@ -48,9 +48,9 @@ async function main() {
 	);
 
 	// Discover all monorepo package roots from workspace config
-	const packageRoots = workspaces.packages.flatMap((pattern) => [
-		...new Bun.Glob(pattern).scanSync({ onlyFiles: false }),
-	]);
+	const packageRoots = workspaces.packages.flatMap((pattern) =>
+		[...new Bun.Glob(join(pattern, 'package.json')).scanSync()].map(dirname),
+	);
 
 	const dirsToRemove = [
 		'node_modules',


### PR DESCRIPTION
This PR fixes an issue where /apps/README.md was detected as an app folder for cleanup.

<!--
Write narrative prose, not a form.

Open with why this change exists, then explain the shape of the change.
Do not include Summary, Changes, Testing, Test Plan, or Verification sections.
Mention commands run in the agent or chat final response, not the PR body.

For API changes, include before/after code examples.
For structural refactors, include a small before/after shape or composition tree.
Do not list files changed. The diff tab already does that.

For feat: and fix: PRs only, add:

## Changelog
- Add or fix the user-visible outcome

Omit Changelog for chore:, refactor:, docs:, test:, build:, and ci: PRs.

Use Closes #123 only when the PR fully resolves an issue.

Paste screenshots or recordings for UI changes.

PRs touching apps/api/, apps/self-host/, packages/sync/, or packages/server/ require @braden-w review per CODEOWNERS.
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783175319&installation_id=128463665&pr_number=1898&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1898&signature=3fc740f85e2bfed91e0b8aab8c74163c29526f9a58594a1d11993e269d7f721f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->