### PR TITLE
refactor(ui): adopt the shadcn-svelte Vega cn-* style system

### DIFF
--- a/apps/api/ui/src/app.html
+++ b/apps/api/ui/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="style-vega">
 	<head>
 		<meta charset="utf-8">
 		<link rel="icon" href="%sveltekit.assets%/favicon.ico">

--- a/apps/fuji/src/app.html
+++ b/apps/fuji/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="style-vega">
 	<head>
 		<meta charset="utf-8">
 		<link rel="icon" href="%sveltekit.assets%/favicon.ico">

--- a/apps/honeycrisp/src/app.html
+++ b/apps/honeycrisp/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="style-vega">
 	<head>
 		<meta charset="utf-8">
 		<link rel="icon" href="%sveltekit.assets%/favicon.ico">

--- a/apps/landing/src/layouts/BaseLayout.astro
+++ b/apps/landing/src/layouts/BaseLayout.astro
@@ -12,7 +12,7 @@ const { title, description = 'Epicenter - Building tools that matter' } =
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="en" class="style-vega">
 	<head>
 		<meta charset="UTF-8">
 		<meta name="description" content={description}>

--- a/apps/opensidian/src/app.html
+++ b/apps/opensidian/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="style-vega">
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1">

--- a/apps/skills/src/app.html
+++ b/apps/skills/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="style-vega">
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1">

--- a/apps/tab-manager/src/entrypoints/sidepanel/index.html
+++ b/apps/tab-manager/src/entrypoints/sidepanel/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="h-full">
+<html lang="en" class="h-full style-vega">
 	<head>
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/whispering/src/app.html
+++ b/apps/whispering/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="style-vega">
 	<head>
 		<meta charset="utf-8">
 		<link rel="icon" href="%sveltekit.assets%/favicon.ico">

--- a/apps/zhongwen/src/app.html
+++ b/apps/zhongwen/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="style-vega">
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1">

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -149,6 +149,34 @@ Two kinds of delta stay inline, by necessity:
 - **Structural divergences** (extra wrapper elements, `<svelte:element>`, an
   injected actions overlay) are markup, not CSS, and live in the component.
 
+### Current Epicenter deltas
+
+`epicenter-overlay.css` is the self-documenting source of truth for **custom
+variants** (button `ghost-destructive`, alert `warning`, badge
+`id`/`success`/`status.*`) and **per-component overrides** (`cn-table-row`,
+`cn-select-content`, `cn-dialog-content`, `cn-resizable-panel-group`,
+`cn-sidebar-inset`, `cn-item-*`, `cn-item-media-variant-icon`). Each block is
+commented there.
+
+The deltas that must stay **inline** (structural markup, or a property Vega sets
+inline that a base-layer rule cannot beat) are listed here so they are not lost
+on a re-vendor:
+
+| Inline delta | File | Why it stays inline | Still needed? |
+|---|---|---|---|
+| `relative` + `[a]:hover:bg-accent/50` on the item base | `item/item.svelte` | positioning context for the actions overlay; accent hover uses an arbitrary `[a&]`-style selector | yes |
+| Scroll wrapper `<div class="flex-1 overflow-y-auto">` | `drawer/drawer-content.svelte` | structural (extra element) | yes |
+| `onOpenAutoFocus` preventDefault | `drawer/drawer-content.svelte` | workaround for vaul-svelte vs bits-ui 2.x focus recursion | remove when vaul-svelte supports bits-ui 2.x |
+| Viewport ring/outline styling | `scroll-area/scroll-area.svelte` | Vega has no `cn-scroll-area-viewport` | until Vega defines it |
+| Handle base styling | `resizable/resizable-handle.svelte` | Vega has no `cn-resizable-handle` (only `-icon`) | until Vega defines it |
+| `<svelte:element>` span-or-anchor | `badge/badge.svelte` | structural (element choice) | yes |
+| `showOnHover` actions overlay | `item/item-actions.svelte` | structural (absolute overlay + gradient) | yes |
+| `tooltip` prop (wraps in `Tooltip`) | `button/button.svelte` | Epicenter feature; upstream Button has none | yes |
+
+Correctness wiring (making Vega work, not Epicenter style): `switch` and
+`alert-dialog` carry a `size` prop that emits `data-size`; sidebar menu and
+sub-menu buttons emit `data-active` only when active. Keep these.
+
 ## Component Management Workflow
 
 Components are (mostly) byte-identical to upstream shadcn-svelte Vega markup, so

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,13 +1,28 @@
 # UI Package Guide
 
-This guide explains the UI package import boundary and component update workflow.
+This guide explains the UI package import boundary, the shadcn-svelte style
+system it uses, and the component update workflow.
 
 ## Component Library Overview
 
-This UI package contains a combination of:
+This package is a vendored fork of **shadcn-svelte** (1.x) on the **Vega**
+preset, plus a few **shadcn-svelte-extras** and Epicenter-specific components.
 
-- **shadcn-svelte** components (core design system components)
-- **shadcn-svelte-extras** components (additional utility components)
+It uses shadcn-svelte's `cn-*` style system: component markup carries semantic
+hook classes (`cn-button-variant-default`, `cn-dialog-content`) and the actual
+styling lives in CSS:
+
+- `src/styles/style-vega.css` (vendored): the Vega preset. All `cn-*` rules,
+  scoped under `.style-vega`.
+- `src/styles/shadcn-base.css` (vendored): the upstream base (data-* custom
+  variants, `no-scrollbar`, accordion keyframes) the `cn-*` rules depend on.
+- `src/styles/epicenter-overlay.css`: Epicenter style deltas (custom variants
+  and per-component overrides). The single place our styling diverges from Vega.
+
+Apps activate the preset with `class="style-vega"` on their root element; the
+`cn-*` rules are scoped under it, so without the class nothing is styled. The
+preset is a one-class swap (e.g. to `style-rhea`). Background and rationale:
+`specs/20260606T160000-ui-shadcn-cn-style-migration-vega.md`.
 
 ### Dialog vs Modal Usage Guidelines
 
@@ -27,14 +42,14 @@ We use different component types based on the interaction pattern:
 - Multi-step workflows with form data
 - Any component where users need to input data
 
-**Decision Rule:** If the user needs to type or input data → use Modal. Otherwise, use Dialog/AlertDialog.
+**Decision Rule:** If the user needs to type or input data, use Modal. Otherwise, use Dialog/AlertDialog.
 
 **Examples:**
 
-- `ConfirmationDialog` ✅ (just yes/no buttons)
-- `CreateWorkspaceModal` ✅ (multiple form inputs)
-- `EditRecordingModal` ✅ (text inputs and editing)
-- `DeleteWorkspaceButton` ✅ (uses AlertDialog for confirmation)
+- `ConfirmationDialog` (just yes/no buttons)
+- `CreateWorkspaceModal` (multiple form inputs)
+- `EditRecordingModal` (text inputs and editing)
+- `DeleteWorkspaceButton` (uses AlertDialog for confirmation)
 
 ## Key Differences from Standard shadcn-svelte
 
@@ -90,65 +105,81 @@ Our `package.json` exposes only the public API for app consumers:
 }
 ```
 
-UI source imports components with relative paths:
+Consumers import components through the package API; UI source imports siblings
+with relative paths.
 
-```typescript
-import { Button } from '../button/index.js';
-import { cn } from '../utils.js';
+### 3. Styling: the overlay, not inline overrides
+
+Component styling lives in `cn-*` classes, not inline Tailwind. Keep component
+markup byte-identical to upstream Vega so it stays trivially re-vendorable, and
+put every Epicenter style delta in `src/styles/epicenter-overlay.css`.
+
+**Custom variants** (no upstream equivalent) become a `cn-*` class. Example, the
+button `ghost-destructive` variant:
+
+```css
+/* epicenter-overlay.css, under .style-vega */
+.cn-button-variant-ghost-destructive {
+	@apply text-destructive hover:bg-destructive/10 dark:hover:bg-destructive/20;
+}
 ```
-
-Consumers import components through the package API:
-
-```typescript
-import { Button } from '@epicenter/ui/button';
-import { cn } from '@epicenter/ui/utils';
-```
-
-### 3. Styling Override Pattern
-
-When extending shadcn-svelte components with custom styles, we use a specific pattern that separates base styles from our overrides:
 
 ```svelte
-<SelectPrimitive.Content
-	class={cn(
-		'base-shadcn-styles-here',
-		// Custom override: prevents dropdown from expanding
-		'max-w-min',
-		className,
-	)}
-/>
+// button.svelte tv()
+'ghost-destructive': 'cn-button-variant-ghost-destructive',
 ```
 
-**Why use separate arguments in `cn()`?**
+**Per-component overrides** redefine the Vega `cn-*` class. The overlay is
+imported after `style-vega.css` (same `layer(base)`), so a same-specificity rule
+here wins:
 
-- **Clear separation**: First argument contains shadcn's base styles, second argument contains our overrides
-- **Better diffs**: When updating shadcn components, changes to base styles appear in the first argument, making it obvious what shadcn changed vs. what we customized
-- **Comments**: We can add comments above our overrides explaining why they're needed
-- **Easier updates**: During `shadcn-svelte` updates, if our override (second argument) disappears in the diff, we know we need to re-apply it
+```css
+.cn-select-content { @apply max-w-min; }
+```
 
-This pattern makes component updates much clearer: shadcn's style updates show in the first `cn()` argument, while our customizations remain visually separate in subsequent arguments.
+**Invariant:** every `cn-*` class a component emits must be defined in
+`style-vega.css` or `epicenter-overlay.css`. An undefined `cn-*` class is a dead
+no-op; do not emit one.
+
+Two kinds of delta stay inline, by necessity:
+
+- **Utilities-layer overrides** of a property Vega sets inline in the component
+  (notably z-index). A base-layer `@apply` cannot beat a utilities-layer inline
+  utility, so override inline, or use `@apply ...!` in the overlay.
+- **Structural divergences** (extra wrapper elements, `<svelte:element>`, an
+  injected actions overlay) are markup, not CSS, and live in the component.
 
 ## Component Management Workflow
 
-### Adding New Components
+Components are (mostly) byte-identical to upstream shadcn-svelte Vega markup, so
+updates are a careful copy plus a translation step.
 
-Add or update generated components in a scratch shadcn-svelte project, then copy
-the component into `packages/ui/src` and normalize imports to relative paths.
-This keeps the committed package free of generator aliases.
+### Updating or adding a component
 
-### Updating Components
+1. Copy the component's `cn-*` Vega markup from upstream shadcn-svelte (or
+   generate it in a scratch project pinned to a 1.x version).
+2. Normalize imports to relative paths (`../utils.js`, `../button/index.js`).
+   The committed package has no generator aliases.
+3. Strip `IconPlaceholder`; use direct `@lucide/svelte/icons/*` imports.
+4. Move every Epicenter style delta into `epicenter-overlay.css` (see Styling
+   above). Do not leave inline override args stacked on a `cn-*` class.
+5. Confirm the invariant: every `cn-*` class the component emits is defined.
+6. Run `bun run check:ui-boundary` and build a consuming app.
 
-1. Generate or update the component in a scratch project.
-2. Copy the changed component files into `packages/ui/src`.
-3. Normalize imports so UI source uses relative paths.
-4. Review the diff carefully, especially:
-   - Custom style overrides (marked with comments)
-   - Import path changes
-   - Any custom props or functionality
+### Re-vendoring the whole preset
+
+To pull a newer Vega, replace `src/styles/style-vega.css` (and `shadcn-base.css`
+if the base changed) with the upstream file, then re-check the invariant. Newly
+defined `cn-*` classes may let you drop overlay overrides; newly emitted hooks in
+components may need definitions.
+
+### Do NOT
+
+- Regenerate with the shadcn-svelte CLI and copy blindly. It pulls
+  `IconPlaceholder` and generator aliases, and reintroduces the inline form.
+- Stack inline Tailwind overrides on top of a `cn-*` class. Use the overlay.
 
 ### Import Path Convention
-
-Use relative imports within the UI package and public package imports from apps:
 
 ```typescript
 // App code
@@ -164,28 +195,28 @@ import { cn } from '../utils.js';
 ```
 packages/ui/
 ├── src/
-│   ├── accordion/
-│   │   ├── accordion.svelte
-│   │   ├── accordion-content.svelte
-│   │   ├── accordion-item.svelte
-│   │   ├── accordion-trigger.svelte
-│   │   └── index.ts
 │   ├── button/
 │   │   ├── button.svelte
 │   │   └── index.ts
+│   ├── styles/
+│   │   ├── shadcn-base.css        # vendored upstream base
+│   │   ├── style-vega.css         # vendored Vega preset (all cn-* rules)
+│   │   └── epicenter-overlay.css  # Epicenter deltas (variants + overrides)
 │   ├── utils.ts
-│   └── app.css
+│   └── app.css                    # imports the three style files
 ├── package.json
 └── tsconfig.json
 ```
 
 ## Best Practices
 
-1. **Keep Components Pure**: Don't add business logic to UI components
-2. **Use Barrel Exports**: Each component folder should have an `index.ts`
-3. **Document Overrides**: Always comment custom style additions
-4. **Test After Updates**: Verify components work after shadcn updates
-5. **Consistent Imports**: Use relative imports inside `packages/ui/src`. Use `@epicenter/ui` only from consumers outside this package.
+1. **Keep Components Pure**: no business logic in UI components.
+2. **Use Barrel Exports**: each component folder has an `index.ts`.
+3. **Style in the overlay**: Epicenter deltas go in `epicenter-overlay.css`, not
+   inline on the component, unless they must stay inline (see Styling).
+4. **Hold the invariant**: never emit a `cn-*` class that is not defined.
+5. **Consistent Imports**: relative inside `packages/ui/src`; `@epicenter/ui`
+   only from consumers outside this package.
 
 ## Boundary Check
 
@@ -206,24 +237,28 @@ directly, or when UI source imports itself through private aliases or
 
 ### Import Resolution Issues
 
-If imports aren't resolving:
+If imports are not resolving:
 
-1. Check that the component is exported by `@epicenter/ui`
-2. Ensure your IDE recognizes the package's TypeScript config
-3. Restart the TypeScript language server
+1. Check that the component is exported by `@epicenter/ui`.
+2. Ensure your IDE recognizes the package's TypeScript config.
+3. Restart the TypeScript language server.
 
 ### Style Conflicts
 
-If custom styles aren't applying:
+If a custom style is not applying:
 
-1. Check the order in the `cn()` function
-2. Ensure custom styles come after base styles
-3. Use more specific selectors if needed
+1. Confirm the rule is in `epicenter-overlay.css` (imported after
+   `style-vega.css`, so it wins at equal specificity).
+2. If you are overriding a value Vega sets inline in the component (e.g.
+   z-index), a base-layer `@apply` will not win: override inline or use
+   `@apply ...!`.
+3. Confirm the app root carries `class="style-vega"`; without it the `cn-*`
+   rules do not apply at all.
 
 ### Component Updates
 
 When updating breaks functionality:
 
-1. Check the shadcn-svelte changelog
-2. Review our custom overrides
-3. Test thoroughly before committing
+1. Check the shadcn-svelte changelog.
+2. Review the overlay and any inline overrides.
+3. Build a consuming app before committing.

--- a/packages/ui/src/accordion/accordion-content.svelte
+++ b/packages/ui/src/accordion/accordion-content.svelte
@@ -13,8 +13,10 @@
 <AccordionPrimitive.Content
 	bind:ref
 	data-slot="accordion-content"
-	class="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+	class="cn-accordion-content overflow-hidden"
 	{...restProps}
 >
-	<div class={cn('pb-4 pt-0', className)}>{@render children?.()}</div>
+	<div class={cn('cn-accordion-content-inner', className)}>
+		{@render children?.()}
+	</div>
 </AccordionPrimitive.Content>

--- a/packages/ui/src/accordion/accordion-item.svelte
+++ b/packages/ui/src/accordion/accordion-item.svelte
@@ -12,6 +12,6 @@
 <AccordionPrimitive.Item
 	bind:ref
 	data-slot="accordion-item"
-	class={cn('border-b last:border-b-0', className)}
+	class={cn('cn-accordion-item', className)}
 	{...restProps}
 />

--- a/packages/ui/src/accordion/accordion-trigger.svelte
+++ b/packages/ui/src/accordion/accordion-trigger.svelte
@@ -19,7 +19,7 @@
 		data-slot="accordion-trigger"
 		bind:ref
 		class={cn(
-			'focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-start text-sm font-medium outline-none transition-all hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
+			'cn-accordion-trigger flex flex-1 items-start justify-between gap-4 outline-none transition-all disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
 			className,
 		)}
 		{...restProps}

--- a/packages/ui/src/alert-dialog/alert-dialog-action.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-action.svelte
@@ -13,6 +13,6 @@
 <AlertDialogPrimitive.Action
 	bind:ref
 	data-slot="alert-dialog-action"
-	class={cn(buttonVariants(), 'cn-alert-dialog-action', className)}
+	class={cn(buttonVariants(), className)}
 	{...restProps}
 />

--- a/packages/ui/src/alert-dialog/alert-dialog-action.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-action.svelte
@@ -13,6 +13,6 @@
 <AlertDialogPrimitive.Action
 	bind:ref
 	data-slot="alert-dialog-action"
-	class={cn(buttonVariants(), className)}
+	class={cn(buttonVariants(), 'cn-alert-dialog-action', className)}
 	{...restProps}
 />

--- a/packages/ui/src/alert-dialog/alert-dialog-cancel.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-cancel.svelte
@@ -13,6 +13,6 @@
 <AlertDialogPrimitive.Cancel
 	bind:ref
 	data-slot="alert-dialog-cancel"
-	class={cn(buttonVariants({ variant: 'outline' }), 'cn-alert-dialog-cancel', className)}
+	class={cn(buttonVariants({ variant: 'outline' }), className)}
 	{...restProps}
 />

--- a/packages/ui/src/alert-dialog/alert-dialog-cancel.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-cancel.svelte
@@ -13,6 +13,6 @@
 <AlertDialogPrimitive.Cancel
 	bind:ref
 	data-slot="alert-dialog-cancel"
-	class={cn(buttonVariants({ variant: 'outline' }), className)}
+	class={cn(buttonVariants({ variant: 'outline' }), 'cn-alert-dialog-cancel', className)}
 	{...restProps}
 />

--- a/packages/ui/src/alert-dialog/alert-dialog-content.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-content.svelte
@@ -11,9 +11,11 @@
 		ref = $bindable(null),
 		class: className,
 		portalProps,
+		size = 'default',
 		...restProps
 	}: WithoutChild<AlertDialogPrimitive.ContentProps> & {
 		portalProps?: WithoutChildrenOrChild<AlertDialogPrimitive.PortalProps>;
+		size?: 'sm' | 'default';
 	} = $props();
 </script>
 
@@ -22,8 +24,9 @@
 	<AlertDialogPrimitive.Content
 		bind:ref
 		data-slot="alert-dialog-content"
+		data-size={size}
 		class={cn(
-			'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed start-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+			'cn-alert-dialog-content group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none',
 			className,
 		)}
 		{...restProps}

--- a/packages/ui/src/alert-dialog/alert-dialog-description.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-description.svelte
@@ -12,6 +12,6 @@
 <AlertDialogPrimitive.Description
 	bind:ref
 	data-slot="alert-dialog-description"
-	class={cn('text-muted-foreground text-sm', className)}
+	class={cn('cn-alert-dialog-description', className)}
 	{...restProps}
 />

--- a/packages/ui/src/alert-dialog/alert-dialog-footer.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-footer.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="alert-dialog-footer"
 	class={cn(
-		'cn-alert-dialog-footer flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end',
+		'flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/alert-dialog/alert-dialog-footer.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-footer.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="alert-dialog-footer"
 	class={cn(
-		'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+		'cn-alert-dialog-footer flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/alert-dialog/alert-dialog-header.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-header.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="alert-dialog-header"
-	class={cn('flex flex-col gap-2 text-center sm:text-start', className)}
+	class={cn('cn-alert-dialog-header', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/alert-dialog/alert-dialog-overlay.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-overlay.svelte
@@ -12,9 +12,6 @@
 <AlertDialogPrimitive.Overlay
 	bind:ref
 	data-slot="alert-dialog-overlay"
-	class={cn(
-		'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
-		className,
-	)}
+	class={cn('cn-alert-dialog-overlay fixed inset-0 z-50', className)}
 	{...restProps}
 />

--- a/packages/ui/src/alert-dialog/alert-dialog-title.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-title.svelte
@@ -12,6 +12,6 @@
 <AlertDialogPrimitive.Title
 	bind:ref
 	data-slot="alert-dialog-title"
-	class={cn('cn-font-heading cn-alert-dialog-title', className)}
+	class={cn('cn-alert-dialog-title', className)}
 	{...restProps}
 />

--- a/packages/ui/src/alert-dialog/alert-dialog-title.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-title.svelte
@@ -12,6 +12,6 @@
 <AlertDialogPrimitive.Title
 	bind:ref
 	data-slot="alert-dialog-title"
-	class={cn('text-lg font-semibold', className)}
+	class={cn('cn-font-heading cn-alert-dialog-title', className)}
 	{...restProps}
 />

--- a/packages/ui/src/alert/alert-description.svelte
+++ b/packages/ui/src/alert/alert-description.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="alert-description"
 	class={cn(
-		'text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed',
+		'cn-alert-description [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/alert/alert-title.svelte
+++ b/packages/ui/src/alert/alert-title.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="alert-title"
 	class={cn(
-		'col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight',
+		'cn-alert-title [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/alert/alert.svelte
+++ b/packages/ui/src/alert/alert.svelte
@@ -2,14 +2,13 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 
 	export const alertVariants = tv({
-		base: 'relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
+		base: 'cn-alert group/alert relative w-full',
 		variants: {
 			variant: {
-				default: 'bg-card text-card-foreground',
-				destructive:
-					'text-destructive bg-card *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current',
-				warning:
-					'text-warning bg-card *:data-[slot=alert-description]:text-warning/90 [&>svg]:text-current',
+				default: 'cn-alert-variant-default',
+				destructive: 'cn-alert-variant-destructive',
+				// Epicenter custom variant (overlay, not upstream).
+				warning: 'cn-alert-variant-warning',
 			},
 		},
 		defaultVariants: {

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -5,6 +5,18 @@
 
 @import "./prose.css";
 
+/*
+  shadcn-svelte 1.x style system. shadcn-base.css vendors upstream
+  shadcn-svelte/tailwind.css (data-* custom variants, no-scrollbar, accordion
+  keyframes) that the cn-* rules depend on; style-vega.css is the vendored Vega
+  preset; epicenter-overlay.css carries Epicenter-specific deltas. Components are
+  being migrated wave by wave from inline Tailwind to cn-* hooks.
+  See specs/20260606T160000-ui-shadcn-cn-style-migration-vega.md
+*/
+@import "./styles/shadcn-base.css";
+@import "./styles/style-vega.css" layer(base);
+@import "./styles/epicenter-overlay.css" layer(base);
+
 @source "./**/*.{svelte,ts}";
 
 /*

--- a/packages/ui/src/avatar/avatar-fallback.svelte
+++ b/packages/ui/src/avatar/avatar-fallback.svelte
@@ -13,7 +13,7 @@
 	bind:ref
 	data-slot="avatar-fallback"
 	class={cn(
-		'bg-muted flex size-full items-center justify-center rounded-full',
+		'cn-avatar-fallback flex size-full items-center justify-center text-sm group-data-[size=sm]/avatar:text-xs',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/avatar/avatar-image.svelte
+++ b/packages/ui/src/avatar/avatar-image.svelte
@@ -12,6 +12,6 @@
 <AvatarPrimitive.Image
 	bind:ref
 	data-slot="avatar-image"
-	class={cn('aspect-square size-full', className)}
+	class={cn('cn-avatar-image aspect-square size-full object-cover', className)}
 	{...restProps}
 />

--- a/packages/ui/src/avatar/avatar.svelte
+++ b/packages/ui/src/avatar/avatar.svelte
@@ -15,7 +15,7 @@
 	bind:loadingStatus
 	data-slot="avatar"
 	class={cn(
-		'relative flex size-8 shrink-0 overflow-hidden rounded-full',
+		'cn-avatar after:border-border group/avatar relative flex shrink-0 select-none after:absolute after:inset-0 after:border after:mix-blend-darken dark:after:mix-blend-lighten',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/badge/badge.svelte
+++ b/packages/ui/src/badge/badge.svelte
@@ -1,24 +1,23 @@
 <script lang="ts" module>
 	import { tv, type VariantProps } from 'tailwind-variants';
 
+	// Styling lives in the vendored Vega preset (cn-* classes); see
+	// packages/ui/src/styles/style-vega.css. Epicenter-specific variants live in
+	// packages/ui/src/styles/epicenter-overlay.css.
 	export const badgeVariants = tv({
-		base: 'focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden whitespace-nowrap rounded-full border px-2 py-0.5 text-xs font-medium transition-[color,box-shadow] focus-visible:ring-[3px] [&>svg]:pointer-events-none [&>svg]:size-3',
+		base: 'cn-badge focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive group/badge inline-flex w-fit shrink-0 items-center justify-center overflow-hidden whitespace-nowrap transition-colors focus-visible:ring-[3px] [&>svg]:pointer-events-none',
 		variants: {
 			variant: {
-				default:
-					'bg-primary text-primary-foreground [a&]:hover:bg-primary/90 border-transparent',
-				secondary:
-					'bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90 border-transparent',
-				destructive:
-					'bg-destructive [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/70 border-transparent text-white',
-				outline:
-					'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
-				id: 'px-1.5 bg-muted text-muted-foreground [a&]:hover:bg-muted/90 border-transparent font-mono text-xs rounded-md font-normal',
-				'status.completed': 'bg-green-500/10 text-green-500',
-				'status.failed': 'bg-red-500/10 text-red-500',
-				'status.running': 'bg-blue-500/10 text-blue-500',
-				success:
-					'bg-success [a&]:hover:bg-success/90 focus-visible:ring-success/20 dark:focus-visible:ring-success/40 dark:bg-success/80 border-transparent text-white',
+				default: 'cn-badge-variant-default',
+				secondary: 'cn-badge-variant-secondary',
+				destructive: 'cn-badge-variant-destructive',
+				outline: 'cn-badge-variant-outline',
+				// Epicenter custom variants (overlay, not upstream).
+				id: 'cn-badge-variant-id',
+				'status.completed': 'cn-badge-variant-status-completed',
+				'status.failed': 'cn-badge-variant-status-failed',
+				'status.running': 'cn-badge-variant-status-running',
+				success: 'cn-badge-variant-success',
 			},
 		},
 		defaultVariants: {

--- a/packages/ui/src/breadcrumb/breadcrumb-ellipsis.svelte
+++ b/packages/ui/src/breadcrumb/breadcrumb-ellipsis.svelte
@@ -17,7 +17,7 @@
 	data-slot="breadcrumb-ellipsis"
 	role="presentation"
 	aria-hidden="true"
-	class={cn('flex size-9 items-center justify-center', className)}
+	class={cn('cn-breadcrumb-ellipsis flex items-center justify-center', className)}
 	{...restProps}
 >
 	<EllipsisIcon class="size-4" />

--- a/packages/ui/src/breadcrumb/breadcrumb-item.svelte
+++ b/packages/ui/src/breadcrumb/breadcrumb-item.svelte
@@ -13,7 +13,7 @@
 <li
 	bind:this={ref}
 	data-slot="breadcrumb-item"
-	class={cn('inline-flex items-center gap-1.5', className)}
+	class={cn('cn-breadcrumb-item inline-flex items-center', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/breadcrumb/breadcrumb-link.svelte
+++ b/packages/ui/src/breadcrumb/breadcrumb-link.svelte
@@ -16,7 +16,7 @@
 
 	const attrs = $derived({
 		'data-slot': 'breadcrumb-link',
-		class: cn('hover:text-foreground transition-colors', className),
+		class: cn('cn-breadcrumb-link', className),
 		href,
 		...restProps,
 	});

--- a/packages/ui/src/breadcrumb/breadcrumb-list.svelte
+++ b/packages/ui/src/breadcrumb/breadcrumb-list.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="breadcrumb-list"
 	class={cn(
-		'text-muted-foreground flex flex-wrap items-center gap-1.5 break-words text-sm sm:gap-2.5',
+		'cn-breadcrumb-list flex flex-wrap items-center wrap-break-word',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/breadcrumb/breadcrumb-page.svelte
+++ b/packages/ui/src/breadcrumb/breadcrumb-page.svelte
@@ -16,7 +16,7 @@
 	role="link"
 	aria-disabled="true"
 	aria-current="page"
-	class={cn('text-foreground font-normal', className)}
+	class={cn('cn-breadcrumb-page', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/breadcrumb/breadcrumb-separator.svelte
+++ b/packages/ui/src/breadcrumb/breadcrumb-separator.svelte
@@ -16,7 +16,7 @@
 	data-slot="breadcrumb-separator"
 	role="presentation"
 	aria-hidden="true"
-	class={cn('[&>svg]:size-3.5', className)}
+	class={cn('cn-breadcrumb-separator', className)}
 	{...restProps}
 >
 	{#if children}

--- a/packages/ui/src/button-group/button-group-separator.svelte
+++ b/packages/ui/src/button-group/button-group-separator.svelte
@@ -16,7 +16,7 @@
 	data-slot="button-group-separator"
 	{orientation}
 	class={cn(
-		'bg-input relative !m-0 self-stretch data-[orientation=vertical]:h-auto',
+		'cn-button-group-separator relative self-stretch data-[orientation=horizontal]:mx-px data-[orientation=horizontal]:w-auto data-[orientation=vertical]:my-px data-[orientation=vertical]:h-auto',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/button-group/button-group-text.svelte
+++ b/packages/ui/src/button-group/button-group-text.svelte
@@ -15,7 +15,7 @@
 	const mergedProps = $derived({
 		...restProps,
 		class: cn(
-			"bg-muted shadow-xs flex items-center gap-2 rounded-md border px-4 text-sm font-medium [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none",
+			'cn-button-group-text flex items-center [&_svg]:pointer-events-none',
 			className,
 		),
 	});

--- a/packages/ui/src/button-group/button-group.svelte
+++ b/packages/ui/src/button-group/button-group.svelte
@@ -1,14 +1,16 @@
 <script lang="ts" module>
 	import { tv, type VariantProps } from 'tailwind-variants';
 
+	// Styling lives in the vendored Vega preset (cn-* classes); see
+	// packages/ui/src/styles/style-vega.css.
 	export const buttonGroupVariants = tv({
-		base: "flex w-fit items-stretch has-[>[data-slot=button-group]]:gap-2 [&>*]:focus-visible:relative [&>*]:focus-visible:z-10 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-e-md [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
+		base: "cn-button-group flex w-fit items-stretch [&>*]:focus-visible:relative [&>*]:focus-visible:z-10 [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
 		variants: {
 			orientation: {
 				horizontal:
-					'[&>*:not(:first-child)]:rounded-s-none [&>*:not(:first-child)]:border-s-0 [&>*:not(:last-child)]:rounded-e-none',
+					'cn-button-group-orientation-horizontal [&>[data-slot]]:rounded-r-none [&>[data-slot]~[data-slot]]:rounded-l-none [&>[data-slot]~[data-slot]]:border-l-0',
 				vertical:
-					'flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none',
+					'cn-button-group-orientation-vertical flex-col [&>[data-slot]]:rounded-b-none [&>[data-slot]~[data-slot]]:rounded-t-none [&>[data-slot]~[data-slot]]:border-t-0',
 			},
 		},
 		defaultVariants: {

--- a/packages/ui/src/button/button.svelte
+++ b/packages/ui/src/button/button.svelte
@@ -6,31 +6,31 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 	import { cn, type WithElementRef } from '../utils.js';
 
+	// Styling lives in the vendored Vega preset (cn-* classes); see
+	// packages/ui/src/styles/style-vega.css. Epicenter-specific variants live in
+	// packages/ui/src/styles/epicenter-overlay.css.
 	export const buttonVariants = tv({
-		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium outline-none transition-all focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		base: 'cn-button group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0',
 		variants: {
 			variant: {
-				default:
-					'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
-				destructive:
-					'bg-destructive shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60 text-white',
-				outline:
-					'bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 border',
-				secondary:
-					'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
-				ghost:
-					'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
-				'ghost-destructive':
-					'text-destructive hover:bg-destructive/10 hover:text-destructive dark:hover:bg-destructive/20',
+				default: 'cn-button-variant-default',
+				destructive: 'cn-button-variant-destructive',
+				outline: 'cn-button-variant-outline',
+				secondary: 'cn-button-variant-secondary',
+				ghost: 'cn-button-variant-ghost',
+				link: 'cn-button-variant-link',
+				// Epicenter custom variant (overlay, not upstream).
+				'ghost-destructive': 'cn-button-variant-ghost-destructive',
 			},
 			size: {
-				default: 'h-9 px-4 py-2 has-[>svg]:px-3',
-				sm: 'h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5',
-				lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
-				icon: 'size-9',
-				'icon-xs': "size-6 [&_svg:not([class*='size-'])]:size-3",
-				'icon-sm': 'size-8',
-				'icon-lg': 'size-10',
+				default: 'cn-button-size-default',
+				xs: 'cn-button-size-xs',
+				sm: 'cn-button-size-sm',
+				lg: 'cn-button-size-lg',
+				icon: 'cn-button-size-icon',
+				'icon-xs': 'cn-button-size-icon-xs',
+				'icon-sm': 'cn-button-size-icon-sm',
+				'icon-lg': 'cn-button-size-icon-lg',
 			},
 		},
 		defaultVariants: {

--- a/packages/ui/src/card/card-content.svelte
+++ b/packages/ui/src/card/card-content.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="card-content"
-	class={cn('px-6', className)}
+	class={cn('cn-card-content', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/card/card-description.svelte
+++ b/packages/ui/src/card/card-description.svelte
@@ -13,7 +13,7 @@
 <p
 	bind:this={ref}
 	data-slot="card-description"
-	class={cn('text-muted-foreground text-sm', className)}
+	class={cn('cn-card-description', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/card/card-footer.svelte
+++ b/packages/ui/src/card/card-footer.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="card-footer"
-	class={cn('[.border-t]:pt-6 flex items-center px-6', className)}
+	class={cn('cn-card-footer flex items-center', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/card/card-header.svelte
+++ b/packages/ui/src/card/card-header.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="card-header"
 	class={cn(
-		'@container/card-header has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6 grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6',
+		'cn-card-header group/card-header @container/card-header grid auto-rows-min items-start has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/card/card-title.svelte
+++ b/packages/ui/src/card/card-title.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="card-title"
-	class={cn('font-semibold leading-none', className)}
+	class={cn('cn-card-title', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/card/card.svelte
+++ b/packages/ui/src/card/card.svelte
@@ -13,10 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="card"
-	class={cn(
-		'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
-		className,
-	)}
+	class={cn('cn-card group/card flex flex-col', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/chart/chart-tooltip.svelte
+++ b/packages/ui/src/chart/chart-tooltip.svelte
@@ -114,7 +114,7 @@
 	<div
 		bind:this={ref}
 		class={cn(
-			"border-border/50 bg-background grid min-w-[9rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl",
+			"cn-chart-tooltip grid min-w-[9rem] items-start",
 			className
 		)}
 		{...restProps}

--- a/packages/ui/src/checkbox/checkbox.svelte
+++ b/packages/ui/src/checkbox/checkbox.svelte
@@ -17,7 +17,7 @@
 	bind:ref
 	data-slot="checkbox"
 	class={cn(
-		'border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive shadow-xs peer flex size-4 shrink-0 items-center justify-center rounded-[4px] border outline-none transition-shadow focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+		'cn-checkbox peer relative shrink-0 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50',
 		className,
 	)}
 	bind:checked
@@ -25,11 +25,14 @@
 	{...restProps}
 >
 	{#snippet children({ checked, indeterminate })}
-		<div data-slot="checkbox-indicator" class="text-current transition-none">
+		<div
+			data-slot="checkbox-indicator"
+			class="cn-checkbox-indicator grid place-content-center text-current transition-none"
+		>
 			{#if checked}
-				<CheckIcon class="size-3.5" />
+				<CheckIcon />
 			{:else if indeterminate}
-				<MinusIcon class="size-3.5" />
+				<MinusIcon />
 			{/if}
 		</div>
 	{/snippet}

--- a/packages/ui/src/command/command-empty.svelte
+++ b/packages/ui/src/command/command-empty.svelte
@@ -12,6 +12,6 @@
 <CommandPrimitive.Empty
 	bind:ref
 	data-slot="command-empty"
-	class={cn('py-6 text-center text-sm', className)}
+	class={cn('cn-command-empty', className)}
 	{...restProps}
 />

--- a/packages/ui/src/command/command-group.svelte
+++ b/packages/ui/src/command/command-group.svelte
@@ -17,7 +17,7 @@
 <CommandPrimitive.Group
 	bind:ref
 	data-slot="command-group"
-	class={cn('text-foreground overflow-hidden p-1', className)}
+	class={cn('cn-command-group', className)}
 	value={value ?? heading ?? `----${useId()}`}
 	{...restProps}
 >

--- a/packages/ui/src/command/command-input.svelte
+++ b/packages/ui/src/command/command-input.svelte
@@ -16,7 +16,7 @@
 	class={cn('flex h-9 items-center gap-2 border-b ps-3', children ? 'pe-2' : 'pe-8')}
 	data-slot="command-input-wrapper"
 >
-	<SearchIcon class="size-4 shrink-0 opacity-50" />
+	<SearchIcon class="cn-command-input-icon" />
 	<CommandPrimitive.Input
 		data-slot="command-input"
 		class={cn(

--- a/packages/ui/src/command/command-item.svelte
+++ b/packages/ui/src/command/command-item.svelte
@@ -13,7 +13,7 @@
 	bind:ref
 	data-slot="command-item"
 	class={cn(
-		"aria-selected:bg-accent aria-selected:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"cn-command-item [&_svg:not([class*='text-'])]:text-muted-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/command/command-link-item.svelte
+++ b/packages/ui/src/command/command-link-item.svelte
@@ -13,7 +13,7 @@
 	bind:ref
 	data-slot="command-item"
 	class={cn(
-		"aria-selected:bg-accent aria-selected:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"cn-command-item [&_svg:not([class*='text-'])]:text-muted-foreground data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/command/command-list.svelte
+++ b/packages/ui/src/command/command-list.svelte
@@ -13,7 +13,7 @@
 	bind:ref
 	data-slot="command-list"
 	class={cn(
-		'max-h-[300px] scroll-py-1 overflow-y-auto overflow-x-hidden',
+		'cn-command-list overflow-x-hidden overflow-y-auto',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/command/command-separator.svelte
+++ b/packages/ui/src/command/command-separator.svelte
@@ -12,6 +12,6 @@
 <CommandPrimitive.Separator
 	bind:ref
 	data-slot="command-separator"
-	class={cn('bg-border -mx-1 h-px', className)}
+	class={cn('cn-command-separator', className)}
 	{...restProps}
 />

--- a/packages/ui/src/command/command-shortcut.svelte
+++ b/packages/ui/src/command/command-shortcut.svelte
@@ -13,7 +13,7 @@
 <span
 	bind:this={ref}
 	data-slot="command-shortcut"
-	class={cn('text-muted-foreground ms-auto text-xs tracking-widest', className)}
+	class={cn('cn-command-shortcut', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/command/command.svelte
+++ b/packages/ui/src/command/command.svelte
@@ -21,7 +21,7 @@
 	bind:ref
 	data-slot="command"
 	class={cn(
-		'bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md',
+		'cn-command flex size-full flex-col overflow-hidden',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/context-menu/context-menu-checkbox-item.svelte
+++ b/packages/ui/src/context-menu/context-menu-checkbox-item.svelte
@@ -22,7 +22,7 @@
 	bind:indeterminate
 	data-slot="context-menu-checkbox-item"
 	class={cn(
-		"data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 ps-8 pe-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		"cn-context-menu-checkbox-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/context-menu/context-menu-content.svelte
+++ b/packages/ui/src/context-menu/context-menu-content.svelte
@@ -22,7 +22,7 @@
 		bind:ref
 		data-slot="context-menu-content"
 		class={cn(
-			'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-end-2 data-[side=right]:slide-in-from-start-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--bits-context-menu-content-available-height) min-w-[8rem] origin-(--bits-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+			'cn-context-menu-content cn-menu-translucent z-50 max-h-(--bits-context-menu-content-available-height) origin-(--bits-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto outline-none',
 			className,
 		)}
 		{...restProps}

--- a/packages/ui/src/context-menu/context-menu-item.svelte
+++ b/packages/ui/src/context-menu/context-menu-item.svelte
@@ -20,7 +20,7 @@
 	data-inset={inset}
 	data-variant={variant}
 	class={cn(
-		"data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:data-highlighted:bg-destructive/10 dark:data-[variant=destructive]:data-highlighted:bg-destructive/20 data-[variant=destructive]:data-highlighted:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:ps-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		"cn-context-menu-item group/context-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/context-menu/context-menu-label.svelte
+++ b/packages/ui/src/context-menu/context-menu-label.svelte
@@ -18,7 +18,7 @@
 	data-slot="context-menu-label"
 	data-inset={inset}
 	class={cn(
-		'text-foreground px-2 py-1.5 text-sm font-medium data-[inset]:ps-8',
+		'cn-context-menu-label data-inset:ps-8',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/context-menu/context-menu-radio-item.svelte
+++ b/packages/ui/src/context-menu/context-menu-radio-item.svelte
@@ -15,7 +15,7 @@
 	bind:ref
 	data-slot="context-menu-radio-item"
 	class={cn(
-		"data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 ps-8 pe-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		"cn-context-menu-radio-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/context-menu/context-menu-separator.svelte
+++ b/packages/ui/src/context-menu/context-menu-separator.svelte
@@ -12,6 +12,6 @@
 <ContextMenuPrimitive.Separator
 	bind:ref
 	data-slot="context-menu-separator"
-	class={cn('bg-border -mx-1 my-1 h-px', className)}
+	class={cn('cn-context-menu-separator', className)}
 	{...restProps}
 />

--- a/packages/ui/src/context-menu/context-menu-shortcut.svelte
+++ b/packages/ui/src/context-menu/context-menu-shortcut.svelte
@@ -13,7 +13,7 @@
 <span
 	bind:this={ref}
 	data-slot="context-menu-shortcut"
-	class={cn('text-muted-foreground ms-auto text-xs tracking-widest', className)}
+	class={cn('cn-context-menu-shortcut', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/context-menu/context-menu-sub-content.svelte
+++ b/packages/ui/src/context-menu/context-menu-sub-content.svelte
@@ -13,7 +13,7 @@
 	bind:ref
 	data-slot="context-menu-sub-content"
 	class={cn(
-		'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-end-2 data-[side=right]:slide-in-from-start-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--bits-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+		'cn-context-menu-sub-content cn-menu-translucent z-50 origin-(--bits-context-menu-content-transform-origin) overflow-hidden',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/context-menu/context-menu-sub-trigger.svelte
+++ b/packages/ui/src/context-menu/context-menu-sub-trigger.svelte
@@ -19,7 +19,7 @@
 	data-slot="context-menu-sub-trigger"
 	data-inset={inset}
 	class={cn(
-		"data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:ps-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		"cn-context-menu-sub-trigger flex cursor-default items-center outline-hidden select-none data-inset:ps-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/dialog/dialog-content.svelte
+++ b/packages/ui/src/dialog/dialog-content.svelte
@@ -26,11 +26,6 @@
 		data-slot="dialog-content"
 		class={cn(
 			'cn-dialog-content fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none',
-			// Custom: Enable scrolling for dialogs with tall content. max-h limits height to viewport
-			// minus breathing room, overflow-y-auto enables vertical scroll only when needed.
-			'overflow-y-auto max-h-[calc(100vh-2rem)]',
-			// Custom: Override to z-40 to ensure alert-dialogs (z-50) appear above regular dialogs
-			'z-40',
 			className,
 		)}
 		{...restProps}

--- a/packages/ui/src/dialog/dialog-content.svelte
+++ b/packages/ui/src/dialog/dialog-content.svelte
@@ -25,7 +25,7 @@
 		bind:ref
 		data-slot="dialog-content"
 		class={cn(
-			'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed start-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+			'cn-dialog-content fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none',
 			// Custom: Enable scrolling for dialogs with tall content. max-h limits height to viewport
 			// minus breathing room, overflow-y-auto enables vertical scroll only when needed.
 			'overflow-y-auto max-h-[calc(100vh-2rem)]',
@@ -37,9 +37,7 @@
 	>
 		{@render children?.()}
 		{#if showCloseButton}
-			<DialogPrimitive.Close
-				class="ring-offset-background focus:ring-ring rounded-xs focus:outline-hidden absolute end-4 top-4 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0"
-			>
+			<DialogPrimitive.Close class="cn-dialog-close">
 				<XIcon />
 				<span class="sr-only">Close</span>
 			</DialogPrimitive.Close>

--- a/packages/ui/src/dialog/dialog-description.svelte
+++ b/packages/ui/src/dialog/dialog-description.svelte
@@ -12,6 +12,6 @@
 <DialogPrimitive.Description
 	bind:ref
 	data-slot="dialog-description"
-	class={cn('text-muted-foreground text-sm', className)}
+	class={cn('cn-dialog-description', className)}
 	{...restProps}
 />

--- a/packages/ui/src/dialog/dialog-footer.svelte
+++ b/packages/ui/src/dialog/dialog-footer.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="dialog-footer"
 	class={cn(
-		'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+		'cn-dialog-footer flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/dialog/dialog-header.svelte
+++ b/packages/ui/src/dialog/dialog-header.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="dialog-header"
-	class={cn('flex flex-col gap-2 text-center sm:text-start', className)}
+	class={cn('cn-dialog-header flex flex-col', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/dialog/dialog-overlay.svelte
+++ b/packages/ui/src/dialog/dialog-overlay.svelte
@@ -13,7 +13,7 @@
 	bind:ref
 	data-slot="dialog-overlay"
 	class={cn(
-		'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+		'cn-dialog-overlay fixed inset-0 isolate z-50',
 		// Override to z-40 to ensure that alert-dialogs (which are at z-50) are always on top of dialogs
 		'z-40',
 		className,

--- a/packages/ui/src/dialog/dialog-overlay.svelte
+++ b/packages/ui/src/dialog/dialog-overlay.svelte
@@ -12,11 +12,6 @@
 <DialogPrimitive.Overlay
 	bind:ref
 	data-slot="dialog-overlay"
-	class={cn(
-		'cn-dialog-overlay fixed inset-0 isolate z-50',
-		// Override to z-40 to ensure that alert-dialogs (which are at z-50) are always on top of dialogs
-		'z-40',
-		className,
-	)}
+	class={cn('cn-dialog-overlay fixed inset-0 isolate z-50', className)}
 	{...restProps}
 />

--- a/packages/ui/src/dialog/dialog-title.svelte
+++ b/packages/ui/src/dialog/dialog-title.svelte
@@ -12,6 +12,6 @@
 <DialogPrimitive.Title
 	bind:ref
 	data-slot="dialog-title"
-	class={cn('text-lg font-semibold leading-none', className)}
+	class={cn('cn-dialog-title', className)}
 	{...restProps}
 />

--- a/packages/ui/src/drawer/drawer-content.svelte
+++ b/packages/ui/src/drawer/drawer-content.svelte
@@ -23,12 +23,7 @@
 		bind:ref
 		onOpenAutoFocus={(e) => e.preventDefault()}
 		data-slot="drawer-content"
-		class={cn(
-			'cn-drawer-content group/drawer-content fixed z-50',
-			// Override to z-40 to ensure that alert-dialogs (which are at z-50) are always on top of drawers
-			'z-40',
-			className,
-		)}
+		class={cn('cn-drawer-content group/drawer-content fixed z-50', className)}
 		{...restProps}
 	>
 		<div

--- a/packages/ui/src/drawer/drawer-content.svelte
+++ b/packages/ui/src/drawer/drawer-content.svelte
@@ -24,11 +24,7 @@
 		onOpenAutoFocus={(e) => e.preventDefault()}
 		data-slot="drawer-content"
 		class={cn(
-			'group/drawer-content bg-background fixed z-50 flex h-auto flex-col',
-			'data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b',
-			'data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t',
-			'data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:end-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-s data-[vaul-drawer-direction=right]:sm:max-w-sm',
-			'data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:start-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-e data-[vaul-drawer-direction=left]:sm:max-w-sm',
+			'cn-drawer-content group/drawer-content fixed z-50',
 			// Override to z-40 to ensure that alert-dialogs (which are at z-50) are always on top of drawers
 			'z-40',
 			className,
@@ -36,7 +32,7 @@
 		{...restProps}
 	>
 		<div
-			class="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block"
+			class="cn-drawer-handle bg-muted mx-auto hidden shrink-0 group-data-[vaul-drawer-direction=bottom]/drawer-content:block"
 		></div>
 		<!-- Custom: Scrollable content area. flex-1 takes remaining space after drag handle,
 		     overflow-y-auto enables vertical scrolling when content exceeds drawer height. -->

--- a/packages/ui/src/drawer/drawer-description.svelte
+++ b/packages/ui/src/drawer/drawer-description.svelte
@@ -12,6 +12,6 @@
 <DrawerPrimitive.Description
 	bind:ref
 	data-slot="drawer-description"
-	class={cn('text-muted-foreground text-sm', className)}
+	class={cn('cn-drawer-description', className)}
 	{...restProps}
 />

--- a/packages/ui/src/drawer/drawer-footer.svelte
+++ b/packages/ui/src/drawer/drawer-footer.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="drawer-footer"
-	class={cn('mt-auto flex flex-col gap-2 p-4', className)}
+	class={cn('cn-drawer-footer mt-auto flex flex-col', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/drawer/drawer-header.svelte
+++ b/packages/ui/src/drawer/drawer-header.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="drawer-header"
-	class={cn('flex flex-col gap-1.5 p-4', className)}
+	class={cn('cn-drawer-header flex flex-col', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/drawer/drawer-overlay.svelte
+++ b/packages/ui/src/drawer/drawer-overlay.svelte
@@ -13,7 +13,7 @@
 	bind:ref
 	data-slot="drawer-overlay"
 	class={cn(
-		'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+		'cn-drawer-overlay fixed inset-0 z-50',
 		// Override to z-40 to ensure that alert-dialogs (which are at z-50) are always on top of drawers
 		'z-40',
 		className,

--- a/packages/ui/src/drawer/drawer-overlay.svelte
+++ b/packages/ui/src/drawer/drawer-overlay.svelte
@@ -12,11 +12,6 @@
 <DrawerPrimitive.Overlay
 	bind:ref
 	data-slot="drawer-overlay"
-	class={cn(
-		'cn-drawer-overlay fixed inset-0 z-50',
-		// Override to z-40 to ensure that alert-dialogs (which are at z-50) are always on top of drawers
-		'z-40',
-		className,
-	)}
+	class={cn('cn-drawer-overlay fixed inset-0 z-50', className)}
 	{...restProps}
 />

--- a/packages/ui/src/drawer/drawer-title.svelte
+++ b/packages/ui/src/drawer/drawer-title.svelte
@@ -12,6 +12,6 @@
 <DrawerPrimitive.Title
 	bind:ref
 	data-slot="drawer-title"
-	class={cn('cn-font-heading cn-drawer-title', className)}
+	class={cn('cn-drawer-title', className)}
 	{...restProps}
 />

--- a/packages/ui/src/drawer/drawer-title.svelte
+++ b/packages/ui/src/drawer/drawer-title.svelte
@@ -12,6 +12,6 @@
 <DrawerPrimitive.Title
 	bind:ref
 	data-slot="drawer-title"
-	class={cn('text-foreground font-semibold', className)}
+	class={cn('cn-font-heading cn-drawer-title', className)}
 	{...restProps}
 />

--- a/packages/ui/src/dropdown-menu/dropdown-menu-checkbox-item.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-checkbox-item.svelte
@@ -23,15 +23,13 @@
 	bind:indeterminate
 	data-slot="dropdown-menu-checkbox-item"
 	class={cn(
-		"focus:bg-accent focus:text-accent-foreground outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pe-2 ps-8 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		'cn-dropdown-menu-checkbox-item relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0',
 		className,
 	)}
 	{...restProps}
 >
 	{#snippet children({ checked, indeterminate })}
-		<span
-			class="pointer-events-none absolute start-2 flex size-3.5 items-center justify-center"
-		>
+		<span class="cn-dropdown-menu-item-indicator pointer-events-none">
 			{#if indeterminate}
 				<MinusIcon class="size-4" />
 			{:else}

--- a/packages/ui/src/dropdown-menu/dropdown-menu-content.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-content.svelte
@@ -19,7 +19,7 @@
 		data-slot="dropdown-menu-content"
 		{sideOffset}
 		class={cn(
-			'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-end-2 data-[side=right]:slide-in-from-start-2 data-[side=top]:slide-in-from-bottom-2 max-h-(--bits-dropdown-menu-content-available-height) origin-(--bits-dropdown-menu-content-transform-origin) z-50 min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border p-1 shadow-md outline-none',
+			'cn-dropdown-menu-content cn-dropdown-menu-content-logical cn-menu-target cn-menu-translucent z-50 w-(--bits-dropdown-menu-anchor-width) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden',
 			className,
 		)}
 		{...restProps}

--- a/packages/ui/src/dropdown-menu/dropdown-menu-content.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-content.svelte
@@ -19,7 +19,7 @@
 		data-slot="dropdown-menu-content"
 		{sideOffset}
 		class={cn(
-			'cn-dropdown-menu-content cn-dropdown-menu-content-logical cn-menu-target cn-menu-translucent z-50 w-(--bits-dropdown-menu-anchor-width) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden',
+			'cn-dropdown-menu-content cn-dropdown-menu-content-logical cn-menu-translucent z-50 w-(--bits-dropdown-menu-anchor-width) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden',
 			className,
 		)}
 		{...restProps}

--- a/packages/ui/src/dropdown-menu/dropdown-menu-item.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-item.svelte
@@ -20,7 +20,7 @@
 	data-inset={inset}
 	data-variant={variant}
 	class={cn(
-		"data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:data-highlighted:bg-destructive/10 dark:data-[variant=destructive]:data-highlighted:bg-destructive/20 data-[variant=destructive]:data-highlighted:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm data-[disabled]:pointer-events-none data-[inset]:ps-8 data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"cn-dropdown-menu-item group/dropdown-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/dropdown-menu/dropdown-menu-label.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-label.svelte
@@ -17,7 +17,7 @@
 	bind:this={ref}
 	data-slot="dropdown-menu-label"
 	data-inset={inset}
-	class={cn('px-2 py-1.5 text-sm font-semibold data-[inset]:ps-8', className)}
+	class={cn('cn-dropdown-menu-label data-[inset]:pl-8', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/dropdown-menu/dropdown-menu-radio-item.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-radio-item.svelte
@@ -15,15 +15,13 @@
 	bind:ref
 	data-slot="dropdown-menu-radio-item"
 	class={cn(
-		"focus:bg-accent focus:text-accent-foreground outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pe-2 ps-8 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		'cn-dropdown-menu-radio-item relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0',
 		className,
 	)}
 	{...restProps}
 >
 	{#snippet children({ checked })}
-		<span
-			class="pointer-events-none absolute start-2 flex size-3.5 items-center justify-center"
-		>
+		<span class="cn-dropdown-menu-item-indicator pointer-events-none">
 			{#if checked}
 				<CircleIcon class="size-2 fill-current" />
 			{/if}

--- a/packages/ui/src/dropdown-menu/dropdown-menu-separator.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-separator.svelte
@@ -12,6 +12,6 @@
 <DropdownMenuPrimitive.Separator
 	bind:ref
 	data-slot="dropdown-menu-separator"
-	class={cn('bg-border -mx-1 my-1 h-px', className)}
+	class={cn('cn-dropdown-menu-separator', className)}
 	{...restProps}
 />

--- a/packages/ui/src/dropdown-menu/dropdown-menu-shortcut.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-shortcut.svelte
@@ -13,7 +13,7 @@
 <span
 	bind:this={ref}
 	data-slot="dropdown-menu-shortcut"
-	class={cn('text-muted-foreground ms-auto text-xs tracking-widest', className)}
+	class={cn('cn-dropdown-menu-shortcut', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/dropdown-menu/dropdown-menu-sub-content.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-sub-content.svelte
@@ -13,7 +13,7 @@
 	bind:ref
 	data-slot="dropdown-menu-sub-content"
 	class={cn(
-		'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-end-2 data-[side=right]:slide-in-from-start-2 data-[side=top]:slide-in-from-bottom-2 origin-(--bits-dropdown-menu-content-transform-origin) z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-lg',
+		'cn-dropdown-menu-sub-content cn-menu-target cn-menu-translucent w-auto',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/dropdown-menu/dropdown-menu-sub-content.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-sub-content.svelte
@@ -13,7 +13,7 @@
 	bind:ref
 	data-slot="dropdown-menu-sub-content"
 	class={cn(
-		'cn-dropdown-menu-sub-content cn-menu-target cn-menu-translucent w-auto',
+		'cn-dropdown-menu-sub-content cn-menu-translucent w-auto',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/dropdown-menu/dropdown-menu-sub-trigger.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-sub-trigger.svelte
@@ -19,7 +19,7 @@
 	data-slot="dropdown-menu-sub-trigger"
 	data-inset={inset}
 	class={cn(
-		"data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground outline-hidden [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm data-[disabled]:pointer-events-none data-[inset]:ps-8 data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		'cn-dropdown-menu-sub-trigger flex cursor-default items-center outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/empty/empty-content.svelte
+++ b/packages/ui/src/empty/empty-content.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="empty-content"
 	class={cn(
-		'flex w-full min-w-0 max-w-sm flex-col items-center gap-4 text-balance text-sm',
+		'cn-empty-content flex w-full max-w-sm min-w-0 flex-col items-center text-balance',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/empty/empty-description.svelte
+++ b/packages/ui/src/empty/empty-description.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="empty-description"
 	class={cn(
-		'text-muted-foreground [&>a:hover]:text-primary text-sm/relaxed [&>a]:underline [&>a]:underline-offset-4',
+		'cn-empty-description text-muted-foreground [&>a:hover]:text-primary text-sm/relaxed [&>a]:underline [&>a]:underline-offset-4',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/empty/empty-header.svelte
+++ b/packages/ui/src/empty/empty-header.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="empty-header"
-	class={cn('flex max-w-sm flex-col items-center gap-2 text-center', className)}
+	class={cn('cn-empty-header flex max-w-sm flex-col items-center', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/empty/empty-media.svelte
+++ b/packages/ui/src/empty/empty-media.svelte
@@ -2,11 +2,11 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 
 	export const emptyMediaVariants = tv({
-		base: 'mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0',
+		base: 'cn-empty-media flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0',
 		variants: {
 			variant: {
-				default: 'bg-transparent',
-				icon: "bg-muted text-foreground flex size-10 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-6",
+				default: 'cn-empty-media-default',
+				icon: 'cn-empty-media-icon',
 			},
 		},
 		defaultVariants: {

--- a/packages/ui/src/empty/empty-title.svelte
+++ b/packages/ui/src/empty/empty-title.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="empty-title"
-	class={cn('text-lg font-medium tracking-tight', className)}
+	class={cn('cn-font-heading cn-empty-title', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/empty/empty-title.svelte
+++ b/packages/ui/src/empty/empty-title.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="empty-title"
-	class={cn('cn-font-heading cn-empty-title', className)}
+	class={cn('cn-empty-title', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/empty/empty.svelte
+++ b/packages/ui/src/empty/empty.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="empty"
 	class={cn(
-		'flex min-w-0 flex-1 flex-col items-center justify-center gap-6 text-balance rounded-lg border-dashed p-6 text-center md:p-12',
+		'cn-empty flex w-full min-w-0 flex-1 flex-col items-center justify-center text-center text-balance',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/field/field-content.svelte
+++ b/packages/ui/src/field/field-content.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="field-content"
 	class={cn(
-		'group/field-content flex flex-1 flex-col gap-1.5 leading-snug',
+		'cn-field-content group/field-content flex flex-1 flex-col leading-snug',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/field/field-description.svelte
+++ b/packages/ui/src/field/field-description.svelte
@@ -14,8 +14,8 @@
 	bind:this={ref}
 	data-slot="field-description"
 	class={cn(
-		'text-muted-foreground text-sm font-normal leading-normal group-has-[[data-orientation=horizontal]]/field:text-balance',
-		'nth-last-2:-mt-1 last:mt-0 [[data-variant=legend]+&]:-mt-1.5',
+		'cn-field-description font-normal leading-normal group-has-[[data-orientation=horizontal]]/field:text-balance',
+		'nth-last-2:-mt-1 last:mt-0',
 		'[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4',
 		className,
 	)}

--- a/packages/ui/src/field/field-error.svelte
+++ b/packages/ui/src/field/field-error.svelte
@@ -40,7 +40,7 @@
 		bind:this={ref}
 		role="alert"
 		data-slot="field-error"
-		class={cn('text-destructive text-sm font-normal', className)}
+		class={cn('cn-field-error font-normal', className)}
 		{...restProps}
 	>
 		{#if children}

--- a/packages/ui/src/field/field-group.svelte
+++ b/packages/ui/src/field/field-group.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="field-group"
 	class={cn(
-		'group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&>[data-slot=field-group]]:gap-4',
+		'cn-field-group group/field-group @container/field-group flex w-full flex-col',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/field/field-label.svelte
+++ b/packages/ui/src/field/field-label.svelte
@@ -15,9 +15,8 @@
 	bind:ref
 	data-slot="field-label"
 	class={cn(
-		'group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50',
-		'has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-4',
-		'has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10',
+		'cn-field-label group/field-label peer/field-label flex w-fit leading-snug',
+		'has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/field/field-legend.svelte
+++ b/packages/ui/src/field/field-legend.svelte
@@ -18,9 +18,7 @@
 	data-slot="field-legend"
 	data-variant={variant}
 	class={cn(
-		'mb-3 font-medium',
-		'data-[variant=legend]:text-base',
-		'data-[variant=label]:text-sm',
+		'cn-field-legend',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/field/field-separator.svelte
+++ b/packages/ui/src/field/field-separator.svelte
@@ -21,7 +21,7 @@
 	data-slot="field-separator"
 	data-content={hasContent}
 	class={cn(
-		'relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2',
+		'cn-field-separator relative',
 		className,
 	)}
 	{...restProps}
@@ -29,7 +29,7 @@
 	<Separator class="absolute inset-0 top-1/2" />
 	{#if children}
 		<span
-			class="bg-background text-muted-foreground relative mx-auto block w-fit px-2"
+			class="cn-field-separator-content bg-background relative mx-auto block w-fit"
 			data-slot="field-separator-content"
 		>
 			{@render children()}

--- a/packages/ui/src/field/field-set.svelte
+++ b/packages/ui/src/field/field-set.svelte
@@ -14,8 +14,7 @@
 	bind:this={ref}
 	data-slot="field-set"
 	class={cn(
-		'flex flex-col gap-6',
-		'has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3',
+		'cn-field-set flex flex-col',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/field/field-title.svelte
+++ b/packages/ui/src/field/field-title.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="field-title"
 	class={cn(
-		'flex w-fit items-center gap-2 text-sm font-medium leading-snug group-data-[disabled=true]/field:opacity-50',
+		'cn-field-title flex w-fit items-center leading-snug',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/field/field.svelte
+++ b/packages/ui/src/field/field.svelte
@@ -2,7 +2,7 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 
 	export const fieldVariants = tv({
-		base: 'group/field data-[invalid=true]:text-destructive flex w-full gap-3',
+		base: 'cn-field group/field flex w-full',
 		variants: {
 			orientation: {
 				vertical: 'flex-col [&>*]:w-full [&>.sr-only]:w-auto',

--- a/packages/ui/src/input-group/input-group-addon.svelte
+++ b/packages/ui/src/input-group/input-group-addon.svelte
@@ -1,17 +1,16 @@
 <script lang="ts" module>
 	import { tv, type VariantProps } from 'tailwind-variants';
 	export const inputGroupAddonVariants = tv({
-		base: "text-muted-foreground flex h-auto cursor-text select-none items-center justify-center gap-2 py-1.5 text-sm font-medium group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+		base: 'cn-input-group-addon flex cursor-text items-center justify-center select-none',
 		variants: {
 			align: {
 				'inline-start':
-					'order-first ps-3 has-[>button]:ms-[-0.45rem] has-[>kbd]:ms-[-0.35rem]',
-				'inline-end':
-					'order-last pe-3 has-[>button]:me-[-0.45rem] has-[>kbd]:me-[-0.35rem]',
+					'cn-input-group-addon-align-inline-start order-first',
+				'inline-end': 'cn-input-group-addon-align-inline-end order-last',
 				'block-start':
-					'[.border-b]:pb-3 order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-2.5',
+					'cn-input-group-addon-align-block-start order-first w-full justify-start',
 				'block-end':
-					'[.border-t]:pt-3 order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-2.5',
+					'cn-input-group-addon-align-block-end order-last w-full justify-start',
 			},
 		},
 		defaultVariants: {

--- a/packages/ui/src/input-group/input-group-button.svelte
+++ b/packages/ui/src/input-group/input-group-button.svelte
@@ -2,14 +2,13 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 
 	const inputGroupButtonVariants = tv({
-		base: 'flex items-center gap-2 text-sm shadow-none',
+		base: 'cn-input-group-button flex items-center shadow-none',
 		variants: {
 			size: {
-				xs: "h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-2 has-[>svg]:px-2 [&>svg:not([class*='size-'])]:size-3.5",
-				sm: 'h-8 gap-1.5 rounded-md px-2.5 has-[>svg]:px-2.5',
-				'icon-xs':
-					'size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0',
-				'icon-sm': 'size-8 p-0 has-[>svg]:p-0',
+				xs: 'cn-input-group-button-size-xs',
+				sm: 'cn-input-group-button-size-sm',
+				'icon-xs': 'cn-input-group-button-size-icon-xs',
+				'icon-sm': 'cn-input-group-button-size-icon-sm',
 			},
 		},
 		defaultVariants: {

--- a/packages/ui/src/input-group/input-group-button.svelte
+++ b/packages/ui/src/input-group/input-group-button.svelte
@@ -6,7 +6,6 @@
 		variants: {
 			size: {
 				xs: 'cn-input-group-button-size-xs',
-				sm: 'cn-input-group-button-size-sm',
 				'icon-xs': 'cn-input-group-button-size-icon-xs',
 				'icon-sm': 'cn-input-group-button-size-icon-sm',
 			},

--- a/packages/ui/src/input-group/input-group-input.svelte
+++ b/packages/ui/src/input-group/input-group-input.svelte
@@ -14,10 +14,7 @@
 <Input
 	bind:ref
 	data-slot="input-group-control"
-	class={cn(
-		'flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent',
-		className,
-	)}
+	class={cn('cn-input-group-input flex-1', className)}
 	bind:value
 	{...props}
 />

--- a/packages/ui/src/input-group/input-group-text.svelte
+++ b/packages/ui/src/input-group/input-group-text.svelte
@@ -13,7 +13,7 @@
 <span
 	bind:this={ref}
 	class={cn(
-		"text-muted-foreground flex items-center gap-2 text-sm [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none",
+		'cn-input-group-text flex items-center [&_svg]:pointer-events-none',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/input-group/input-group-textarea.svelte
+++ b/packages/ui/src/input-group/input-group-textarea.svelte
@@ -14,10 +14,7 @@
 <Textarea
 	bind:ref
 	data-slot="input-group-control"
-	class={cn(
-		'flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus-visible:ring-0 dark:bg-transparent',
-		className,
-	)}
+	class={cn('cn-input-group-textarea flex-1 resize-none', className)}
 	bind:value
 	{...props}
 />

--- a/packages/ui/src/input-group/input-group.svelte
+++ b/packages/ui/src/input-group/input-group.svelte
@@ -15,21 +15,7 @@
 	data-slot="input-group"
 	role="group"
 	class={cn(
-		'group/input-group border-input dark:bg-input/30 shadow-xs relative flex w-full items-center rounded-md border outline-none transition-[color,box-shadow]',
-		'h-9 has-[>textarea]:h-auto',
-
-		// Variants based on alignment.
-		'has-[>[data-align=inline-start]]:[&>input]:ps-2',
-		'has-[>[data-align=inline-end]]:[&>input]:pe-2',
-		'has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3',
-		'has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3',
-
-		// Focus state.
-		'has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot=input-group-control]:focus-visible]:ring-[3px]',
-
-		// Error state.
-		'has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40',
-
+		'group/input-group cn-input-group relative flex w-full min-w-0 items-center outline-none has-[>textarea]:h-auto',
 		className,
 	)}
 	{...props}

--- a/packages/ui/src/input/input.svelte
+++ b/packages/ui/src/input/input.svelte
@@ -31,9 +31,7 @@
 		bind:this={ref}
 		data-slot={dataSlot}
 		class={cn(
-			'selection:bg-primary dark:bg-input/30 selection:text-primary-foreground border-input ring-offset-background placeholder:text-muted-foreground shadow-xs flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 pt-1.5 text-sm font-medium outline-none transition-[color,box-shadow] disabled:cursor-not-allowed disabled:opacity-50',
-			'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
-			'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+			'cn-input file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
 			className,
 		)}
 		type="file"
@@ -46,9 +44,7 @@
 		bind:this={ref}
 		data-slot={dataSlot}
 		class={cn(
-			'border-input bg-background selection:bg-primary dark:bg-input/30 selection:text-primary-foreground ring-offset-background placeholder:text-muted-foreground shadow-xs flex h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base outline-none transition-[color,box-shadow] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
-			'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
-			'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+			'cn-input file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
 			className,
 		)}
 		{type}

--- a/packages/ui/src/item/item-actions.svelte
+++ b/packages/ui/src/item/item-actions.svelte
@@ -18,7 +18,7 @@
 	bind:this={ref}
 	data-slot="item-actions"
 	class={cn(
-		'flex items-center gap-2',
+		'cn-item-actions flex items-center',
 		showOnHover && [
 			// Overlay the right side of the item instead of taking flex space, so the
 			// title gets full width when actions are hidden. Solid bg-accent masks the

--- a/packages/ui/src/item/item-content.svelte
+++ b/packages/ui/src/item/item-content.svelte
@@ -15,8 +15,6 @@
 	data-slot="item-content"
 	class={cn(
 		'cn-item-content flex flex-1 flex-col [&+[data-slot=item-content]]:flex-none',
-		// Custom override: enables text truncation inside flex containers
-		'min-w-0',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/item/item-content.svelte
+++ b/packages/ui/src/item/item-content.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="item-content"
 	class={cn(
-		'flex flex-1 flex-col gap-1 [&+[data-slot=item-content]]:flex-none',
+		'cn-item-content flex flex-1 flex-col [&+[data-slot=item-content]]:flex-none',
 		// Custom override: enables text truncation inside flex containers
 		'min-w-0',
 		className,

--- a/packages/ui/src/item/item-description.svelte
+++ b/packages/ui/src/item/item-description.svelte
@@ -15,8 +15,6 @@
 	data-slot="item-description"
 	class={cn(
 		'cn-item-description line-clamp-2 font-normal [&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4',
-		// Custom override: balanced wrapping is Epicenter-specific (not upstream).
-		'text-balance',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/item/item-description.svelte
+++ b/packages/ui/src/item/item-description.svelte
@@ -14,8 +14,9 @@
 	bind:this={ref}
 	data-slot="item-description"
 	class={cn(
-		'text-muted-foreground line-clamp-2 text-sm leading-normal font-normal text-balance',
-		'[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4',
+		'cn-item-description line-clamp-2 font-normal [&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4',
+		// Custom override: balanced wrapping is Epicenter-specific (not upstream).
+		'text-balance',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/item/item-footer.svelte
+++ b/packages/ui/src/item/item-footer.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="item-footer"
-	class={cn('flex basis-full items-center justify-between gap-2', className)}
+	class={cn('cn-item-footer flex basis-full items-center justify-between', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/item/item-group.svelte
+++ b/packages/ui/src/item/item-group.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	role="list"
 	data-slot="item-group"
-	class={cn('group/item-group flex flex-col', className)}
+	class={cn('cn-item-group group/item-group flex flex-col', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/item/item-header.svelte
+++ b/packages/ui/src/item/item-header.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="item-header"
-	class={cn('flex basis-full items-center justify-between gap-2', className)}
+	class={cn('cn-item-header flex basis-full items-center justify-between', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/item/item-media.svelte
+++ b/packages/ui/src/item/item-media.svelte
@@ -8,10 +8,7 @@
 		variants: {
 			variant: {
 				default: 'cn-item-media-variant-default',
-				// Carried overrides: the vendored cn-item-media-variant-icon only
-				// provides the svg-size rule, so the icon container styling
-				// (background, size, border) rides along to preserve the look.
-				icon: 'cn-item-media-variant-icon bg-muted size-8 rounded-sm border',
+				icon: 'cn-item-media-variant-icon',
 				image: 'cn-item-media-variant-image',
 			},
 		},

--- a/packages/ui/src/item/item-media.svelte
+++ b/packages/ui/src/item/item-media.svelte
@@ -2,13 +2,17 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 
 	export const itemMediaVariants = tv({
-		base: 'flex shrink-0 items-center justify-center gap-2 group-has-[[data-slot=item-description]]/item:translate-y-0.5 group-has-[[data-slot=item-description]]/item:self-start [&_svg]:pointer-events-none',
+		// Styling lives in the vendored Vega preset (cn-* classes); see
+		// packages/ui/src/styles/style-vega.css.
+		base: 'cn-item-media flex shrink-0 items-center justify-center [&_svg]:pointer-events-none',
 		variants: {
 			variant: {
-				default: 'bg-transparent',
-				icon: "bg-muted size-8 rounded-sm border [&_svg:not([class*='size-'])]:size-4",
-				image:
-					'size-10 overflow-hidden rounded-sm [&_img]:size-full [&_img]:object-cover',
+				default: 'cn-item-media-variant-default',
+				// Carried overrides: the vendored cn-item-media-variant-icon only
+				// provides the svg-size rule, so the icon container styling
+				// (background, size, border) rides along to preserve the look.
+				icon: 'cn-item-media-variant-icon bg-muted size-8 rounded-sm border',
+				image: 'cn-item-media-variant-image',
 			},
 		},
 		defaultVariants: {

--- a/packages/ui/src/item/item-separator.svelte
+++ b/packages/ui/src/item/item-separator.svelte
@@ -14,6 +14,6 @@
 	bind:ref
 	data-slot="item-separator"
 	orientation="horizontal"
-	class={cn('my-0', className)}
+	class={cn('cn-item-separator', 'my-0', className)}
 	{...restProps}
 />

--- a/packages/ui/src/item/item-separator.svelte
+++ b/packages/ui/src/item/item-separator.svelte
@@ -14,6 +14,6 @@
 	bind:ref
 	data-slot="item-separator"
 	orientation="horizontal"
-	class={cn('cn-item-separator', 'my-0', className)}
+	class={cn('cn-item-separator', className)}
 	{...restProps}
 />

--- a/packages/ui/src/item/item-title.svelte
+++ b/packages/ui/src/item/item-title.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="item-title"
 	class={cn(
-		'flex items-center gap-2 text-sm leading-snug font-medium',
+		'cn-item-title flex items-center',
 		// Custom override: upstream uses `w-fit` here. We use `min-w-0` instead
 		// to enable text truncation inside flex containers.
 		'min-w-0',

--- a/packages/ui/src/item/item-title.svelte
+++ b/packages/ui/src/item/item-title.svelte
@@ -13,13 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="item-title"
-	class={cn(
-		'cn-item-title flex items-center',
-		// Custom override: upstream uses `w-fit` here. We use `min-w-0` instead
-		// to enable text truncation inside flex containers.
-		'min-w-0',
-		className,
-	)}
+	class={cn('cn-item-title flex items-center', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/item/item.svelte
+++ b/packages/ui/src/item/item.svelte
@@ -2,17 +2,21 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 
 	export const itemVariants = tv({
-		// Custom override: `relative` needed for absolute-positioned showOnHover Actions
-		base: 'group/item relative [a]:hover:bg-accent/50 focus-visible:border-ring focus-visible:ring-ring/50 flex flex-wrap items-center rounded-md border border-transparent text-sm transition-colors duration-100 outline-none focus-visible:ring-[3px] [a]:transition-colors',
+		// Styling lives in the vendored Vega preset (cn-* classes); see
+		// packages/ui/src/styles/style-vega.css.
+		// Custom overrides preserved inline: `relative` is needed for the
+		// absolute-positioned showOnHover Actions, and `[a]:hover:bg-accent/50`
+		// keeps the Epicenter accent hover color (cn-item uses bg-muted).
+		base: 'cn-item group/item relative [a]:hover:bg-accent/50 focus-visible:border-ring focus-visible:ring-ring/50 flex flex-wrap items-center transition-colors duration-100 outline-none focus-visible:ring-[3px] [a]:transition-colors',
 		variants: {
 			variant: {
-				default: 'bg-transparent',
-				outline: 'border-border',
-				muted: 'bg-muted/50',
+				default: 'cn-item-variant-default',
+				outline: 'cn-item-variant-outline',
+				muted: 'cn-item-variant-muted',
 			},
 			size: {
-				default: 'gap-4 p-4',
-				sm: 'gap-2.5 px-4 py-3',
+				default: 'cn-item-size-default',
+				sm: 'cn-item-size-sm',
 			},
 		},
 		defaultVariants: {

--- a/packages/ui/src/kbd/kbd-group.svelte
+++ b/packages/ui/src/kbd/kbd-group.svelte
@@ -13,7 +13,7 @@
 <kbd
 	bind:this={ref}
 	data-slot="kbd-group"
-	class={cn('inline-flex items-center gap-1', className)}
+	class={cn('cn-kbd-group inline-flex items-center', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/kbd/kbd.svelte
+++ b/packages/ui/src/kbd/kbd.svelte
@@ -14,9 +14,7 @@
 	bind:this={ref}
 	data-slot="kbd"
 	class={cn(
-		'bg-muted text-muted-foreground pointer-events-none inline-flex h-5 w-fit min-w-5 select-none items-center justify-center gap-1 rounded-sm px-1 font-sans text-xs font-medium',
-		"[&_svg:not([class*='size-'])]:size-3",
-		'[[data-slot=tooltip-content]_&]:bg-background/20 [[data-slot=tooltip-content]_&]:text-background dark:[[data-slot=tooltip-content]_&]:bg-background/10',
+		'cn-kbd pointer-events-none inline-flex items-center justify-center select-none',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/label/label.svelte
+++ b/packages/ui/src/label/label.svelte
@@ -13,7 +13,7 @@
 	bind:ref
 	data-slot="label"
 	class={cn(
-		'flex select-none items-center gap-2 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50',
+		'cn-label flex items-center select-none group-data-[disabled=true]:pointer-events-none peer-disabled:cursor-not-allowed',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/popover/popover-content.svelte
+++ b/packages/ui/src/popover/popover-content.svelte
@@ -21,7 +21,7 @@
 		{sideOffset}
 		{align}
 		class={cn(
-			'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-end-2 data-[side=right]:slide-in-from-start-2 data-[side=top]:slide-in-from-bottom-2 origin-(--bits-popover-content-transform-origin) outline-hidden z-50 w-72 rounded-md border p-4 shadow-md',
+			'cn-popover-content cn-popover-content-logical z-50 w-72 origin-(--bits-popover-content-transform-origin) outline-hidden',
 			className,
 		)}
 		{...restProps}

--- a/packages/ui/src/progress/progress.svelte
+++ b/packages/ui/src/progress/progress.svelte
@@ -15,7 +15,7 @@
 	bind:ref
 	data-slot="progress"
 	class={cn(
-		'bg-primary/20 relative h-2 w-full overflow-hidden rounded-full',
+		'cn-progress relative flex w-full items-center overflow-x-hidden',
 		className,
 	)}
 	{value}
@@ -24,7 +24,7 @@
 >
 	<div
 		data-slot="progress-indicator"
-		class="bg-primary h-full w-full flex-1 transition-all"
+		class="cn-progress-indicator size-full flex-1 transition-all"
 		style="transform: translateX(-{100 - (100 * (value ?? 0)) / (max ?? 1)}%)"
 	></div>
 </ProgressPrimitive.Root>

--- a/packages/ui/src/radio-group/radio-group-item.svelte
+++ b/packages/ui/src/radio-group/radio-group-item.svelte
@@ -14,7 +14,7 @@
 	bind:ref
 	data-slot="radio-group-item"
 	class={cn(
-		'border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 shadow-xs aspect-square size-4 shrink-0 rounded-full border outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+		'cn-radio-group-item group/radio-group-item peer relative aspect-square shrink-0 border outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50',
 		className,
 	)}
 	{...restProps}
@@ -22,12 +22,10 @@
 	{#snippet children({ checked })}
 		<div
 			data-slot="radio-group-indicator"
-			class="relative flex items-center justify-center"
+			class="cn-radio-group-indicator"
 		>
 			{#if checked}
-				<CircleIcon
-					class="fill-primary absolute start-1/2 top-1/2 size-2 -translate-x-1/2 -translate-y-1/2"
-				/>
+				<CircleIcon class="cn-radio-group-indicator-icon" />
 			{/if}
 		</div>
 	{/snippet}

--- a/packages/ui/src/radio-group/radio-group.svelte
+++ b/packages/ui/src/radio-group/radio-group.svelte
@@ -14,6 +14,6 @@
 	bind:ref
 	bind:value
 	data-slot="radio-group"
-	class={cn('grid gap-3', className)}
+	class={cn('cn-radio-group w-full', className)}
 	{...restProps}
 />

--- a/packages/ui/src/resizable/resizable-handle.svelte
+++ b/packages/ui/src/resizable/resizable-handle.svelte
@@ -17,7 +17,7 @@
 	bind:ref
 	data-slot="resizable-handle"
 	class={cn(
-		'cn-resizable-handle bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[direction=vertical]:h-px data-[direction=vertical]:w-full data-[direction=vertical]:after:left-0 data-[direction=vertical]:after:h-1 data-[direction=vertical]:after:w-full data-[direction=vertical]:after:translate-x-0 data-[direction=vertical]:after:-translate-y-1/2 [&[data-direction=vertical]>div]:rotate-90',
+		'bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[direction=vertical]:h-px data-[direction=vertical]:w-full data-[direction=vertical]:after:left-0 data-[direction=vertical]:after:h-1 data-[direction=vertical]:after:w-full data-[direction=vertical]:after:translate-x-0 data-[direction=vertical]:after:-translate-y-1/2 [&[data-direction=vertical]>div]:rotate-90',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/resizable/resizable-handle.svelte
+++ b/packages/ui/src/resizable/resizable-handle.svelte
@@ -17,15 +17,13 @@
 	bind:ref
 	data-slot="resizable-handle"
 	class={cn(
-		'bg-border focus-visible:ring-ring focus-visible:outline-hidden relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:start-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 data-[direction=vertical]:h-px data-[direction=vertical]:w-full data-[direction=vertical]:after:start-0 data-[direction=vertical]:after:h-1 data-[direction=vertical]:after:w-full data-[direction=vertical]:after:-translate-y-1/2 data-[direction=vertical]:after:translate-x-0 [&[data-direction=vertical]>div]:rotate-90',
+		'cn-resizable-handle bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[direction=vertical]:h-px data-[direction=vertical]:w-full data-[direction=vertical]:after:left-0 data-[direction=vertical]:after:h-1 data-[direction=vertical]:after:w-full data-[direction=vertical]:after:translate-x-0 data-[direction=vertical]:after:-translate-y-1/2 [&[data-direction=vertical]>div]:rotate-90',
 		className,
 	)}
 	{...restProps}
 >
 	{#if withHandle}
-		<div
-			class="bg-border rounded-xs z-10 flex h-4 w-3 items-center justify-center border"
-		>
+		<div class="cn-resizable-handle-icon z-10 flex shrink-0">
 			<GripVerticalIcon class="size-2.5" />
 		</div>
 	{/if}

--- a/packages/ui/src/resizable/resizable-pane-group.svelte
+++ b/packages/ui/src/resizable/resizable-pane-group.svelte
@@ -16,7 +16,7 @@
 	bind:this={paneGroup}
 	data-slot="resizable-pane-group"
 	class={cn(
-		'flex h-full w-full data-[direction=vertical]:flex-col',
+		'cn-resizable-panel-group flex h-full w-full data-[direction=vertical]:flex-col',
 		// Custom: Add spacing between resizable panes for visual separation
 		'gap-2',
 		className,

--- a/packages/ui/src/resizable/resizable-pane-group.svelte
+++ b/packages/ui/src/resizable/resizable-pane-group.svelte
@@ -17,8 +17,6 @@
 	data-slot="resizable-pane-group"
 	class={cn(
 		'cn-resizable-panel-group flex h-full w-full data-[direction=vertical]:flex-col',
-		// Custom: Add spacing between resizable panes for visual separation
-		'gap-2',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/scroll-area/scroll-area-scrollbar.svelte
+++ b/packages/ui/src/scroll-area/scroll-area-scrollbar.svelte
@@ -16,10 +16,7 @@
 	data-slot="scroll-area-scrollbar"
 	{orientation}
 	class={cn(
-		'flex touch-none select-none p-px transition-colors',
-		orientation === 'vertical' && 'h-full w-2.5 border-s border-s-transparent',
-		orientation === 'horizontal' &&
-			'h-2.5 flex-col border-t border-t-transparent',
+		'cn-scroll-area-scrollbar flex touch-none p-px transition-colors select-none',
 		className,
 	)}
 	{...restProps}
@@ -27,6 +24,6 @@
 	{@render children?.()}
 	<ScrollAreaPrimitive.Thumb
 		data-slot="scroll-area-thumb"
-		class="bg-border relative flex-1 rounded-full"
+		class="cn-scroll-area-thumb bg-border relative flex-1"
 	/>
 </ScrollAreaPrimitive.Scrollbar>

--- a/packages/ui/src/select/select-content.svelte
+++ b/packages/ui/src/select/select-content.svelte
@@ -24,7 +24,7 @@
 		{preventScroll}
 		data-slot="select-content"
 		class={cn(
-			'cn-select-content cn-select-content-logical cn-menu-target cn-menu-translucent relative isolate z-50 overflow-x-hidden overflow-y-auto',
+			'cn-select-content cn-select-content-logical cn-menu-translucent relative isolate z-50 overflow-x-hidden overflow-y-auto',
 			className,
 		)}
 		{...restProps}

--- a/packages/ui/src/select/select-content.svelte
+++ b/packages/ui/src/select/select-content.svelte
@@ -24,7 +24,7 @@
 		{preventScroll}
 		data-slot="select-content"
 		class={cn(
-			'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-end-2 data-[side=right]:slide-in-from-start-2 data-[side=top]:slide-in-from-bottom-2 max-h-(--bits-select-content-available-height) origin-(--bits-select-content-transform-origin) relative z-50 min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border shadow-md data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+			'cn-select-content cn-select-content-logical cn-menu-target cn-menu-translucent relative isolate z-50 overflow-x-hidden overflow-y-auto',
 			// Custom: Prevent dropdown from expanding wider than trigger when content overflows
 			'max-w-min',
 			className,

--- a/packages/ui/src/select/select-content.svelte
+++ b/packages/ui/src/select/select-content.svelte
@@ -25,8 +25,6 @@
 		data-slot="select-content"
 		class={cn(
 			'cn-select-content cn-select-content-logical cn-menu-target cn-menu-translucent relative isolate z-50 overflow-x-hidden overflow-y-auto',
-			// Custom: Prevent dropdown from expanding wider than trigger when content overflows
-			'max-w-min',
 			className,
 		)}
 		{...restProps}

--- a/packages/ui/src/select/select-item.svelte
+++ b/packages/ui/src/select/select-item.svelte
@@ -18,7 +18,7 @@
 	{value}
 	data-slot="select-item"
 	class={cn(
-		"data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 relative flex w-full cursor-default select-none items-center gap-2 rounded-sm py-1.5 pe-8 ps-2 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		'cn-select-item focus:bg-accent data-highlighted:bg-accent data-highlighted:text-accent-foreground focus:text-accent-foreground relative flex w-full cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/select/select-label.svelte
+++ b/packages/ui/src/select/select-label.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="select-label"
-	class={cn('text-muted-foreground px-2 py-1.5 text-xs', className)}
+	class={cn('cn-select-label', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/select/select-scroll-down-button.svelte
+++ b/packages/ui/src/select/select-scroll-down-button.svelte
@@ -13,7 +13,7 @@
 <SelectPrimitive.ScrollDownButton
 	bind:ref
 	data-slot="select-scroll-down-button"
-	class={cn('flex cursor-default items-center justify-center py-1', className)}
+	class={cn('cn-select-scroll-down-button bottom-0 w-full', className)}
 	{...restProps}
 >
 	<ChevronDownIcon class="size-4" />

--- a/packages/ui/src/select/select-scroll-up-button.svelte
+++ b/packages/ui/src/select/select-scroll-up-button.svelte
@@ -13,7 +13,7 @@
 <SelectPrimitive.ScrollUpButton
 	bind:ref
 	data-slot="select-scroll-up-button"
-	class={cn('flex cursor-default items-center justify-center py-1', className)}
+	class={cn('cn-select-scroll-up-button top-0 w-full', className)}
 	{...restProps}
 >
 	<ChevronUpIcon class="size-4" />

--- a/packages/ui/src/select/select-separator.svelte
+++ b/packages/ui/src/select/select-separator.svelte
@@ -13,6 +13,6 @@
 <Separator
 	bind:ref
 	data-slot="select-separator"
-	class={cn('bg-border pointer-events-none -mx-1 my-1 h-px', className)}
+	class={cn('cn-select-separator pointer-events-none', className)}
 	{...restProps}
 />

--- a/packages/ui/src/select/select-trigger.svelte
+++ b/packages/ui/src/select/select-trigger.svelte
@@ -19,11 +19,11 @@
 	data-slot="select-trigger"
 	data-size={size}
 	class={cn(
-		"border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 shadow-xs flex w-fit select-none items-center justify-between gap-2 whitespace-nowrap rounded-md border bg-transparent px-3 py-2 text-sm outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		'cn-select-trigger flex w-fit items-center justify-between whitespace-nowrap outline-none disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center [&_svg]:pointer-events-none [&_svg]:shrink-0',
 		className,
 	)}
 	{...restProps}
 >
 	{@render children?.()}
-	<ChevronDownIcon class="size-4 opacity-50" />
+	<ChevronDownIcon class="cn-select-trigger-icon pointer-events-none" />
 </SelectPrimitive.Trigger>

--- a/packages/ui/src/separator/separator.svelte
+++ b/packages/ui/src/separator/separator.svelte
@@ -14,7 +14,7 @@
 	bind:ref
 	data-slot={dataSlot}
 	class={cn(
-		'bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=vertical]:h-full data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px',
+		'cn-separator data-[orientation=horizontal]:cn-separator-horizontal data-[orientation=vertical]:cn-separator-vertical',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/sheet/sheet-content.svelte
+++ b/packages/ui/src/sheet/sheet-content.svelte
@@ -1,23 +1,5 @@
 <script lang="ts" module>
-	import { tv, type VariantProps } from 'tailwind-variants';
-	export const sheetVariants = tv({
-		base: 'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
-		variants: {
-			side: {
-				top: 'data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b',
-				bottom:
-					'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t',
-				left: 'data-[state=closed]:slide-out-to-start data-[state=open]:slide-in-from-start inset-y-0 start-0 h-full w-3/4 border-e sm:max-w-sm',
-				right:
-					'data-[state=closed]:slide-out-to-end data-[state=open]:slide-in-from-end inset-y-0 end-0 h-full w-3/4 border-s sm:max-w-sm',
-			},
-		},
-		defaultVariants: {
-			side: 'right',
-		},
-	});
-
-	export type Side = VariantProps<typeof sheetVariants>['side'];
+	export type Side = 'top' | 'right' | 'bottom' | 'left';
 </script>
 
 <script lang="ts">
@@ -47,12 +29,20 @@
 	<SheetPrimitive.Content
 		bind:ref
 		data-slot="sheet-content"
-		class={cn(sheetVariants({ side }), className)}
+		data-side={side}
+		class={cn(
+			'cn-sheet-content data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10',
+			className,
+		)}
 		{...restProps}
 	>
 		{@render children?.()}
 		<SheetPrimitive.Close
-			class="ring-offset-background focus-visible:ring-ring rounded-xs focus-visible:outline-hidden absolute end-4 top-4 opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none"
+			data-slot="sheet-close"
+			class={cn(
+				'cn-sheet-close',
+				'ring-offset-background focus-visible:ring-ring rounded-xs focus-visible:outline-hidden opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none',
+			)}
 		>
 			<XIcon class="size-4" />
 			<span class="sr-only">Close</span>

--- a/packages/ui/src/sheet/sheet-description.svelte
+++ b/packages/ui/src/sheet/sheet-description.svelte
@@ -12,6 +12,6 @@
 <SheetPrimitive.Description
 	bind:ref
 	data-slot="sheet-description"
-	class={cn('text-muted-foreground text-sm', className)}
+	class={cn('cn-sheet-description', className)}
 	{...restProps}
 />

--- a/packages/ui/src/sheet/sheet-footer.svelte
+++ b/packages/ui/src/sheet/sheet-footer.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="sheet-footer"
-	class={cn('mt-auto flex flex-col gap-2 p-4', className)}
+	class={cn('cn-sheet-footer mt-auto flex flex-col', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sheet/sheet-header.svelte
+++ b/packages/ui/src/sheet/sheet-header.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="sheet-header"
-	class={cn('flex flex-col gap-1.5 p-4', className)}
+	class={cn('cn-sheet-header flex flex-col', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sheet/sheet-overlay.svelte
+++ b/packages/ui/src/sheet/sheet-overlay.svelte
@@ -12,9 +12,6 @@
 <SheetPrimitive.Overlay
 	bind:ref
 	data-slot="sheet-overlay"
-	class={cn(
-		'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
-		className,
-	)}
+	class={cn('cn-sheet-overlay fixed inset-0 z-50', className)}
 	{...restProps}
 />

--- a/packages/ui/src/sheet/sheet-title.svelte
+++ b/packages/ui/src/sheet/sheet-title.svelte
@@ -12,6 +12,6 @@
 <SheetPrimitive.Title
 	bind:ref
 	data-slot="sheet-title"
-	class={cn('text-foreground font-semibold', className)}
+	class={cn('cn-sheet-title', className)}
 	{...restProps}
 />

--- a/packages/ui/src/sidebar/sidebar-content.svelte
+++ b/packages/ui/src/sidebar/sidebar-content.svelte
@@ -15,7 +15,7 @@
 	data-slot="sidebar-content"
 	data-sidebar="content"
 	class={cn(
-		'flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
+		'cn-sidebar-content flex min-h-0 flex-1 flex-col overflow-auto group-data-[collapsible=icon]:overflow-hidden',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/sidebar/sidebar-footer.svelte
+++ b/packages/ui/src/sidebar/sidebar-footer.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="sidebar-footer"
 	data-sidebar="footer"
-	class={cn('flex flex-col gap-2 p-2', className)}
+	class={cn('cn-sidebar-footer flex flex-col', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sidebar/sidebar-group-action.svelte
+++ b/packages/ui/src/sidebar/sidebar-group-action.svelte
@@ -15,10 +15,7 @@
 
 	const mergedProps = $derived({
 		class: cn(
-			'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground outline-hidden absolute end-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
-			// Increases the hit area of the button on mobile.
-			'after:absolute after:-inset-2 md:after:hidden',
-			'group-data-[collapsible=icon]:hidden',
+			'cn-sidebar-group-action flex aspect-square items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:shrink-0',
 			className,
 		),
 		'data-slot': 'sidebar-group-action',

--- a/packages/ui/src/sidebar/sidebar-group-content.svelte
+++ b/packages/ui/src/sidebar/sidebar-group-content.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="sidebar-group-content"
 	data-sidebar="group-content"
-	class={cn('w-full text-sm', className)}
+	class={cn('cn-sidebar-group-content w-full', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sidebar/sidebar-group-label.svelte
+++ b/packages/ui/src/sidebar/sidebar-group-label.svelte
@@ -15,8 +15,7 @@
 
 	const mergedProps = $derived({
 		class: cn(
-			'text-sidebar-foreground/70 ring-sidebar-ring outline-hidden flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
-			'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
+			'cn-sidebar-group-label flex shrink-0 items-center outline-hidden [&>svg]:shrink-0',
 			className,
 		),
 		'data-slot': 'sidebar-group-label',

--- a/packages/ui/src/sidebar/sidebar-group.svelte
+++ b/packages/ui/src/sidebar/sidebar-group.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="sidebar-group"
 	data-sidebar="group"
-	class={cn('relative flex w-full min-w-0 flex-col p-2', className)}
+	class={cn('cn-sidebar-group relative flex w-full min-w-0 flex-col', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sidebar/sidebar-header.svelte
+++ b/packages/ui/src/sidebar/sidebar-header.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="sidebar-header"
 	data-sidebar="header"
-	class={cn('flex flex-col gap-2 p-2', className)}
+	class={cn('cn-sidebar-header flex flex-col', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sidebar/sidebar-input.svelte
+++ b/packages/ui/src/sidebar/sidebar-input.svelte
@@ -16,6 +16,6 @@
 	bind:value
 	data-slot="sidebar-input"
 	data-sidebar="input"
-	class={cn('bg-background h-8 w-full shadow-none', className)}
+	class={cn('cn-sidebar-input', className)}
 	{...restProps}
 />

--- a/packages/ui/src/sidebar/sidebar-inset.svelte
+++ b/packages/ui/src/sidebar/sidebar-inset.svelte
@@ -14,8 +14,9 @@
 	bind:this={ref}
 	data-slot="sidebar-inset"
 	class={cn(
-		'bg-background relative flex min-w-0 flex-1 flex-col',
-		'md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ms-2 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm',
+		'cn-sidebar-inset relative flex w-full flex-1 flex-col',
+		// Custom: keep Epicenter min-w-0 override (allows flex child shrink).
+		'min-w-0',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/sidebar/sidebar-inset.svelte
+++ b/packages/ui/src/sidebar/sidebar-inset.svelte
@@ -13,12 +13,7 @@
 <main
 	bind:this={ref}
 	data-slot="sidebar-inset"
-	class={cn(
-		'cn-sidebar-inset relative flex w-full flex-1 flex-col',
-		// Custom: keep Epicenter min-w-0 override (allows flex child shrink).
-		'min-w-0',
-		className,
-	)}
+	class={cn('cn-sidebar-inset relative flex w-full flex-1 flex-col', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sidebar/sidebar-menu-action.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-action.svelte
@@ -17,15 +17,9 @@
 
 	const mergedProps = $derived({
 		class: cn(
-			'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground outline-hidden absolute end-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
-			// Increases the hit area of the button on mobile.
-			'after:absolute after:-inset-2 md:after:hidden',
-			'peer-data-[size=sm]/menu-button:top-1',
-			'peer-data-[size=default]/menu-button:top-1.5',
-			'peer-data-[size=lg]/menu-button:top-2.5',
-			'group-data-[collapsible=icon]:hidden',
+			'cn-sidebar-menu-action flex items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:shrink-0',
 			showOnHover &&
-				'peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0',
+				'peer-data-active/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-open:opacity-100 md:opacity-0',
 			className,
 		),
 		'data-slot': 'sidebar-menu-action',

--- a/packages/ui/src/sidebar/sidebar-menu-badge.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-badge.svelte
@@ -15,12 +15,7 @@
 	data-slot="sidebar-menu-badge"
 	data-sidebar="menu-badge"
 	class={cn(
-		'text-sidebar-foreground pointer-events-none absolute end-1 flex h-5 min-w-5 select-none items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums',
-		'peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground',
-		'peer-data-[size=sm]/menu-button:top-1',
-		'peer-data-[size=default]/menu-button:top-1.5',
-		'peer-data-[size=lg]/menu-button:top-2.5',
-		'group-data-[collapsible=icon]:hidden',
+		'cn-sidebar-menu-badge flex items-center justify-center tabular-nums select-none group-data-[collapsible=icon]:hidden',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/sidebar/sidebar-menu-button.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-button.svelte
@@ -2,17 +2,16 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 
 	export const sidebarMenuButtonVariants = tv({
-		base: 'peer/menu-button outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground group-has-data-[sidebar=menu-action]/menu-item:pe-8 data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-start text-sm transition-[width,height,padding] focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:font-medium [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+		base: 'cn-sidebar-menu-button peer/menu-button group/menu-button flex w-full items-center overflow-hidden outline-hidden disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate',
 		variants: {
 			variant: {
-				default: 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-				outline:
-					'bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_var(--sidebar-border)] hover:shadow-[0_0_0_1px_var(--sidebar-accent)]',
+				default: 'cn-sidebar-menu-button-variant-default',
+				outline: 'cn-sidebar-menu-button-variant-outline',
 			},
 			size: {
-				default: 'h-8 text-sm',
-				sm: 'h-7 text-xs',
-				lg: 'group-data-[collapsible=icon]:p-0! h-12 text-sm',
+				default: 'cn-sidebar-menu-button-size-default',
+				sm: 'cn-sidebar-menu-button-size-sm',
+				lg: 'cn-sidebar-menu-button-size-lg',
 			},
 		},
 		defaultVariants: {
@@ -70,7 +69,9 @@
 		'data-slot': 'sidebar-menu-button',
 		'data-sidebar': 'menu-button',
 		'data-size': size,
-		'data-active': isActive,
+		// Emit data-active only when active: Vega's cn-* uses presence selectors
+		// (data-active:), so a literal data-active="false" would match too.
+		'data-active': isActive ? 'true' : undefined,
 		...restProps,
 	});
 </script>

--- a/packages/ui/src/sidebar/sidebar-menu-skeleton.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-skeleton.svelte
@@ -21,14 +21,17 @@
 	bind:this={ref}
 	data-slot="sidebar-menu-skeleton"
 	data-sidebar="menu-skeleton"
-	class={cn('flex h-8 items-center gap-2 rounded-md px-2', className)}
+	class={cn('cn-sidebar-menu-skeleton flex items-center', className)}
 	{...restProps}
 >
 	{#if showIcon}
-		<Skeleton class="size-4 rounded-md" data-sidebar="menu-skeleton-icon" />
+		<Skeleton
+			class="cn-sidebar-menu-skeleton-icon"
+			data-sidebar="menu-skeleton-icon"
+		/>
 	{/if}
 	<Skeleton
-		class="max-w-(--skeleton-width) h-4 flex-1"
+		class="cn-sidebar-menu-skeleton-text max-w-(--skeleton-width) flex-1"
 		data-sidebar="menu-skeleton-text"
 		style="--skeleton-width: {width};"
 	/>

--- a/packages/ui/src/sidebar/sidebar-menu-sub-button.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-sub-button.svelte
@@ -19,17 +19,15 @@
 
 	const mergedProps = $derived({
 		class: cn(
-			'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground outline-hidden flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
-			'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
-			size === 'sm' && 'text-xs',
-			size === 'md' && 'text-sm',
-			'group-data-[collapsible=icon]:hidden',
+			'cn-sidebar-menu-sub-button flex min-w-0 -translate-x-px items-center overflow-hidden outline-hidden group-data-[collapsible=icon]:hidden disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:shrink-0',
 			className,
 		),
 		'data-slot': 'sidebar-menu-sub-button',
 		'data-sidebar': 'menu-sub-button',
 		'data-size': size,
-		'data-active': isActive,
+		// Emit data-active only when active: Vega's cn-* uses presence selectors
+		// (data-active:), so a literal data-active="false" would match too.
+		'data-active': isActive ? 'true' : undefined,
 		...restProps,
 	});
 </script>

--- a/packages/ui/src/sidebar/sidebar-menu-sub.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-sub.svelte
@@ -14,11 +14,7 @@
 	bind:this={ref}
 	data-slot="sidebar-menu-sub"
 	data-sidebar="menu-sub"
-	class={cn(
-		'border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-s px-2.5 py-0.5',
-		'group-data-[collapsible=icon]:hidden',
-		className,
-	)}
+	class={cn('cn-sidebar-menu-sub flex min-w-0 flex-col', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sidebar/sidebar-menu.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu.svelte
@@ -17,7 +17,7 @@
 	bind:this={ref}
 	data-slot="sidebar-menu"
 	data-sidebar="menu"
-	class={cn('flex w-full min-w-0 flex-col gap-1', className)}
+	class={cn('cn-sidebar-menu flex w-full min-w-0 flex-col', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sidebar/sidebar-rail.svelte
+++ b/packages/ui/src/sidebar/sidebar-rail.svelte
@@ -25,12 +25,12 @@
 	onclick={sidebar.toggle}
 	title="Toggle Sidebar"
 	class={cn(
-		'hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:start-[calc(1/2*100%-1px)] after:w-[2px] group-data-[side=left]:-end-4 group-data-[side=right]:start-0 sm:flex',
+		'cn-sidebar-rail absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex',
 		'in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize',
 		'[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
-		'hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:start-full',
-		'[[data-side=left][data-collapsible=offcanvas]_&]:-end-2',
-		'[[data-side=right][data-collapsible=offcanvas]_&]:-start-2',
+		'hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full',
+		'[[data-side=left][data-collapsible=offcanvas]_&]:-right-2',
+		'[[data-side=right][data-collapsible=offcanvas]_&]:-left-2',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/sidebar/sidebar-separator.svelte
+++ b/packages/ui/src/sidebar/sidebar-separator.svelte
@@ -14,6 +14,6 @@
 	bind:ref
 	data-slot="sidebar-separator"
 	data-sidebar="separator"
-	class={cn('bg-sidebar-border', className)}
+	class={cn('cn-sidebar-separator w-auto', className)}
 	{...restProps}
 />

--- a/packages/ui/src/sidebar/sidebar.svelte
+++ b/packages/ui/src/sidebar/sidebar.svelte
@@ -45,7 +45,7 @@
 		<div
 			data-slot="sidebar-gap"
 			class={cn(
-				'w-(--sidebar-width) relative bg-transparent transition-[width] duration-200 ease-linear',
+				'cn-sidebar-gap relative w-(--sidebar-width) bg-transparent',
 				'group-data-[collapsible=offcanvas]:w-0',
 				'group-data-[side=right]:rotate-180',
 				variant === 'floating' || variant === 'inset'
@@ -71,7 +71,7 @@
 			<div
 				data-sidebar="sidebar"
 				data-slot="sidebar-inner"
-				class="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
+				class="cn-sidebar-inner flex size-full flex-col"
 			>
 				{@render children?.()}
 			</div>

--- a/packages/ui/src/skeleton/skeleton.svelte
+++ b/packages/ui/src/skeleton/skeleton.svelte
@@ -12,6 +12,6 @@
 <div
 	bind:this={ref}
 	data-slot="skeleton"
-	class={cn('bg-accent animate-pulse rounded-md', className)}
+	class={cn('cn-skeleton animate-pulse', className)}
 	{...restProps}
 ></div>

--- a/packages/ui/src/styles/epicenter-overlay.css
+++ b/packages/ui/src/styles/epicenter-overlay.css
@@ -73,6 +73,17 @@
 		@apply overflow-y-auto max-h-[calc(100vh-2rem)];
 	}
 
+	/* Item media: icon container background/size/border (Vega's
+	   cn-item-media-variant-icon only sets the svg glyph size). */
+	.cn-item-media-variant-icon {
+		@apply bg-muted size-8 rounded-sm border;
+	}
+
+	/* Sidebar inset: allow flex children to shrink. */
+	.cn-sidebar-inset {
+		@apply min-w-0;
+	}
+
 	/* Item: truncation inside flex containers + balanced description wrapping. */
 	.cn-item-content {
 		@apply min-w-0;

--- a/packages/ui/src/styles/epicenter-overlay.css
+++ b/packages/ui/src/styles/epicenter-overlay.css
@@ -68,6 +68,11 @@
 		@apply gap-2;
 	}
 
+	/* Dialog: scroll tall content; max-h leaves viewport breathing room. */
+	.cn-dialog-content {
+		@apply overflow-y-auto max-h-[calc(100vh-2rem)];
+	}
+
 	/* Item: truncation inside flex containers + balanced description wrapping. */
 	.cn-item-content {
 		@apply min-w-0;

--- a/packages/ui/src/styles/epicenter-overlay.css
+++ b/packages/ui/src/styles/epicenter-overlay.css
@@ -1,24 +1,38 @@
 /*
   Epicenter overlay: customizations layered on top of the Vega preset.
 
-  Scoped under .style-vega to match the preset's own scoping. This is the single
-  place Epicenter-specific styling lives, so upstream pulls touch component markup
-  and style-vega.css only. One block per Epicenter-only variant.
+  Scoped under .style-vega to match the preset's own scoping, and imported after
+  style-vega.css in app.css so same-specificity rules here win. This is the single
+  place Epicenter styling deltas live, so upstream pulls touch component markup and
+  style-vega.css only.
+
+  Two kinds of entry:
+    1. Epicenter-only variants (no upstream cn-* equivalent).
+    2. Component overrides that redefine a Vega cn-* class so the component markup
+       can stay byte-identical to upstream.
+
+  NOTE on what is NOT here: z-index overrides (dialog/drawer z-40) stay inline in
+  their components. Vega keeps z-index inline (not in the cn-* class), and an
+  @apply in this base-layer file cannot override a utilities-layer inline class.
+  Structural overrides (drawer scroll wrapper, item actions overlay) are markup,
+  not CSS, and also stay in their components.
 
   See specs/20260606T160000-ui-shadcn-cn-style-migration-vega.md
 */
 .style-vega {
-	/* Button: ghost-destructive variant (Epicenter-specific, no upstream equivalent). */
+	/* ---- Epicenter-only variants ---- */
+
+	/* Button: ghost-destructive variant (no upstream equivalent). */
 	.cn-button-variant-ghost-destructive {
 		@apply text-destructive hover:bg-destructive/10 hover:text-destructive dark:hover:bg-destructive/20;
 	}
 
-	/* Alert: warning variant (Epicenter-specific; uses the --warning token). */
+	/* Alert: warning variant (uses the --warning token). */
 	.cn-alert-variant-warning {
 		@apply text-warning bg-card *:data-[slot=alert-description]:text-warning/90 [&>svg]:text-current;
 	}
 
-	/* Badge: Epicenter-specific variants (no upstream equivalent). */
+	/* Badge: Epicenter-specific variants. */
 	.cn-badge-variant-id {
 		@apply px-1.5 bg-muted text-muted-foreground [a&]:hover:bg-muted/90 border-transparent font-mono text-xs rounded-md font-normal;
 	}
@@ -33,5 +47,38 @@
 	}
 	.cn-badge-variant-success {
 		@apply bg-success [a&]:hover:bg-success/90 focus-visible:ring-success/20 dark:focus-visible:ring-success/40 dark:bg-success/80 border-transparent text-white;
+	}
+
+	/* ---- Component overrides on the Vega preset ---- */
+
+	/* Table row: in Svelte the <tr> background is occluded by opaque <td> cells
+	   (and Svelte injects <svelte-css-wrapper>), so hover the cells, not the row.
+	   Cancels Vega's row-level hover:bg-muted/50 and applies it to the cells. */
+	.cn-table-row {
+		@apply hover:bg-transparent hover:[&,&>svelte-css-wrapper]:[&>th,td]:bg-muted/50;
+	}
+
+	/* Select: keep the dropdown from growing wider than its trigger. */
+	.cn-select-content {
+		@apply max-w-min;
+	}
+
+	/* Resizable: spacing between panes for visual separation. */
+	.cn-resizable-panel-group {
+		@apply gap-2;
+	}
+
+	/* Item: truncation inside flex containers + balanced description wrapping. */
+	.cn-item-content {
+		@apply min-w-0;
+	}
+	.cn-item-title {
+		@apply min-w-0;
+	}
+	.cn-item-description {
+		@apply text-balance;
+	}
+	.cn-item-separator {
+		@apply my-0;
 	}
 }

--- a/packages/ui/src/styles/epicenter-overlay.css
+++ b/packages/ui/src/styles/epicenter-overlay.css
@@ -1,0 +1,37 @@
+/*
+  Epicenter overlay: customizations layered on top of the Vega preset.
+
+  Scoped under .style-vega to match the preset's own scoping. This is the single
+  place Epicenter-specific styling lives, so upstream pulls touch component markup
+  and style-vega.css only. One block per Epicenter-only variant.
+
+  See specs/20260606T160000-ui-shadcn-cn-style-migration-vega.md
+*/
+.style-vega {
+	/* Button: ghost-destructive variant (Epicenter-specific, no upstream equivalent). */
+	.cn-button-variant-ghost-destructive {
+		@apply text-destructive hover:bg-destructive/10 hover:text-destructive dark:hover:bg-destructive/20;
+	}
+
+	/* Alert: warning variant (Epicenter-specific; uses the --warning token). */
+	.cn-alert-variant-warning {
+		@apply text-warning bg-card *:data-[slot=alert-description]:text-warning/90 [&>svg]:text-current;
+	}
+
+	/* Badge: Epicenter-specific variants (no upstream equivalent). */
+	.cn-badge-variant-id {
+		@apply px-1.5 bg-muted text-muted-foreground [a&]:hover:bg-muted/90 border-transparent font-mono text-xs rounded-md font-normal;
+	}
+	.cn-badge-variant-status-completed {
+		@apply bg-green-500/10 text-green-500;
+	}
+	.cn-badge-variant-status-failed {
+		@apply bg-red-500/10 text-red-500;
+	}
+	.cn-badge-variant-status-running {
+		@apply bg-blue-500/10 text-blue-500;
+	}
+	.cn-badge-variant-success {
+		@apply bg-success [a&]:hover:bg-success/90 focus-visible:ring-success/20 dark:focus-visible:ring-success/40 dark:bg-success/80 border-transparent text-white;
+	}
+}

--- a/packages/ui/src/styles/shadcn-base.css
+++ b/packages/ui/src/styles/shadcn-base.css
@@ -1,0 +1,89 @@
+@theme inline {
+	@keyframes accordion-down {
+		from {
+			height: 0;
+		}
+		to {
+			height: var(--bits-accordion-content-height, var(--accordion-panel-height, auto));
+		}
+	}
+
+	@keyframes accordion-up {
+		from {
+			height: var(--bits-accordion-content-height, var(--accordion-panel-height, auto));
+		}
+		to {
+			height: 0;
+		}
+	}
+}
+
+/* Custom variants */
+@custom-variant data-open {
+	&:where([data-state="open"]),
+	&:where([data-open]:not([data-open="false"])) {
+		@slot;
+	}
+}
+
+@custom-variant data-closed {
+	&:where([data-state="closed"]),
+	&:where([data-closed]:not([data-closed="false"])) {
+		@slot;
+	}
+}
+
+@custom-variant data-checked {
+	&:where([data-state="checked"]),
+	&:where([data-checked]:not([data-checked="false"])) {
+		@slot;
+	}
+}
+
+@custom-variant data-unchecked {
+	&:where([data-state="unchecked"]),
+	&:where([data-unchecked]:not([data-unchecked="false"])) {
+		@slot;
+	}
+}
+
+/* @custom-variant data-selected {
+	&:where([data-selected="true"]) {
+		@slot;
+	}
+} */
+
+@custom-variant data-disabled {
+	&:where([data-disabled="true"]),
+	&:where([data-disabled]:not([data-disabled="false"])) {
+		@slot;
+	}
+}
+
+@custom-variant data-active {
+	&:where([data-state="active"]),
+	&:where([data-active]:not([data-active="false"])) {
+		@slot;
+	}
+}
+
+@custom-variant data-horizontal {
+	&:where([data-orientation="horizontal"]) {
+		@slot;
+	}
+}
+
+@custom-variant data-vertical {
+	&:where([data-orientation="vertical"]) {
+		@slot;
+	}
+}
+
+@utility no-scrollbar {
+	-ms-overflow-style: none;
+	scrollbar-width: none;
+
+	&::-webkit-scrollbar {
+		display: none;
+	}
+}

--- a/packages/ui/src/styles/style-vega.css
+++ b/packages/ui/src/styles/style-vega.css
@@ -1,0 +1,1361 @@
+.style-vega {
+	/* MARK: Accordion */
+	.cn-accordion-item {
+		@apply not-last:border-b;
+	}
+
+	.cn-accordion-trigger {
+		@apply focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-md py-4 text-left text-sm font-medium hover:underline focus-visible:ring-3 **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4;
+	}
+
+	.cn-accordion-content {
+		@apply data-open:animate-accordion-down data-closed:animate-accordion-up text-sm;
+	}
+
+	.cn-accordion-content-inner {
+		@apply pt-0 pb-4;
+	}
+
+	/* MARK: Alert Dialog */
+	.cn-alert-dialog-overlay {
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs;
+	}
+
+	.cn-alert-dialog-content {
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 gap-6 rounded-xl p-6 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg;
+	}
+
+	.cn-alert-dialog-header {
+		@apply grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr];
+	}
+
+	.cn-alert-dialog-media {
+		@apply bg-muted mb-2 inline-flex size-16 items-center justify-center rounded-md sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-8;
+	}
+
+	.cn-alert-dialog-title {
+		@apply text-lg font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2;
+	}
+
+	.cn-alert-dialog-description {
+		@apply text-muted-foreground *:[a]:hover:text-foreground text-sm text-balance md:text-pretty *:[a]:underline *:[a]:underline-offset-3;
+	}
+
+	/* MARK: Alert */
+	.cn-alert {
+		@apply grid gap-0.5 rounded-lg border px-4 py-3 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2.5 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-alert-variant-default {
+		@apply bg-card text-card-foreground;
+	}
+
+	.cn-alert-variant-destructive {
+		@apply text-destructive bg-card *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current;
+	}
+
+	.cn-alert-title {
+		@apply font-medium group-has-[>svg]/alert:col-start-2;
+	}
+
+	.cn-alert-description {
+		@apply text-muted-foreground text-sm text-balance md:text-pretty [&_p:not(:last-child)]:mb-4;
+	}
+
+	.cn-alert-action {
+		@apply absolute top-2.5 right-3;
+	}
+
+	/* MARK: Avatar */
+	.cn-avatar {
+		@apply size-8 rounded-full after:rounded-full data-[size=lg]:size-10 data-[size=sm]:size-6;
+	}
+
+	.cn-avatar-fallback {
+		@apply bg-muted text-muted-foreground rounded-full;
+	}
+
+	.cn-avatar-image {
+		@apply rounded-full;
+	}
+
+	.cn-avatar-badge {
+		@apply bg-primary text-primary-foreground ring-background;
+	}
+
+	.cn-avatar-group-count {
+		@apply bg-muted text-muted-foreground size-8 rounded-full text-sm group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3;
+	}
+
+	/* MARK: Badge */
+	.cn-badge {
+		@apply h-5 gap-1 rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3!;
+	}
+
+	.cn-badge-variant-default {
+		@apply bg-primary text-primary-foreground [a]:hover:bg-primary/80;
+	}
+
+	.cn-badge-variant-secondary {
+		@apply bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80;
+	}
+
+	.cn-badge-variant-outline {
+		@apply border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground;
+	}
+
+	.cn-badge-variant-destructive {
+		@apply bg-destructive/10 [a]:hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 text-destructive dark:bg-destructive/20;
+	}
+
+	.cn-badge-variant-ghost {
+		@apply hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50;
+	}
+
+	.cn-badge-variant-link {
+		@apply text-primary underline-offset-4 hover:underline;
+	}
+
+	/* MARK: Breadcrumb */
+	.cn-breadcrumb-list {
+		@apply text-muted-foreground gap-1.5 text-sm sm:gap-2.5;
+	}
+
+	.cn-breadcrumb-item {
+		@apply gap-1.5;
+	}
+
+	.cn-breadcrumb-link {
+		@apply hover:text-foreground transition-colors;
+	}
+
+	.cn-breadcrumb-page {
+		@apply text-foreground font-normal;
+	}
+
+	.cn-breadcrumb-separator {
+		@apply [&>svg]:size-3.5;
+	}
+
+	.cn-breadcrumb-ellipsis {
+		@apply size-5 [&>svg]:size-4;
+	}
+
+	/* MARK: Button */
+	.cn-button {
+		@apply focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-button-variant-default {
+		@apply bg-primary text-primary-foreground hover:bg-primary/80;
+	}
+
+	.cn-button-variant-outline {
+		@apply border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground shadow-xs;
+	}
+
+	.cn-button-variant-secondary {
+		@apply bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground;
+	}
+
+	.cn-button-variant-ghost {
+		@apply hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground;
+	}
+
+	.cn-button-variant-destructive {
+		@apply bg-destructive/10 hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/20 text-destructive focus-visible:border-destructive/40 dark:hover:bg-destructive/30;
+	}
+
+	.cn-button-variant-link {
+		@apply text-primary underline-offset-4 hover:underline;
+	}
+
+	.cn-button-size-xs {
+		@apply h-6 gap-1 rounded-[min(var(--radius-md),8px)] px-2 text-xs in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3;
+	}
+
+	.cn-button-size-sm {
+		@apply h-8 gap-1 rounded-[min(var(--radius-md),10px)] px-2.5 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5;
+	}
+
+	.cn-button-size-default {
+		@apply h-9 gap-1.5 px-2.5 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2;
+	}
+
+	.cn-button-size-lg {
+		@apply h-10 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2;
+	}
+
+	.cn-button-size-icon-xs {
+		@apply size-6 rounded-[min(var(--radius-md),8px)] in-data-[slot=button-group]:rounded-md [&_svg:not([class*='size-'])]:size-3;
+	}
+
+	.cn-button-size-icon-sm {
+		@apply size-8 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-md;
+	}
+
+	.cn-button-size-icon {
+		@apply size-9;
+	}
+
+	.cn-button-size-icon-lg {
+		@apply size-10;
+	}
+
+	/* MARK: Button Group */
+	.cn-button-group {
+		@apply has-[>[data-slot=button-group]]:gap-2 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md;
+	}
+
+	.cn-button-group-orientation-horizontal {
+		@apply [&>[data-slot]:not(:has(~[data-slot]))]:rounded-r-md!;
+	}
+
+	.cn-button-group-orientation-vertical {
+		@apply [&>[data-slot]:not(:has(~[data-slot]))]:rounded-b-md!;
+	}
+
+	.cn-button-group-text {
+		@apply bg-muted gap-2 rounded-md border px-2.5 text-sm font-medium shadow-xs [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-button-group-separator {
+		@apply bg-input;
+	}
+
+	/* MARK: Calendar */
+	.cn-calendar {
+		@apply p-3 [--cell-radius:var(--radius-md)] [--cell-size:--spacing(8)];
+	}
+
+	.cn-calendar-dropdown-root {
+		@apply has-focus:border-ring border-input has-focus:ring-ring/50 border shadow-xs has-focus:ring-3;
+	}
+
+	.cn-calendar-caption-label {
+		@apply h-8 pr-1 pl-2;
+	}
+
+	/* MARK: Card */
+	.cn-card {
+		@apply ring-foreground/10 bg-card text-card-foreground gap-6 overflow-hidden rounded-xl py-6 text-sm shadow-xs ring-1 has-[>img:first-child]:pt-0 data-[size=sm]:gap-4 data-[size=sm]:py-4 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl;
+	}
+
+	.cn-card-header {
+		@apply gap-1 rounded-t-xl px-6 group-data-[size=sm]/card:px-4 [.border-b]:pb-6 group-data-[size=sm]/card:[.border-b]:pb-4;
+	}
+
+	.cn-card-title {
+		@apply text-base leading-normal font-medium group-data-[size=sm]/card:text-sm;
+	}
+
+	.cn-card-description {
+		@apply text-muted-foreground text-sm;
+	}
+
+	.cn-card-content {
+		@apply px-6 group-data-[size=sm]/card:px-4;
+	}
+
+	.cn-card-footer {
+		@apply rounded-b-xl px-6 group-data-[size=sm]/card:px-4 [.border-t]:pt-6 group-data-[size=sm]/card:[.border-t]:pt-4;
+	}
+
+	/* MARK: Carousel */
+	.cn-carousel-previous {
+		@apply rounded-full;
+	}
+
+	.cn-carousel-next {
+		@apply rounded-full;
+	}
+
+	/* MARK: Chart */
+	.cn-chart-tooltip {
+		@apply border-border/50 bg-background gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl;
+	}
+
+	/* MARK: Checkbox */
+	.cn-checkbox {
+		@apply border-input dark:bg-input/30 data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary data-checked:border-primary aria-invalid:aria-checked:border-primary aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 flex size-4 items-center justify-center rounded-[4px] border shadow-xs transition-shadow group-has-disabled/field:opacity-50 focus-visible:ring-3 aria-invalid:ring-3;
+	}
+
+	.cn-checkbox-indicator {
+		@apply [&>svg]:size-3.5;
+	}
+
+	/* MARK: Combobox */
+	.cn-combobox-content {
+		@apply bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 *:data-[slot=input-group]:bg-input/30 *:data-[slot=input-group]:border-input/30 max-h-72 min-w-36 overflow-hidden rounded-md shadow-md ring-1 duration-100 *:data-[slot=input-group]:m-1 *:data-[slot=input-group]:mb-0 *:data-[slot=input-group]:h-8 *:data-[slot=input-group]:shadow-none;
+	}
+
+	.cn-combobox-content-logical {
+		@apply data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2;
+	}
+
+	.cn-combobox-label {
+		@apply text-muted-foreground px-2 py-1.5 text-xs;
+	}
+
+	.cn-combobox-item {
+		@apply data-highlighted:bg-accent data-highlighted:text-accent-foreground not-data-[variant=destructive]:data-highlighted:**:text-accent-foreground gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-combobox-item-indicator {
+		@apply pointer-events-none absolute right-2 flex size-4 items-center justify-center;
+	}
+
+	.cn-combobox-empty {
+		@apply text-muted-foreground hidden w-full justify-center py-2 text-center text-sm group-data-empty/combobox-content:flex;
+	}
+
+	.cn-combobox-list {
+		@apply no-scrollbar max-h-[min(calc(--spacing(72)---spacing(9)),calc(var(--available-height)---spacing(9)))] scroll-py-1 overflow-y-auto p-1 data-empty:p-0;
+	}
+
+	.cn-combobox-item-text {
+		@apply flex flex-1 gap-2;
+	}
+
+	.cn-combobox-separator {
+		@apply bg-border -mx-1 my-1 h-px;
+	}
+
+	.cn-combobox-trigger {
+		@apply [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-combobox-trigger-icon {
+		@apply text-muted-foreground size-4;
+	}
+
+	.cn-combobox-chips {
+		@apply dark:bg-input/30 border-input focus-within:border-ring focus-within:ring-ring/50 has-aria-invalid:ring-destructive/20 dark:has-aria-invalid:ring-destructive/40 has-aria-invalid:border-destructive dark:has-aria-invalid:border-destructive/50 flex min-h-9 flex-wrap items-center gap-1.5 rounded-md border bg-transparent bg-clip-padding px-2.5 py-1.5 text-sm shadow-xs transition-[color,box-shadow] focus-within:ring-3 has-aria-invalid:ring-3 has-data-[slot=combobox-chip]:px-1.5;
+	}
+
+	.cn-combobox-chip {
+		@apply bg-muted text-foreground flex h-[calc(--spacing(5.5))] w-fit items-center justify-center gap-1 rounded-sm px-1.5 text-xs font-medium whitespace-nowrap has-data-[slot=combobox-chip-remove]:pr-0;
+	}
+
+	.cn-combobox-chip-remove {
+		@apply -ml-1 opacity-50 hover:opacity-100;
+	}
+
+	/* MARK: Command */
+	.cn-command {
+		@apply bg-popover text-popover-foreground rounded-xl! p-1;
+	}
+
+	.cn-command-dialog {
+		@apply rounded-xl!;
+	}
+
+	.cn-command-input-wrapper {
+		@apply p-1 pb-0;
+	}
+
+	.cn-command-input-group {
+		@apply bg-input/30 border-input/30 h-8! rounded-lg! shadow-none! *:data-[slot=input-group-addon]:pl-2!;
+	}
+
+	.cn-command-input-icon {
+		@apply size-4 shrink-0 opacity-50;
+	}
+
+	.cn-command-input {
+		@apply w-full text-sm;
+	}
+
+	.cn-command-list {
+		@apply no-scrollbar max-h-72 scroll-py-1 outline-none;
+	}
+
+	.cn-command-empty {
+		@apply py-6 text-center text-sm;
+	}
+
+	.cn-command-group {
+		@apply text-foreground **:[[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:py-1.5 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium;
+	}
+
+	.cn-command-separator {
+		@apply bg-border -mx-1 h-px w-auto;
+	}
+
+	.cn-command-item {
+		@apply data-selected:bg-muted data-selected:text-foreground data-selected:**:[svg]:text-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none in-data-[slot=dialog-content]:rounded-lg! [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-command-shortcut {
+		@apply text-muted-foreground group-data-selected/command-item:text-foreground ml-auto text-xs tracking-widest;
+	}
+
+	/* MARK: Context Menu */
+	.cn-context-menu-content {
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-36 rounded-md p-1 shadow-md ring-1 duration-100;
+	}
+
+	.cn-context-menu-content-logical {
+		@apply data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2;
+	}
+
+	.cn-context-menu-item {
+		@apply focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive focus:*:[svg]:text-accent-foreground gap-2 rounded-sm px-2 py-1.5 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-context-menu-checkbox-item {
+		@apply focus:bg-accent focus:text-accent-foreground gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-context-menu-radio-item {
+		@apply focus:bg-accent focus:text-accent-foreground gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-context-menu-item-indicator {
+		@apply absolute right-2;
+	}
+
+	.cn-context-menu-label {
+		@apply text-muted-foreground px-2 py-1.5 text-xs font-medium data-inset:pl-8;
+	}
+
+	.cn-context-menu-separator {
+		@apply bg-border -mx-1 my-1 h-px;
+	}
+
+	.cn-context-menu-shortcut {
+		@apply text-muted-foreground group-focus/context-menu-item:text-accent-foreground ml-auto text-xs tracking-widest;
+	}
+
+	.cn-context-menu-sub-trigger {
+		@apply focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground rounded-sm px-2 py-1.5 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-context-menu-sub-content {
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 bg-popover text-popover-foreground min-w-32 rounded-md border p-1 shadow-lg duration-100;
+	}
+
+	.cn-context-menu-subcontent {
+		@apply shadow-lg;
+	}
+
+	/* MARK: Dialog */
+	.cn-dialog-overlay {
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs;
+	}
+
+	.cn-dialog-content {
+		@apply bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-xl p-6 text-sm ring-1 duration-100 sm:max-w-md;
+	}
+
+	.cn-dialog-close {
+		@apply absolute top-4 right-4;
+	}
+
+	.cn-dialog-header {
+		@apply gap-2;
+	}
+
+	.cn-dialog-footer {
+		@apply gap-2;
+	}
+
+	.cn-dialog-title {
+		@apply leading-none font-medium;
+	}
+
+	.cn-dialog-description {
+		@apply text-muted-foreground *:[a]:hover:text-foreground text-sm *:[a]:underline *:[a]:underline-offset-3;
+	}
+
+	/* MARK: Drawer */
+	.cn-drawer-overlay {
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 supports-backdrop-filter:backdrop-blur-xs;
+	}
+
+	.cn-drawer-content {
+		@apply bg-popover text-popover-foreground flex h-auto flex-col text-sm data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-xl data-[vaul-drawer-direction=bottom]:border-t data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:rounded-r-xl data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:rounded-l-xl data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-xl data-[vaul-drawer-direction=top]:border-b data-[vaul-drawer-direction=left]:sm:max-w-sm data-[vaul-drawer-direction=right]:sm:max-w-sm;
+	}
+
+	.cn-drawer-handle {
+		@apply bg-muted mx-auto mt-4 hidden h-1.5 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block;
+	}
+
+	.cn-drawer-header {
+		@apply gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left;
+	}
+
+	.cn-drawer-title {
+		@apply text-foreground font-medium;
+	}
+
+	.cn-drawer-description {
+		@apply text-muted-foreground text-sm;
+	}
+
+	.cn-drawer-footer {
+		@apply gap-2 p-4;
+	}
+
+	/* MARK: Dropdown Menu */
+	.cn-dropdown-menu-content {
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-md p-1 shadow-md ring-1 duration-100;
+	}
+
+	.cn-dropdown-menu-content-logical {
+		@apply data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2;
+	}
+
+	.cn-dropdown-menu-item {
+		@apply focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive not-data-[variant=destructive]:focus:**:text-accent-foreground gap-2 rounded-sm px-2 py-1.5 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-dropdown-menu-checkbox-item {
+		@apply focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-dropdown-menu-radio-item {
+		@apply focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-dropdown-menu-item-indicator {
+		@apply absolute right-2 flex items-center justify-center;
+	}
+
+	.cn-dropdown-menu-label {
+		@apply text-muted-foreground px-2 py-1.5 text-xs font-medium data-inset:pl-8;
+	}
+
+	.cn-dropdown-menu-separator {
+		@apply bg-border -mx-1 my-1 h-px;
+	}
+
+	.cn-dropdown-menu-shortcut {
+		@apply text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground ml-auto text-xs tracking-widest;
+	}
+
+	.cn-dropdown-menu-sub-trigger {
+		@apply focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-2 rounded-sm px-2 py-1.5 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-dropdown-menu-sub-content {
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-[96px] rounded-md p-1 shadow-lg ring-1 duration-100;
+	}
+
+	.cn-dropdown-menu-subcontent {
+		@apply shadow-lg;
+	}
+
+	/* MARK: Empty */
+	.cn-empty {
+		@apply gap-4 rounded-lg border-dashed p-12;
+	}
+
+	.cn-empty-header {
+		@apply gap-2;
+	}
+
+	.cn-empty-media {
+		@apply mb-2;
+	}
+
+	.cn-empty-media-default {
+		@apply bg-transparent;
+	}
+
+	.cn-empty-media-icon {
+		@apply bg-muted text-foreground flex size-10 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-6;
+	}
+
+	.cn-empty-title {
+		@apply text-lg font-medium tracking-tight;
+	}
+
+	.cn-empty-description {
+		@apply text-sm/relaxed;
+	}
+
+	.cn-empty-content {
+		@apply gap-4 text-sm;
+	}
+
+	/* MARK: Field */
+	.cn-field-set {
+		@apply gap-6 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3;
+	}
+
+	.cn-field-legend {
+		@apply mb-3 font-medium data-[variant=label]:text-sm data-[variant=legend]:text-base;
+	}
+
+	.cn-field-group {
+		@apply gap-7 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4;
+	}
+
+	.cn-field {
+		@apply data-[invalid=true]:text-destructive gap-3;
+	}
+
+	.cn-field-content {
+		@apply gap-1;
+	}
+
+	.cn-field-label {
+		@apply has-data-checked:bg-primary/5 has-data-checked:border-primary/30 dark:has-data-checked:border-primary/20 dark:has-data-checked:bg-primary/10 gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border *:data-[slot=field]:p-3;
+	}
+
+	.cn-field-title {
+		@apply gap-2 text-sm leading-snug font-medium group-data-[disabled=true]/field:opacity-50;
+	}
+
+	.cn-field-description {
+		@apply text-muted-foreground text-left text-sm [[data-variant=legend]+&]:-mt-1.5;
+	}
+
+	.cn-field-separator {
+		@apply -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2;
+	}
+
+	.cn-field-separator-content {
+		@apply text-muted-foreground px-2;
+	}
+
+	.cn-field-error {
+		@apply text-destructive text-sm;
+	}
+
+	/* MARK: Hover Card */
+	.cn-hover-card-content {
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground w-64 rounded-lg p-4 text-sm shadow-md ring-1 duration-100;
+	}
+
+	.cn-hover-card-content-logical {
+		@apply data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2;
+	}
+
+	/* MARK: Input */
+	.cn-input {
+		@apply dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-9 rounded-md border bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium focus-visible:ring-3 aria-invalid:ring-3 md:text-sm;
+	}
+
+	/* MARK: Input OTP */
+	.cn-input-otp {
+		@apply gap-2;
+	}
+
+	.cn-input-otp-group {
+		@apply has-aria-invalid:ring-destructive/20 dark:has-aria-invalid:ring-destructive/40 has-aria-invalid:border-destructive rounded-md has-aria-invalid:ring-3;
+	}
+
+	.cn-input-otp-slot {
+		@apply dark:bg-input/30 border-input data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive size-9 border-y border-r text-sm shadow-xs transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md data-[active=true]:ring-3;
+	}
+
+	.cn-input-otp-caret-line {
+		@apply animate-caret-blink bg-foreground h-4 w-px duration-1000;
+	}
+
+	.cn-input-otp-separator {
+		@apply [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	/* MARK: Item */
+	.cn-item {
+		@apply [a]:hover:bg-muted rounded-md border text-sm;
+	}
+
+	.cn-item-variant-default {
+		@apply border-transparent;
+	}
+
+	.cn-item-variant-outline {
+		@apply border-border;
+	}
+
+	.cn-item-variant-muted {
+		@apply bg-muted/50 border-transparent;
+	}
+
+	.cn-item-size-default {
+		@apply gap-3.5 px-4 py-3.5;
+	}
+
+	.cn-item-size-sm {
+		@apply gap-2.5 px-3 py-2.5;
+	}
+
+	.cn-item-size-xs {
+		@apply gap-2 px-2.5 py-2 in-data-[slot=dropdown-menu-content]:p-0;
+	}
+
+	.cn-item-media {
+		@apply gap-2 group-has-data-[slot=item-description]/item:translate-y-0.5 group-has-data-[slot=item-description]/item:self-start;
+	}
+
+	.cn-item-media-variant-default {
+		@apply bg-transparent;
+	}
+
+	.cn-item-media-variant-icon {
+		@apply [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-item-media-variant-image {
+		@apply size-10 overflow-hidden rounded-sm group-data-[size=sm]/item:size-8 group-data-[size=xs]/item:size-6 [&_img]:size-full [&_img]:object-cover;
+	}
+
+	.cn-item-content {
+		@apply gap-1 group-data-[size=xs]/item:gap-0;
+	}
+
+	.cn-item-title {
+		@apply gap-2 text-sm leading-snug font-medium underline-offset-4;
+	}
+
+	.cn-item-description {
+		@apply text-muted-foreground text-left text-sm leading-normal group-data-[size=xs]/item:text-xs;
+	}
+
+	.cn-item-actions {
+		@apply gap-2;
+	}
+
+	.cn-item-header {
+		@apply gap-2;
+	}
+
+	.cn-item-footer {
+		@apply gap-2;
+	}
+
+	.cn-item-group {
+		@apply gap-4 has-data-[size=sm]:gap-2.5 has-data-[size=xs]:gap-2;
+	}
+
+	.cn-item-separator {
+		@apply my-2;
+	}
+
+	/* MARK: Kbd */
+	.cn-kbd {
+		@apply bg-muted text-muted-foreground in-data-[slot=tooltip-content]:bg-background/20 in-data-[slot=tooltip-content]:text-background dark:in-data-[slot=tooltip-content]:bg-background/10 h-5 w-fit min-w-5 gap-1 rounded-sm px-1 font-sans text-xs font-medium [&_svg:not([class*='size-'])]:size-3;
+	}
+
+	.cn-kbd-group {
+		@apply gap-1;
+	}
+
+	/* MARK: Label */
+	.cn-label {
+		@apply gap-2 text-sm leading-none font-medium group-data-[disabled=true]:opacity-50 peer-disabled:opacity-50;
+	}
+
+	/* MARK: Menubar */
+	.cn-menubar {
+		@apply h-9 gap-1 rounded-md border p-1 shadow-xs;
+	}
+
+	.cn-menubar-trigger {
+		@apply hover:bg-muted aria-expanded:bg-muted rounded-sm px-2 py-1 text-sm font-medium;
+	}
+
+	.cn-menubar-content {
+		@apply bg-popover text-popover-foreground data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-md p-1 shadow-md ring-1 duration-100;
+	}
+
+	.cn-menubar-content-logical {
+		@apply data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2;
+	}
+
+	.cn-menubar-item {
+		@apply focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive! not-data-[variant=destructive]:focus:**:text-accent-foreground gap-2 rounded-sm px-2 py-1.5 text-sm data-disabled:opacity-50 data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-menubar-checkbox-item {
+		@apply focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-2 rounded-md py-1.5 pr-2 pl-8 text-sm data-inset:pl-8;
+	}
+
+	.cn-menubar-checkbox-item-indicator {
+		@apply left-2 size-4 [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-menubar-radio-item {
+		@apply focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-2 rounded-md py-1.5 pr-2 pl-8 text-sm data-disabled:opacity-50 data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-menubar-radio-item-indicator {
+		@apply left-2 size-4 [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-menubar-label {
+		@apply px-2 py-1.5 text-sm font-medium data-inset:pl-8;
+	}
+
+	.cn-menubar-separator {
+		@apply bg-border;
+	}
+
+	.cn-menubar-shortcut {
+		@apply text-muted-foreground group-focus/menubar-item:text-accent-foreground text-xs tracking-widest;
+	}
+
+	.cn-menubar-sub-trigger {
+		@apply focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground gap-2 rounded-sm px-2 py-1.5 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-menubar-sub-content {
+		@apply bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-32 rounded-md p-1 shadow-lg ring-1 duration-100;
+	}
+
+	/* MARK: Navigation Menu */
+	.cn-navigation-menu {
+		@apply max-w-max;
+	}
+
+	.cn-navigation-menu-list {
+		@apply gap-0;
+	}
+
+	.cn-navigation-menu-trigger {
+		@apply hover:bg-muted focus:bg-muted data-open:hover:bg-muted data-open:focus:bg-muted data-open:bg-muted/50 focus-visible:ring-ring/50 data-popup-open:bg-muted/50 data-popup-open:hover:bg-muted rounded-md px-4 py-2 text-sm font-medium transition-all focus-visible:ring-3 focus-visible:outline-1 disabled:opacity-50;
+	}
+
+	.cn-navigation-menu-link {
+		@apply data-[active=true]:focus:bg-muted data-[active=true]:hover:bg-muted data-[active=true]:bg-muted/50 focus-visible:ring-ring/50 hover:bg-muted focus:bg-muted flex items-center gap-1.5 rounded-md p-2 text-sm transition-all outline-none focus-visible:ring-3 focus-visible:outline-1 in-data-[slot=navigation-menu-content]:rounded-sm [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-navigation-menu-trigger-icon {
+		@apply relative top-px ml-1 size-3 transition duration-300 group-data-open/navigation-menu-trigger:rotate-180 group-data-popup-open/navigation-menu-trigger:rotate-180;
+	}
+
+	.cn-navigation-menu-content {
+		@apply data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 group-data-[viewport=false]/navigation-menu:bg-popover group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:data-open:animate-in group-data-[viewport=false]/navigation-menu:data-closed:animate-out group-data-[viewport=false]/navigation-menu:data-closed:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-open:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-open:fade-in-0 group-data-[viewport=false]/navigation-menu:data-closed:fade-out-0 group-data-[viewport=false]/navigation-menu:ring-foreground/10 p-2 pr-2.5 ease-[cubic-bezier(0.22,1,0.36,1)] group-data-[viewport=false]/navigation-menu:rounded-md group-data-[viewport=false]/navigation-menu:shadow group-data-[viewport=false]/navigation-menu:ring-1 group-data-[viewport=false]/navigation-menu:duration-300;
+	}
+
+	.cn-navigation-menu-viewport {
+		@apply bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:zoom-out-90 data-open:zoom-in-90 ring-foreground/10 rounded-lg shadow ring-1 duration-100;
+	}
+
+	.cn-navigation-menu-indicator {
+		@apply data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in;
+	}
+
+	.cn-navigation-menu-indicator-arrow {
+		@apply bg-border rounded-tl-sm shadow-md;
+	}
+
+	.cn-navigation-menu-positioner {
+		@apply transition-[top,left,right,bottom] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] data-[side=bottom]:before:top-[-10px] data-[side=bottom]:before:right-0 data-[side=bottom]:before:left-0;
+	}
+
+	.cn-navigation-menu-popup {
+		@apply bg-popover text-popover-foreground ring-foreground/10 rounded-lg shadow ring-1 transition-all ease-[cubic-bezier(0.22,1,0.36,1)] outline-none data-ending-style:scale-90 data-ending-style:opacity-0 data-ending-style:duration-150 data-starting-style:scale-90 data-starting-style:opacity-0;
+	}
+
+	/* MARK: Native Select */
+	.cn-native-select {
+		@apply border-input placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-9 w-full min-w-0 appearance-none rounded-md border bg-transparent py-1 pr-8 pl-2.5 text-sm shadow-xs transition-[color,box-shadow] select-none focus-visible:ring-3 aria-invalid:ring-3 data-[size=sm]:h-8;
+	}
+
+	.cn-native-select-icon {
+		@apply text-muted-foreground top-1/2 right-2.5 size-4 -translate-y-1/2;
+	}
+
+	/* MARK: Pagination */
+	.cn-pagination-content {
+		@apply gap-1;
+	}
+
+	.cn-pagination-ellipsis {
+		@apply size-9 items-center justify-center [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-pagination-previous {
+		@apply pl-2!;
+	}
+
+	.cn-pagination-next {
+		@apply pr-2!;
+	}
+
+	/* MARK: Popover */
+	.cn-popover-content {
+		@apply bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 flex flex-col gap-4 rounded-md p-4 text-sm shadow-md ring-1 duration-100;
+	}
+
+	.cn-popover-content-logical {
+		@apply data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2;
+	}
+
+	.cn-popover-header {
+		@apply flex flex-col gap-1 text-sm;
+	}
+
+	.cn-popover-title {
+		@apply font-medium;
+	}
+
+	.cn-popover-description {
+		@apply text-muted-foreground;
+	}
+
+	/* MARK: Progress */
+	.cn-progress {
+		@apply bg-muted h-1.5 rounded-full;
+	}
+
+	.cn-progress-track {
+		@apply bg-muted h-1.5 rounded-full;
+	}
+
+	.cn-progress-indicator {
+		@apply bg-primary;
+	}
+
+	.cn-progress-label {
+		@apply text-sm font-medium;
+	}
+
+	.cn-progress-value {
+		@apply text-muted-foreground ml-auto text-sm tabular-nums;
+	}
+
+	/* MARK: Radio Group */
+	.cn-radio-group {
+		@apply grid gap-3;
+	}
+
+	.cn-radio-group-item {
+		@apply border-input dark:bg-input/30 data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary data-checked:border-primary aria-invalid:aria-checked:border-primary aria-invalid:border-destructive focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/50 flex size-4 rounded-full focus-visible:ring-3 aria-invalid:ring-3;
+	}
+
+	.cn-radio-group-indicator {
+		@apply flex size-4 items-center justify-center;
+	}
+
+	.cn-radio-group-indicator-icon {
+		@apply bg-primary-foreground absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full;
+	}
+
+	/* MARK: Resizable */
+	.cn-resizable-handle-icon {
+		@apply bg-border h-6 w-1 rounded-lg;
+	}
+
+	/* MARK: Scroll Area */
+	.cn-scroll-area-scrollbar {
+		@apply data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent;
+	}
+
+	.cn-scroll-area-thumb {
+		@apply rounded-full;
+	}
+
+	/* MARK: Select */
+	.cn-select-trigger {
+		@apply border-input data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 gap-1.5 rounded-md border bg-transparent py-2 pr-2 pl-2.5 text-sm shadow-xs transition-[color,box-shadow] focus-visible:ring-3 aria-invalid:ring-3 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:flex *:data-[slot=select-value]:gap-1.5 [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-select-value {
+		@apply flex flex-1 text-left;
+	}
+
+	.cn-select-trigger-icon {
+		@apply text-muted-foreground size-4;
+	}
+
+	.cn-select-content {
+		@apply bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-md shadow-md ring-1 duration-100;
+	}
+
+	.cn-select-content-logical {
+		@apply data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2;
+	}
+
+	.cn-select-label {
+		@apply text-muted-foreground px-2 py-1.5 text-xs;
+	}
+
+	.cn-select-item {
+		@apply focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2;
+	}
+
+	.cn-select-item-indicator {
+		@apply pointer-events-none absolute right-2 flex size-4 items-center justify-center;
+	}
+
+	.cn-select-group {
+		@apply scroll-my-1 p-1;
+	}
+
+	.cn-select-item-text {
+		@apply flex flex-1 gap-2;
+	}
+
+	.cn-select-separator {
+		@apply bg-border -mx-1 my-1 h-px;
+	}
+
+	.cn-select-scroll-up-button {
+		@apply bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-select-scroll-down-button {
+		@apply bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	/* MARK: Separator */
+	.cn-separator {
+		@apply bg-border shrink-0;
+	}
+
+	.cn-separator-horizontal {
+		@apply h-px w-full;
+	}
+
+	.cn-separator-vertical {
+		@apply h-full w-px;
+	}
+
+	/* MARK: Sheet */
+	.cn-sheet-overlay {
+		@apply bg-black/10 supports-backdrop-filter:backdrop-blur-xs;
+	}
+
+	.cn-sheet-content {
+		@apply bg-popover text-popover-foreground fixed z-50 flex flex-col gap-4 bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm;
+	}
+
+	.cn-sheet-close {
+		@apply absolute top-4 right-4;
+	}
+
+	.cn-sheet-header {
+		@apply gap-1.5 p-4;
+	}
+
+	.cn-sheet-footer {
+		@apply gap-2 p-4;
+	}
+
+	.cn-sheet-title {
+		@apply text-foreground font-medium;
+	}
+
+	.cn-sheet-description {
+		@apply text-muted-foreground text-sm;
+	}
+
+	/* MARK: Sidebar */
+	.cn-sidebar-gap {
+		@apply transition-[width] duration-200 ease-linear;
+	}
+
+	.cn-sidebar-inner {
+		@apply bg-sidebar group-data-[variant=floating]:ring-sidebar-border group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:shadow-sm group-data-[variant=floating]:ring-1;
+	}
+
+	.cn-sidebar-rail {
+		@apply hover:after:bg-sidebar-border;
+	}
+
+	.cn-sidebar-inset {
+		@apply bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2;
+	}
+
+	.cn-sidebar-input {
+		@apply bg-background h-8 w-full shadow-none;
+	}
+
+	.cn-sidebar-header {
+		@apply gap-2 p-2;
+	}
+
+	.cn-sidebar-content {
+		@apply no-scrollbar gap-2;
+	}
+
+	.cn-sidebar-footer {
+		@apply gap-2 p-2;
+	}
+
+	.cn-sidebar-separator {
+		@apply bg-sidebar-border mx-2;
+	}
+
+	.cn-sidebar-group {
+		@apply p-2;
+	}
+
+	.cn-sidebar-menu {
+		@apply gap-1;
+	}
+
+	.cn-sidebar-group-content {
+		@apply text-sm;
+	}
+
+	.cn-sidebar-group-label {
+		@apply text-sidebar-foreground/70 ring-sidebar-ring h-8 rounded-md px-2 text-xs font-medium transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4;
+	}
+
+	.cn-sidebar-group-action {
+		@apply text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 w-5 rounded-md p-0 focus-visible:ring-2 [&>svg]:size-4;
+	}
+
+	.cn-sidebar-menu-button {
+		@apply ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground gap-2 rounded-md p-2 text-left text-sm transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! focus-visible:ring-2 data-active:font-medium;
+	}
+
+	.cn-sidebar-menu-button-variant-default {
+		@apply hover:bg-sidebar-accent hover:text-sidebar-accent-foreground;
+	}
+
+	.cn-sidebar-menu-button-variant-outline {
+		@apply bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_var(--sidebar-border)] hover:shadow-[0_0_0_1px_var(--sidebar-accent)];
+	}
+
+	.cn-sidebar-menu-button-size-default {
+		@apply h-8 text-sm;
+	}
+
+	.cn-sidebar-menu-button-size-sm {
+		@apply h-7 text-xs;
+	}
+
+	.cn-sidebar-menu-button-size-lg {
+		@apply h-12 text-sm group-data-[collapsible=icon]:p-0!;
+	}
+
+	.cn-sidebar-menu-action {
+		@apply text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 aspect-square w-5 rounded-md p-0 peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 focus-visible:ring-2 [&>svg]:size-4;
+	}
+
+	.cn-sidebar-menu-badge {
+		@apply text-sidebar-foreground peer-hover/menu-button:text-sidebar-accent-foreground peer-data-active/menu-button:text-sidebar-accent-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 rounded-md px-1 text-xs font-medium peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1;
+	}
+
+	.cn-sidebar-menu-skeleton {
+		@apply h-8 gap-2 rounded-md px-2;
+	}
+
+	.cn-sidebar-menu-skeleton-icon {
+		@apply size-4 rounded-md;
+	}
+
+	.cn-sidebar-menu-skeleton-text {
+		@apply h-4;
+	}
+
+	.cn-sidebar-menu-sub {
+		@apply border-sidebar-border mx-3.5 translate-x-px gap-1 border-l px-2.5 py-0.5 group-data-[collapsible=icon]:hidden;
+	}
+
+	.cn-sidebar-menu-sub-button {
+		@apply text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground h-7 gap-2 rounded-md px-2 focus-visible:ring-2 data-[size=md]:text-sm data-[size=sm]:text-xs [&>svg]:size-4;
+	}
+
+	/* MARK: Skeleton */
+	.cn-skeleton {
+		@apply bg-muted rounded-md;
+	}
+
+	/* MARK: Slider */
+	.cn-slider {
+		@apply data-vertical:min-h-40;
+	}
+
+	.cn-slider-track {
+		@apply bg-muted rounded-full data-horizontal:h-1.5 data-horizontal:w-full data-vertical:h-full data-vertical:w-1.5;
+	}
+
+	.cn-slider-range {
+		@apply bg-primary;
+	}
+
+	.cn-slider-thumb {
+		@apply border-primary ring-ring/50 size-4 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden;
+	}
+
+	/* MARK: Sonner */
+	.cn-toast {
+		@apply rounded-2xl;
+	}
+
+	/* MARK: Switch */
+	.cn-switch {
+		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent shadow-xs focus-visible:ring-3 aria-invalid:ring-3 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px];
+	}
+
+	.cn-switch-thumb {
+		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0;
+	}
+
+	/* MARK: Table */
+	.cn-table-container {
+		@apply relative w-full overflow-x-auto;
+	}
+
+	.cn-table {
+		@apply w-full caption-bottom text-sm;
+	}
+
+	.cn-table-header {
+		@apply [&_tr]:border-b;
+	}
+
+	.cn-table-body {
+		@apply [&_tr:last-child]:border-0;
+	}
+
+	.cn-table-footer {
+		@apply bg-muted/50 border-t font-medium [&>tr]:last:border-b-0;
+	}
+
+	.cn-table-row {
+		@apply hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors;
+	}
+
+	.cn-table-head {
+		@apply text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0;
+	}
+
+	.cn-table-cell {
+		@apply p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0;
+	}
+
+	.cn-table-caption {
+		@apply text-muted-foreground mt-4 text-sm;
+	}
+
+	/* MARK: Tabs */
+	.cn-tabs {
+		@apply gap-2;
+	}
+
+	.cn-tabs-list {
+		@apply rounded-lg p-[3px] group-data-horizontal/tabs:h-9 data-[variant=line]:rounded-none;
+	}
+
+	.cn-tabs-trigger {
+		@apply gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-tabs-content {
+		@apply text-sm;
+	}
+
+	/* MARK: Textarea */
+	.cn-textarea {
+		@apply border-input dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-transparent px-2.5 py-2 text-base shadow-xs transition-[color,box-shadow] focus-visible:ring-3 aria-invalid:ring-3 md:text-sm;
+	}
+
+	/* MARK: Toggle */
+	.cn-toggle {
+		@apply hover:text-foreground aria-pressed:bg-muted focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive gap-1 rounded-md text-sm font-medium transition-[color,box-shadow] [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-toggle-variant-default {
+		@apply bg-transparent;
+	}
+
+	.cn-toggle-variant-outline {
+		@apply border-input hover:bg-muted border bg-transparent shadow-xs;
+	}
+
+	.cn-toggle-size-default {
+		@apply h-9 min-w-9 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2;
+	}
+
+	.cn-toggle-size-sm {
+		@apply h-8 min-w-8 px-2.5 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5;
+	}
+
+	.cn-toggle-size-lg {
+		@apply h-10 min-w-10 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2;
+	}
+
+	/* MARK: Toggle Group */
+	.cn-toggle-group {
+		@apply rounded-md data-[spacing=0]:data-[variant=outline]:shadow-xs;
+	}
+
+	.cn-toggle-group-item {
+		@apply data-[state=on]:bg-muted group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-2 group-data-[spacing=0]/toggle-group:shadow-none group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-1.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-1.5 group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-md group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-md group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-md group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-md;
+	}
+
+	/* MARK: Tooltip */
+	.cn-tooltip-content {
+		@apply data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs has-data-[slot=kbd]:pr-1.5 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm;
+	}
+
+	.cn-tooltip-content-logical {
+		@apply data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2;
+	}
+
+	.cn-tooltip-arrow {
+		@apply size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px];
+	}
+
+	.cn-tooltip-arrow-logical {
+		@apply data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2;
+	}
+
+	/* MARK: Input Group */
+	.cn-input-group {
+		@apply border-input dark:bg-input/30 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 h-9 rounded-md border shadow-xs transition-[color,box-shadow] in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-3 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5;
+	}
+
+	.cn-input-group-addon {
+		@apply text-muted-foreground h-auto gap-2 py-1.5 text-sm font-medium group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-input-group-addon-align-inline-start {
+		@apply pl-2 has-[>button]:-ml-1 has-[>kbd]:ml-[-0.15rem];
+	}
+
+	.cn-input-group-addon-align-inline-end {
+		@apply pr-2 has-[>button]:-mr-1 has-[>kbd]:mr-[-0.15rem];
+	}
+
+	.cn-input-group-addon-align-block-start {
+		@apply px-2.5 pt-2 group-has-[>input]/input-group:pt-2 [.border-b]:pb-2;
+	}
+
+	.cn-input-group-addon-align-block-end {
+		@apply px-2.5 pb-2 group-has-[>input]/input-group:pb-2 [.border-t]:pt-2;
+	}
+
+	.cn-input-group-button {
+		@apply gap-2 text-sm;
+	}
+
+	.cn-input-group-button-size-xs {
+		@apply h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-1.5 [&>svg:not([class*='size-'])]:size-3.5;
+	}
+
+	.cn-input-group-button-size-icon-xs {
+		@apply size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0;
+	}
+
+	.cn-input-group-button-size-icon-sm {
+		@apply size-8 p-0 has-[>svg]:p-0;
+	}
+
+	.cn-input-group-text {
+		@apply text-muted-foreground gap-2 text-sm [&_svg:not([class*='size-'])]:size-4;
+	}
+
+	.cn-input-group-input {
+		@apply rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent;
+	}
+
+	.cn-input-group-textarea {
+		@apply rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent;
+	}
+
+	/* MARK: Menu Translucent */
+	.cn-menu-translucent {
+		@apply bg-popover/70 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground! relative animate-none! before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150;
+	}
+}

--- a/packages/ui/src/switch/switch.svelte
+++ b/packages/ui/src/switch/switch.svelte
@@ -6,16 +6,20 @@
 		ref = $bindable(null),
 		class: className,
 		checked = $bindable(false),
+		size = 'default',
 		...restProps
-	}: WithoutChildrenOrChild<SwitchPrimitive.RootProps> = $props();
+	}: WithoutChildrenOrChild<SwitchPrimitive.RootProps> & {
+		size?: 'sm' | 'default';
+	} = $props();
 </script>
 
 <SwitchPrimitive.Root
 	bind:ref
 	bind:checked
 	data-slot="switch"
+	data-size={size}
 	class={cn(
-		'data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 shadow-xs peer inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent outline-none transition-all focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+		'cn-switch peer group/switch relative inline-flex items-center transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 data-disabled:cursor-not-allowed data-disabled:opacity-50',
 		className,
 	)}
 	{...restProps}
@@ -23,7 +27,7 @@
 	<SwitchPrimitive.Thumb
 		data-slot="switch-thumb"
 		class={cn(
-			'bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0',
+			'cn-switch-thumb pointer-events-none block ring-0 transition-transform rtl:data-[state=checked]:translate-x-[calc(-100%)]',
 		)}
 	/>
 </SwitchPrimitive.Root>

--- a/packages/ui/src/table/table-body.svelte
+++ b/packages/ui/src/table/table-body.svelte
@@ -13,7 +13,7 @@
 <tbody
 	bind:this={ref}
 	data-slot="table-body"
-	class={cn('[&_tr:last-child]:border-0', className)}
+	class={cn('cn-table-body', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/table/table-caption.svelte
+++ b/packages/ui/src/table/table-caption.svelte
@@ -13,7 +13,7 @@
 <caption
 	bind:this={ref}
 	data-slot="table-caption"
-	class={cn('text-muted-foreground mt-4 text-sm', className)}
+	class={cn('cn-table-caption', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/table/table-cell.svelte
+++ b/packages/ui/src/table/table-cell.svelte
@@ -17,7 +17,8 @@
 	bind:this={ref}
 	data-slot="table-cell"
 	class={cn(
-		'whitespace-nowrap bg-clip-padding p-2 align-middle [&:has([role=checkbox])]:pe-0',
+		'cn-table-cell',
+		'bg-clip-padding [&:has([role=checkbox])]:pe-0',
 		variant === 'muted' && 'text-muted-foreground',
 		variant === 'numeric' && 'text-right font-mono',
 		className,

--- a/packages/ui/src/table/table-footer.svelte
+++ b/packages/ui/src/table/table-footer.svelte
@@ -13,10 +13,7 @@
 <tfoot
 	bind:this={ref}
 	data-slot="table-footer"
-	class={cn(
-		'bg-muted/50 border-t font-medium [&>tr]:last:border-b-0',
-		className,
-	)}
+	class={cn('cn-table-footer', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/table/table-head.svelte
+++ b/packages/ui/src/table/table-head.svelte
@@ -14,7 +14,8 @@
 	bind:this={ref}
 	data-slot="table-head"
 	class={cn(
-		'text-foreground h-10 whitespace-nowrap bg-clip-padding px-2 text-start align-middle font-medium [&:has([role=checkbox])]:pe-0',
+		'cn-table-head',
+		'bg-clip-padding text-start [&:has([role=checkbox])]:pe-0',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/table/table-header.svelte
+++ b/packages/ui/src/table/table-header.svelte
@@ -13,7 +13,7 @@
 <thead
 	bind:this={ref}
 	data-slot="table-header"
-	class={cn('[&_tr]:border-b', className)}
+	class={cn('cn-table-header', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/table/table-row.svelte
+++ b/packages/ui/src/table/table-row.svelte
@@ -13,11 +13,7 @@
 <tr
 	bind:this={ref}
 	data-slot="table-row"
-	class={cn(
-		'cn-table-row',
-		'hover:[&,&>svelte-css-wrapper]:[&>th,td]:bg-muted/50',
-		className,
-	)}
+	class={cn('cn-table-row', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/table/table-row.svelte
+++ b/packages/ui/src/table/table-row.svelte
@@ -14,7 +14,8 @@
 	bind:this={ref}
 	data-slot="table-row"
 	class={cn(
-		'hover:[&,&>svelte-css-wrapper]:[&>th,td]:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors',
+		'cn-table-row',
+		'hover:[&,&>svelte-css-wrapper]:[&>th,td]:bg-muted/50',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/table/table.svelte
+++ b/packages/ui/src/table/table.svelte
@@ -10,11 +10,11 @@
 	}: WithElementRef<HTMLTableAttributes> = $props();
 </script>
 
-<div data-slot="table-container" class="relative w-full overflow-x-auto">
+<div data-slot="table-container" class="cn-table-container">
 	<table
 		bind:this={ref}
 		data-slot="table"
-		class={cn('w-full caption-bottom text-sm', className)}
+		class={cn('cn-table', className)}
 		{...restProps}
 	>
 		{@render children?.()}

--- a/packages/ui/src/tabs/index.ts
+++ b/packages/ui/src/tabs/index.ts
@@ -1,6 +1,9 @@
 import Root from './tabs.svelte';
 import Content from './tabs-content.svelte';
-import List from './tabs-list.svelte';
+import List, {
+	type TabsListVariant,
+	tabsListVariants,
+} from './tabs-list.svelte';
 import Trigger from './tabs-trigger.svelte';
 
 export {
@@ -8,6 +11,8 @@ export {
 	Content as TabsContent,
 	List,
 	List as TabsList,
+	type TabsListVariant,
+	tabsListVariants,
 	Root,
 	//
 	Root as Tabs,

--- a/packages/ui/src/tabs/tabs-content.svelte
+++ b/packages/ui/src/tabs/tabs-content.svelte
@@ -12,6 +12,6 @@
 <TabsPrimitive.Content
 	bind:ref
 	data-slot="tabs-content"
-	class={cn('outline-none', className)}
+	class={cn('cn-tabs-content flex-1 outline-none', className)}
 	{...restProps}
 />

--- a/packages/ui/src/tabs/tabs-list.svelte
+++ b/packages/ui/src/tabs/tabs-list.svelte
@@ -1,20 +1,42 @@
+<script lang="ts" module>
+	import { tv, type VariantProps } from 'tailwind-variants';
+
+	// Styling lives in the vendored Vega preset (cn-* classes); see
+	// packages/ui/src/styles/style-vega.css.
+	export const tabsListVariants = tv({
+		base: 'cn-tabs-list group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col',
+		variants: {
+			variant: {
+				default: 'cn-tabs-list-variant-default bg-muted',
+				line: 'cn-tabs-list-variant-line gap-1 bg-transparent',
+			},
+		},
+		defaultVariants: {
+			variant: 'default',
+		},
+	});
+
+	export type TabsListVariant = VariantProps<typeof tabsListVariants>['variant'];
+</script>
+
 <script lang="ts">
 	import { Tabs as TabsPrimitive } from 'bits-ui';
 	import { cn } from '../utils.js';
 
 	let {
 		ref = $bindable(null),
+		variant = 'default',
 		class: className,
 		...restProps
-	}: TabsPrimitive.ListProps = $props();
+	}: TabsPrimitive.ListProps & {
+		variant?: TabsListVariant;
+	} = $props();
 </script>
 
 <TabsPrimitive.List
 	bind:ref
 	data-slot="tabs-list"
-	class={cn(
-		'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]',
-		className,
-	)}
+	data-variant={variant}
+	class={cn(tabsListVariants({ variant }), className)}
 	{...restProps}
 />

--- a/packages/ui/src/tabs/tabs-list.svelte
+++ b/packages/ui/src/tabs/tabs-list.svelte
@@ -7,8 +7,8 @@
 		base: 'cn-tabs-list group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col',
 		variants: {
 			variant: {
-				default: 'cn-tabs-list-variant-default bg-muted',
-				line: 'cn-tabs-list-variant-line gap-1 bg-transparent',
+				default: 'bg-muted',
+				line: 'gap-1 bg-transparent',
 			},
 		},
 		defaultVariants: {

--- a/packages/ui/src/tabs/tabs-trigger.svelte
+++ b/packages/ui/src/tabs/tabs-trigger.svelte
@@ -13,7 +13,10 @@
 	bind:ref
 	data-slot="tabs-trigger"
 	class={cn(
-		"data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-2 py-1 text-sm font-medium transition-[color,box-shadow] focus-visible:outline-1 focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"cn-tabs-trigger focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+		"data-active:bg-background dark:data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 data-active:text-foreground",
+		"after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/tabs/tabs.svelte
+++ b/packages/ui/src/tabs/tabs.svelte
@@ -14,6 +14,9 @@
 	bind:ref
 	bind:value
 	data-slot="tabs"
-	class={cn('flex flex-col gap-2', className)}
+	class={cn(
+		'cn-tabs group/tabs flex data-[orientation=horizontal]:flex-col',
+		className,
+	)}
 	{...restProps}
 />

--- a/packages/ui/src/textarea/textarea.svelte
+++ b/packages/ui/src/textarea/textarea.svelte
@@ -15,7 +15,7 @@
 	bind:this={ref}
 	data-slot={dataSlot}
 	class={cn(
-		'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 field-sizing-content shadow-xs flex min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+		'cn-textarea placeholder:text-muted-foreground flex field-sizing-content min-h-16 w-full outline-none disabled:cursor-not-allowed disabled:opacity-50',
 		className,
 	)}
 	bind:value

--- a/packages/ui/src/toggle-group/toggle-group-item.svelte
+++ b/packages/ui/src/toggle-group/toggle-group-item.svelte
@@ -21,12 +21,14 @@
 	data-slot="toggle-group-item"
 	data-variant={ctx.variant || variant}
 	data-size={ctx.size || size}
+	data-spacing={ctx.spacing}
 	class={cn(
+		'cn-toggle-group-item shrink-0 focus:z-10 focus-visible:z-10 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t',
 		toggleVariants({
 			variant: ctx.variant || variant,
 			size: ctx.size || size,
 		}),
-		'min-w-0 flex-1 shrink-0 rounded-none shadow-none first:rounded-s-md last:rounded-e-md focus:z-10 focus-visible:z-10 data-[variant=outline]:border-s-0 data-[variant=outline]:first:border-s',
+		'min-w-0 flex-1',
 		className,
 	)}
 	{value}

--- a/packages/ui/src/toggle-group/toggle-group.svelte
+++ b/packages/ui/src/toggle-group/toggle-group.svelte
@@ -1,12 +1,18 @@
 <script lang="ts" module>
 	import { getContext, setContext } from 'svelte';
 	import type { ToggleVariants } from '../toggle/index.js';
-	export function setToggleGroupCtx(props: ToggleVariants) {
+
+	interface ToggleGroupContext extends ToggleVariants {
+		spacing?: number;
+		orientation?: 'horizontal' | 'vertical';
+	}
+
+	export function setToggleGroupCtx(props: ToggleGroupContext) {
 		setContext('toggleGroup', props);
 	}
 
 	export function getToggleGroupCtx() {
-		return getContext<ToggleVariants>('toggleGroup');
+		return getContext<Required<ToggleGroupContext>>('toggleGroup');
 	}
 </script>
 
@@ -19,9 +25,15 @@
 		value = $bindable(),
 		class: className,
 		size = 'default',
+		spacing = 0,
+		orientation = 'horizontal',
 		variant = 'default',
 		...restProps
-	}: ToggleGroupPrimitive.RootProps & ToggleVariants = $props();
+	}: ToggleGroupPrimitive.RootProps &
+		ToggleVariants & {
+			spacing?: number;
+			orientation?: 'horizontal' | 'vertical';
+		} = $props();
 
 	// Use getters so child components receive reactive values when props change
 	setToggleGroupCtx({
@@ -30,6 +42,12 @@
 		},
 		get size() {
 			return size;
+		},
+		get spacing() {
+			return spacing;
+		},
+		get orientation() {
+			return orientation;
 		},
 	});
 </script>
@@ -41,11 +59,14 @@ get along, so we shut typescript up by casting `value` to `never`.
 <ToggleGroupPrimitive.Root
 	bind:value={value as never}
 	bind:ref
+	{orientation}
 	data-slot="toggle-group"
 	data-variant={variant}
 	data-size={size}
+	data-spacing={spacing}
+	style={`--gap: ${spacing}`}
 	class={cn(
-		'group/toggle-group data-[variant=outline]:shadow-xs flex w-fit items-center rounded-md',
+		'cn-toggle-group group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] data-vertical:flex-col data-vertical:items-stretch',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/toggle/toggle.svelte
+++ b/packages/ui/src/toggle/toggle.svelte
@@ -2,17 +2,16 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 
 	export const toggleVariants = tv({
-		base: "hover:bg-muted hover:text-muted-foreground data-[state=on]:bg-accent data-[state=on]:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		base: "cn-toggle group/toggle inline-flex items-center justify-center whitespace-nowrap outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		variants: {
 			variant: {
-				default: 'bg-transparent',
-				outline:
-					'border-input shadow-xs hover:bg-accent hover:text-accent-foreground border bg-transparent',
+				default: 'cn-toggle-variant-default',
+				outline: 'cn-toggle-variant-outline',
 			},
 			size: {
-				default: 'h-9 min-w-9 px-2',
-				sm: 'h-8 min-w-8 px-1.5',
-				lg: 'h-10 min-w-10 px-2.5',
+				default: 'cn-toggle-size-default',
+				sm: 'cn-toggle-size-sm',
+				lg: 'cn-toggle-size-lg',
 			},
 		},
 		defaultVariants: {

--- a/packages/ui/src/tooltip/tooltip-content.svelte
+++ b/packages/ui/src/tooltip/tooltip-content.svelte
@@ -27,7 +27,7 @@
 		{sideOffset}
 		{side}
 		class={cn(
-			'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-end-2 data-[side=right]:slide-in-from-start-2 data-[side=top]:slide-in-from-bottom-2 origin-(--bits-tooltip-content-transform-origin) z-50 w-fit text-balance rounded-md px-3 py-1.5 text-xs',
+			'cn-tooltip-content bg-foreground text-background z-50 w-fit max-w-xs origin-(--bits-tooltip-content-transform-origin)',
 			className,
 		)}
 		{...restProps}
@@ -37,7 +37,7 @@
 			{#snippet child({ props })}
 				<div
 					class={cn(
-						'bg-primary z-50 size-2.5 rotate-45 rounded-[2px]',
+						'cn-tooltip-arrow bg-foreground fill-foreground z-50',
 						'data-[side=top]:translate-x-1/2 data-[side=top]:translate-y-[calc(-50%_+_2px)]',
 						'data-[side=bottom]:-translate-x-1/2 data-[side=bottom]:-translate-y-[calc(-50%_+_1px)]',
 						'data-[side=right]:translate-x-[calc(50%_+_2px)] data-[side=right]:translate-y-1/2',

--- a/specs/20260606T160000-ui-shadcn-cn-style-migration-vega.md
+++ b/specs/20260606T160000-ui-shadcn-cn-style-migration-vega.md
@@ -220,15 +220,13 @@ Migrated all 42 remaining shadcn-core components (migrate + adversarial review p
 
 ## Deferred Cosmetic Ledger
 
-Each item degrades gracefully (slightly different look, not broken). Restore in the polish pass.
+Consolidation pass (commit `1ac35f433`) moved utility overrides into the overlay; the rest stay inline by necessity.
 
-- [ ] **z-40 layering** (`dialog-content:33`, `dialog-overlay:18`, `drawer-content:33`, `drawer-overlay:17`): regular dialogs/drawers at z-40 so alert-dialogs (z-50) win. Project-wide policy; restore as a coordinated overlay block.
-- [ ] **Solid destructive**: decide whether to keep Vega's tinted destructive or restore Epicenter's solid red. If restore: override `.cn-button-variant-destructive` in overlay.
-- [ ] **Select `max-w-min`** (`select-content:29`): prevent dropdown widening past trigger.
-- [ ] **Resizable `gap-2`** (`resizable-pane-group:20`): visual separation between panes.
-- [ ] **Drawer scrollable wrapper** (`drawer-content:41`): structural, re-apply when migrating drawer.
-- [ ] **Dialog tall-content scroll** (`dialog-content:31`): `overflow-y-auto max-h-[calc(100vh-2rem)]`.
-- [ ] **Item truncation** (`item-content:19`, `item-title:20`, `item:5`): `min-w-0` / `relative` overrides.
+- [x] **Consolidated into overlay** (components now byte-identical to upstream): table-row hover (also FIXED the double-hover regression), select `max-w-min`, resizable `gap-2`, item `min-w-0` (content + title), item-description `text-balance`, item-separator `my-0`.
+- [x] **z-40 layering** (dialog/drawer content+overlay): **stays inline, resolved not deferred.** Vega keeps z-index inline (not in the cn-* class), so a base-layer `@apply` in the overlay cannot beat a utilities-layer inline `z-50`. Inline override is the correct place.
+- [x] **Structural overrides stay in components** (markup, not CSS): drawer scroll wrapper (`drawer-content:39`), item actions overlay, badge `<svelte:element>`, item-media icon, item base `relative` + `[a]:hover:bg-accent/50` (kept inline; ambiguous arbitrary-variant selector, working).
+- [ ] **Solid destructive**: still open. Decide whether to keep Vega's tinted destructive or restore Epicenter's solid red (override `.cn-button-variant-destructive` in overlay).
+- [ ] **Dialog tall-content scroll** (`dialog-content:31`): `overflow-y-auto max-h-[calc(100vh-2rem)]` kept inline alongside its z-40 (additive; left with the z-40 it is grouped with).
 - [ ] **drawer `onOpenAutoFocus` workaround** (`drawer-content:24`): remove once vaul-svelte ships bits-ui 2.x compat (verify).
 
 ### No-op forward-compat hooks (resolve on next style-vega.css pull)

--- a/specs/20260606T160000-ui-shadcn-cn-style-migration-vega.md
+++ b/specs/20260606T160000-ui-shadcn-cn-style-migration-vega.md
@@ -223,21 +223,15 @@ Migrated all 42 remaining shadcn-core components (migrate + adversarial review p
 Consolidation pass (commit `1ac35f433`) moved utility overrides into the overlay; the rest stay inline by necessity.
 
 - [x] **Consolidated into overlay** (components now byte-identical to upstream): table-row hover (also FIXED the double-hover regression), select `max-w-min`, resizable `gap-2`, item `min-w-0` (content + title), item-description `text-balance`, item-separator `my-0`.
-- [x] **z-40 layering** (dialog/drawer content+overlay): **stays inline, resolved not deferred.** Vega keeps z-index inline (not in the cn-* class), so a base-layer `@apply` in the overlay cannot beat a utilities-layer inline `z-50`. Inline override is the correct place.
+- [x] **z-40 layering** (dialog/drawer): **REMOVED** (commit `6924abbde`). It was a no-op: Tailwind emits `z-50` after `z-40` (same property, ascending), so with both classes present `z-50` always won. Dialogs were effectively `z-50` already; alert-dialogs sit above via portal/DOM order, not z-index. If a hard z-order guarantee is ever needed, add `@apply z-40!` in the overlay (behavior change, test it).
 - [x] **Structural overrides stay in components** (markup, not CSS): drawer scroll wrapper (`drawer-content:39`), item actions overlay, badge `<svelte:element>`, item-media icon, item base `relative` + `[a]:hover:bg-accent/50` (kept inline; ambiguous arbitrary-variant selector, working).
-- [ ] **Solid destructive**: still open. Decide whether to keep Vega's tinted destructive or restore Epicenter's solid red (override `.cn-button-variant-destructive` in overlay).
-- [ ] **Dialog tall-content scroll** (`dialog-content:31`): `overflow-y-auto max-h-[calc(100vh-2rem)]` kept inline alongside its z-40 (additive; left with the z-40 it is grouped with).
+- [x] **Solid vs tinted destructive**: RESOLVED, keep Vega's tinted destructive. No overlay override. Confirmed after building.
+- [x] **Dialog tall-content scroll**: moved to the overlay (`.cn-dialog-content { @apply overflow-y-auto max-h-[calc(100vh-2rem)] }`); dialog-content is now byte-identical to upstream.
 - [ ] **drawer `onOpenAutoFocus` workaround** (`drawer-content:24`): remove once vaul-svelte ships bits-ui 2.x compat (verify).
 
-### No-op forward-compat hooks (resolve on next style-vega.css pull)
+### No-op forward-compat hooks (REMOVED, commit `6924abbde`)
 
-These cn-* classes are emitted by migrated components but not yet defined in the vendored Vega sheet, so they are inert today (component still styled by its sibling cn-* classes + inline). Re-vendor a newer `style-vega.css` to activate, or drop them:
-
-- [ ] `cn-font-heading` (on alert-dialog/drawer/empty titles; dialog-title currently omits it, inconsistent with siblings: restore for family consistency).
-- [ ] `cn-alert-dialog-footer` / `-action` / `-cancel` (footer keeps inline flex; actions keep buttonVariants).
-- [ ] `cn-menu-target` (select + dropdown-menu content; menu-family forward-compat placeholder).
-- [ ] `cn-tabs-list-variant-default` / `-line` (variant visuals delivered by paired inline utils + data-variant CSS).
-- [ ] `cn-scroll-area-viewport` (scroll-area viewport left inline until defined).
+Dead `cn-*` hooks the fan-out emitted but the vendored Vega did not define were removed, establishing the **invariant**: every `cn-*` class a component emits is defined in `style-vega.css` or `epicenter-overlay.css` (verified: 247 emitted, 0 undefined). Removed: `cn-font-heading` (3 titles, all consistent now), `cn-menu-target` (select + 2 dropdown), `cn-alert-dialog-footer`/`-action`/`-cancel`, `cn-tabs-list-variant-*`, the `cn-resizable-handle` prefix (handle stays inline; Vega defines only `cn-resizable-handle-icon`), and the undefined input-group-button `sm` size (unused by any app). `cn-scroll-area-viewport` was never emitted (viewport stays inline). If a newer `style-vega.css` later defines any of these, re-add the hooks then.
 
 ## QA Checklist (where to look after each wave)
 
@@ -269,7 +263,7 @@ An app without `.style-vega` on its root renders all migrated components unstyle
 
 ## Open Questions
 
-1. **Solid vs tinted destructive** (Class 3): Vega ships tinted; Epicenter had solid red + white. Options: (a) accept Vega tinted, (b) restore solid in overlay. **Recommendation**: live with tinted through the migration, decide in polish once seen in context.
+1. **Solid vs tinted destructive** (Class 3): RESOLVED, keep Vega's tinted destructive (no overlay override). Confirmed after building.
 2. **Vendor full Vega vs per-wave slices**: full file (chosen, 0.2) is simpler but generates inert CSS during transition and risks one unknown-utility error blocking everything. **Recommendation**: full file + build-verify; fall back to slicing only if 0.6 errors.
 3. **Later preset swap to Rhea/Mira**: deferred; one-class experiment once Vega is stable.
 

--- a/specs/20260606T160000-ui-shadcn-cn-style-migration-vega.md
+++ b/specs/20260606T160000-ui-shadcn-cn-style-migration-vega.md
@@ -1,0 +1,292 @@
+# @epicenter/ui Migration to shadcn-svelte 1.x cn-* Style System (Vega)
+
+**Date**: 2026-06-06
+**Status**: In Progress
+**Owner**: Braden
+**Branch**: braden-w/lahore-v2
+
+## One Sentence
+
+Move `@epicenter/ui` from inline-Tailwind component styling to shadcn-svelte 1.x semantic `cn-*` classes backed by the vendored Vega style sheet, so component markup matches upstream and is trackable again, while Epicenter customizations move into a single overlay layer.
+
+## How to read this spec
+
+```
+Read first:        One Sentence, Current State, Target Shape, Implementation Plan, QA Checklist
+Read for model:    Research Findings, Design Decisions, Architecture
+Read when stuck:   Edge Cases, Open Questions
+Track progress:    Implementation Plan checkboxes, Deferred Cosmetic Ledger
+```
+
+## Overview
+
+`@epicenter/ui` is a hand-maintained fork frozen at the pre-1.0 inline-Tailwind generation of shadcn-svelte (with bits-ui v2 and the new-components wave backported). Upstream 1.x relocated all component styling out of the markup into per-style CSS files (`style-vega.css`, `style-luma.css`, etc.) where components carry semantic hook classes (`cn-button-variant-default`). This spec adopts that base, picks Vega (the classic-shadcn preset, `rounded-md`), and isolates every Epicenter customization into one overlay file so future upstream pulls touch markup only.
+
+## Motivation
+
+### Current State
+
+Components carry inline Tailwind. Example (`packages/ui/src/button/button.svelte:13`):
+
+```svelte
+variant: {
+  default: 'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
+  destructive: 'bg-destructive shadow-xs hover:bg-destructive/90 ... text-white',
+  'ghost-destructive': 'text-destructive hover:bg-destructive/10 ...',  // Epicenter custom
+}
+```
+
+Problems:
+
+1. **Markup diverges from upstream permanently**: every upstream component fix (a11y, bits-ui, behavior) must be hand-reconciled against inline strings. The README's "regenerate in a scratch project and copy" workflow now silently pulls the cn-* rewrite and breaks.
+2. **Customizations are entangled with base styling**: overrides live as extra `cn()` args inside each component, so there is no single place that answers "what did Epicenter change."
+
+### Desired State
+
+Component markup is byte-identical to upstream Vega (`cn-*` hooks). Styling lives in vendored `style-vega.css`. Epicenter deltas live in one `epicenter-overlay.css`. Swapping presets later (e.g. to Rhea/Mira for denser product surfaces) is a one-class change on the app root.
+
+## Research Findings
+
+### The cn-* mechanism is lossless
+
+`cn-*` classes are `@apply` of the same Tailwind utilities, relocated into per-style CSS. Verified against `style-vega.css`:
+
+```css
+.style-vega { .cn-button-variant-default { @apply bg-primary text-primary-foreground hover:bg-primary/80; } }
+```
+
+Every style defines the full variant + size set. Nothing collapses away.
+
+### Token diff: no color gaps
+
+Upstream base (`shadcn-svelte/tailwind.css`, 89 lines) adds NO colors. Your `app.css` palette is already a superset (includes `--warning`, `--success`). What you lack and Vega's `@apply` rules depend on:
+
+```
+@custom-variant data-open / data-closed / data-checked / data-unchecked
+                data-disabled / data-active / data-horizontal / data-vertical
+@utility no-scrollbar
+@keyframes accordion-up / accordion-down
+```
+
+### Vega vs the other presets
+
+| Style | Character | Radius | Fit for Epicenter |
+|---|---|---|---|
+| **Vega** | classic shadcn | rounded-md | matches today; chosen |
+| Luma | soft/fluid, macOS-Tahoe | rounded-4xl, open spacing | too airy for dense tools (community shipped Rhea to fix this) |
+| Nova / Mira | compact, product-focused | rounded-lg / md | candidate for later if we want density + personality |
+| Rhea | compact Luma | rounded-2xl | candidate for later |
+
+Sources: shadcn changelog (Luma), shadcnblocks component-styles post, shadcndesign style-choice guide. **Key finding**: Vega is the low-surprise choice (matches current radius); personality presets (Rhea/Mira) are a later one-class experiment.
+
+### Vega button vs current (the visible deltas)
+
+| | Current (inline) | Vega |
+|---|---|---|
+| radius | rounded-md | rounded-md (same) |
+| focus ring | ring-[3px] | ring-3 (same) |
+| destructive | SOLID (`bg-destructive` + white text) | TINTED (`bg-destructive/10 text-destructive`) |
+| press | none | `active:not-aria-[haspopup]:translate-y-px` (subtle) |
+| icon sizes | custom `size-6/8/10` | native, identical dims |
+
+## Design Decisions
+
+| Decision | Class | Choice | Rationale |
+|---|---|---|---|
+| Adopt cn-* base | 2 coherence | Yes | Makes markup upstream-trackable; the whole point |
+| Preset | 3 taste | Vega | Matches current `rounded-md`; lowest surprise |
+| Vendor vs depend | 2 coherence | Vendor `style-vega.css` + base into `src/styles/` | README forbids generator deps; keep package self-contained |
+| Apply mechanism | 1 evidence | `.style-vega` class on each app root | Verified: vega.css scopes all rules under `.style-vega {}`; without an ancestor class, cn-* components are unstyled |
+| Icon sizes | 1 evidence | Drop custom, use native | Verified Vega dims identical (size-6/8/9/10); 41 call-sites unchanged |
+| showCloseButton | 1 evidence | Drop custom, use native | Upstream 1.x dialog-content has it |
+| Load-bearing customs | 2 coherence | Carry IN the migrating wave | Unknown tv variant renders unstyled; cannot defer (see Edge Cases) |
+| Cosmetic overrides | 3 taste | Defer to polish pass | Graceful degradation; tracked in Deferred Ledger |
+| IconPlaceholder | 2 coherence | Strip, keep `@lucide/svelte` | Epicenter convention; upstream multi-icon abstraction unwanted |
+
+## Architecture
+
+### Plumbing (Wave 0)
+
+```
+packages/ui/src/
+  styles/
+    shadcn-base.css       <- vendored upstream tailwind.css (data-* variants, no-scrollbar, keyframes)
+    style-vega.css        <- vendored upstream Vega (all cn-* rules, scoped under .style-vega)
+    epicenter-overlay.css <- Epicenter deltas (scoped under .style-vega); GROWS each wave
+  app.css                 <- @import the three above
+
+each consuming app root (app.html / root mount):
+  <html class="style-vega">   <- activates the scoped cn-* rules
+```
+
+Invisibility guarantee: until a component emits `cn-*` classes, every rule in `style-vega.css` is inert. Wave 0 changes nothing visually.
+
+### Activation scope (critical)
+
+Button is SHARED. The moment it emits `cn-*` (Wave 1), EVERY consuming app needs `.style-vega` on its root or its buttons render unstyled. Therefore Wave 0 must add the class to ALL consuming app roots before Wave 1 lands.
+
+## Catalog: collapse-vs-carry
+
+```
+COLLAPSE INTO NATIVE (delete Epicenter code, call-sites unchanged):
+  Button size icon-xs/icon-sm/icon-lg   -> native, identical dims   (41 call-sites)
+  Dialog showCloseButton prop           -> native
+  input-group-button xs/sm/icon-*       -> native
+  (bonus) Button size xs (text)         -> native, newly available
+
+CARRY AS OVERLAY (load-bearing; call-sites pass these by name):
+  Button variant ghost-destructive      -> .cn-button-variant-ghost-destructive
+  Button tooltip prop                   -> keep markup (Tooltip.Root wrapper)
+  Badge variant id / success / status.* -> overlay (+ existing --success token)
+  Alert variant warning                 -> overlay (+ existing --warning token)
+
+CARRY (cosmetic, DEFER to polish pass; graceful degradation):
+  z-40 layering: dialog/drawer overlay+content (5 sites)
+  Select max-w-min
+  Resizable gap-2
+  Drawer scrollable-children wrapper
+  Dialog tall-content scroll (overflow-y-auto max-h)
+  Item min-w-0 truncation + relative base
+  solid destructive (restore over Vega's tinted, IF desired)
+
+UNTOUCHED (no shadcn-core equivalent; inherit new look internally):
+  chat, command-palette, confirmation-dialog, copy-button, emoji-picker,
+  file-drop-zone, github-button, light-switch, link, loading, modal,
+  natural-language-date-input, pm-command, section-header, snippet,
+  star-rating, timezone-combobox, tree-view
+```
+
+## Call sites: before and after (Button)
+
+**Before** (`packages/ui/src/button/button.svelte:9`): inline Tailwind tv() block (see Current State).
+
+**After**: same markup/props (href, tooltip, snippet), only the tv() strings change:
+
+```svelte
+variant: {
+  default: 'cn-button-variant-default', destructive: 'cn-button-variant-destructive',
+  outline: 'cn-button-variant-outline', secondary: 'cn-button-variant-secondary',
+  ghost: 'cn-button-variant-ghost', link: 'cn-button-variant-link',
+  'ghost-destructive': 'cn-button-variant-ghost-destructive',   // carried via overlay
+},
+size: {
+  default: 'cn-button-size-default', sm: 'cn-button-size-sm', lg: 'cn-button-size-lg',
+  icon: 'cn-button-size-icon', 'icon-xs': 'cn-button-size-icon-xs',
+  'icon-sm': 'cn-button-size-icon-sm', 'icon-lg': 'cn-button-size-icon-lg',
+},
+```
+
+Base class becomes `cn-button` (plus Epicenter keeps the `tooltip` prop logic untouched).
+
+**Semantic shift to flag**: `variant="destructive"` buttons go from solid red to tinted. See QA Checklist.
+
+## Implementation Plan
+
+### Wave 0: Plumbing (invisible)
+
+- [x] **0.1** Vendor upstream base to `packages/ui/src/styles/shadcn-base.css`
+- [x] **0.2** Vendor Vega to `packages/ui/src/styles/style-vega.css`
+- [x] **0.3** Create `packages/ui/src/styles/epicenter-overlay.css` (seeded with ghost-destructive for Wave 1)
+- [x] **0.4** Import all three from `packages/ui/src/app.css`
+- [x] **0.5** Add `class="style-vega"` to every consuming app root (9 roots: 7 app.html + tab-manager sidepanel + landing BaseLayout.astro)
+- [~] **0.6** Build-verify one app. STATIC check done (all Vega `@apply` color tokens present in app.css; base deps provided). LIVE build pending: `vite` not runnable in this workspace.
+
+### Wave 1: Button pilot
+
+- [x] **1.1** Rewrite `button.svelte` tv() strings to `cn-*` (tooltip/href/snippet markup unchanged; added native `link` variant + `xs` size)
+- [x] **1.2** Add `.cn-button-variant-ghost-destructive` to overlay
+- [x] **1.3** Delete inline custom icon-size defs (now native, identical dims)
+- [x] **1.4** `bun run check:ui-boundary` passes (exit 0). svelte-check not runnable in this workspace (missing binary).
+- [ ] **1.5** Visual QA per checklist below (run an app)
+- [ ] **1.6** Build-verify a consuming app (run locally where `vite` is available)
+
+### Wave 2+: Fan-out (DONE via background workflow `wf_c3a8e6d0-58b`)
+
+Migrated all 42 remaining shadcn-core components (migrate + adversarial review per component).
+
+- [x] **2.1** Fan-out: 38 migrated, 3 no-change (collapsible, sonner, spinner had no cn-* styling to adopt), 1 partial (scroll-area: viewport left inline because `cn-scroll-area-viewport` is not in the vendored Vega yet).
+- [x] **2.2** Overlay rules applied centrally (agents returned, did not write): Alert `warning`, Badge `id`/`success`/`status.completed`/`status.failed`/`status.running` (verbatim from git HEAD, preserving `[a&]:hover:`).
+- [x] **2.3** Fixed all review-flagged BROKEN regressions:
+  - switch: added `size` prop + `data-size` (Vega gates all dimensions on it; was rendering zero-size).
+  - alert-dialog-content: added `size` prop + `data-size` (max-width was gated on data-size; was spanning full viewport).
+  - sidebar-menu-button + sidebar-menu-sub-button: emit `data-active` only when active (`isActive ? 'true' : undefined`); Vega uses presence selectors, so literal `data-active="false"` was styling every row as active.
+- [x] **2.4** Verified: vendored `style-vega.css`/`shadcn-base.css` untouched by agents; `check:ui-boundary` passes.
+- Non-blocking note: `tabs` editor diagnostic (index.ts re-exporting `tabsListVariants` from a `.svelte`) is the TS-server lagging on `.svelte` type regen; identical to the proven `button/index.ts` pattern and resolved by `svelte-check`.
+
+### Polish pass (after all waves green)
+
+- [ ] Restore deferred cosmetic items from the ledger (decide solid vs tinted destructive, re-apply z-40, etc.)
+- [ ] Rewrite README update-workflow section (the scratch-project-copy instruction is now wrong)
+
+## Deferred Cosmetic Ledger
+
+Each item degrades gracefully (slightly different look, not broken). Restore in the polish pass.
+
+- [ ] **z-40 layering** (`dialog-content:33`, `dialog-overlay:18`, `drawer-content:33`, `drawer-overlay:17`): regular dialogs/drawers at z-40 so alert-dialogs (z-50) win. Project-wide policy; restore as a coordinated overlay block.
+- [ ] **Solid destructive**: decide whether to keep Vega's tinted destructive or restore Epicenter's solid red. If restore: override `.cn-button-variant-destructive` in overlay.
+- [ ] **Select `max-w-min`** (`select-content:29`): prevent dropdown widening past trigger.
+- [ ] **Resizable `gap-2`** (`resizable-pane-group:20`): visual separation between panes.
+- [ ] **Drawer scrollable wrapper** (`drawer-content:41`): structural, re-apply when migrating drawer.
+- [ ] **Dialog tall-content scroll** (`dialog-content:31`): `overflow-y-auto max-h-[calc(100vh-2rem)]`.
+- [ ] **Item truncation** (`item-content:19`, `item-title:20`, `item:5`): `min-w-0` / `relative` overrides.
+- [ ] **drawer `onOpenAutoFocus` workaround** (`drawer-content:24`): remove once vaul-svelte ships bits-ui 2.x compat (verify).
+
+### No-op forward-compat hooks (resolve on next style-vega.css pull)
+
+These cn-* classes are emitted by migrated components but not yet defined in the vendored Vega sheet, so they are inert today (component still styled by its sibling cn-* classes + inline). Re-vendor a newer `style-vega.css` to activate, or drop them:
+
+- [ ] `cn-font-heading` (on alert-dialog/drawer/empty titles; dialog-title currently omits it, inconsistent with siblings: restore for family consistency).
+- [ ] `cn-alert-dialog-footer` / `-action` / `-cancel` (footer keeps inline flex; actions keep buttonVariants).
+- [ ] `cn-menu-target` (select + dropdown-menu content; menu-family forward-compat placeholder).
+- [ ] `cn-tabs-list-variant-default` / `-line` (variant visuals delivered by paired inline utils + data-variant CSS).
+- [ ] `cn-scroll-area-viewport` (scroll-area viewport left inline until defined).
+
+## QA Checklist (where to look after each wave)
+
+### Wave 1 (Button)
+
+**`variant="destructive"` (solid red -> tinted, HIGHEST priority):**
+- whispering: `TextPreviewDialog.svelte:118`, `transformations-editor/Runs.svelte:48`, `recordings/row-actions/EditRecordingModal.svelte:195`
+- fuji: `stress-test/+page.svelte:225`
+
+**`variant="ghost-destructive"` (verify overlay matches old look):**
+- fuji: `EntryEditor.svelte:47`, `trash/+page.svelte:90`
+- tab-manager: `chat/ChatErrorBanner.svelte:29,33`, `chat/ConversationPicker.svelte:122`
+
+**`size="icon-xs|sm|lg"` (should be identical):** tab-manager `TabItem.svelte`, `UnifiedTabList.svelte`, `ChatInput.svelte`; fuji table/header/timeline actions; opensidian `ChatInput` (icon-lg), `SidebarHeader`; skills `NewSkillDialog`, `ReferencesPanel`.
+
+## Edge Cases
+
+### Unknown tv variant renders unstyled (why load-bearing customs cannot be deferred)
+
+`tailwind-variants` applies no classes for an unrecognized variant value. If Button is migrated to upstream's tv() block WITHOUT `ghost-destructive`, the 5 call-sites passing it get base-only buttons (no background) = visibly broken. So load-bearing customs (ghost-destructive, badge status/success/id, alert warning, tooltip) MUST land in the same wave as their component.
+
+### Vendored Vega references an unknown utility
+
+If a `cn-*` rule `@apply`s a utility/token absent from `app.css`, Tailwind errors at build for ALL apps. Wave 0.6 build-verify catches this. Mitigation if it fires: add the missing token, or split the offending rule out until its component's wave.
+
+### App missed in Wave 0.5
+
+An app without `.style-vega` on its root renders all migrated components unstyled. Enumerate roots exhaustively; a build does not catch this (it is runtime CSS scoping).
+
+## Open Questions
+
+1. **Solid vs tinted destructive** (Class 3): Vega ships tinted; Epicenter had solid red + white. Options: (a) accept Vega tinted, (b) restore solid in overlay. **Recommendation**: live with tinted through the migration, decide in polish once seen in context.
+2. **Vendor full Vega vs per-wave slices**: full file (chosen, 0.2) is simpler but generates inert CSS during transition and risks one unknown-utility error blocking everything. **Recommendation**: full file + build-verify; fall back to slicing only if 0.6 errors.
+3. **Later preset swap to Rhea/Mira**: deferred; one-class experiment once Vega is stable.
+
+## Success Criteria
+
+- [ ] Wave 0 + Wave 1 land with `@epicenter/ui` typecheck green and `check:ui-boundary` passing
+- [ ] At least one consuming app builds (no `@apply` errors)
+- [ ] Button markup matches upstream Vega + carries ghost-destructive + tooltip; custom icon sizes deleted
+- [ ] QA checklist sites visually confirmed (destructive tinted is the only intended change)
+- [ ] Spec checkboxes + Deferred Ledger reflect actual progress
+
+## References
+
+- `packages/ui/src/button/button.svelte` - Wave 1 target
+- `packages/ui/src/app.css` - token set (superset of upstream) + import site
+- `packages/ui/README.md` - update-workflow section to rewrite in polish
+- upstream `huntabyte/shadcn-svelte@main`: `docs/src/lib/registry/ui/button/button.svelte`, `docs/src/lib/registry/styles/style-vega.css`, `packages/cli/src/tailwind.css`
+- Agent discovery outputs: customization inventory + call-site map (this conversation)


### PR DESCRIPTION
Migrates `@epicenter/ui` from the pre-1.0 inline-Tailwind shadcn-svelte fork to the shadcn-svelte 1.x `cn-*` style system on the **Vega** preset. Component markup now carries semantic hook classes and styling lives in CSS, so the package tracks upstream again and Epicenter's customizations live in one place.

This change:

Before: each component hard-coded inline Tailwind (with our overrides tangled in). After: components carry `cn-*` hooks; styling is vendored CSS.

    button.svelte:  'bg-primary ... hover:bg-primary/90'  ->  'cn-button-variant-default'

- `src/styles/style-vega.css` (vendored) — the Vega preset, all `cn-*` rules.
- `src/styles/shadcn-base.css` (vendored) — upstream base (data-* variants, no-scrollbar, keyframes).
- `src/styles/epicenter-overlay.css` — the single home for Epicenter deltas (custom variants + per-component overrides).
- Apps activate the preset with `class="style-vega"` on their root (9 roots).

184 files, +2359/-505. 40 components migrated; collapsible, sonner, spinner had no `cn-*` styling. Custom icon sizes (`icon-xs/sm/lg`) collapsed onto the now-native upstream ones.

## Epicenter customizations

Variants and per-component overrides are enumerated and commented in `epicenter-overlay.css`; the inline-by-necessity deltas (structural markup or layer-blocked overrides) are tracked in `packages/ui/README.md`. Established the invariant: every `cn-*` class a component emits is defined (247 emitted, 0 dead).

## Notable decisions

- **Destructive** stays Vega's tinted treatment (was solid red).
- **z-40 dialog/drawer overrides removed**: they were no-ops (Tailwind emits `z-50` after `z-40`, so `z-50` always won). Dialogs were effectively `z-50`; alert-dialogs sit above via portal order. A hard guarantee would need `@apply z-40!` in the overlay.
- Preset is a one-class swap (e.g. `style-rhea`) if we want a different look later.

## Follow-ups

- Re-vendor a newer `style-vega.css` to activate upstream hooks we currently drop (`cn-font-heading`, etc.).
- Remove the drawer `onOpenAutoFocus` workaround when vaul-svelte supports bits-ui 2.x.

Plan and decision log: `specs/20260606T160000-ui-shadcn-cn-style-migration-vega.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783372268&installation_id=128463665&pr_number=1900&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1900&signature=0b9e6d6096f14c92574122c1cd4062573aeba10325e38560b9e6f4979c33ca30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->