### PR TITLE
fix(whispering): wait for settings before onboarding

### DIFF
--- a/apps/whispering/src/routes/(app)/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/+layout.svelte
@@ -33,7 +33,6 @@
 	import AppLayout from './_components/AppLayout.svelte';
 	import BottomNav from './_components/BottomNav.svelte';
 	import VerticalNav from './_components/VerticalNav.svelte';
-
 	let { children } = $props();
 
 	let sidebarOpen = $state(false);

--- a/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
+++ b/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
@@ -15,6 +15,7 @@
 	} from '$lib/constants/audio';
 	import { services } from '$lib/services';
 	import { tauri } from '#platform/tauri';
+	import { whispering } from '#platform/whispering';
 	import { manualRecorder } from '$lib/state/manual-recorder.svelte';
 	import { recordings } from '$lib/state/recordings.svelte';
 	import { settings } from '$lib/state/settings.svelte';
@@ -55,7 +56,7 @@
 		// Sync operations - run immediately, these are fast
 		window.commands = commandCallbacks;
 		window.goto = goto;
-		registerOnboarding();
+		void registerOnboardingWhenReady();
 		// On macOS the listener starts when Accessibility is granted (the single
 		// gate the whole dictation flow shares); this is its one subscriber.
 		cleanupAccessibilityPermission = registerAccessibilityPermission({
@@ -92,6 +93,11 @@
 		shortcutListenerDestroyed = true;
 		cleanupShortcutListener?.();
 	});
+
+	async function registerOnboardingWhenReady() {
+		await whispering.whenReady;
+		registerOnboarding();
+	}
 
 	if (tauri) {
 		syncWindowAlwaysOnTopWithRecorderState(tauri);


### PR DESCRIPTION
## Summary
- Wait for Whispering workspace readiness before running onboarding configuration checks
- Keep the setup nudge on the existing `/setup` route introduced by the setup wizard work
- Leave deleted legacy settings migration code deleted

Replaces #1709.

## Why
`AppLayout` currently checks onboarding immediately on mount. On startup, persisted workspace settings may still be hydrating from IndexedDB, so the check can briefly see defaults and show a false setup toast even when a device already has valid Whispering settings.

PR #1976 changed the `/setup` flow into a wizard, but it intentionally left the onboarding nudge lifecycle to `main`. Current `main` still calls `registerOnboarding()` immediately; this PR changes only that timing.

## Testing
- `git diff --check`
- `bun install --frozen-lockfile`
- `bun run typecheck` from `apps/whispering`: 0 errors, 0 warnings
- `bun run build` from `apps/whispering`

## CI note
The Preview Deployment check currently fails after the custom build succeeds because Wrangler has no `CLOUDFLARE_API_TOKEN` in the workflow environment. The failure is in the deploy step, not the Whispering build.

## Manual validation
- Launch Whispering with persisted Whisper C++ settings and confirm no repeated false setup toast
- Confirm incomplete setup still routes users to `/setup`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783377983&installation_id=128463665&pr_number=1901&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1901&signature=5c40e591716aab09b92df499358f214e812493f8d5ea2befd123b5e262d96b45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->