### PR TITLE
fix(whispering): handle quick-release push-to-talk correctly

### DIFF
--- a/apps/whispering/src/lib/operations/recording.ts
+++ b/apps/whispering/src/lib/operations/recording.ts
@@ -57,7 +57,11 @@ function isVadRecordingActive() {
 	);
 }
 
-export async function startManualRecording() {
+let manualStartPromise: Promise<void> | null = null;
+let manualStopPromise: Promise<void> | null = null;
+let stopAfterManualStart = false;
+
+async function startManualRecordingNow() {
 	settings.set('recording.mode', 'manual');
 
 	const loading = report.loading({
@@ -90,7 +94,23 @@ export async function startManualRecording() {
 	sound.playSoundIfEnabled('manual-start');
 }
 
-export async function stopManualRecording() {
+export async function startManualRecording() {
+	if (manualRecorder.state === 'RECORDING') return;
+	if (manualStartPromise) return manualStartPromise;
+
+	manualStartPromise = startManualRecordingNow();
+	try {
+		await manualStartPromise;
+	} finally {
+		manualStartPromise = null;
+	}
+
+	if (!stopAfterManualStart) return;
+	stopAfterManualStart = false;
+	await stopManualRecording();
+}
+
+async function stopManualRecordingNow() {
 	const loading = report.loading({
 		title: '⏸️ Stopping recording...',
 		description: 'Finalizing your audio capture...',
@@ -127,6 +147,24 @@ export async function stopManualRecording() {
 		source,
 		durationMs,
 	});
+}
+
+export async function stopManualRecording() {
+	if (manualStartPromise && manualRecorder.state !== 'RECORDING') {
+		stopAfterManualStart = true;
+		await manualStartPromise;
+		return;
+	}
+
+	if (manualRecorder.state !== 'RECORDING') return;
+	if (manualStopPromise) return manualStopPromise;
+
+	manualStopPromise = stopManualRecordingNow();
+	try {
+		await manualStopPromise;
+	} finally {
+		manualStopPromise = null;
+	}
 }
 
 export function toggleManualRecording() {


### PR DESCRIPTION
## Summary
- Queue a manual stop/release that arrives while manual recording startup is still in flight
- Consume that queued stop after startup finishes so quick push-to-talk taps do not latch recording on
- No-op safely for repeated starts while already recording and repeated stops while idle/stopping

Replaces #1672.
Fixes #1671.

## Why
The old PR touched obsolete query-action code. Current manual recording lives in `apps/whispering/src/lib/operations/recording.ts` and `apps/whispering/src/lib/state/manual-recorder.svelte.ts`. This keeps the fix at the operation layer that receives push-to-talk press/release commands.

PR #1976 changed the setup wizard. It did not touch the manual recording operation path, so it does not replace this fix.

## Testing
- No focused manual-recorder test harness exists under `apps/whispering`
- `git diff --check`
- `bun install --frozen-lockfile`
- `bun run typecheck` from `apps/whispering`: 0 errors, 0 warnings
- `bun run build` from `apps/whispering`

## CI note
The Preview Deployment check currently fails after the custom build succeeds because Wrangler has no `CLOUDFLARE_API_TOKEN` in the workflow environment. The failure is in the deploy step, not the Whispering build.

## Manual macOS validation
- Quick press/release during startup should not leave recording latched on
- Hold-to-talk should still start on press and stop on release
- Repeated press/start while recording should no-op safely

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783378000&installation_id=128463665&pr_number=1902&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1902&signature=17db7dbf1e70363f63e1c667e394224c38044ef6eb2ec5ccb85a537268baf8cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->