### PR TITLE
docs: refresh root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
     <img width="200" src="https://github.com/user-attachments/assets/9e210c52-2740-43b6-af3f-e6eaf4b5c397" alt="Epicenter">
   </a>
   <h1 align="center">Epicenter</h1>
-  <p align="center"><strong>Local-first apps. One workspace you own.</strong></p>
-  <p align="center">Your data lives on your machine as plain Markdown and SQLite: files you can grep, version, open in Obsidian, and keep forever.</p>
-  <p align="center">Whispering, our desktop speech-to-text app for macOS, Windows, and Linux, is installable today.</p>
+  <p align="center"><strong>Local-first apps that write to files you own.</strong></p>
+  <p align="center">Your data lives on your machine as plain Markdown and SQLite: grep it, version it, open it in Obsidian. When an app stops mattering, your files don't.</p>
+  <p align="center">Start with <a href="apps/whispering">Whispering</a>, our desktop speech-to-text app. You can install it today.</p>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -265,5 +265,5 @@ See the root [LICENSE](LICENSE), [FINANCIAL_SUSTAINABILITY.md](FINANCIAL_SUSTAIN
 </p>
 
 <p align="center">
-  <sub>Local-first | Own your data | Markdown | SQLite | Yjs | Open source</sub>
+  <sub>When an app stops mattering, your files don't. Local-first, open source, built on Yjs.</sub>
 </p>

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
   </a>
   <h1 align="center">Epicenter</h1>
   <p align="center"><strong>Local-first apps. One workspace you own.</strong></p>
-  <p align="center">Capture in purpose-built apps. Read the generated Markdown. Query the SQLite mirror.<br>Curate what matters into Markdown folders you can grep, version, and keep forever. Sync between devices when you want.</p>
-  <p align="center">Whispering is downloadable today. A workspace-native refresh of Whispering is in progress, and the shared workspace for tabs, notes, drafts, and publishing is being built in public on <code>@epicenter/workspace</code>.</p>
+  <p align="center">Your data lives on your machine as plain Markdown and SQLite: files you can grep, version, open in Obsidian, and keep forever.</p>
+  <p align="center">Whispering, our desktop speech-to-text app for macOS, Windows, and Linux, is installable today.</p>
 </p>
 
 <p align="center">
@@ -47,7 +47,7 @@
 
 ## Install Whispering
 
-[Whispering](apps/whispering) is the first shipped app in the Epicenter repo: a desktop speech-to-text tool for macOS, Windows, and Linux.
+[Whispering](apps/whispering) is Epicenter's desktop speech-to-text app for macOS, Windows, and Linux.
 
 ```bash
 brew install --cask whispering
@@ -63,7 +63,7 @@ Press a shortcut, speak, optionally transform the transcript, and paste the resu
 
 The hard problem with local-first apps is synchronization. If each device has its own SQLite file or Markdown folder, how do you keep them in sync? [`@epicenter/workspace`](packages/workspace) answers by making Yjs the source of truth, then projecting app state to SQLite for queries and Markdown for reading.
 
-The package gives apps typed tables, local persistence, materializers, collaboration hooks, and validated actions.
+Alongside typed tables, local persistence, collaboration hooks, and validated actions, the package gives apps materializers, the writers that project state to disk.
 
 ```typescript
 import { column, createWorkspace, defineTable } from '@epicenter/workspace';
@@ -93,18 +93,18 @@ workspace.tables.notes.set({
 
 ## How It Works
 
-Epicenter separates app-owned data from user-owned Markdown. The model is being built in public; [Matter](apps/matter) is the current WIP front for the folders-you-own side: a typed grid that edits ordinary Markdown folders directly. It does not write into `apps/<name>/`.
+Epicenter separates app-owned data from user-owned Markdown. App output belongs under `apps/<name>/`; folders you own stay ordinary Markdown.
 
 ```txt
 workspace/
-|-- apps/<name>/        generated app projections; read, grep, quote, copy
+|-- apps/<name>/        generated app output; read, grep, quote, copy
 |-- .epicenter/         machine state; ignore
 |-- journal/            your Markdown; edit, commit, curate, publish
 |-- ideas/              your Markdown
 `-- publish/            your publishable artifacts
 ```
 
-The rule is simple: `apps/<name>/` is for reading app output, not hand-editing it. To change app data, use the app or a validated CLI action. To keep something forever, copy it into a folder you own.
+The rule is simple: `apps/<name>/` is for reading app output, not hand-editing it. To change app data, use the app or a CLI action validated against the app's schema. To keep something forever, copy it into a folder you own.
 
 Your folders are ordinary Markdown: grep them, open them in Obsidian, version them with Git, publish them with whatever static site stack you like.
 
@@ -130,7 +130,7 @@ updatedAt: "2026-06-10T16:49:59.180Z"
 Follow up on the README framing.
 ```
 
-Matter already implements this pattern for the folders you own: it keeps a disposable `matter.sqlite` mirror of each managed folder, so agents and scripts can query your Markdown as SQL:
+Matter applies the same SQLite-mirror idea to the folders you own: it keeps a disposable `matter.sqlite` mirror of each managed folder, so agents and scripts can query your Markdown as SQL:
 
 ```bash
 sqlite3 matter.sqlite 'select "name" from "journal" limit 5;'
@@ -138,9 +138,9 @@ sqlite3 matter.sqlite 'select "name" from "journal" limit 5;'
 
 ## Status
 
-Whispering is the first shipped app: install it today on macOS, Windows, or Linux. A larger workspace-native refresh of Whispering is in progress, and current installs will receive it through the normal release path.
+A refresh of Whispering built on the workspace is in progress, and current installs will receive it through the normal release path.
 
-The shared workspace for tabs, notes, drafts, and publishing is being built in public around `@epicenter/workspace`. [Matter](apps/matter) is the current WIP front for the folders-you-own side: it edits ordinary Markdown folders and keeps `matter.sqlite` as a query mirror. Other app folders are public research and prototypes.
+The shared workspace for tabs, notes, drafts, and publishing is being built in public around `@epicenter/workspace`. [Matter](apps/matter) is an early app for user-owned Markdown folders: it edits ordinary Markdown directly and keeps `matter.sqlite` as a query mirror. Other app folders are public research and prototypes.
 
 ## Trust Boundaries
 
@@ -148,13 +148,13 @@ Pick the trust model you want.
 
 | Path | What leaves your device |
 | --- | --- |
-| Whispering with local Whisper C++ | Audio can stay on your device. Transcripts and settings are stored locally by the desktop app. |
+| Whispering with local Whisper C++ | Audio stays on your device when you use local Whisper C++. Transcripts and settings are stored locally by the desktop app. |
 | Whispering with a cloud transcription provider | Audio goes from your device to the provider you choose. Epicenter servers are not in that transcription path. |
 | Whispering transformations | Transcript text goes to the LLM provider you choose when you enable that step. |
 | Hosted Epicenter API or sync | Encrypted workspace updates, account/session data, and enabled hosted feature requests go to Epicenter servers. |
 | Self-hosted deployable | You control the server, secrets, deployment, and infrastructure boundary. |
 
-Signed-in workspace sync sends encrypted CRDT values over Yjs. On hosted Epicenter, encryption keys are server-managed; self-hosting moves the key boundary to infrastructure you control. See the [encryption design](docs/encryption.md) for the full trust model.
+Signed-in workspace sync sends encrypted CRDT values over Yjs. Hosted Epicenter manages keys for you; self-hosting keeps key management in infrastructure you control. See the [encryption design](docs/encryption.md) for the full trust model.
 
 The detailed privacy notes for Whispering live in [apps/whispering](apps/whispering).
 
@@ -236,7 +236,7 @@ bun run check
 
 ## Design Notes
 
-Implementation specs and design notes live in [specs/](specs). Start with [docs/README.md](docs/README.md), [specs/README.md](specs/README.md), and the current front-door plan in [specs/20260610T173324-root-readme-public-front-door.md](specs/20260610T173324-root-readme-public-front-door.md).
+Implementation specs and design notes live in [specs/](specs). Start with [docs/README.md](docs/README.md) and [specs/README.md](specs/README.md).
 
 ## Contributing
 
@@ -252,9 +252,9 @@ Epicenter uses a two-tier split:
 
 - [MIT](licenses/LICENSE-MIT) for the local-first-on-Yjs developer toolkit: `@epicenter/workspace`, `@epicenter/ui`, `@epicenter/filesystem`, and `@epicenter/sync`.
 - [AGPL-3.0](licenses/LICENSE-AGPL-3.0) or later for non-toolkit app surfaces, hosted server code, and internal packages.
-- Proprietary is a deferred, empty tier. Revenue is intended to come from hosting and services, not from selling closed licenses.
+- There is no proprietary tier today. Revenue is intended to come from hosting and services, not from selling closed licenses.
 
-The toolkit dependency closure is MIT, enforced by `bun run check:licenses`. The license split follows the same broad pattern as Plausible and PostHog for hosted open-source services, and Yjs for MIT core libraries with copyleft server pieces.
+Every dependency of the toolkit packages is MIT-compatible, enforced by `bun run check:licenses`. The license split follows the same broad pattern as Plausible and PostHog for hosted open-source services, and Yjs for MIT core libraries with copyleft server pieces.
 
 See the root [LICENSE](LICENSE), [FINANCIAL_SUSTAINABILITY.md](FINANCIAL_SUSTAINABILITY.md), and [licensing strategy spec](specs/20260428T120000-licensing-strategy.md) for the full model.
 

--- a/README.md
+++ b/README.md
@@ -3,26 +3,24 @@
     <img width="200" src="https://github.com/user-attachments/assets/9e210c52-2740-43b6-af3f-e6eaf4b5c397" alt="Epicenter">
   </a>
   <h1 align="center">Epicenter</h1>
-  <p align="center">Local-first, open-source apps</p>
-  <p align="center">One folder of plain text and SQLite on your machine, synced across all your devices.<br>Grep it, query it, host it wherever you want.</p>
+  <p align="center"><strong>Local-first apps. One workspace you own.</strong></p>
+  <p align="center">Capture in purpose-built apps. Read the generated Markdown. Query the SQLite mirror.<br>Curate what matters into Markdown folders you can grep, version, and keep forever. Sync between devices when you want.</p>
+  <p align="center">Whispering is downloadable today. A workspace-native refresh of Whispering is in progress, and the shared workspace for tabs, notes, drafts, and publishing is being built in public on <code>@epicenter/workspace</code>.</p>
 </p>
 
 <p align="center">
-  <!-- GitHub Stars Badge -->
   <a href="https://github.com/EpicenterHQ/epicenter" target="_blank">
     <img alt="GitHub stars" src="https://img.shields.io/github/stars/EpicenterHQ/epicenter?style=flat-square" />
   </a>
-  <!-- Latest Version Badge -->
-  <img src="https://img.shields.io/github/v/release/EpicenterHQ/epicenter?style=flat-square&label=Latest%20Version&color=brightgreen" />
-  <!-- License Badge -->
+  <a href="https://github.com/EpicenterHQ/epicenter/releases/latest" target="_blank">
+    <img alt="Latest release" src="https://img.shields.io/github/v/release/EpicenterHQ/epicenter?style=flat-square&label=Latest%20Release&color=brightgreen" />
+  </a>
   <a href="LICENSE" target="_blank">
     <img alt="License" src="https://img.shields.io/github/license/EpicenterHQ/epicenter.svg?style=flat-square" />
   </a>
-  <!-- Discord Badge -->
   <a href="https://go.epicenter.so/discord" target="_blank">
     <img alt="Discord" src="https://img.shields.io/badge/Discord-Join%20us-5865F2?style=flat-square&logo=discord&logoColor=white" />
   </a>
-  <!-- Platform Support Badges -->
   <a href="https://github.com/EpicenterHQ/epicenter/releases" target="_blank">
     <img alt="macOS" src="https://img.shields.io/badge/-macOS-black?style=flat-square&logo=apple&logoColor=white" />
   </a>
@@ -35,309 +33,230 @@
 </p>
 
 <p align="center">
-  <a href="#apps">Apps</a> •
-  <a href="#architecture">Architecture</a> •
-  <a href="#packages">Packages</a> •
-  <a href="#for-developers">For Developers</a> •
-  <a href="#quick-start">Quick Start</a> •
-  <a href="#contributing">Contributing</a> •
-  <a href="https://go.epicenter.so/discord">Discord</a>
+  <a href="#install-whispering">Install</a> |
+  <a href="#build-with-the-toolkit">Toolkit</a> |
+  <a href="#how-it-works">How It Works</a> |
+  <a href="#status">Status</a> |
+  <a href="#trust-boundaries">Trust</a> |
+  <a href="#repo-map">Repo Map</a> |
+  <a href="#development">Development</a> |
+  <a href="#license">License</a>
 </p>
 
 ---
 
-## What is Epicenter?
+## Install Whispering
 
-Epicenter is an ecosystem of open-source, local-first apps. Your notes, transcripts, and chat histories live in a single folder of plain text and SQLite on your machine. Every tool we build reads and writes to the same place. It's open, tweakable, and yours. Grep it, open it in Obsidian, version it with Git, host it wherever you want.
-
-Under the hood, Yjs CRDTs are the single source of truth. They materialize *down* to SQLite (for fast queries) and markdown (for human-readable files). Sync happens over the Yjs protocol; the server is a relay, not an authority. It never sees your content.
-
-The library that powers this, [`@epicenter/workspace`](packages/workspace), is something other developers can build on too. Define a typed schema, get CRDT-backed tables with multi-device sync handled for you.
-
-## Architecture
-
-Epicenter has three different backend boundaries on purpose:
-
-```txt
-Domains split by public protocol role.
-Deployables split by infrastructure and operational boundary.
-Hono modules split by code composition boundary.
-```
-
-Epicenter ships one shared server library and two deployables. The library is `packages/server`; the deployables compose it with different ownership rules:
-
-```txt
-apps/api          hosted personal cloud  (api.epicenter.so)
-                  composes packages/server with personal()
-                  bundles billing routes, dashboard SPA, Autumn policies
-                  worker/ + ui/ deploy as one Cloudflare Worker
-
-apps/self-host     self-hosted shared wiki reference  (community-supported)
-                  composes packages/server with shared({ admit })
-                  no billing surface, no dashboard, deployment-owned secrets
-                  trust boundary: deployer holds ENCRYPTION_SECRETS
-                                   -> functionally zero-knowledge against Epicenter
-```
-
-Inside `packages/server`, route groups mount onto a shared Hono app via
-`mountSessionApp`, `mountRoomsApp`, `mountAssetsApp`, `mountAiApp`, and `authApp`.
-The `personal()` and `shared({ admit })` factories choose the partition rule;
-everything else is shared. The hosted-only billing code (`packages/billing`'s
-old contents, plus `/api/billing/*` routes and the dashboard SPA) lives inside
-`apps/api/worker/billing/` and `apps/api/ui/`. Self-hosted shared-wiki deployments
-never see it.
-
-```
-                              ┌──────────────────────────────────┐
-                              │         @epicenter/api           │
-                              │   Cloudflare Workers + DO hub    │
-                              │   auth · sync relay · AI chat    │
-                              └──────────┬───────────────────────┘
-                                         │ y-websocket protocol
-                    ┌────────────────────┼──────────────────────┐
-                    │                    │                      │
-               ┌────▼──────┐       ┌─────▼────────┐      ┌──────▼──────┐
-               │ Whispering│       │  Opensidian  │      │ Tab Manager │
-               │  (Tauri)  │       │ (SvelteKit)  │      │  (WXT ext)  │
-               └────┬──────┘       └─────┬────────┘      └──────┬──────┘
-                    │                    │                      │
-          ┌─────────┴────────────────────┴──────────────────────┘
-          │              All apps share these layers:
-          │
-    ┌─────▼───────────────────────────────────────────────────────────┐
-    │                     MIDDLEWARE / ADAPTERS                       │
-    │  @epicenter/svelte    : Svelte integration, auth, persistence   │
-    │  @epicenter/filesystem : POSIX file layer over Yjs              │
-    │  @epicenter/skills    : skill/reference tables                  │
-    └──────────────────────────────┬──────────────────────────────────┘
-                                   │
-    ┌──────────────────────────────▼───────────────────────────────────┐
-    │                           CORE                                   │
-    │  @epicenter/workspace : typed schemas, Yjs CRDTs, extensions,    │
-    │                         E2E encryption, lifecycle, materializers │
-    │  @epicenter/sync      : protocol encoding/decoding, V2 updates   │
-    │  @epicenter/constants : app URLs, versions, shared config        │
-    │  @epicenter/ui        : shadcn-svelte component library          │
-    │  @epicenter/cli       : TypeBox→yargs CLI, auth/session APIs     │
-    └──────────────────────────────────────────────────────────────────┘
-```
-
-The dependency flow is strict: core has zero upward dependencies, middleware only reaches into core, and apps compose both. [`@epicenter/workspace`](packages/workspace) is the gravitational center; every middleware package and most apps depend on it. The sync server is a relay, not an authority; it never sees your content because encryption happens client-side before anything leaves the device.
-
-[Full architecture walkthrough →](docs/architecture.md) · [Encryption design →](docs/encryption.md)
-
-## Apps
-
-<table>
-  <tr>
-    <td align="center" width="50%">
-      <h3><a href="apps/whispering">Whispering</a></h3>
-      <p>Press shortcut, speak, get text. Desktop transcription that cuts out the middleman. Bring your own API key or run locally with Whisper C++.</p>
-      <p><strong><a href="apps/whispering">Source</a></strong> · <strong><a href="apps/whispering#install-whispering">Install</a></strong></p>
-    </td>
-    <td align="center" width="50%">
-      <h3><a href="apps/opensidian">Opensidian</a></h3>
-      <p>Local-first note-taking with a built-in bash terminal, end-to-end encryption, and real-time sync. Your notes live in a CRDT-backed virtual filesystem.</p>
-      <p><strong><a href="apps/opensidian">Source</a></strong> · <strong><a href="https://opensidian.com">Try it</a></strong></p>
-    </td>
-  </tr>
-  <tr>
-    <td align="center" width="50%">
-      <h3><a href="apps/tab-manager">Tab Manager</a></h3>
-      <p>Browser extension side panel for managing tabs with workspace sync and AI chat that can call workspace tools with inline approval.</p>
-      <p><strong><a href="apps/tab-manager">Source</a></strong></p>
-    </td>
-    <td align="center" width="50%">
-      <h3><a href="apps/honeycrisp">Honeycrisp</a></h3>
-      <p>Apple Notes-style local-first notes app. Folders, rich-text editing with ProseMirror, and collaborative sync via Yjs.</p>
-      <p><strong><a href="apps/honeycrisp">Source</a></strong></p>
-    </td>
-  </tr>
-  <tr>
-    <td align="center" width="50%">
-      <h3><a href="apps/api">Epicenter API</a></h3>
-      <p>The hub server. Auth, real-time sync via Durable Objects, and AI inference. Everything that needs a single authority across devices.</p>
-      <p><strong><a href="apps/api">Source</a></strong></p>
-    </td>
-    <td align="center" width="50%">
-      <h3>Build your own</h3>
-      <p>The <a href="packages/workspace"><code>@epicenter/workspace</code></a> library makes it straightforward to build apps that share the same CRDT-backed data. Define a schema, get tables, add sync.</p>
-    </td>
-  </tr>
-</table>
-
-Also in the repo: [Fuji](apps/fuji) (personal CMS), [Zhongwen](apps/zhongwen) (Mandarin learning chat), [Skills Editor](apps/skills) (agent skill manager), and [Landing](apps/landing) (public site).
-
-## Packages
-
-| Package | Description | License |
-| --- | --- | --- |
-| [`@epicenter/workspace`](packages/workspace) | Core library. Typed schemas, Yjs CRDTs, extension builder, E2E encryption, materializers. Everything builds on this. | MIT |
-| [`@epicenter/sync`](packages/sync) | Yjs sync protocol encoding/decoding. Dumb server, smart client; protocol framing is separate from transport. | MIT |
-| [`@epicenter/ui`](packages/ui) | shadcn-svelte component library shared across all apps. | MIT |
-| [`@epicenter/svelte`](packages/svelte-utils) | Svelte 5 integration: persisted state, auth UI, and workspace gates. | AGPL-3.0 |
-| [`@epicenter/filesystem`](packages/filesystem) | POSIX-style virtual filesystem over Yjs workspace tables. `mkdir`, `mv`, `rm`, `stat`. | MIT |
-| [`@epicenter/skills`](packages/skills) | Skill and reference tables for AI-enhanced workspace apps. | AGPL-3.0 |
-| [`@epicenter/cli`](packages/cli) | The `epicenter` command. TypeBox schemas become CLI flags automatically. | AGPL-3.0 |
-| [`@epicenter/constants`](packages/constants) | Shared URLs, ports, and version info across the monorepo. | AGPL-3.0 |
-| [`@epicenter/auth`](packages/auth) | Framework-agnostic auth core. Imperative subscription API over better-auth. | AGPL-3.0 |
-
-## For Developers
-
-The hard problem with local-first apps is synchronization. If each device has its own SQLite file, how do you keep them in sync? If each device has its own markdown folder, same question. We ended up using Yjs CRDTs as the single source of truth, then materializing that data *down* to SQLite (for fast SQL reads) and markdown (for human-readable files). Yjs handles the sync; SQLite and markdown handle the reads.
-
-The [`@epicenter/workspace`](packages/workspace) package wraps this into a single API. Define a schema, get CRDT-backed tables, attach providers to materialize to SQLite or markdown, and add sync when you're ready.
-
-```typescript
-import {
-  attachIndexedDb,
-  column,
-  createWorkspace,
-  defineTable,
-  openCollaboration,
-  roomWsUrl,
-} from '@epicenter/workspace';
-
-const posts = defineTable({
-  id: column.string(),
-  title: column.string(),
-  published: column.boolean(),
-});
-
-function openBlog(id: string, ownerId, deviceId, auth) {
-  const workspace = createWorkspace({
-    id,
-    tables: { posts },
-    kv: {},
-  });
-  const idb = attachIndexedDb(workspace.ydoc);
-  const collaboration = openCollaboration(workspace.ydoc, {
-    url: roomWsUrl({ baseURL: auth.baseURL, ownerId, guid: workspace.ydoc.guid, deviceId }),
-    openWebSocket: auth.openWebSocket,
-    onReconnectSignal: auth.onStateChange,
-    waitFor: idb.whenLoaded,
-    actions: {},
-  });
-
-  return { ...workspace, idb, collaboration };
-}
-
-const workspace = openBlog('epicenter-blog', myOwnerId, 'browser-dev', auth);
-workspace.tables.posts.set({ id: '1', title: 'Hello', published: false });
-```
-
-Each user gets their own database. Schema definitions are plain JSON, so they work with MCP and OpenAPI out of the box. Write to Yjs and SQLite updates; edit a markdown file and the CRDT merges it in.
-
-**[Read the full workspace docs →](packages/workspace/README.md)**
-
-## Where We're Headed
-
-More apps are in progress. Each one shares the same workspace, so data flows between them without import/export. The [`@epicenter/workspace`](packages/workspace) library handles the hard parts (schemas, CRDT sync, materialization), so each new app is mostly UI.
-
-Epicenter Cloud will provide hosted sync for people who don't want to run their own server. Same model as Supabase selling hosted Postgres or Liveblocks selling hosted collaboration. Self-hosting is and will remain first-class. The sync server is open source under AGPL, and when you run it yourself, you control the encryption keys and trust boundary.
-
-## Quick Start
-
-### Install Whispering
+[Whispering](apps/whispering) is the first shipped app in the Epicenter repo: a desktop speech-to-text tool for macOS, Windows, and Linux.
 
 ```bash
 brew install --cask whispering
 ```
 
-Or download directly from [GitHub Releases](https://github.com/EpicenterHQ/epicenter/releases/latest) for macOS (.dmg), Windows (.msi), or Linux (.AppImage, .deb, .rpm).
+On Windows and Linux, download the installer from the [latest release](https://github.com/EpicenterHQ/epicenter/releases/latest).
 
-**[Full installation guide →](apps/whispering#install-whispering)**
+Press a shortcut, speak, optionally transform the transcript, and paste the result where you were working. No Epicenter account is required. You can run local Whisper C++ for offline transcription, or bring your own API key for providers like Groq, OpenAI, and ElevenLabs.
 
-### Build from Source
+[Install Whispering](apps/whispering#install-whispering) | [Download latest release](https://github.com/EpicenterHQ/epicenter/releases/latest)
+
+## Build With The Toolkit
+
+The hard problem with local-first apps is synchronization. If each device has its own SQLite file or Markdown folder, how do you keep them in sync? [`@epicenter/workspace`](packages/workspace) answers by making Yjs the source of truth, then projecting app state to SQLite for queries and Markdown for reading.
+
+The package gives apps typed tables, local persistence, materializers, collaboration hooks, and validated actions.
+
+```typescript
+import { column, createWorkspace, defineTable } from '@epicenter/workspace';
+
+const notes = defineTable({
+  id: column.string(),
+  title: column.string(),
+  body: column.string(),
+});
+
+const workspace = createWorkspace({
+  id: 'notes',
+  tables: { notes },
+  kv: {},
+});
+
+workspace.tables.notes.set({
+  id: '1',
+  title: 'Hello',
+  body: 'Follow up on the README framing.',
+});
+
+// Materializers can project that row to Markdown files and SQLite rows.
+```
+
+[Read the workspace package docs](packages/workspace/README.md)
+
+## How It Works
+
+Epicenter separates app-owned data from user-owned Markdown. The model is being built in public; [Matter](apps/matter) is the current WIP front for the folders-you-own side: a typed grid that edits ordinary Markdown folders directly. It does not write into `apps/<name>/`.
+
+```txt
+workspace/
+|-- apps/<name>/        generated app projections; read, grep, quote, copy
+|-- .epicenter/         machine state; ignore
+|-- journal/            your Markdown; edit, commit, curate, publish
+|-- ideas/              your Markdown
+`-- publish/            your publishable artifacts
+```
+
+The rule is simple: `apps/<name>/` is for reading app output, not hand-editing it. To change app data, use the app or a validated CLI action. To keep something forever, copy it into a folder you own.
+
+Your folders are ordinary Markdown: grep them, open them in Obsidian, version them with Git, publish them with whatever static site stack you like.
+
+```txt
+purpose-built app
+  -> Yjs live state
+  -> Markdown projection for human reading
+  -> SQLite mirror for local queries
+  -> curated Markdown when something is worth keeping
+```
+
+Yjs handles live app state, offline edits, and multi-device sync. SQLite gives scripts and views a fast query surface. Markdown gives you files you can read, quote, copy, version, and publish.
+
+A generated Markdown projection is meant to be boring on purpose (this is the target shape):
+
+```md
+---
+id: note_123
+title: Morning capture
+source: app
+updatedAt: "2026-06-10T16:49:59.180Z"
+---
+Follow up on the README framing.
+```
+
+Matter already implements this pattern for the folders you own: it keeps a disposable `matter.sqlite` mirror of each managed folder, so agents and scripts can query your Markdown as SQL:
 
 ```bash
-# Prerequisites: Bun, local Postgres, and Infisical access for API secrets
+sqlite3 matter.sqlite 'select "name" from "journal" limit 5;'
+```
+
+## Status
+
+Whispering is the first shipped app: install it today on macOS, Windows, or Linux. A larger workspace-native refresh of Whispering is in progress, and current installs will receive it through the normal release path.
+
+The shared workspace for tabs, notes, drafts, and publishing is being built in public around `@epicenter/workspace`. [Matter](apps/matter) is the current WIP front for the folders-you-own side: it edits ordinary Markdown folders and keeps `matter.sqlite` as a query mirror. Other app folders are public research and prototypes.
+
+## Trust Boundaries
+
+Pick the trust model you want.
+
+| Path | What leaves your device |
+| --- | --- |
+| Whispering with local Whisper C++ | Audio can stay on your device. Transcripts and settings are stored locally by the desktop app. |
+| Whispering with a cloud transcription provider | Audio goes from your device to the provider you choose. Epicenter servers are not in that transcription path. |
+| Whispering transformations | Transcript text goes to the LLM provider you choose when you enable that step. |
+| Hosted Epicenter API or sync | Encrypted workspace updates, account/session data, and enabled hosted feature requests go to Epicenter servers. |
+| Self-hosted deployable | You control the server, secrets, deployment, and infrastructure boundary. |
+
+Signed-in workspace sync sends encrypted CRDT values over Yjs. On hosted Epicenter, encryption keys are server-managed; self-hosting moves the key boundary to infrastructure you control. See the [encryption design](docs/encryption.md) for the full trust model.
+
+The detailed privacy notes for Whispering live in [apps/whispering](apps/whispering).
+
+## Repo Map
+
+### Product And Workspace Surfaces
+
+| Surface | Status | Notes |
+| --- | --- | --- |
+| [Whispering](apps/whispering) | Installable app | Desktop speech-to-text with local and bring-your-own-provider transcription paths. |
+| [Matter](apps/matter) | WIP product work | Typed grid for user-owned Markdown folders. It edits ordinary `.md` files directly; `matter.sqlite` is a disposable query mirror. |
+| [API](apps/api) | Hosted infrastructure | Personal cloud Worker for hosted Epicenter services. Includes hosted-only billing and dashboard code. |
+| [Self-host](apps/self-host) | Reference deployable | Community-supported shared wiki deployable without hosted billing. |
+| Other app folders | Research and prototypes | Useful history and experiments, not the current product lineup. |
+
+### Packages
+
+These packages carry the main architecture.
+
+| Package | Role | License |
+| --- | --- | --- |
+| [`@epicenter/workspace`](packages/workspace) | Core workspace primitives: typed schemas, Yjs documents, local persistence, materializers, actions, and collaboration hooks. | MIT |
+| [`@epicenter/sync`](packages/sync) | Yjs sync protocol encoding and decoding. Protocol framing lives separately from transport. | MIT |
+| [`@epicenter/ui`](packages/ui) | Shared Svelte component library used by multiple app surfaces. | MIT |
+| [`@epicenter/filesystem`](packages/filesystem) | POSIX-style virtual filesystem helpers over workspace data. | MIT |
+| [`@epicenter/server`](packages/server) | Shared Hono server library composed by the hosted API and self-host reference deployable. | AGPL-3.0-or-later |
+| [`@epicenter/cli`](packages/cli) | The `epicenter` command and local or hosted API workflows. | AGPL-3.0-or-later |
+
+## Architecture
+
+The server side is split into one shared library and two deployable folders:
+
+```txt
+packages/server
+  shared Hono library
+  route composition for auth, sessions, rooms, assets, and provider-backed APIs
+
+apps/api
+  hosted personal Cloudflare Worker
+  composes packages/server with personal()
+  owns hosted-only dashboard and billing code
+
+apps/self-host
+  self-hosted shared wiki reference deployable
+  composes packages/server with shared({ admit })
+  community-supported
+  no hosted billing surface
+```
+
+[Full architecture walkthrough](docs/architecture.md) | [Encryption design](docs/encryption.md)
+
+## Development
+
+Use Bun in this repo.
+
+```bash
 git clone https://github.com/EpicenterHQ/epicenter.git
 cd epicenter
 bun install
+```
+
+Root `bun dev` starts the current default local workflow: the API and Tab Manager.
+
+```bash
 bun dev
+bun run dev:api
+bun run dev:tab-manager:ui
 ```
 
-Root `bun dev` starts one local workflow: the API and Tab Manager. See
-[`apps/api/README.md`](apps/api/README.md) for local Postgres and Infisical
-setup. Use `bun run dev:api` for only the local API, or
-`bun run dev:tab-manager:ui` for only the extension UI. App folders still
-support `bun dev` for focused local work on that app. Rust is only needed for
-Tauri apps like Whispering.
+See [apps/api/README.md](apps/api/README.md) for local Postgres and Infisical setup. Rust is needed for Tauri surfaces such as Whispering and Matter.
 
-### Troubleshooting
-
-If things break after switching branches or pulling changes:
+Useful checks:
 
 ```bash
-bun clean    # Clears caches and node_modules
-bun install  # Reinstall dependencies
+bun run typecheck
+bun run test
+bun run check
 ```
 
-For a full reset including Rust build artifacts (~10GB, takes longer to rebuild):
+## Design Notes
 
-```bash
-bun nuke     # Clears everything including Rust target
-bun install
-```
-
-You rarely need `bun nuke`. Cargo handles incremental builds well. Use `bun clean` first.
-
-### Developing against a local API
-
-Most CLI commands default to the hosted Epicenter API at `https://api.epicenter.so`. If you are iterating on `apps/api` and want the CLI pointed at your local server, use the `cli:local` script:
-
-```bash
-bun run cli:local auth login
-```
-
-See [`packages/cli/README.md`](packages/cli/README.md) for the full environment table and per-host token file behavior.
+Implementation specs and design notes live in [specs/](specs). Start with [docs/README.md](docs/README.md), [specs/README.md](specs/README.md), and the current front-door plan in [specs/20260610T173324-root-readme-public-front-door.md](specs/20260610T173324-root-readme-public-front-door.md).
 
 ## Contributing
 
-We're looking for contributors who are passionate about open source, local-first software, or just want to build with Svelte and TypeScript.
+Contributions are welcome. Good entry points are docs, Whispering fixes, local-first infrastructure, Svelte interfaces, and small changes that make the repo easier to understand.
 
-**[Read the Contributing Guide →](CONTRIBUTING.md)**
+[Read the Contributing Guide](CONTRIBUTING.md)
 
-Contributors coordinate in our [Discord](https://go.epicenter.so/discord).
-
-## Tech Stack
-
-<p align="center">
-  <img alt="Svelte 5" src="https://img.shields.io/badge/-Svelte%205-orange?style=flat-square&logo=svelte&logoColor=white" />
-  <img alt="Tauri" src="https://img.shields.io/badge/-Tauri-blue?style=flat-square&logo=tauri&logoColor=white" />
-  <img alt="TypeScript" src="https://img.shields.io/badge/-TypeScript-blue?style=flat-square&logo=typescript&logoColor=white" />
-  <img alt="Rust" src="https://img.shields.io/badge/-Rust-orange?style=flat-square&logo=rust&logoColor=white" />
-  <img alt="Yjs" src="https://img.shields.io/badge/-Yjs-green?style=flat-square" />
-  <img alt="Cloudflare Workers" src="https://img.shields.io/badge/-Cloudflare%20Workers-F38020?style=flat-square&logo=cloudflare&logoColor=white" />
-  <img alt="Tailwind CSS" src="https://img.shields.io/badge/-Tailwind%20CSS-38B2AC?style=flat-square&logo=tailwind-css&logoColor=white" />
-</p>
-
-## Design Decisions
-
-We publish our implementation specs. These are the reasoning behind non-obvious architectural choices: alternatives considered, trade-offs made, and why we landed where we did.
-
-| Spec | What it decided |
-| --- | --- |
-| [Encrypted Workspace Storage](specs/20260213T005300-encrypted-workspace-storage.md) | XChaCha20-Poly1305 at the CRDT value level; server-managed keys with self-hosting as the trust boundary |
-| [Y-Sweet Persistence Architecture](specs/20260212T190000-y-sweet-persistence-architecture.md) | How Yjs documents persist and compact in Durable Objects |
-| [Simple Definition-First Workspace API](specs/20260201T120000-simple-definition-first-workspace.md) | The `defineTable` → `createWorkspace` + `attach*` composition pattern |
-| [Resilient Client Architecture](specs/20260119T231252-resilient-client-architecture.md) | How workspace clients handle offline, reconnect, and extension failures |
-| [Migrate to @epicenter/sync](specs/20260214T120800-migrate-y-sweet-to-epicenter-sync.md) | Custom sync protocol replacing Y-Sweet with our own framing layer |
-
-All 112 implemented specs live in [`specs/`](specs/).
+Contributors coordinate in [Discord](https://go.epicenter.so/discord).
 
 ## License
 
-Epicenter uses a sharp two-tier split:
+Epicenter uses a two-tier split:
 
-- **[MIT](licenses/LICENSE-MIT)** for the local-first-on-Yjs developer toolkit: `@epicenter/workspace`, `@epicenter/ui`, `@epicenter/filesystem`, and `@epicenter/sync`. An external developer can `npm install` any of these and embed them in a closed-source product; the toolkit's dependency closure is entirely MIT, enforced by `bun run check:licenses`.
-- **[AGPL-3.0](licenses/LICENSE-AGPL-3.0)** for everything else Epicenter ships: all 12 apps and the Epicenter-internal packages. Anyone hosting or distributing a modified version must share their changes.
-- **Proprietary (deferred, empty)** as an escape hatch only. Revenue comes from hosting Epicenter Cloud, not from selling licenses, so this tier is intended to stay empty.
+- [MIT](licenses/LICENSE-MIT) for the local-first-on-Yjs developer toolkit: `@epicenter/workspace`, `@epicenter/ui`, `@epicenter/filesystem`, and `@epicenter/sync`.
+- [AGPL-3.0](licenses/LICENSE-AGPL-3.0) or later for non-toolkit app surfaces, hosted server code, and internal packages.
+- Proprietary is a deferred, empty tier. Revenue is intended to come from hosting and services, not from selling closed licenses.
 
-This follows the same pattern as [Plausible](https://github.com/plausible/analytics) and [PostHog](https://github.com/PostHog/posthog) (AGPL apps and servers, hosted SaaS as revenue), and [Yjs](https://github.com/yjs/yjs) (MIT core library, AGPL `y-redis` server).
+The toolkit dependency closure is MIT, enforced by `bun run check:licenses`. The license split follows the same broad pattern as Plausible and PostHog for hosted open-source services, and Yjs for MIT core libraries with copyleft server pieces.
 
-See the root [LICENSE](LICENSE) for the full index, [FINANCIAL_SUSTAINABILITY.md](FINANCIAL_SUSTAINABILITY.md) for the narrative, and [specs/20260428T120000-licensing-strategy.md](specs/20260428T120000-licensing-strategy.md) for the threat model and decision procedure.
+See the root [LICENSE](LICENSE), [FINANCIAL_SUSTAINABILITY.md](FINANCIAL_SUSTAINABILITY.md), and [licensing strategy spec](specs/20260428T120000-licensing-strategy.md) for the full model.
 
 ---
 
@@ -346,5 +265,5 @@ See the root [LICENSE](LICENSE) for the full index, [FINANCIAL_SUSTAINABILITY.md
 </p>
 
 <p align="center">
-  <sub>Local-first · CRDT · Own your data · Open source</sub>
+  <sub>Local-first | Own your data | Markdown | SQLite | Yjs | Open source</sub>
 </p>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,12 @@
 # Documentation
 
-This directory contains knowledge articles, guides, and reference materials for the Whispering project.
+This directory contains knowledge articles, guides, and reference materials for Epicenter.
+
+## Start Here
+
+- [Positioning](positioning.md): canonical public claims and vocabulary rules.
+- [Architecture](architecture.md): the repo's main server, app, package, and deployment boundaries.
+- [Encryption](encryption.md): the signed-in sync trust model and key boundaries.
 
 ## Directory Structure
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -35,7 +35,7 @@ One line, for one-line surfaces (GitHub About, social preview, link cards):
 
 The hero cut, for heroes (root README, epicenter.so):
 
-> **Local-first apps. One workspace you own.** Your data lives on your machine as plain Markdown and SQLite: files you can grep, version, open in Obsidian, and keep forever.
+> **Local-first apps that write to files you own.** Your data lives on your machine as plain Markdown and SQLite: grep it, version it, open it in Obsidian. When an app stops mattering, your files don't.
 
 One paragraph, for anyone giving us thirty seconds (website about page, CONTRIBUTING, talk bios):
 
@@ -59,9 +59,12 @@ Under the hood, app-owned state lives in Yjs, materializes to SQLite for fast qu
 
 ## The Proof Line
 
-Every shipped surface longer than one line carries exactly one proof line, stated without caveats:
+Every shipped surface longer than one line carries exactly one proof line, stated without caveats. The proof line is a claim, not finished copy: each surface writes its own sentence, in keeping with the rule that finished copy belongs to the surface that ships it. The sentence must carry:
 
-> Whispering, our desktop speech-to-text app for macOS, Windows, and Linux, is installable today.
+- Whispering, by name
+- desktop speech-to-text
+- you can install it today
+- macOS, Windows, and Linux, somewhere on the surface (platform badges or adjacent copy count)
 
 Roadmap language stays out of heroes. "A refresh built on the workspace is in progress" and "being built in public" are Status-section sentences; in a hero they hedge the only shipped product and tell a first-time reader to wait.
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -27,13 +27,13 @@ What we refuse to build is the strategy. No partial sync: a workspace is one ful
 
 ## The Spine
 
-One message at four lengths. Longer cuts add detail. No cut contradicts a shorter one, and every claim from a shorter cut survives in the longer cuts.
+One message, cut to length and audience. Longer cuts add detail. No cut contradicts a shorter one, and every claim from a shorter cut survives in the longer cuts.
 
 One line, for one-line surfaces (GitHub About, social preview, link cards):
 
 > Local-first apps that write to files you own.
 
-The hero cut, for heroes (root README, epicenter.so):
+The hero cut, for the root README hero:
 
 > **Local-first apps that write to files you own.** Your data lives on your machine as plain Markdown and SQLite: grep it, version it, open it in Obsidian. When an app stops mattering, your files don't.
 
@@ -45,7 +45,11 @@ The developer cut, for `@epicenter/workspace` and other toolkit surfaces (npm, p
 
 > A local-first workspace engine for TypeScript apps: Yjs as the source of truth, Markdown and SQLite as the outputs.
 
-The developer cut is the only cut with its own framing. It exists because npm readers evaluate an API, not a product. Everything else derives from the user-facing cuts above.
+The public cut, for epicenter.so and other general-audience surfaces:
+
+> Apps come and go. Your files shouldn't. Epicenter apps save everything you make as ordinary files in a folder on your computer, so what matters to you outlives every app that made it.
+
+The developer and public cuts are the only cuts with their own framing. The developer cut exists because npm readers evaluate an API, not a product. The public cut exists because epicenter.so readers are not evaluating an architecture: it restates the one-line cut with the vocabulary translated. Markdown, SQLite, local-first, CRDT, and Yjs stay out of public heroes; on a public surface the mechanism appears below the fold, after the benefit it guarantees, never as the headline. Everything else derives from the user-facing cuts above.
 
 Headlines, tweets, launch posts, and package copy derive from these cuts but live in the surface that publishes them. If a derived surface needs a claim the spine does not make, fix the spine first.
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -1,33 +1,98 @@
 # Positioning
 
-Canonical messaging for Epicenter. Every public surface should derive from this document: README, landing page, package descriptions, social posts.
+Canonical positioning for Epicenter. This doc owns the public claims and the rules for deriving copy from them. Finished copy belongs to the surface that ships it: README, landing page, GitHub About, package metadata, or launch plan.
 
-## One-Liner
+## The Destination
 
-**Local-first apps, one shared workspace.** Your notes, transcripts, and chat histories live in one folder of plain text and SQLite. Every app reads and writes to the same place.
+The product picture all messaging derives from. This section describes the end state, not public copy. Public copy quotes the Spine. The Destination is the compass, never quoted directly.
 
-For developers: a CRDT-powered workspace engine that materializes to SQLite and markdown, with typed schemas and multi-device sync. Not another note app: the infrastructure that apps share.
+One folder on your disk is the whole product:
 
-*"PKM substrate" is accurate but too niche for a tagline. Use it in developer-facing contexts (blog posts, technical talks) but not in the README or landing page hero.*
+```txt
+~/workspace/
+|-- apps/         read-only Markdown projections of live app state
+|-- .epicenter/   machine state; ignore it
+|-- journal/      yours forever
+|-- ideas/        yours forever
+`-- publish/      yours forever
+```
+
+You speak a thought into Whispering and it lands in `apps/whispering/` as Markdown. You save tabs, draft entries, capture whatever, each through a purpose-built app, and every capture becomes a file you can grep. An agent reads the same files, queries the SQLite mirrors with plain SQL, and when it needs to change app state it goes through the same gate you do: `epicenter run <mount>.<action>`, validated against the app's schema. Nothing mutates by editing generated files; the projection is one-way on purpose.
+
+The loop is capture, curate, keep. App output is a disposable inbox, regenerable from the CRDT at any time. What matters graduates into folders you own: ordinary Markdown, tracked in git, still yours after every app in this repo is gone.
+
+The quiet bet: the properties that make a workspace durable for you are the same ones that make it legible to agents. Plain files are the context window. SQLite is the query surface. The action registry is the tool list. Epicenter is the workspace where you and your agents are co-writers under one set of rules.
+
+What we refuse to build is the strategy. No partial sync: a workspace is one full local replica, which is what lets Yjs carry it instead of a private protocol. No row-level permissions: the folder is the unit of sharing. No editing generated projections back into apps: one validated write path, for humans and agents alike. Each refusal pays for the simplicity of everything else.
+
+## The Spine
+
+One message at four lengths. Longer cuts add detail. No cut contradicts a shorter one, and every claim from a shorter cut survives in the longer cuts.
+
+One line, for one-line surfaces (GitHub About, social preview, link cards):
+
+> Local-first apps that write to files you own.
+
+The hero cut, for heroes (root README, epicenter.so):
+
+> **Local-first apps. One workspace you own.** Your data lives on your machine as plain Markdown and SQLite: files you can grep, version, open in Obsidian, and keep forever.
+
+One paragraph, for anyone giving us thirty seconds (website about page, CONTRIBUTING, talk bios):
+
+> Most apps trap your data in their database. Epicenter apps keep live state in CRDTs and project everything to ordinary files on your machine: Markdown you can read and edit, SQLite you can query. When an app stops mattering, your files don't. Start with Whispering, our desktop speech-to-text app; the shared workspace behind it is being built in the open in the same repo.
+
+The developer cut, for `@epicenter/workspace` and other toolkit surfaces (npm, package READMEs, technical talks):
+
+> A local-first workspace engine for TypeScript apps: Yjs as the source of truth, Markdown and SQLite as the outputs.
+
+The developer cut is the only cut with its own framing. It exists because npm readers evaluate an API, not a product. Everything else derives from the user-facing cuts above.
+
+Headlines, tweets, launch posts, and package copy derive from these cuts but live in the surface that publishes them. If a derived surface needs a claim the spine does not make, fix the spine first.
 
 ## The Hook
 
-Most tools store your data in their own silo. Epicenter stores it in one folder on your machine: plain text and SQLite. Every app reads from the same place. Your transcripts inform your notes. Your notes guide your AI. Nothing gets copy-pasted between apps because there's nothing to copy-paste.
+The long-form narrative, for surfaces with room to breathe (landing page body, launch posts, talks). It extends the spine with the claims the short cuts cannot carry: multiple apps share one workspace, and good captures graduate.
 
-Under the hood, Yjs CRDTs are the single source of truth. They materialize *down* to SQLite (for fast queries) and markdown (for human-readable files). Sync happens over the Yjs protocol. The server is a relay, not an authority. It never sees your content if you encrypt it.
+Most tools store your data in their own silo. Epicenter gives purpose-built apps a shared local-first workspace: app data can be browsed as Markdown, queried through SQLite, and curated into folders you control. Your folders are ordinary Markdown: grep them, open them in Obsidian, version them with Git, publish them with whatever static site stack you like. Your transcripts can inform your notes. Your saved tabs can become drafts. Good captures graduate into your long-term workspace instead of staying trapped in the app that caught them.
+
+Under the hood, app-owned state lives in Yjs, materializes to SQLite for fast queries, and materializes to Markdown for human-readable projections. Sync happens over the Yjs protocol when you turn it on. Sync sends encrypted CRDT values. Hosted Epicenter manages keys for you; self-hosting keeps key management in infrastructure you control.
+
+## The Proof Line
+
+Every shipped surface longer than one line carries exactly one proof line, stated without caveats:
+
+> Whispering, our desktop speech-to-text app for macOS, Windows, and Linux, is installable today.
+
+Roadmap language stays out of heroes. "A refresh built on the workspace is in progress" and "being built in public" are Status-section sentences; in a hero they hedge the only shipped product and tell a first-time reader to wait.
+
+## Earned Vocabulary
+
+Some words are internal until the surface earns them. Do not use a term before the reader has seen the thing it names.
+
+| Term | Earned by |
+|---|---|
+| workspace (the folder) | showing the directory tree first |
+| materializer | one defining clause at first use: "materializers, the writers that project state to disk" |
+| projection | showing a generated file next to the state it came from |
+| validated action | naming the validator: the app's schema |
+| workspace-native | never on public surfaces; say "built on the workspace" |
+
+"PKM substrate" is accurate but niche. Use it in technical talks and blog posts, never in a hero or README.
+
+Do not use hype words: `AI-native`, `agentic`, `next-gen`, `revolutionary`, `redefine`, `game changer`, `Web3`, `metaverse`. Do not stack buzzwords. "CRDT-powered AI-first encrypted next-gen offline-first workspace" is a sign to say less and prove more.
 
 ## What Epicenter Is
 
-- An **ecosystem of open-source, local-first apps** that share one workspace
-- A **TypeScript library** (`@epicenter/workspace`) for building CRDT-backed apps with typed schemas
-- A **CLI** (`epicenter`) for inspecting, querying, and automating your workspace from the terminal
+- An **open-source, local-first workspace**: purpose-built apps plus Markdown folders you own
+- A **TypeScript library** (`@epicenter/workspace`) for building CRDT-backed apps with typed schemas, materializers, and actions
+- A **CLI** (`epicenter`) for listing and invoking validated app actions, locally or on a currently online peer
 - A **sync server** (AGPL, self-hostable) that relays encrypted CRDT updates between devices
 
 ## What Epicenter Is Not
 
-- Not a single app (it's a platform multiple apps share)
+- Not a single app (many purpose-built apps share one workspace)
 - Not cloud-first (local-first by default, sync is optional)
-- Not a Notion/Obsidian clone (it's the layer beneath apps like those)
+- Not a Notion or Obsidian clone (it is the workspace layer beneath capture, curation, and publishing tools)
 
 ## Core Claims (Verifiable)
 
@@ -35,23 +100,24 @@ Every claim we make publicly should be provable by inspecting the repo:
 
 | Claim | Proof |
 |---|---|
-| "Plain text and SQLite" | Markdown materializer writes `.md` files with YAML frontmatter. SQLite persistence stores Yjs updates. |
-| "One folder" | All workspace data lives under a single directory per user. |
-| "CRDT-powered sync" | Yjs `Y.Doc` is source of truth; sync uses the Yjs protocol over WebSocket. |
-| "Encrypted at the CRDT level" | `XChaCha20-Poly1305` via `@noble/ciphers`; HKDF-SHA256 key derivation. Row values encrypted before sync. |
+| "We ship" | Whispering installs on macOS, Windows, and Linux through normal release channels. |
+| "Readable Markdown and queryable SQLite" | Markdown materializers write `.md` files with YAML frontmatter. SQLite materializers keep rebuildable query mirrors. |
+| "A workspace you own" | The local project layout separates user-owned folders from generated app projections and hidden machine state. |
+| "CRDT-powered sync" | App-owned live state uses Yjs documents; sync uses the Yjs protocol over WebSocket. |
+| "Encrypted CRDT values" | `XChaCha20-Poly1305` via `@noble/ciphers`; HKDF-SHA256 key derivation. Workspace values are encrypted before they enter the synced Yjs document. |
 | "Self-hostable" | Sync server is open source under AGPL. Run it on your infrastructure, control the encryption keys. |
 | "Bring your own model" | AI features use user-provided API keys. No middleman, no proxy required. |
 
 ## Competitor Positioning
 
 ### vs Obsidian
-> Obsidian is a markdown editor with sync. Epicenter is the offline-first storage substrate where multiple apps share the same CRDT-backed data.
+> Obsidian is a markdown editor with sync. Epicenter is the local-first workspace where purpose-built apps produce readable projections and curated Markdown stays yours.
 
-- **Win**: Shared memory across apps, not per-plugin storage. CRDT sync instead of file-level conflict resolution.
+- **Win**: App output can become durable workspace material without living in per-plugin storage. CRDT sync instead of file-level conflict resolution.
 - **Lose**: Obsidian's plugin ecosystem and years of UX polish. We're earlier.
 
 ### vs Anytype
-> Anytype is a purpose-built encrypted space ecosystem. Epicenter is the Yjs-backed substrate that lets many apps share the same schema and data.
+> Anytype is a purpose-built encrypted space ecosystem. Epicenter is the Yjs-backed workspace where apps project readable files and curated Markdown stays yours.
 
 - **Win**: Standard CRDT stack (Yjs, widely adopted and battle-tested) vs custom protocol. Developer-facing API with typed schemas, not just an end-user app.
 - **Lose**: Anytype's product is more complete today. Their P2P sync story is more mature.
@@ -59,7 +125,7 @@ Every claim we make publicly should be provable by inspecting the repo:
 ### vs Logseq
 > Logseq is an outliner-first app. Epicenter is the structured local-first storage engine that can power outline UIs without trapping data in a single app.
 
-- **Win**: SQL + structured schemas. Shared memory across tools. Encryption.
+- **Win**: SQL plus structured schemas. Purpose-built capture tools can project into a workspace you control. Encrypted CRDT values for sync.
 - **Lose**: Logseq's block/journal UX is more native. Larger community.
 
 ### vs Standard Notes
@@ -75,7 +141,9 @@ Every claim we make publicly should be provable by inspecting the repo:
 - **Lose**: Notion's UX, templates, collaboration, and distribution are years ahead.
 
 ### vs Karpathy's "Second Brain" System
-> Karpathy showed the architecture. Epicenter is the runtime.
+> Karpathy showed the folder. Epicenter is the local-first app layer around it.
+
+Karpathy's "second brain" post is the strongest entry point: three folders of Markdown, a schema file, and AI organizing everything. Epicenter keeps that philosophy and adds sync, schemas, encryption, and CLI actions.
 
 - **Win**: CRDT sync across devices, typed schemas, encryption, CLI automation: everything raw folders can't do.
 - **Lose**: Karpathy's system wins on simplicity. A folder of markdown files needs zero infrastructure.
@@ -88,48 +156,10 @@ The two stacks converged from opposite premises: typed tables, query subscriptio
 - **Win**: One folder you own, plain text and SQLite you can grep without the app, built on standard Yjs rather than a private protocol. Less to learn because the scope is smaller.
 - **Lose**: Jazz scales to large shared datasets and multi-user row-level access that Epicenter deliberately won't. For a synced multi-user app database, Jazz is the better tool and further along.
 
-## Headlines and Hooks
+Trigger to split: if Competitor Positioning stops deriving from the spine or grows beyond quick battlecards, move it into its own competitor file.
 
-### Hacker News
-1. "A local-first PKM substrate: CRDT-powered tables that materialize to SQLite and markdown"
-2. "Stop arguing about apps. Own a portable workspace that multiple tools share"
-3. "CRDTs + plain files: offline-first notes without sync nightmares"
+## Package Copy
 
-### Twitter/X
-1. "Your notes shouldn't depend on a vendor. Here's the CRDT-based way to keep them in a folder"
-2. "Markdown is the export. The real system is the CRDT state that powers conflict-free sync"
-3. "Notion stores knowledge in the cloud. Epicenter stores it in your folder"
+Each package's npm description and keywords live in its `package.json`; that file is the owner and this doc does not duplicate it. The rule when writing one: user-facing packages derive from the user cuts of the spine, `@epicenter/workspace` derives from the developer cut, and every description leads with what the package does, not what category it is in.
 
-### Karpathy Angle (strongest entry point)
-Karpathy's "second brain" post (41K bookmarks) describes: three folders of .md files + a schema file (CLAUDE.md) + AI organizes everything. Epicenter is the infrastructure version of that system, with the same philosophy (local files, AI organizes, no cloud lock-in), but with real sync, real schemas, real encryption, and a CLI that makes "compile the wiki" a single command.
-
-## Keywords
-
-### Use These
-`local-first`, `CRDT`, `Yjs`, `offline-first`, `own your data`, `conflict-free sync`, `personal knowledge base`, `PKM`, `second brain`, `plain text`, `SQLite`, `markdown`, `self-hosted`, `open source`, `end-to-end encryption`, `multi-device sync`, `materialize`, `workspace`
-
-### Avoid These
-`AI-native`, `agentic`, `next-gen`, `revolutionary`, `redefine`, `game changer`, `Web3`, `metaverse`, buzzword-stacking ("CRDT-powered AI-first encrypted next-gen offline-first workspace": say less, prove more)
-
-## Package Descriptions
-
-Canonical descriptions for npm/GitHub discoverability:
-
-| Package | Description |
-|---|---|
-| `@epicenter/workspace` | Local-first workspace engine. CRDT-powered tables that materialize to SQLite and markdown, with typed schemas and multi-device sync. |
-| `@epicenter/cli` | CLI for Epicenter workspaces. Inspect tables, query data, run actions, and manage sync from the terminal. |
-| `@epicenter/sync` | Yjs-based sync protocol for Epicenter. Handles CRDT document exchange, awareness, and RPC over WebSocket. |
-| `@epicenter/vault` | Adapter and MCP layer for Epicenter. Schema migrations, codec pipelines, and data access patterns. |
-| `@epicenter/filesystem` | Filesystem operations for Epicenter workspaces. Read, write, and watch plain text and markdown files. |
-| `@epicenter/skills` | Skill definitions and loaders for Epicenter workspace actions. |
-| `@epicenter/ui` | Shared UI components for Epicenter apps. Built with Svelte 5 and shadcn-svelte. |
-
-## Keywords per Package
-
-| Package | Keywords |
-|---|---|
-| `@epicenter/workspace` | `local-first`, `CRDT`, `Yjs`, `offline-first`, `SQLite`, `markdown`, `personal knowledge base`, `PKM`, `second brain`, `sync`, `workspace`, `typed schema` |
-| `@epicenter/cli` | `local-first`, `CLI`, `workspace`, `CRDT`, `offline-first`, `PKM`, `terminal` |
-| `@epicenter/sync` | `Yjs`, `CRDT`, `sync`, `WebSocket`, `offline-first`, `local-first`, `real-time` |
-| `@epicenter/vault` | `local-first`, `schema`, `migrations`, `MCP`, `adapter`, `CRDT`, `markdown` |
+Trigger to revisit: if package descriptions drift off-spine again, add a check script.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # @epicenter/cli
 
-> Introspect and invoke `defineQuery` / `defineMutation` actions exposed by configured project mounts, locally or on a peer that's online right now.
+> Introspect and invoke `defineQuery` / `defineMutation` actions exposed by configured project mounts, locally or on a currently online peer.
 
 Each verb is a one-line shell shortcut for one workspace primitive:
 
@@ -41,18 +41,18 @@ The same env var and scripts apply to every command that talks to the API, inclu
 ```bash
 epicenter auth login
 
-epicenter daemon up -C ~/vault
+epicenter daemon up -C ~/workspace
 epicenter daemon ps
-epicenter daemon logs -C ~/vault
-epicenter daemon down -C ~/vault
+epicenter daemon logs -C ~/workspace
+epicenter daemon down -C ~/workspace
 
-epicenter list -C ~/vault
-epicenter list fuji.entries_update -C ~/vault
+epicenter list -C ~/workspace
+epicenter list fuji.entries_update -C ~/workspace
 
-epicenter run fuji.entries_update '{"id":"entry_1","tags":["triaged"]}' -C ~/vault
-epicenter run fuji.entries_update '{"id":"entry_1","tags":["triaged"]}' --peer user-1 -C ~/vault
+epicenter run fuji.entries_update '{"id":"entry_1","tags":["triaged"]}' -C ~/workspace
+epicenter run fuji.entries_update '{"id":"entry_1","tags":["triaged"]}' --peer user-1 -C ~/workspace
 
-epicenter peers -C ~/vault
+epicenter peers -C ~/workspace
 ```
 
 `-C` is a start directory for project discovery. Discovery walks upward until it finds `epicenter.config.ts`, then the daemon starts every mount in that config.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@epicenter/cli",
 	"version": "0.1.0",
-	"description": "Introspect and invoke defineQuery/defineMutation actions from configured project mounts.",
+	"description": "CLI for Epicenter workspaces. List and invoke mounted actions locally or on online peers.",
 	"keywords": [
 		"local-first",
 		"CLI",

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -318,11 +318,11 @@ Ordering is obvious (later `attach*` and `open*` calls see earlier ones through 
 
 Tables validate and migrate on read, not on write. `set(...)` writes the row shape TypeScript already approved. `get(...)` returns a wellcrafted `Result<TRow | null, TableParseError>`: parse failures surface as `error`, missing rows as `data: null`, and old versions are migrated to the latest schema before being returned.
 
-That trade-off is deliberate. It keeps the write path cheap and pushes schema evolution into one place:the table definition.
+That trade-off is deliberate. It keeps the write path cheap and pushes schema evolution into one place: the table definition.
 
 ### Storage scales with active data, not edit history
 
-With Yjs garbage collection enabled, storage tracks the live document much more closely than the number of operations that happened over time. Deleted rows, overwritten values, and old content states collapse down to compact metadata. The workspace grows because you keep more data:not because you clicked save a thousand times.
+With Yjs garbage collection enabled, storage tracks the live document much more closely than the number of operations that happened over time. Deleted rows, overwritten values, and old content states collapse down to compact metadata. The workspace grows because you keep more data, not because you clicked save a thousand times.
 
 ## Architecture Overview
 

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -1,8 +1,28 @@
-# Epicenter: Yjs-First Collaborative Workspace System
+# @epicenter/workspace
 
-The hard problem with local-first apps is synchronization. If each device has its own SQLite file, how do you keep them in sync? If each device has its own markdown folder, same question.
+A local-first workspace engine for TypeScript apps: Yjs is the source of truth; SQLite and Markdown are read-only materialized projections.
 
-`@epicenter/workspace` solves that by making Yjs the source of truth. Tables, KV entries, and document content all live in a `Y.Doc`; persistence, sync, and materializers hang off that core as attachment primitives. Write to the workspace, and everything else reacts.
+The hard problem with local-first apps is synchronization. If each device has its own SQLite file, how do you keep them in sync? If each device has its own Markdown folder, same question.
+
+`@epicenter/workspace` solves that by making Yjs the source of truth for app-owned state. Tables, KV entries, and document content all live in a `Y.Doc`; persistence, sync, validated actions, and materializers hang off that core as attachment primitives. Write to the workspace, and everything else reacts.
+
+Materializers are for reading. SQLite gives scripts, apps, and agents a fast SQL view. Markdown gives people a file-shaped export for review, git, publishing, or static output. Neither one is the app's mutation API.
+
+```txt
+Read path:
+  person / script / agent
+    -> SQL against the read-only SQLite mirror
+    -> Markdown files generated from the workspace
+
+Write path:
+  app UI / TanStack AI tool / Bun script / epicenter CLI
+    -> workspace action
+    -> live Y.Doc tables, KV, or child content docs
+    -> sync peers
+    -> SQLite mirror and Markdown export refresh
+```
+
+Agents can still edit ordinary project files. They should not patch generated `.md` files to mutate app data. Give them actions instead: browser chat uses `actionsToAiTools`, scripts use `connectDaemonActions`, and humans or automation can call `epicenter run <mount>.<action>`. The action writes the Yjs datastore; the materializers write the files back out.
 
 The current center is small:
 
@@ -329,27 +349,32 @@ Note: Schema definitions are stored in static TypeScript modules, not in the Y.D
 The Y.Doc carries data. Your definition files carry meaning.
 ```
 
-### Three-Layer Data Flow
+### Read and write flow
 
-```
-┌────────────────────────────────────────────────────────────────────┐
-│  WRITE FLOW                                                         │
-│                                                                     │
-│  App code / action → Y.Doc updated → Extensions react              │
-│                       │                                             │
-│              ┌────────┼────────┐                                    │
-│              ▼        ▼        ▼                                    │
-│         IndexedDB  WebSocket  Markdown                              │
-│         or SQLite   sync      materializer                          │
-└────────────────────────────────────────────────────────────────────┘
+The main split is source of truth versus projection. Anything that changes app data enters through the workspace. Anything that only needs a fast or human-readable view can read a materialized output.
 
-┌────────────────────────────────────────────────────────────────────┐
-│  READ FLOW                                                          │
-│                                                                     │
-│  Simple reads → table / kv helpers over Y.Doc                       │
-│  Rich text  → document handles over timeline Y.Docs                 │
-│  Derived reads → extension exports built on the same core           │
-└────────────────────────────────────────────────────────────────────┘
+```txt
+Writes:
+  UI component
+  TanStack AI tool
+  Bun script
+  epicenter run <mount>.<action>
+    -> defineMutation action
+      -> Y.Doc tables, KV, or child content docs
+        -> sync peers
+        -> persistence
+        -> SQLite materializer
+        -> Markdown materializer
+
+Reads:
+  table / KV helpers
+    -> Y.Doc
+
+  openSqliteReader
+    -> read-only SQLite mirror
+
+  editor, reviewer, publisher, agent
+    -> generated Markdown files
 ```
 
 ### Multi-Device Sync Topology
@@ -867,7 +892,7 @@ Browser apps use `attachIndexedDb(ydoc)` for unauthenticated docs, or `attachLoc
 
 For authenticated apps, call `await wipeLocalStorage({ server, ownerId })` after disposing the bundle to delete every owner-scoped encrypted IDB database on the current browser profile (sign-out, "delete my local data", account switch).
 
-`attachBunSqliteMaterializer` and `attachMarkdownExport` are not persistence: they project workspace rows into queryable SQLite tables or `.md` files. See the materializer subsections below.
+`attachBunSqliteMaterializer` and `attachMarkdownExport` are not persistence: they project workspace rows into queryable SQLite tables or `.md` files. They are read surfaces, not write surfaces. Projection actions such as `sqlite_rebuild`, `sqlite_search`, and `markdown_rebuild` maintain or query the projection; app data mutations stay in app-defined actions. See the materializer subsections below.
 
 ```typescript
 import {
@@ -961,9 +986,9 @@ Ordering is just lexical: `collaboration` reads `idb.whenLoaded` as `waitFor` be
 
 ### Markdown seam: read-only export
 
-Markdown comes from one seam, `attachMarkdownExport` (in `@epicenter/workspace/document/materializer/markdown`): a continuous, ONE-WAY Yjs to disk projection with free serialization (custom `filename`, `toMarkdown`, per-table `dir`). It exposes a single `markdown_rebuild` mutation for a destructive full re-export (orphan cleanup after a filename or layout change); there is no import path.
+Markdown comes from one seam, `attachMarkdownExport` (in `@epicenter/workspace/document/materializer/markdown`): a continuous, one-way Yjs to disk projection with free serialization (custom `filename`, `toMarkdown`, per-table `dir`). It exposes a single `markdown_rebuild` mutation for a destructive full re-export (orphan cleanup after a filename or layout change); there is no import path.
 
-The projection is read-only on purpose. The materialized `.md` is never read back into Yjs, so it carries no round-trip obligation and can shape the output however a human-readable export or a published site wants. App data mutates only through validated actions (`epicenter run <mount>.<action>`), never by editing the materialized files. The sqlite materializer is the read-only sibling for a relational projection.
+The projection is read-only on purpose. The materialized `.md` is never read back into Yjs, so it carries no round-trip obligation and can shape the output however a human-readable export or a published site wants. App data mutates through validated actions (`epicenter run <mount>.<action>`, `connectDaemonActions`, or TanStack AI tools created by `actionsToAiTools`), never by editing the materialized files. If an app needs Markdown as the authoring format, that parser/editor belongs in an app action or UI surface that writes Yjs. This export is not that path. The SQLite materializer is the read-only sibling for a relational projection.
 
 ```typescript
 import {
@@ -1003,6 +1028,8 @@ void openNotes;
 ### SQLite materializer
 
 The SQLite materializer is exported from `@epicenter/workspace/document/materializer/sqlite`. It mirrors every table in the workspace bundle into queryable SQLite tables with optional FTS5 full-text search. Pass the workspace directly; use the keyed `fts` slot to opt specific columns into FTS5.
+
+Treat the mirror as a read-only SQL projection. Scripts open it with `openSqliteReader`, which sets `PRAGMA query_only = ON`; app writes go through the daemon action path (`connectDaemonActions` or `epicenter run`) so the live Y.Doc stays authoritative and the mirror catches up from the same source as every other projection.
 
 ```typescript
 import {
@@ -1642,9 +1669,9 @@ import {
 
 These matter when you are writing low-level tooling against raw Yjs structures.
 
-## MCP Integration
+## AI, CLI, and MCP Integration
 
-The core package does not export an MCP server. What it does export is the metadata you need to build one:
+The core package does not export an MCP server or own every adapter. What it does export is the action surface those adapters need:
 
 - actions with `type`, `title`, `description`, and `input`
 - `Object.entries(actions)` to iterate the flat registry
@@ -1652,7 +1679,9 @@ The core package does not export an MCP server. What it does export is the metad
 - `toActionMeta(action)` to project an action to its wire-safe shape
 - `@epicenter/workspace/ai`: `actionsToAiTools(...)` for TanStack AI tool bindings
 
-That is enough to build adapters that expose workspace actions over HTTP, CLI, or MCP without coupling the core package to one transport.
+That is enough to expose workspace actions over HTTP, CLI, TanStack AI, or MCP without coupling the core package to one transport.
+
+For AI editing, expose workspace mutations as tools. `actionsToAiTools(...)` does not teach the model to patch the materialized Markdown folder. It wires tool calls to the same action handlers the UI and CLI use. Query tools can read data; mutation tools write Yjs and are marked `needsApproval: true` by default.
 
 ### Setup
 

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -389,8 +389,8 @@ Epicenter supports distributed sync where Y.Doc instances replicate across devic
    └────┬─────┘           └────┬─────┘              └────┬─────┘
         │                      │                         │
    (no server)            ┌────▼─────┐              ┌────▼─────┐
-        │                 │ Elysia   │◄────────────►│ Elysia   │
-        │                 │ :3913    │  server-to-  │ :3913    │
+        │                 │ Hono     │◄────────────►│ Hono     │
+        │                 │ relay    │  server-to-  │ relay    │
         │                 └────┬─────┘    server    └────┬─────┘
         │                      │                         │
         └──────────────────────┴─────────────────────────┘

--- a/specs/20260612T063520-landing-page-public-realignment.md
+++ b/specs/20260612T063520-landing-page-public-realignment.md
@@ -1,0 +1,216 @@
+# Landing Page Public Realignment
+
+**Date**: 2026-06-12
+**Status**: Draft
+**Owner**: Braden
+**Branch**: not started (suggest `landing/public-realignment`)
+
+## One Sentence
+
+Rebuild the epicenter.so root page (`apps/landing/src/pages/index.astro`) as a five-screen public-audience page that sells Whispering as the tonight-useful product and reveals the file-ownership guarantee on scroll, deriving all copy from the new public cut in `docs/positioning.md`.
+
+## Overview
+
+The landing page runs pre-spine copy ("memory" vocabulary, the Destination presented as shipped, "Star on GitHub" as primary CTA). This spec replaces the page structure and copy. The audience split is a locked owner decision: the GitHub README serves developers; epicenter.so serves the general public.
+
+## Motivation
+
+### Current State
+
+`apps/landing/src/pages/index.astro` hero (verbatim):
+
+```txt
+h1:   Local-First, Open-Source Apps
+sub:  One folder of plain text and SQLite on your machine. Every tool we
+      build shares this memory. It's open, tweakable, and yours.
+CTA:  [Star on GitHub]  [Join the Discord]
+...
+h2:   Tools that share your memory
+      Record a meeting in Whispering. Edit the transcript in Obsidian.
+      Query it with your AI. No copy-pasting, no exports.
+      (under a Badge labeled "Available now")
+```
+
+This creates problems:
+
+1. **Off-spine vocabulary**: "memory" is the page's organizing metaphor; the positioning spine does not use it.
+2. **Destination quoted as shipped**: the Whispering-to-Obsidian-to-AI loop is the vision, displayed under "Available now." `docs/positioning.md` forbids quoting the Destination directly.
+3. **Inverted CTA**: the public-facing surface funnels visitors to GitHub, the developer surface. Nothing on the page asks the visitor to install the one thing that ships.
+4. **No tonight-useful pitch**: the shipped superpower (hold a key, speak, words land at your cursor) appears nowhere. The page is all guarantee and vision; the public converts on usefulness and trusts the download because of the philosophy, not the reverse.
+5. **Jargon for the wrong reader**: "plain text and SQLite" headline a page whose locked audience does not know what SQLite is.
+
+### Desired State
+
+A five-screen page where every claim above the fold is shipped, every mechanism appears below the fold after the benefit it guarantees, and the only primary CTA is downloading Whispering.
+
+## Research Findings
+
+Two research passes inform this spec (full output lives in the planning conversation; the durable conclusions are recorded here).
+
+### Taste corpus (10 OSS and consumer-crypto landing pages)
+
+| Page | What it models |
+| --- | --- |
+| Signal | Outcome as headline ("Speak Freely"), protocol name literally in parentheses. The model for consumer-facing technical guarantees. |
+| Obsidian | Architecture translated to benefit: "local-first" becomes "Your thoughts are yours.", open formats become "you're never locked in." Section headlines all start with "Your". |
+| Standard Notes | Consumer metaphors backed by clickable receipts (audits, longevity statement, source). Metaphor without receipts curdles into marketing. |
+| Zed | Earliness handled with authorship ("A letter from the team"), not roadmap apologetics. |
+| Bun | "View install script" next to the install button: trust gestures cost one link. |
+| Tailscale, 1Password | Negative examples: enterprise drift, buzzword tide line ("for the AI era"), CTA addressed to budgets instead of users. |
+
+Extracted principles applied in this spec: outcome as headline with technology demoted to subordinate clauses; "your" as the workhorse word; negation claims ("No ads. No trackers. No kidding.") over feature claims; one CTA verb; wit as a trust signal; one reader per surface.
+
+### Marketer pass (line grades for the public audience)
+
+| Line | Verdict |
+| --- | --- |
+| "Apps come and go. Your files shouldn't." | Keep. Names a loss everyone has lived. Becomes the ownership section header and opens the public cut. |
+| "Local-first apps that write to files you own." | README only. "local-first" is insider vocabulary. |
+| "Manage your life in Markdown and SQLite." | Kill for public surfaces. Banked for launch posts aimed at HN. |
+| "Speak. It becomes a file you keep." | Vision section only, staged as vision; the flow is not shipped. |
+| "If we disappear tomorrow, your files won't notice." | Inside the founder letter only. Never adjacent to the CTA. |
+| "This folder is the whole product." | Kill for public surfaces. |
+
+**Key finding**: the page must sell what is useful tonight (Whispering); the ownership guarantee lands harder as a discovered fact on scroll than as a promised one in the hero.
+
+## Design Decisions
+
+| Decision | Class | Choice | Rationale |
+| --- | --- | --- | --- |
+| Audience for epicenter.so | Locked (owner) | General public; README owns developers | Owner decision, 2026-06-12. Do not re-litigate. |
+| Copy source | 2 coherence | Derive from the public cut in `docs/positioning.md` | New spine cut added 2026-06-12; restates the one-liner with vocabulary translated. |
+| Hero subject | 2 coherence | Whispering, the felt experience | The only honest download; proof line rule says no roadmap in heroes. |
+| Vocabulary above the fold | 2 coherence | No Markdown, SQLite, local-first, CRDT, Yjs | Public cut framing rule in positioning.md. |
+| Vision staging | 2 coherence | Screen 4 says "That's what we're building" explicitly | Lets the page show the folder vision without claiming it ships. |
+| Export button gag placement | 3 taste | Screen 2, not the hero | As hero it is a one-trick front door; at screen 2 it demonstrates the guarantee right after the product earns attention. Revisit when: a second app ships and the guarantee needs less explaining. |
+| Founder letter placement | 3 taste | Second to last, five lines max | Letters earn their read after usefulness is established; skimmers read two lines and the signature. |
+| Agents paragraph | 3 taste | Cut from this page | "Agents" reads as spyware or salesmen to the public. Revisit when: agent workflows are a shipped user-facing feature. |
+| Primary CTA | 2 coherence | "Download Whispering, free" with OS detection | One acquisition verb; "free" and platform answer the public's two real questions. |
+| GitHub and Discord links | 2 coherence | Footer and nav, not hero CTAs | Developers find the door themselves (corpus principle 12). |
+
+## Architecture
+
+Five screens, one register shift (useful, then funny, then serious, then hopeful, then human):
+
+```txt
+Screen 1  THE SUPERPOWER
+  h1:  Talk instead of type.
+  sub: Whispering is a free speech-to-text app for your computer.
+       Hold a key, say it, and the words land wherever your cursor
+       is: email, doc, chat, anything.
+  CTA: [ Download Whispering, free ]  [ Watch it work (20 seconds) ]
+  visual: real screen recording; words appearing in an ordinary email draft
+
+Screen 2  THE GAG
+  A giant button labeled "Export your data".
+  Click -> flips to "Already done."
+  sub: Other apps make you beg for your own data. Epicenter apps keep
+       it as ordinary files on your computer from day one, so there is
+       nothing to export because nothing was held.
+
+Screen 3  THE GUARANTEE
+  h2:  Apps come and go. Your files shouldn't.
+  sub: Epicenter apps save everything you make as ordinary files in a
+       folder on your computer. Readable now, readable in twenty years,
+       no account required.
+  visual: a row of generic app icons fading to gray while one plain
+          folder stays solid; caption "this folder is on your computer,
+          not ours"
+
+Screen 4  THE VISION (staged as vision)
+  h2:  Everything you make, in one folder you keep.
+  sub: That's what we're building: small apps for speaking, saving,
+       and writing that all put their work into ordinary files on your
+       computer. The first one, Whispering, is ready today.
+  CTA: [ Start with Whispering ]  [ Follow the build ]
+
+Screen 5  THE LETTER
+  Five short lines in Braden's first-person voice. Must include the
+  "if we disappeared tomorrow, your files wouldn't notice" beat here
+  and nowhere else. Ends with an invitation, then the final download
+  button.
+```
+
+Copy status: screens 1 through 4 above are approved draft copy; refine rhythm but do not change claims. Screen 5 needs owner-written or owner-approved text (see Open Questions).
+
+## Implementation Plan
+
+### Phase 1: Structure and copy
+
+- [ ] **1.1** Create branch, audit `apps/landing/src/pages/index.astro` and its components (`RotatingHeadline`, `RotatingTagline`, `CorePrinciples`, `PrinciplesRotatingHeadline`, `ToolCard`) for what survives, what is rewritten, what is deleted.
+- [ ] **1.2** Rebuild `index.astro` with the five-screen structure and the copy above. Update `BaseLayout` title and meta description to derive from the public cut.
+- [ ] **1.3** Wire the primary CTA to OS-detected download (reuse `components/whispering/OSDetector.svelte` if it fits), with the releases page as fallback.
+- [ ] **1.4** Remove all "memory" copy and the "Available now" Destination quote. Grep the landing app for `memory`, `SQLite`, `local-first`, `CRDT` and relocate or delete each hit per the public cut rule.
+
+### Phase 2: Interactions
+
+- [ ] **2.1** Export button flip (screen 2). One state change, no library ceremony; it must work without JS as a static joke (button renders, flip text visible below it) per the Ghostty empty-shell failure in the corpus.
+- [ ] **2.2** App-icons-fade, folder-stays visual (screen 3). CSS-only preferred.
+- [ ] **2.3** Page load and scroll reveals: one well-orchestrated staggered reveal, not scattered micro-interactions.
+
+### Phase 3: Assets
+
+- [ ] **3.1** Record the 20-second Whispering demo (hold key, speak a real sentence, words land in an email draft). Until it exists, ship a typed-text simulation clearly built from real app behavior; do not fake the unshipped speak-to-file flow.
+- [ ] **3.2** Founder letter final text from owner.
+
+### Phase 4: Verify and clean
+
+- [ ] **4.1** Build passes (`bun run` build for `apps/landing`), pages render with JS disabled.
+- [ ] **4.2** Banned-word and vocabulary sweep (see Success Criteria).
+- [ ] **4.3** Delete dead components and the `archive/index-v1.astro` copy drift if unreferenced.
+
+## Edge Cases
+
+### Relationship to /whispering
+
+The site already has `pages/whispering.astro`. The root page now also leads with Whispering. Rule: the root page sells the felt experience in one screen and links out; `whispering.astro` keeps depth (providers, settings, FAQ). Do not duplicate the deep content on the root page.
+
+### Visitor with JS disabled or a crawler
+
+Every screen must read as static copy. The gag degrades to its punchline text; the demo degrades to a still frame plus the headline.
+
+### The visitor who is a developer anyway
+
+They get one quiet door: the footer and nav keep GitHub links, and screen 4's "Follow the build" can point to the repo. Nothing else on the page addresses them; the README is their surface.
+
+## Open Questions
+
+1. **Founder letter text**
+   - The voice is the asset; generated text defeats the point.
+   - **Recommendation**: Braden drafts five lines; implementer typesets but does not write it. Placeholder lorem is acceptable for layout review.
+
+2. **"Watch it work" treatment**
+   - Options: (a) real screen recording, (b) scripted in-page typing simulation, (c) link to a short video.
+   - **Recommendation**: (b) now, replaced by (a) when recorded. Both must show shipped behavior only.
+
+3. **Visual and typography direction**
+   - The corpus says text-only heroes work when the headline carries an argument, and abstract mood illustration is the weakest choice. Avoid generic AI-slop aesthetics (no purple gradients, no Inter-by-default).
+   - **Recommendation**: warm, paper-like, characterful type; the recorded demo is the only hero imagery. Run the frontend-design skill at implementation time.
+
+4. **A "How is it free?" link**
+   - The marketer's cost-story direction (subscription resentment) was not chosen for the hero, but the question is real for the public.
+   - **Recommendation**: one footer or screen-1-adjacent link to an honest cost explanation (bring your own key, or local and free). Defer if it grows scope.
+
+## Adjacent Work
+
+- Deferred: swap screen 1 for the live speak-to-file demonstration when the Whispering workspace refresh ships. This is the v2 hero; treat "the landing page can finally be the demo" as one definition of done for that refresh.
+- Deferred: launch-post copy ("Manage your life in Markdown and SQLite" is banked for HN-facing surfaces, not this page).
+- Opportunistic: align `pages/whispering.astro` copy with the spine if touched.
+
+## Success Criteria
+
+- [ ] Above the fold contains no instance of: Markdown, SQLite, local-first, CRDT, Yjs, workspace (the folder sense), or any banned hype word.
+- [ ] Every claim above the fold is shipped behavior; the only vision copy on the page sits under explicit "that's what we're building" staging.
+- [ ] Primary CTA on screens 1, 4, and 5 is downloading Whispering; "Star on GitHub" is not a hero CTA.
+- [ ] "memory" vocabulary and the "Available now" Destination quote are gone from the landing app.
+- [ ] Page reads correctly with JavaScript disabled.
+- [ ] `apps/landing` builds clean.
+- [ ] Meta title and description derive from the public cut.
+
+## References
+
+- `apps/landing/src/pages/index.astro` - the page being replaced
+- `apps/landing/src/pages/whispering.astro` - depth page; boundary defined in Edge Cases
+- `apps/landing/src/components/whispering/OSDetector.svelte` - reuse for OS-detected download CTA
+- `docs/positioning.md` - the Spine (public cut), Proof Line elements, Earned Vocabulary, banned words
+- `README.md` (root) - the developer surface; the contrast this page is allowed to assume


### PR DESCRIPTION
Reframes the root README around the public promise we settled on: local-first apps and one workspace the reader owns.

The README now gives newcomers two clear paths: install Whispering today, or build with @epicenter/workspace. It also names the important boundary: app-owned state can project to Markdown and SQLite, while user-owned Markdown folders stay editable and curatable outside generated app output.