### PR TITLE
feat(cli): stabilize daemon actions and projection teardown

### DIFF
--- a/apps/fuji/src/lib/format.ts
+++ b/apps/fuji/src/lib/format.ts
@@ -5,8 +5,8 @@
  * components don't duplicate formatting logic.
  */
 
-import { formatDistanceToNowStrict } from 'date-fns';
 import type { IanaTimeZone } from '@epicenter/workspace';
+import { formatDistanceToNowStrict } from 'date-fns';
 
 /**
  * Format a `DateTimeString` as a human-readable relative time, e.g.

--- a/apps/fuji/src/lib/workspace/project.ts
+++ b/apps/fuji/src/lib/workspace/project.ts
@@ -131,6 +131,7 @@ export function fuji(opts: FujiMountOptions = {}) {
 				openWebSocket,
 				onReconnectSignal,
 				actions,
+				materializers: [sqlite, markdown],
 			});
 
 			return defineWorkspace({

--- a/apps/honeycrisp/honeycrisp.ts
+++ b/apps/honeycrisp/honeycrisp.ts
@@ -14,6 +14,7 @@
  *  - `apps/honeycrisp/project.ts`  -> `honeycrisp(opts?)` mount factory
  */
 
+import { field } from '@epicenter/field';
 import {
 	attachRichText,
 	createDisposableCache,
@@ -30,7 +31,6 @@ import {
 	nullable,
 	onLocalUpdate,
 } from '@epicenter/workspace';
-import { field } from '@epicenter/field';
 import Type from 'typebox';
 import type { Brand } from 'wellcrafted/brand';
 import * as Y from 'yjs';

--- a/apps/honeycrisp/project.ts
+++ b/apps/honeycrisp/project.ts
@@ -80,6 +80,7 @@ export function honeycrisp(opts: HoneycrispMountOptions = {}) {
 				openWebSocket,
 				onReconnectSignal,
 				actions,
+				materializers: [sqlite, markdown],
 			});
 
 			return defineWorkspace({

--- a/apps/matter/scripts/inspect.ts
+++ b/apps/matter/scripts/inspect.ts
@@ -15,9 +15,14 @@ import { readFolder } from '../src/lib/core/folder';
 
 const dir = process.argv[2] ?? '../../examples/matter/sample-vault/drafts';
 
-const names = (await readdir(dir)).filter((name) => name.endsWith('.md')).sort();
+const names = (await readdir(dir))
+	.filter((name) => name.endsWith('.md'))
+	.sort();
 const entries = await Promise.all(
-	names.map(async (name) => ({ name, content: await readFile(join(dir, name), 'utf8') })),
+	names.map(async (name) => ({
+		name,
+		content: await readFile(join(dir, name), 'utf8'),
+	})),
 );
 
 // Load the folder's model if it has one, so inspect shows conformance, not just
@@ -36,8 +41,12 @@ const cell = (value: unknown): string => {
 };
 
 console.log(`\nFolder: ${dir}`);
-console.log(`Files: ${entries.length}   Readable rows: ${rows.length}   Unreadable: ${unreadable.length}`);
-console.log(`Mode: ${view.mode}${view.mode === 'unmodeled' && view.modelError ? ` (model error: ${view.modelError.message})` : ''}\n`);
+console.log(
+	`Files: ${entries.length}   Readable rows: ${rows.length}   Unreadable: ${unreadable.length}`,
+);
+console.log(
+	`Mode: ${view.mode}${view.mode === 'unmodeled' && view.modelError ? ` (model error: ${view.modelError.message})` : ''}\n`,
+);
 
 if (view.mode === 'unmodeled') {
 	console.log('No model: raw columns (keys only, no inferred kinds):');
@@ -47,7 +56,9 @@ if (view.mode === 'unmodeled') {
 	const keys = view.columns;
 	console.log('  ' + ['file', ...keys].map((k) => k.padEnd(16)).join(''));
 	for (const row of rows) {
-		const cells = keys.map((k) => cell(row.frontmatter[k]).slice(0, 15).padEnd(16));
+		const cells = keys.map((k) =>
+			cell(row.frontmatter[k]).slice(0, 15).padEnd(16),
+		);
 		console.log('  ' + row.name.padEnd(16) + cells.join(''));
 	}
 } else {
@@ -63,12 +74,15 @@ if (view.mode === 'unmodeled') {
 		const flag = conf.rowValid ? ' ' : '!';
 		const cells = conf.cells.map((c) => c.state.padEnd(16));
 		const extras = conf.extras.length ? `  +${conf.extras.length} extra` : '';
-		console.log(`${flag} ` + conf.row.name.padEnd(16) + cells.join('') + extras);
+		console.log(
+			`${flag} ` + conf.row.name.padEnd(16) + cells.join('') + extras,
+		);
 	}
 }
 
 if (unreadable.length) {
 	console.log('\nUnreadable (would route to "Can\'t read"):');
-	for (const u of unreadable) console.log(`  ${u.name.padEnd(16)} ${u.error.message}`);
+	for (const u of unreadable)
+		console.log(`  ${u.name.padEnd(16)} ${u.error.message}`);
 }
 console.log('');

--- a/apps/matter/src/app.html
+++ b/apps/matter/src/app.html
@@ -1,14 +1,15 @@
 <!doctype html>
 <html lang="en" class="style-vega">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>Matter</title>
 		<script>
 			const mode = localStorage.getItem('mode-watcher-mode') ?? 'dark';
 			const isLight =
 				mode === 'light' ||
-				(mode === 'system' && matchMedia('(prefers-color-scheme: light)').matches);
+				(mode === 'system' &&
+					matchMedia('(prefers-color-scheme: light)').matches);
 			document.documentElement.classList.toggle('dark', !isLight);
 			document.documentElement.style.colorScheme = isLight ? 'light' : 'dark';
 			localStorage.setItem('mode-watcher-mode', mode);

--- a/apps/matter/src/lib/bindings/FileDelta.ts
+++ b/apps/matter/src/lib/bindings/FileDelta.ts
@@ -11,4 +11,7 @@
  * same `tag`/`rename_all`, so the wire shape and the generated type stay in lockstep
  * by construction.
  */
-export type FileDelta = { "kind": "content", fileName: string, text: string, } | { "kind": "removed", fileName: string, } | { "kind": "unreadable", fileName: string, };
+export type FileDelta =
+	| { kind: 'content'; fileName: string; text: string }
+	| { kind: 'removed'; fileName: string }
+	| { kind: 'unreadable'; fileName: string };

--- a/apps/matter/src/lib/components/fields/field-props.ts
+++ b/apps/matter/src/lib/components/fields/field-props.ts
@@ -20,8 +20,8 @@
  * wrapper, not the Field).
  */
 
-import type { NeedsValueCell, OkCell } from '$lib/core/conformance';
 import type { Field } from '@epicenter/field';
+import type { NeedsValueCell, OkCell } from '$lib/core/conformance';
 
 /**
  * Commit a new value for this cell's field. The {@link ModeledCell} wrapper binds

--- a/apps/matter/src/lib/core/conformance.test.ts
+++ b/apps/matter/src/lib/core/conformance.test.ts
@@ -28,7 +28,11 @@ describe('classifyRow (per-cell conformance, everything required)', () => {
 	});
 
 	test('an absent required field is NEEDS_VALUE (invalid)', () => {
-		const row: Row = { fileName: 'b.md', frontmatter: { title: 'Hi' }, body: '' };
+		const row: Row = {
+			fileName: 'b.md',
+			frontmatter: { title: 'Hi' },
+			body: '',
+		};
 		const c = classifyRow(cols, row);
 		expect(c.cells.map((x) => x.state)).toEqual([
 			'OK',
@@ -53,7 +57,11 @@ describe('classifyRow (per-cell conformance, everything required)', () => {
 	// `title` is absent; both classify identically (NEEDS_VALUE, since required).
 	test('absent key and explicit null are the SAME empty', () => {
 		const absent: Row = { fileName: 'd.md', frontmatter: {}, body: '' };
-		const nul: Row = { fileName: 'e.md', frontmatter: { title: null }, body: '' };
+		const nul: Row = {
+			fileName: 'e.md',
+			frontmatter: { title: null },
+			body: '',
+		};
 		expect(classifyRow(cols, absent).cells[0]?.state).toBe('NEEDS_VALUE');
 		expect(classifyRow(cols, nul).cells[0]?.state).toBe('NEEDS_VALUE');
 	});

--- a/apps/matter/src/lib/core/folder.test.ts
+++ b/apps/matter/src/lib/core/folder.test.ts
@@ -7,11 +7,18 @@ describe('readFolder', () => {
 			{ fileName: 'a.md', content: '---\ntitle: A\nrating: 5\n---\nbody' },
 			{ fileName: 'b.md', content: '---\ntitle: B\n---\nbody' },
 			{ fileName: 'broken.md', content: '---\ntitle: [unclosed\n---\nbody' },
-			{ fileName: 'conflict.md', content: '<<<<<<< HEAD\nx\n=======\ny\n>>>>>>> z\n' },
+			{
+				fileName: 'conflict.md',
+				content: '<<<<<<< HEAD\nx\n=======\ny\n>>>>>>> z\n',
+			},
 			{ fileName: 'raw.md', content: '# no frontmatter' },
 		]);
 
-		expect(result.rows.map((r) => r.fileName)).toEqual(['a.md', 'b.md', 'raw.md']);
+		expect(result.rows.map((r) => r.fileName)).toEqual([
+			'a.md',
+			'b.md',
+			'raw.md',
+		]);
 		expect(result.unreadable.map((u) => [u.fileName, u.error.name])).toEqual([
 			['broken.md', 'InvalidYaml'],
 			['conflict.md', 'ConflictMarkers'],
@@ -34,7 +41,10 @@ describe('readFolder', () => {
 			[
 				{ fileName: 'a.md', content: '---\ntitle: A\nrating: 5\n---\nbody' },
 				{ fileName: 'b.md', content: '---\ntitle: B\n---\nbody' }, // rating absent -> NEEDS_VALUE
-				{ fileName: 'c.md', content: '---\ntitle: C\nrating: "high"\n---\nbody' }, // INVALID
+				{
+					fileName: 'c.md',
+					content: '---\ntitle: C\nrating: "high"\n---\nbody',
+				}, // INVALID
 			],
 			model,
 		);

--- a/apps/matter/src/lib/core/model.test.ts
+++ b/apps/matter/src/lib/core/model.test.ts
@@ -71,7 +71,9 @@ describe('parseModel (raw text)', () => {
 	});
 
 	test('parses a valid file', () => {
-		const { data, error } = parseModel('{"fields":{"title":{"type":"string"}}}');
+		const { data, error } = parseModel(
+			'{"fields":{"title":{"type":"string"}}}',
+		);
 		expect(error).toBeNull();
 		expect(data?.fields).toHaveLength(1);
 	});

--- a/apps/matter/src/lib/core/model.ts
+++ b/apps/matter/src/lib/core/model.ts
@@ -27,13 +27,13 @@
  * carries a bare `kind` and has no `nullable`.
  */
 
+import { compile, type Field, recognize } from '@epicenter/field';
 import {
 	defineErrors,
 	extractErrorMessage,
 	type InferErrors,
 } from 'wellcrafted/error';
 import { Err, Ok, type Result, trySync } from 'wellcrafted/result';
-import { compile, type Field, recognize } from '@epicenter/field';
 
 /** Why a stored `matter.json` could not be read into a usable model at all. */
 export const MatterModelError = defineErrors({
@@ -57,9 +57,7 @@ export type MatterModel = {
 };
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
-	return (
-		typeof value === 'object' && value !== null && !Array.isArray(value)
-	);
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 /**
@@ -102,7 +100,9 @@ export function validateModel(
  * (carrying the parser error as `cause`) rather than throwing, so a junk file degrades
  * to the raw view with a diagnostic.
  */
-export function parseModel(text: string): Result<MatterModel, MatterModelError> {
+export function parseModel(
+	text: string,
+): Result<MatterModel, MatterModelError> {
 	const { data: raw, error } = trySync({
 		try: () => JSON.parse(text) as unknown,
 		catch: (cause) => MatterModelError.InvalidJson({ cause }),

--- a/apps/matter/src/lib/core/parse.test.ts
+++ b/apps/matter/src/lib/core/parse.test.ts
@@ -14,7 +14,9 @@ describe('parseMarkdown', () => {
 	});
 
 	test('no frontmatter is an empty mapping and the whole file is body', () => {
-		const { data, error } = parseMarkdown('# Just a heading\n\nno frontmatter here');
+		const { data, error } = parseMarkdown(
+			'# Just a heading\n\nno frontmatter here',
+		);
 		expect(error).toBeNull();
 		expect(data).toEqual({
 			frontmatter: {},
@@ -34,7 +36,8 @@ describe('parseMarkdown', () => {
 	});
 
 	test('conflict markers are unreadable, never silently parsed', () => {
-		const raw = '---\ntitle: x\n<<<<<<< HEAD\nstatus: a\n=======\nstatus: b\n>>>>>>> other\n---\nbody';
+		const raw =
+			'---\ntitle: x\n<<<<<<< HEAD\nstatus: a\n=======\nstatus: b\n>>>>>>> other\n---\nbody';
 		expect(parseMarkdown(raw).error?.name).toBe('ConflictMarkers');
 	});
 

--- a/apps/matter/src/lib/core/serialize.test.ts
+++ b/apps/matter/src/lib/core/serialize.test.ts
@@ -46,7 +46,8 @@ describe('serializeEntry', () => {
  */
 describe('edit cycle (parse -> edit -> serialize -> parse)', () => {
 	test('round-trip identity by VALUE: a no-op cycle preserves every value and the body', () => {
-		const raw = '---\ntitle: My Post\nstatus: draft\ntags:\n  - a\n  - b\n---\n# Body\n\ntext';
+		const raw =
+			'---\ntitle: My Post\nstatus: draft\ntags:\n  - a\n  - b\n---\n# Body\n\ntext';
 		const before = parseMarkdown(raw).data;
 		const after = parseMarkdown(editField(raw, 'status', 'draft')).data;
 		expect(after).toEqual(before);
@@ -79,9 +80,9 @@ describe('edit cycle (parse -> edit -> serialize -> parse)', () => {
 	});
 
 	test('clearing the last field drops the fence to body-only', () => {
-		expect(editField('---\ntitle: Hello\n---\n# Body\ntext', 'title', undefined)).toBe(
-			'# Body\ntext',
-		);
+		expect(
+			editField('---\ntitle: Hello\n---\n# Body\ntext', 'title', undefined),
+		).toBe('# Body\ntext');
 	});
 
 	test('an invalid-against-the-model value survives by value (stays editable)', () => {

--- a/apps/matter/src/lib/core/sqlite.test.ts
+++ b/apps/matter/src/lib/core/sqlite.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'bun:test';
 import { classifyRows } from './conformance';
 import { validateModel } from './model';
-import { projectToSqlite } from './sqlite';
 import type { Row } from './parse';
+import { projectToSqlite } from './sqlite';
 
 function model(fields: Record<string, Record<string, unknown>>) {
 	const { data, error } = validateModel({ fields });

--- a/apps/matter/src/lib/core/sqlite.ts
+++ b/apps/matter/src/lib/core/sqlite.ts
@@ -26,9 +26,9 @@
  *     CHECK would only reject the very drafts the filter exists to surface.
  */
 
+import { type Field, storageOf } from '@epicenter/field';
 import type { RowConformance } from './conformance';
 import type { MatterModel } from './model';
-import { storageOf, type Field } from '@epicenter/field';
 
 /** A SQLite-bindable scalar. A missing (NEEDS_VALUE) cell binds NULL, so values are nullable. */
 export type SqlValue = string | number | null;

--- a/apps/matter/src/lib/open-vaults.svelte.ts
+++ b/apps/matter/src/lib/open-vaults.svelte.ts
@@ -19,9 +19,9 @@
  * agree on the open set.
  */
 
+import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
-import { open as openDialog } from '@tauri-apps/plugin-dialog';
 
 /** One open vault as persisted: an opaque id, the absolute folder path, its basename label. */
 export type OpenVault = { id: string; path: string; folderName: string };
@@ -97,7 +97,11 @@ function createOpenVaults() {
 		}
 		// Opaque, URL-safe, collision-free: the URL carries this, not the raw path (paths
 		// contain `/` and special chars that are fragile in a URL).
-		const vault: OpenVault = { id: crypto.randomUUID(), path, folderName: basename(path) };
+		const vault: OpenVault = {
+			id: crypto.randomUUID(),
+			path,
+			folderName: basename(path),
+		};
 		vaults = [...vaults, vault];
 		persist();
 		await goto(`/vault/${vault.id}`);

--- a/apps/matter/src/lib/vault.svelte.ts
+++ b/apps/matter/src/lib/vault.svelte.ts
@@ -22,12 +22,14 @@
  * `bun run tauri dev`.
  */
 
-import { invoke, Channel } from '@tauri-apps/api/core';
+import { Channel, invoke } from '@tauri-apps/api/core';
 import { SvelteMap } from 'svelte/reactivity';
 import { extractErrorMessage } from 'wellcrafted/error';
 import { Err, type Result, tryAsync } from 'wellcrafted/result';
-import { editBody, editField } from './core/serialize';
-import { MIRROR_TABLE, projectToSqlite, quoteIdent } from './core/sqlite';
+// One file's observable state, pushed by `watch_folder` (content / removed /
+// unreadable). Generated from the Rust `FileDelta` enum by ts-rs, so the IPC payload
+// has one source of truth; regenerate with `cargo test` in `src-tauri`.
+import type { FileDelta } from './bindings/FileDelta';
 import {
 	buildView,
 	type FolderRead,
@@ -36,10 +38,8 @@ import {
 	type UnreadableFile,
 } from './core/folder';
 import { parseEntry, type Row } from './core/parse';
-// One file's observable state, pushed by `watch_folder` (content / removed /
-// unreadable). Generated from the Rust `FileDelta` enum by ts-rs, so the IPC payload
-// has one source of truth; regenerate with `cargo test` in `src-tauri`.
-import type { FileDelta } from './bindings/FileDelta';
+import { editBody, editField } from './core/serialize';
+import { MIRROR_TABLE, projectToSqlite, quoteIdent } from './core/sqlite';
 
 /** The vault's own folder name (its basename). Per-file paths are Rust's. */
 const basename = (path: string) => path.split(/[/\\]/).pop() ?? path;
@@ -135,10 +135,11 @@ export function createVault(path: string) {
 	function reconcileMirror(): void {
 		const { view } = read;
 		if (view.mode !== 'modeled') return;
-		const { schema, insert, rows: tuples } = projectToSqlite(
-			view.model,
-			view.conformance,
-		);
+		const {
+			schema,
+			insert,
+			rows: tuples,
+		} = projectToSqlite(view.model, view.conformance);
 		void invoke('write_mirror', { path, schema, insert, rows: tuples })
 			.then(() => {
 				mirrorVersion++; // the file is now fresh: wake any reader keyed on the mirror
@@ -154,7 +155,10 @@ export function createVault(path: string) {
 	 * drains, so the map does not grow with the folder.
 	 */
 	const writeTails = new Map<string, Promise<void>>();
-	function serializeWrite(fileName: string, run: () => Promise<void>): Promise<void> {
+	function serializeWrite(
+		fileName: string,
+		run: () => Promise<void>,
+	): Promise<void> {
 		const tail = (writeTails.get(fileName) ?? Promise.resolve()).then(run);
 		const settled = tail.catch(() => {});
 		writeTails.set(fileName, settled);
@@ -178,11 +182,17 @@ export function createVault(path: string) {
 	 * no second copy to drift. A failed write leaves the map untouched (we apply only
 	 * on success) and surfaces in `writeError`.
 	 */
-	function write(fileName: string, edit: (raw: string) => string): Promise<void> {
+	function write(
+		fileName: string,
+		edit: (raw: string) => string,
+	): Promise<void> {
 		return serializeWrite(fileName, async () => {
 			const { data: next, error: failure } = await tryAsync({
 				try: async () => {
-					const raw = await invoke<string | null>('read_entry', { path, fileName });
+					const raw = await invoke<string | null>('read_entry', {
+						path,
+						fileName,
+					});
 					const text = edit(raw ?? '');
 					await invoke('write_entry', { path, fileName, content: text });
 					return text;
@@ -205,7 +215,11 @@ export function createVault(path: string) {
 	 * not clobbered. Writes to one file are serialized, so two quick edits cannot
 	 * interleave their read-modify-write and drop one of the changes.
 	 */
-	function saveField(fileName: string, key: string, value: unknown): Promise<void> {
+	function saveField(
+		fileName: string,
+		key: string,
+		value: unknown,
+	): Promise<void> {
 		return write(fileName, (raw) => editField(raw, key, value));
 	}
 
@@ -250,11 +264,13 @@ export function createVault(path: string) {
 	channel.onmessage = applyDeltas;
 	let watchId: number | undefined;
 	let disposed = false;
-	const whenReady = invoke<number>('watch_folder', { path, channel }).then((id) => {
-		// Disposed before the id arrived: drop the watcher that just resolved.
-		if (disposed) void invoke('unwatch_folder', { id });
-		else watchId = id;
-	});
+	const whenReady = invoke<number>('watch_folder', { path, channel }).then(
+		(id) => {
+			// Disposed before the id arrived: drop the watcher that just resolved.
+			if (disposed) void invoke('unwatch_folder', { id });
+			else watchId = id;
+		},
+	);
 	/** Stop the OS watch. The keyed route component calls this when it is torn down (a tab switch or close). */
 	function dispose(): void {
 		disposed = true;
@@ -298,4 +314,7 @@ export type Vault = ReturnType<typeof createVault>;
  * the disk lifecycle (`whenReady` / `dispose` / `path`), so the demo is an honest
  * drop-in rather than a vault pretending to watch a folder.
  */
-export type FolderGridVault = Pick<Vault, 'folderName' | 'read' | 'saveField' | 'saveBody'>;
+export type FolderGridVault = Pick<
+	Vault,
+	'folderName' | 'read' | 'saveField' | 'saveBody'
+>;

--- a/apps/matter/src/routes/demo/demo-vault.svelte.ts
+++ b/apps/matter/src/routes/demo/demo-vault.svelte.ts
@@ -14,8 +14,8 @@
  */
 
 import { SvelteMap } from 'svelte/reactivity';
-import { editBody, editField } from '$lib/core/serialize';
 import { type FolderRead, readFolder } from '$lib/core/folder';
+import { editBody, editField } from '$lib/core/serialize';
 import type { FolderGridVault } from '$lib/vault.svelte';
 import { DEMO_MODEL_TEXT, DEMO_ROWS } from './fixtures';
 
@@ -27,11 +27,12 @@ export function createDemoVault(folderName = 'sample-vault/drafts') {
 		DEMO_ROWS.map((row) => [row.fileName, row.content]),
 	);
 
-	const read = $derived.by((): FolderRead =>
-		readFolder(
-			[...entries].map(([fileName, content]) => ({ fileName, content })),
-			DEMO_MODEL_TEXT,
-		),
+	const read = $derived.by(
+		(): FolderRead =>
+			readFolder(
+				[...entries].map(([fileName, content]) => ({ fileName, content })),
+				DEMO_MODEL_TEXT,
+			),
 	);
 
 	/** Apply one transform to a file's freshest text, the demo's analog of `write`. */

--- a/apps/opensidian/opensidian.ts
+++ b/apps/opensidian/opensidian.ts
@@ -14,12 +14,12 @@
  *  - `apps/opensidian/project.ts`                    -> `opensidian()` mount factory
  */
 
+import { field, jsonValue } from '@epicenter/field';
 import {
 	type FileId,
 	fileContentDocGuid,
 	filesTable,
 } from '@epicenter/filesystem';
-import { field, jsonValue } from '@epicenter/field';
 import {
 	attachTimeline,
 	createDisposableCache,

--- a/apps/tab-manager/project.ts
+++ b/apps/tab-manager/project.ts
@@ -86,6 +86,7 @@ export function tabManager(opts: TabManagerMountOptions = {}) {
 				openWebSocket,
 				onReconnectSignal,
 				actions,
+				materializers: [sqlite, markdown],
 			});
 
 			return defineWorkspace({

--- a/apps/wiki/src/lib/workspace/schema.ts
+++ b/apps/wiki/src/lib/workspace/schema.ts
@@ -20,8 +20,12 @@
  * collaborative or independently-syncing body editing is real.
  */
 
-import { defineTable, type InferTableRow, nullable } from '@epicenter/workspace';
 import { field } from '@epicenter/field';
+import {
+	defineTable,
+	type InferTableRow,
+	nullable,
+} from '@epicenter/workspace';
 import { type TSchema, Type } from 'typebox';
 import type { Brand } from 'wellcrafted/brand';
 import type { JsonObject, JsonValue } from 'wellcrafted/json';

--- a/apps/wiki/src/lib/workspace/wiki.test.ts
+++ b/apps/wiki/src/lib/workspace/wiki.test.ts
@@ -14,8 +14,8 @@ import { expect, test } from 'bun:test';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { nullable } from '@epicenter/workspace';
 import { field } from '@epicenter/field';
+import { nullable } from '@epicenter/workspace';
 import {
 	assembleMarkdown,
 	parseMarkdownFile,

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -61,7 +61,7 @@ npm package).
 
 ## Writes: typed invoke through the daemon
 
-`connectDaemonActions<TActions>({ mount, projectDir })` returns a typed proxy. `mount` is the mount name (`'fuji'` for the Fuji example); the proxy translates `fuji.entries_update({ ... })` into a `POST /invoke` over the daemon's Unix socket in the OS runtime directory. The daemon validates the input against the action's declared schema (invalid input comes back as a usage error), invokes the action in-process against the live Y.Doc, and returns a JSON `Result<T>`.
+`connectDaemonActions<TActions>({ mount, projectDir })` returns a typed proxy. `mount` is the mount name (`'fuji'` for the Fuji example); the proxy translates `fuji.entries_update({ ... })` into a `POST /run` over the daemon's Unix socket in the OS runtime directory. The daemon validates the input against the action's declared schema (invalid input comes back as a usage error), invokes the action in-process against the live Y.Doc, and returns a JSON `Result<T>`.
 
 The mount name comes from each `Mount.name` in the `Mount[]` default-exported by `epicenter.config.ts`. App factories like `fuji()` return a mount whose name is `fuji`.
 

--- a/examples/matter/sample-vault/drafts/matter.json
+++ b/examples/matter/sample-vault/drafts/matter.json
@@ -1,7 +1,10 @@
 {
 	"fields": {
 		"title": { "type": "string" },
-		"status": { "type": "string", "enum": ["draft", "ready", "published", "archived"] },
+		"status": {
+			"type": "string",
+			"enum": ["draft", "ready", "published", "archived"]
+		},
 		"format": { "type": "string", "enum": ["article", "carousel", "video"] },
 		"destinations": { "type": "array", "items": { "type": "string" } },
 		"publishDate": { "type": "string" },

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -82,7 +82,7 @@ describe('createCLI', () => {
 		try {
 			for (const command of ['up', 'down', 'ps', 'logs']) {
 				await expect(createCLI().run([command])).rejects.toThrow(
-					`Unknown command: ${command}`,
+					`Unknown argument: ${command}`,
 				);
 			}
 		} finally {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,11 +1,10 @@
 import yargs from 'yargs';
 import { authCommand } from './commands/auth.js';
 import { daemonCommand } from './commands/daemon.js';
+import { initCommand } from './commands/init.js';
 import { listCommand } from './commands/list.js';
 import { peersCommand } from './commands/peers.js';
 import { runCommand } from './commands/run.js';
-
-const REMOVED_DAEMON_COMMANDS = new Set(['up', 'down', 'ps', 'logs']);
 
 /**
  * Create the Epicenter CLI instance.
@@ -15,8 +14,9 @@ const REMOVED_DAEMON_COMMANDS = new Set(['up', 'down', 'ps', 'logs']);
  * now.
  *
  *   - `auth`:  manage the local machine auth session (pre-workspace)
+ *   - `init`:  scaffold epicenter.config.ts (explicit project creation)
  *   - `daemon`: operate daemon lifecycle commands
- *   - `list`:  tree view of runnable actions (local schema is authoritative)
+ *   - `list`:  runnable actions grouped by mount (local schema is authoritative)
  *   - `run`:   invoke one by mount-prefixed action path; `--peer` dispatches over RPC
  *   - `peers`: enumerate other clients currently online via the workspace presence row
  *
@@ -31,14 +31,10 @@ const REMOVED_DAEMON_COMMANDS = new Set(['up', 'down', 'ps', 'logs']);
 export function createCLI() {
 	return {
 		run: async (argv: string[]) => {
-			const [command] = argv;
-			if (command && REMOVED_DAEMON_COMMANDS.has(command)) {
-				throw new Error(`Unknown command: ${command}`);
-			}
-
 			const cli = yargs()
 				.scriptName('epicenter')
 				.command(authCommand)
+				.command(initCommand)
 				.command(daemonCommand)
 				.command(listCommand)
 				.command(peersCommand)

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Tests for `epicenter init`: scaffolds the default config into the target
+ * directory and leaves an existing config untouched.
+ */
+
+import { afterEach, beforeEach, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { DEFAULT_PROJECT_CONFIG_SOURCE } from '@epicenter/workspace/node';
+import { createCLI } from '../cli.js';
+
+let workDir: string;
+
+beforeEach(() => {
+	workDir = mkdtempSync('/tmp/eps-init-');
+});
+
+afterEach(() => {
+	rmSync(workDir, { recursive: true, force: true });
+});
+
+test('init scaffolds the default config', async () => {
+	await createCLI().run(['init', workDir]);
+
+	expect(readFileSync(join(workDir, 'epicenter.config.ts'), 'utf8')).toBe(
+		DEFAULT_PROJECT_CONFIG_SOURCE,
+	);
+});
+
+test('init leaves an existing config untouched', async () => {
+	const original = 'export default []; // keep me\n';
+	writeFileSync(join(workDir, 'epicenter.config.ts'), original);
+
+	await createCLI().run(['init', workDir]);
+
+	expect(readFileSync(join(workDir, 'epicenter.config.ts'), 'utf8')).toBe(
+		original,
+	);
+});

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,39 @@
+/**
+ * `epicenter init [dir]`: scaffold a new Epicenter project.
+ *
+ * Writes the default `epicenter.config.ts` into the target directory (the
+ * literal directory given; no project-root discovery, because init creates
+ * the root). Idempotent: an existing config is left untouched.
+ *
+ * Project creation is an explicit user decision; `epicenter daemon up` never
+ * scaffolds and instead points here when the config is missing.
+ */
+
+import { existsSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { DEFAULT_PROJECT_CONFIG_SOURCE } from '@epicenter/workspace/node';
+import { cmd } from '../util/cmd.js';
+
+export const initCommand = cmd({
+	command: 'init [dir]',
+	describe: 'Scaffold epicenter.config.ts in a directory.',
+	builder: (yargs) =>
+		yargs.positional('dir', {
+			type: 'string',
+			default: () => process.cwd(),
+			defaultDescription: 'current working directory',
+			describe: 'Directory to become the project root',
+			coerce: (dir: string) => resolve(dir),
+		}),
+	handler: (argv) => {
+		const projectConfigPath = join(argv.dir, 'epicenter.config.ts');
+		if (existsSync(projectConfigPath)) {
+			process.stderr.write(`${projectConfigPath} already exists; left as is\n`);
+			return;
+		}
+		writeFileSync(projectConfigPath, DEFAULT_PROJECT_CONFIG_SOURCE, {
+			mode: 0o600,
+		});
+		process.stdout.write(`created ${projectConfigPath}\n`);
+	},
+});

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -28,7 +28,7 @@ import {
 
 export const listCommand = cmd({
 	command: 'list [path]',
-	describe: 'Tree view of exposed queries and mutations on this device',
+	describe: 'List exposed queries and mutations on this device, by mount',
 	builder: (yargs) =>
 		yargs
 			.positional('path', {
@@ -116,7 +116,7 @@ function renderText(entries: ActionManifest, path: string): void {
 		printActionDetail(path, leaf);
 		return;
 	}
-	printTree(subset, path);
+	printGroupedByMount(subset);
 }
 
 function filterByPath(entries: ActionManifest, path: string): ActionManifest {
@@ -146,48 +146,32 @@ function toActionDescriptor(
 	return desc;
 }
 
-type TreeNode = {
-	name: string;
-	children: Map<string, TreeNode>;
-	action?: ActionManifest[string];
-};
-
-function printTree(entries: ActionManifest, prefix: string): void {
-	const pfx = prefix ? `${prefix}.` : '';
-	const root: TreeNode = { name: '', children: new Map() };
+/**
+ * Action paths are exactly `mount.action_key` (mount names reject dots, action
+ * keys are snake_case), so the manifest is two levels deep by construction.
+ * Render one mount header per group with its actions indented underneath.
+ */
+function printGroupedByMount(entries: ActionManifest): void {
+	const byMount = new Map<string, [string, ActionManifest[string]][]>();
 	for (const [path, action] of Object.entries(entries)) {
-		const rest = prefix ? path.slice(pfx.length) : path;
-		if (!rest) continue;
-		const parts = rest.split('.');
-		let node = root;
-		for (const [idx, seg] of parts.entries()) {
-			let child = node.children.get(seg);
-			if (!child) {
-				child = { name: seg, children: new Map() };
-				node.children.set(seg, child);
-			}
-			node = child;
-			if (idx === parts.length - 1) node.action = action;
+		const dot = path.indexOf('.');
+		const mount = dot === -1 ? path : path.slice(0, dot);
+		const key = dot === -1 ? '' : path.slice(dot + 1);
+		const group = byMount.get(mount);
+		if (group) group.push([key, action]);
+		else byMount.set(mount, [[key, action]]);
+	}
+
+	let first = true;
+	for (const [mount, group] of byMount) {
+		if (!first) console.log('');
+		first = false;
+		console.log(mount);
+		for (const [key, action] of group) {
+			const desc = action.description ? `  ${action.description}` : '';
+			console.log(`  ${key}  (${action.type})${desc}`);
 		}
 	}
-	printChildren(root, '');
-}
-
-function printChildren(node: TreeNode, prefix: string): void {
-	const children = [...node.children.values()];
-	children.forEach((child, idx) => {
-		const isLast = idx === children.length - 1;
-		const branch = isLast ? '└── ' : '├── ';
-		const label = child.action
-			? `${child.name}  (${child.action.type})${
-					child.action.description ? `  ${child.action.description}` : ''
-				}`
-			: child.name;
-		console.log(`${prefix}${branch}${label}`);
-		if (child.children.size > 0) {
-			printChildren(child, prefix + (isLast ? '    ' : '│   '));
-		}
-	});
 }
 
 function printActionDetail(path: string, action: ActionManifest[string]): void {

--- a/packages/cli/src/commands/ps.ts
+++ b/packages/cli/src/commands/ps.ts
@@ -2,7 +2,9 @@
  * `epicenter daemon ps`: list running `daemon up` daemons (this user, this machine).
  *
  * Enumerates `<runtimeDir>/*.meta.json`, pings each socket to confirm
- * liveness, and renders a compact table. Dead-pid metadata and socket files
+ * liveness, and renders a compact table. The socket ping is the single
+ * liveness authority (a dead pid cannot answer it); metadata carries the pid
+ * only so `down` can signal the process. Orphaned metadata and socket files
  * are opportunistically swept through the shared daemon runtime-file cleanup.
  *
  * No `--json` flag in v1; the spec defers it until a tooling consumer
@@ -18,9 +20,6 @@ import {
 	sweepDaemonRuntimeFiles,
 } from '@epicenter/workspace/node';
 import { cmd } from '../util/cmd.js';
-import { isProcessAlive } from '../util/process-alive.js';
-
-const PING_TIMEOUT_MS = 250;
 
 type PsRow = {
 	dir: string;
@@ -48,16 +47,9 @@ export const psCommand = cmd({
 	handler: async () => {
 		const rows: PsRow[] = [];
 		for (const meta of enumerateDaemons()) {
-			// Dead pid: orphan, unlink metadata + socket and skip.
-			if (!isProcessAlive(meta.pid)) {
-				sweepDaemonRuntimeFiles(meta.dir);
-				continue;
-			}
-			// Pid alive but socket unresponsive: also orphan.
-			const responsive = await pingDaemon(
-				socketPathFor(meta.dir),
-				PING_TIMEOUT_MS,
-			);
+			// Socket unresponsive (dead pid, crash leftovers, or a hung daemon):
+			// orphan, unlink metadata + socket and skip.
+			const responsive = await pingDaemon(socketPathFor(meta.dir));
 			if (!responsive) {
 				sweepDaemonRuntimeFiles(meta.dir);
 				continue;

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -4,8 +4,10 @@
  * `epicenter daemon up` daemon.
  *
  * `input` is JSON: inline positional, `@file.json` (curl convention), or stdin.
- * With `--peer <target>`, the invocation is dispatched over the selected
- * mount's RPC channel to a remote peer instead of running locally.
+ * With `--peer <target>`, the daemon dispatches the run over the selected
+ * mount's RPC channel to a remote peer instead of running locally; both
+ * shapes are one `/run` request (the optional `peer` object selects the
+ * target and carries the wait budget).
  *
  * `epicenter run` requires a running daemon for the discovered project.
  * Without `daemon up`, the handler errors with a hint pointing at
@@ -23,9 +25,8 @@ import type { DispatchError } from '@epicenter/workspace';
 import {
 	type DaemonError,
 	getDaemon,
-	type InvokeError,
-	type PeerDispatchError,
-	type PeerDispatchSyncStatus,
+	type PeerSyncStatus,
+	type RunError,
 } from '@epicenter/workspace/node';
 import { extractErrorMessage } from 'wellcrafted/error';
 import type { Result } from 'wellcrafted/result';
@@ -39,8 +40,6 @@ import {
 	output,
 } from '../util/format-output.js';
 import { parseJsonInput, readStdin } from '../util/parse-input.js';
-
-const DEFAULT_PEER_WAIT_MS = 5000;
 
 export const runCommand = cmd({
 	command: 'run <action> [input]',
@@ -64,15 +63,19 @@ export const runCommand = cmd({
 			})
 			.option('wait', {
 				type: 'number',
-				description: `RPC deadline in ms for the peer call; requires --peer (default ${DEFAULT_PEER_WAIT_MS})`,
+				description:
+					'RPC deadline in ms for the peer call; requires --peer (daemon default: 5000)',
 			})
 			.implies('wait', 'peer')
 			.options(formatOptions)
 			.strict(),
 	handler: async (argv) => {
-		const peerTarget =
-			argv.peer && argv.peer.length > 0 ? argv.peer : undefined;
-		const waitMs = argv.wait ?? DEFAULT_PEER_WAIT_MS;
+		if (argv.peer !== undefined && argv.peer.length === 0) {
+			fail(
+				'--peer requires a peer id; run `epicenter peers` to see who is online',
+			);
+			return;
+		}
 		const actionInput = await resolveInput(argv.input);
 
 		const { data: daemon, error: daemonErr } = await getDaemon(argv.C);
@@ -80,29 +83,23 @@ export const runCommand = cmd({
 			fail(daemonErr.message);
 			return;
 		}
-		if (peerTarget === undefined) {
-			renderRunResult(
-				await daemon.invoke({
-					actionPath: argv.action,
-					input: actionInput,
-				}),
-				argv.format,
-			);
-			return;
-		}
 
-		const result = await daemon.dispatch({
+		// A `peer` key with an `undefined` value drops out of the JSON wire
+		// body, so a local run sends no peer fields at all.
+		const result = await daemon.run({
 			actionPath: argv.action,
 			input: actionInput,
-			to: peerTarget,
-			waitMs,
+			peer:
+				argv.peer === undefined
+					? undefined
+					: { to: argv.peer, waitMs: argv.wait },
 		});
 		renderRunResult(result, argv.format);
 	},
 });
 
 function renderRunResult(
-	result: Result<unknown, InvokeError | PeerDispatchError | DaemonError>,
+	result: Result<unknown, RunError | DaemonError>,
 	format: OutputFormat | undefined,
 ): void {
 	if (result.error === null) {
@@ -151,7 +148,7 @@ async function resolveInput(input: string | undefined): Promise<unknown> {
 function emitPeerNotFound(
 	target: string,
 	waitMs: number,
-	syncStatus: PeerDispatchSyncStatus,
+	syncStatus: PeerSyncStatus,
 ): void {
 	const details = [`  reason: ${describePeerMissReason(syncStatus)}`];
 	if (syncStatus.phase === 'connected') {
@@ -201,7 +198,7 @@ export function emitRemoteCallError(
 	}
 }
 
-function describePeerMissReason(status: PeerDispatchSyncStatus): string {
+function describePeerMissReason(status: PeerSyncStatus): string {
 	if (status.phase === 'connected') {
 		return 'connected, but no matching peer was visible';
 	}

--- a/packages/cli/src/commands/up.test.ts
+++ b/packages/cli/src/commands/up.test.ts
@@ -34,7 +34,6 @@ import { MachineAuthStorageError } from '@epicenter/auth/node';
 import { asOwnerId } from '@epicenter/identity';
 import {
 	claimDaemonLease,
-	DEFAULT_PROJECT_CONFIG_SOURCE,
 	metadataPathFor,
 	pingDaemon,
 	socketPathFor,
@@ -218,10 +217,8 @@ describe('runUp: failure cleanup', () => {
 		lease.release();
 	});
 
-	test('writes the default config and starts with no mounts when config is missing', async () => {
-		mkdirSync(join(workDir, 'workspaces', 'demo'), { recursive: true });
-
-		const handle = expectOk(
+	test('errors and scaffolds nothing when config is missing', async () => {
+		const error = expectErr(
 			await runUp({
 				projectDir: workDir,
 				quiet: true,
@@ -229,17 +226,12 @@ describe('runUp: failure cleanup', () => {
 			}),
 		);
 
-		try {
-			expect(handle.mounts).toEqual([]);
-			expect(readFileSync(join(workDir, 'epicenter.config.ts'), 'utf8')).toBe(
-				DEFAULT_PROJECT_CONFIG_SOURCE,
-			);
-			expect(
-				readFileSync(join(workDir, '.epicenter', '.gitignore'), 'utf8'),
-			).toBe('sqlite/\nyjs/\nmd/\nlog/\n');
-		} finally {
-			await handle.teardown();
-		}
+		expect(error.name).toBe('ProjectConfigNotFound');
+		expect(existsSync(join(workDir, 'epicenter.config.ts'))).toBe(false);
+		expect(existsSync(join(workDir, '.epicenter'))).toBe(false);
+
+		const lease = expectOk(claimDaemonLease(workDir));
+		lease.release();
 	});
 
 	test('does not overwrite an existing config when provisioning project data', async () => {

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -24,7 +24,6 @@ import type { StartedMount } from '@epicenter/workspace/daemon';
 import {
 	claimDaemonLease,
 	type DaemonMetadata,
-	DEFAULT_PROJECT_CONFIG_SOURCE,
 	findProjectRoot,
 	openProject,
 	type ProjectConfigError,
@@ -43,7 +42,7 @@ const CLI_VERSION = packageJson.version;
 const upProjectOption = {
 	type: 'string' as const,
 	description:
-		'Project root, directory under a project, or directory where daemon up should create epicenter.config.ts.',
+		'Project root, or any directory under it (discovery walks up to the nearest epicenter.config.ts).',
 	default: () => process.cwd(),
 	defaultDescription: 'current working directory',
 	coerce: (projectDir: string) => projectDir,
@@ -93,8 +92,10 @@ type UpHandle = {
 };
 
 /**
- * Daemon body. Idempotently sets up disk state, opens every configured mount,
- * binds the IPC socket, and returns a handle. The yargs `handler` calls this,
+ * Daemon body. Opens every configured mount (the project must already have an
+ * `epicenter.config.ts`; see `epicenter init`), ensures the `.epicenter`
+ * cache gitignore, binds the IPC socket, and returns a handle. The yargs
+ * `handler` calls this,
  * prints the operator-facing banner, installs SIGINT/SIGTERM, and parks the
  * process; tests call it directly and assert on the returned handle.
  *
@@ -114,7 +115,6 @@ export async function runUp(
 	>
 > {
 	const projectDir = realpathSync(resolveProjectForUp(options.projectDir));
-	provisionProject(projectDir);
 
 	const leaseResult = claimDaemonLease(projectDir);
 	if (leaseResult.error !== null) return leaseResult;
@@ -145,6 +145,7 @@ export async function runUp(
 	const startResult = await openProject({ projectDir, auth });
 	if (startResult.error) return startResult;
 	const mounts = startResult.data;
+	ensureProjectGitignore(projectDir);
 	stack.defer(() =>
 		Promise.allSettled(
 			mounts.map((entry) =>
@@ -201,6 +202,11 @@ export const upCommand = cmd({
 		const { data: handle, error } = await runUp(options);
 		if (error) {
 			process.stderr.write(`${error.message}\n`);
+			if (error.name === 'ProjectConfigNotFound') {
+				process.stderr.write(
+					'run `epicenter init` to scaffold a project here\n',
+				);
+			}
 			process.exit(1);
 		}
 
@@ -239,28 +245,22 @@ function resolveProjectForUp(start: string): string {
 	}
 }
 
-function provisionProject(projectDir: string): void {
-	const projectConfigPath = join(projectDir, 'epicenter.config.ts');
-	if (!existsSync(projectConfigPath)) {
-		writeFileSync(projectConfigPath, DEFAULT_PROJECT_CONFIG_SOURCE, {
-			mode: 0o600,
-		});
-	}
-
+/**
+ * Ensure `.epicenter/` exists (0o700) and is fully gitignored. The attach
+ * primitives (Yjs log, SQLite and markdown materializers) create their own
+ * data dirs on demand, so the daemon's only filesystem provisioning is the
+ * cache-dir ignore rule. `*` ignores everything the runtime ever writes,
+ * including this file, so there is no directory list to keep in sync.
+ * Project creation itself (writing `epicenter.config.ts`) is `epicenter
+ * init`; `daemon up` on a directory without a config fails with a hint
+ * instead of silently scaffolding a project.
+ */
+function ensureProjectGitignore(projectDir: string): void {
 	const projectDataDir = join(projectDir, '.epicenter');
-	mkdirSync(join(projectDataDir, 'sqlite'), { recursive: true, mode: 0o700 });
-	mkdirSync(join(projectDataDir, 'yjs'), { recursive: true, mode: 0o700 });
-	mkdirSync(join(projectDataDir, 'md'), { recursive: true, mode: 0o700 });
-	mkdirSync(join(projectDataDir, 'log'), { recursive: true, mode: 0o700 });
+	mkdirSync(projectDataDir, { recursive: true, mode: 0o700 });
 	const gitignorePath = join(projectDataDir, '.gitignore');
 	if (!existsSync(gitignorePath)) {
-		writeFileSync(
-			gitignorePath,
-			['sqlite/', 'yjs/', 'md/', 'log/', ''].join('\n'),
-			{
-				mode: 0o600,
-			},
-		);
+		writeFileSync(gitignorePath, '*\n', { mode: 0o600 });
 	}
 }
 

--- a/packages/field/src/builders.ts
+++ b/packages/field/src/builders.ts
@@ -51,13 +51,10 @@ import {
 } from 'typebox';
 import type { Brand } from 'wellcrafted/brand';
 import type { JsonValue } from 'wellcrafted/json';
-import { JSON_SCHEMA_KEYWORD } from './field';
 import type { CalendarDateString } from './calendar-date-string';
 import type { DateTimeString } from './datetime-string';
-import {
-	INSTANT_STRING_PATTERN,
-	type InstantString,
-} from './instant-string';
+import { JSON_SCHEMA_KEYWORD } from './field';
+import { INSTANT_STRING_PATTERN, type InstantString } from './instant-string';
 
 type BrandedString = string & Brand<string>;
 
@@ -106,7 +103,9 @@ const boolean = Type.Boolean;
  * or time zone meaning. Stored as `YYYY-MM-DD`, which sorts naturally as TEXT.
  */
 function date(opts?: TSchemaOptions): TUnsafe<CalendarDateString> {
-	return Type.Unsafe<CalendarDateString>(Type.String({ ...opts, format: 'date' }));
+	return Type.Unsafe<CalendarDateString>(
+		Type.String({ ...opts, format: 'date' }),
+	);
 }
 
 /**

--- a/packages/field/src/field.test-d.ts
+++ b/packages/field/src/field.test-d.ts
@@ -106,7 +106,9 @@ export type _JsonTypedStatic = Expect<
 		Static<
 			ReturnType<
 				typeof field.json<
-					ReturnType<typeof Type.Object<{ author: ReturnType<typeof Type.String> }>>
+					ReturnType<
+						typeof Type.Object<{ author: ReturnType<typeof Type.String> }>
+					>
 				>
 			>
 		>,
@@ -115,14 +117,18 @@ export type _JsonTypedStatic = Expect<
 >;
 
 // jsonValue: the canonical any-JSON inner, Static = JsonValue (pinned via Type.Unsafe).
-export type _JsonValueStatic = Expect<Equal<Static<typeof jsonValue>, JsonValue>>;
+export type _JsonValueStatic = Expect<
+	Equal<Static<typeof jsonValue>, JsonValue>
+>;
 
 // field.json(Type.Array(jsonValue)): Static = JsonValue[]. The list-of-arbitrary-JSON
 // pattern the apps share; the inner static flows through Array and field.json unchanged.
 export type _JsonArrayStatic = Expect<
 	Equal<
 		Static<
-			ReturnType<typeof field.json<ReturnType<typeof Type.Array<typeof jsonValue>>>>
+			ReturnType<
+				typeof field.json<ReturnType<typeof Type.Array<typeof jsonValue>>>
+			>
 		>,
 		JsonValue[]
 	>

--- a/packages/field/src/field.test.ts
+++ b/packages/field/src/field.test.ts
@@ -21,7 +21,7 @@ import { describe, expect, test } from 'bun:test';
 import { type TSchema, Type } from 'typebox';
 import { Value } from 'typebox/value';
 import { field, jsonValue } from './builders';
-import { type Kind, KINDS, META_BY_KIND, recognize } from './field';
+import { KINDS, type Kind, META_BY_KIND, recognize } from './field';
 import { INSTANT_STRING_PATTERN } from './instant-string';
 
 /**
@@ -45,7 +45,8 @@ function countMatches(schema: unknown): number {
 }
 
 /** The kind `recognize` assigns, or null when the schema is outside the palette. */
-const kindOf = (schema: unknown): Kind | null => recognize(schema)?.kind ?? null;
+const kindOf = (schema: unknown): Kind | null =>
+	recognize(schema)?.kind ?? null;
 
 // ============================================================================
 // Round-trip: field.* builders are the inverse of recognize
@@ -262,9 +263,9 @@ describe('json: the marker-discriminated escape kind', () => {
 	test('the marker is what flips a bare object from raw to json', () => {
 		// same shape, no marker -> raw; with marker -> json
 		expect(kindOf({ type: 'object', properties: {} })).toBeNull();
-		expect(kindOf({ type: 'object', properties: {}, 'x-json-schema': true })).toBe(
-			'json',
-		);
+		expect(
+			kindOf({ type: 'object', properties: {}, 'x-json-schema': true }),
+		).toBe('json');
 	});
 
 	test('jsonValue: field.json(Type.Array(jsonValue)) is the any-JSON-list pattern, kind json', () => {
@@ -318,7 +319,11 @@ describe('refinements and annotations ride along without changing the kind', () 
 	});
 
 	test('a default rides along on a select without tipping the kind', () => {
-		const s = { type: 'string', enum: ['draft', 'published'], default: 'draft' };
+		const s = {
+			type: 'string',
+			enum: ['draft', 'published'],
+			default: 'draft',
+		};
 		expect(kindOf(s)).toBe('select');
 		expect(countMatches(s)).toBe(1);
 	});

--- a/packages/field/src/field.ts
+++ b/packages/field/src/field.ts
@@ -155,7 +155,10 @@ const LIST_REFINE = {
  * an `Extract`. Each `meta` reads `{ ...discriminators, ...refinements, ...annotations }`.
  */
 const FIELDS = {
-	select: { storage: 'TEXT', meta: Type.Object({ ...enumProps, ...ANNOT }, CLOSED) },
+	select: {
+		storage: 'TEXT',
+		meta: Type.Object({ ...enumProps, ...ANNOT }, CLOSED),
+	},
 	url: {
 		storage: 'TEXT',
 		meta: Type.Object(
@@ -310,7 +313,8 @@ export function recognize(schema: unknown): Recognized | null {
 		// two as `Recognized` is honest. This is the cast at the MODEL boundary; the field
 		// pipeline has exactly one more, at the UI-dispatch boundary in the widget registry.
 		// Everything between the two stays cast-free.
-		if (Value.Check(FIELDS[kind].meta, schema)) return { kind, schema } as Recognized;
+		if (Value.Check(FIELDS[kind].meta, schema))
+			return { kind, schema } as Recognized;
 	}
 	return null;
 }
@@ -347,7 +351,9 @@ export const META_BY_KIND = Object.fromEntries(
  * registered as a load side effect of `typebox/format` (which `Schema.Compile` imports),
  * so the bare compile already enforces them.
  */
-export function compile(schema: Recognized['schema']): (value: unknown) => boolean {
+export function compile(
+	schema: Recognized['schema'],
+): (value: unknown) => boolean {
 	const validator = Schema.Compile(schema);
 	return (value) => validator.Check(value);
 }

--- a/packages/field/src/instant-string.ts
+++ b/packages/field/src/instant-string.ts
@@ -25,9 +25,7 @@ export const InstantString = {
 	 */
 	is(value: unknown): value is InstantString {
 		if (typeof value !== 'string') return false;
-		return (
-			instantStringPattern.test(value) && Format.Test('date-time', value)
-		);
+		return instantStringPattern.test(value) && Format.Test('date-time', value);
 	},
 
 	/**

--- a/packages/filesystem/src/table.ts
+++ b/packages/filesystem/src/table.ts
@@ -1,5 +1,9 @@
 import { field } from '@epicenter/field';
-import { defineTable, nullable, type InferTableRow } from '@epicenter/workspace';
+import {
+	defineTable,
+	type InferTableRow,
+	nullable,
+} from '@epicenter/workspace';
 import type { FileId } from './ids.js';
 
 export const filesTable = defineTable({

--- a/packages/skills/src/tables.ts
+++ b/packages/skills/src/tables.ts
@@ -9,8 +9,12 @@
  * @module
  */
 
-import { defineTable, nullable, type InferTableRow } from '@epicenter/workspace';
 import { field } from '@epicenter/field';
+import {
+	defineTable,
+	type InferTableRow,
+	nullable,
+} from '@epicenter/workspace';
 
 /**
  * Skills table, one row per skill, 1:1 mapping to SKILL.md.

--- a/packages/ui/src/styles/shadcn-base.css
+++ b/packages/ui/src/styles/shadcn-base.css
@@ -4,13 +4,19 @@
 			height: 0;
 		}
 		to {
-			height: var(--bits-accordion-content-height, var(--accordion-panel-height, auto));
+			height: var(
+				--bits-accordion-content-height,
+				var(--accordion-panel-height, auto)
+			);
 		}
 	}
 
 	@keyframes accordion-up {
 		from {
-			height: var(--bits-accordion-content-height, var(--accordion-panel-height, auto));
+			height: var(
+				--bits-accordion-content-height,
+				var(--accordion-panel-height, auto)
+			);
 		}
 		to {
 			height: 0;

--- a/packages/ui/src/tabs/index.ts
+++ b/packages/ui/src/tabs/index.ts
@@ -11,11 +11,11 @@ export {
 	Content as TabsContent,
 	List,
 	List as TabsList,
-	type TabsListVariant,
-	tabsListVariants,
 	Root,
 	//
 	Root as Tabs,
+	type TabsListVariant,
 	Trigger,
 	Trigger as TabsTrigger,
+	tabsListVariants,
 };

--- a/packages/workspace/scripts/yjs-benchmarks/persistence-growth.ts
+++ b/packages/workspace/scripts/yjs-benchmarks/persistence-growth.ts
@@ -14,9 +14,9 @@
  * Run: bun packages/workspace/scripts/yjs-benchmarks/persistence-growth.ts
  */
 
+import { field } from '@epicenter/field';
 import * as Y from 'yjs';
 import { createWorkspace, defineTable } from '../../src/index.js';
-import { field } from '@epicenter/field';
 import { formatBytes } from './helpers.js';
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/packages/workspace/scripts/yjs-benchmarks/stress-add-delete.ts
+++ b/packages/workspace/scripts/yjs-benchmarks/stress-add-delete.ts
@@ -9,9 +9,9 @@
  */
 
 import { unlinkSync } from 'node:fs';
+import { field } from '@epicenter/field';
 import * as Y from 'yjs';
 import { createWorkspace, defineTable } from '../../src/index.js';
-import { field } from '@epicenter/field';
 import { formatBytes, measureTime } from './helpers.js';
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/packages/workspace/src/__benchmarks__/helpers.ts
+++ b/packages/workspace/src/__benchmarks__/helpers.ts
@@ -5,8 +5,8 @@
  * table definitions, row generators, and formatting helpers.
  */
 
-import { Type } from 'typebox';
 import { field } from '@epicenter/field';
+import { Type } from 'typebox';
 import { defineKv } from '../document/define-kv';
 import { defineTable } from '../document/define-table';
 

--- a/packages/workspace/src/client/connect-daemon-actions.ts
+++ b/packages/workspace/src/client/connect-daemon-actions.ts
@@ -7,7 +7,7 @@
  * a flat action proxy backed by a unix-socket `DaemonClient`.
  * `TActions` is type-only: no workspace code runs in the caller process.
  * `DaemonActions<TActions>` rewrites each snake_case action key into the
- * daemon `/invoke` result shape.
+ * daemon `/run` result shape.
  *
  * @example
  * ```ts

--- a/packages/workspace/src/client/daemon-actions.test.ts
+++ b/packages/workspace/src/client/daemon-actions.test.ts
@@ -6,22 +6,21 @@
 
 import { describe, expect, test } from 'bun:test';
 import { Ok } from 'wellcrafted/result';
-import type { InvokeRequest } from '../daemon/app.js';
+import type { RunRequest } from '../daemon/app.js';
 import type { DaemonClient } from '../daemon/client.js';
 import { buildDaemonActions } from './daemon-actions.js';
 
 function makeStubClient() {
-	const calls: { method: 'invoke'; arg: unknown }[] = [];
+	const calls: { method: 'run'; arg: unknown }[] = [];
 	const unreachable = () => {
 		throw new Error('stub: not used by these tests');
 	};
 	const client = {
 		peers: unreachable as DaemonClient['peers'],
 		list: unreachable as DaemonClient['list'],
-		dispatch: unreachable as DaemonClient['dispatch'],
-		invoke: (input: InvokeRequest) => {
-			calls.push({ method: 'invoke', arg: input });
-			return Promise.resolve(Ok(null)) as ReturnType<DaemonClient['invoke']>;
+		run: (input: RunRequest) => {
+			calls.push({ method: 'run', arg: input });
+			return Promise.resolve(Ok(null)) as ReturnType<DaemonClient['run']>;
 		},
 	} satisfies DaemonClient;
 	return { client, calls };
@@ -30,7 +29,7 @@ function makeStubClient() {
 const WORKSPACE = 'demo';
 
 describe('buildDaemonActions workspace facade', () => {
-	test('action invokes literal workspace path over /invoke', async () => {
+	test('action runs literal workspace path over /run', async () => {
 		const { client, calls } = makeStubClient();
 		// biome-ignore lint/suspicious/noExplicitAny: smoke test: shape is irrelevant
 		const workspace: any = buildDaemonActions(client, WORKSPACE);
@@ -38,7 +37,7 @@ describe('buildDaemonActions workspace facade', () => {
 		await workspace.entries_get('xyz');
 
 		expect(calls).toHaveLength(1);
-		expect(calls[0]!.method).toBe('invoke');
+		expect(calls[0]!.method).toBe('run');
 		expect(calls[0]!.arg).toMatchObject({
 			actionPath: 'demo.entries_get',
 			input: 'xyz',

--- a/packages/workspace/src/client/daemon-actions.ts
+++ b/packages/workspace/src/client/daemon-actions.ts
@@ -1,16 +1,16 @@
 /**
  * `buildDaemonActions`: typed proxy that turns a `DaemonClient` into a flat
  * action-root facade. Local call sites use the same snake_case key the action
- * was authored under (`workspace.tabs_open(...)`); each call invokes the
- * daemon's local action registry over the unix socket via `client.invoke`.
+ * was authored under (`workspace.tabs_open(...)`); each call runs the
+ * daemon's local action registry over the unix socket via `client.run`.
  *
  * The proxy is one level: property access returns a function, calling that
- * function fires `client.invoke` with `${mount}.${path}`. `then` is masked at
+ * function fires `client.run` with `${mount}.${path}`. `then` is masked at
  * the root so accidental `await workspace` does not turn it thenable.
  */
 
 import type { Result } from 'wellcrafted/result';
-import type { InvokeError } from '../daemon/action-errors.js';
+import type { RunError } from '../daemon/action-errors.js';
 import { joinDaemonActionPath } from '../daemon/action-path.js';
 import type { DaemonClient, DaemonError } from '../daemon/client.js';
 import type { Action, ActionRegistry } from '../shared/actions.js';
@@ -25,10 +25,17 @@ type DaemonSuccessOutput<TOutput> =
 		? TData
 		: Awaited<TOutput>;
 
+/**
+ * The facade never sends a `peer` target, so by construction the daemon can
+ * only answer with the local-run error variants; the peer variants
+ * (`PeerNotFound`, `RemoteCallFailed`) are excluded from the surface.
+ */
+type LocalRunError = Extract<RunError, { name: 'UsageError' | 'RuntimeError' }>;
+
 type WrapDaemonAction<F> = F extends (...args: infer Args) => infer R
 	? (
 			...args: WithDaemonOptions<Args>
-		) => Promise<Result<DaemonSuccessOutput<R>, InvokeError | DaemonError>>
+		) => Promise<Result<DaemonSuccessOutput<R>, LocalRunError | DaemonError>>
 	: never;
 
 /**
@@ -59,7 +66,7 @@ export function buildDaemonActions<TActions extends ActionRegistry>(
 			if (typeof prop !== 'string') return undefined;
 			if (prop === 'then') return undefined;
 			return (input?: unknown) =>
-				client.invoke({
+				client.run({
 					actionPath: joinDaemonActionPath(mount, prop),
 					input,
 				});

--- a/packages/workspace/src/daemon/action-errors.ts
+++ b/packages/workspace/src/daemon/action-errors.ts
@@ -1,13 +1,24 @@
 /**
- * Domain errors for daemon action routes.
+ * Domain errors for the daemon `/run` route.
  *
- * Local invoke and peer dispatch deliberately use separate response types:
- * local invoke executes this daemon's action registry, while peer dispatch
- * asks a recipient device to decide whether it supports the action.
+ * One union covers both execution targets, because the caller-facing concept
+ * is one: run an action, locally or on a peer. The authorities still differ
+ * inside the handler: a local run consults this daemon's action registry,
+ * while a peer run lets the recipient device decide action existence and the
+ * relay own reachability.
  *
  * Remote call failures keep the remote client error intact so the CLI owns
  * every presentation choice for peer disconnects, timeouts, and other
  * wire-level RPC errors.
+ *
+ * Exit-code mapping (the CLI renderer switches on `name`):
+ *
+ * - `UsageError`: bad action key, bad input, bad wait budget; exitCode=1.
+ * - `RuntimeError`: the local handler returned Err or threw; exitCode=2.
+ * - `PeerNotFound`: `--peer <target>` did not resolve within the wait
+ *   budget; exitCode=3.
+ * - `RemoteCallFailed`: peer resolved but the RPC call itself failed
+ *   (timeout, peer disconnected mid-call, wire error); exitCode=2.
  */
 
 import {
@@ -22,12 +33,9 @@ import type {
 	SyncFailedReason,
 } from '../document/internal/sync-supervisor.js';
 
-type PeerDispatchRemoteError = Exclude<
-	DispatchError,
-	{ name: 'RecipientOffline' }
->;
+type PeerRemoteError = Exclude<DispatchError, { name: 'RecipientOffline' }>;
 
-export type PeerDispatchSyncStatus =
+export type PeerSyncStatus =
 	| { phase: 'offline' }
 	| {
 			phase: 'connecting';
@@ -37,7 +45,7 @@ export type PeerDispatchSyncStatus =
 	| { phase: 'connected' }
 	| { phase: 'failed'; reason: SyncFailedReason };
 
-export const InvokeError = defineErrors({
+export const RunError = defineErrors({
 	UsageError: ({
 		message,
 		suggestions,
@@ -49,28 +57,6 @@ export const InvokeError = defineErrors({
 		message: extractErrorMessage(cause),
 		cause,
 	}),
-});
-export type InvokeError = InferErrors<typeof InvokeError>;
-
-/**
- * CLI-specific failures of peer dispatch. Carrying the failure mode in-band
- * lets the renderer set `process.exitCode` from a single switch, even when the
- * result arrived over IPC.
- *
- * - `UsageError`: bad action key / missing sync; renderer exitCode=1.
- * - `PeerNotFound`: `--peer <target>` did not resolve within `--wait`;
- *   renderer exitCode=3.
- * - `RemoteCallFailed`: peer resolved but the RPC call itself failed
- *   (timeout, peer disconnected mid-call, wire error); renderer exitCode=2.
- */
-export const PeerDispatchError = defineErrors({
-	UsageError: ({
-		message,
-		suggestions,
-	}: {
-		message: string;
-		suggestions?: string[];
-	}) => ({ message, suggestions }),
 	PeerNotFound: ({
 		to,
 		waitMs,
@@ -78,7 +64,7 @@ export const PeerDispatchError = defineErrors({
 	}: {
 		to: string;
 		waitMs: number;
-		syncStatus: PeerDispatchSyncStatus;
+		syncStatus: PeerSyncStatus;
 	}) => ({
 		message: `no peer matches peer id "${to}"`,
 		to,
@@ -91,8 +77,8 @@ export const PeerDispatchError = defineErrors({
 		syncStatus,
 	}: {
 		to: string;
-		cause: PeerDispatchRemoteError;
-		syncStatus: PeerDispatchSyncStatus;
+		cause: PeerRemoteError;
+		syncStatus: PeerSyncStatus;
 	}) => ({
 		message: `remote call failed: ${cause.name}`,
 		cause,
@@ -100,4 +86,4 @@ export const PeerDispatchError = defineErrors({
 		syncStatus,
 	}),
 });
-export type PeerDispatchError = InferErrors<typeof PeerDispatchError>;
+export type RunError = InferErrors<typeof RunError>;

--- a/packages/workspace/src/daemon/action-handler.test.ts
+++ b/packages/workspace/src/daemon/action-handler.test.ts
@@ -1,11 +1,12 @@
 /**
- * Daemon action handler tests.
+ * Daemon `/run` handler tests.
  *
- * Verifies local invoke and peer dispatch stay separate before the response
- * crosses the IPC boundary. The relay owns reachability: a
- * `RecipientOffline` dispatch error surfaces as `PeerNotFound`, every other
- * dispatch error as `RemoteCallFailed`. The `collab.dispatch` path is faked
- * here so the test can drive those outcomes without spinning up real Yjs sync.
+ * One entry point, two execution targets: `peer` absent runs locally against
+ * this daemon's registry, `peer` present dispatches to it. The relay owns
+ * reachability: a `RecipientOffline` dispatch error surfaces as
+ * `PeerNotFound`, every other dispatch error as `RemoteCallFailed`. The
+ * `collab.dispatch` path is faked here so the test can drive those outcomes
+ * without spinning up real Yjs sync.
  */
 
 import { describe, expect, test } from 'bun:test';
@@ -17,8 +18,8 @@ import { DispatchError, type DispatchRequest } from '../document/dispatch.js';
 import type { SyncStatus } from '../document/internal/sync-supervisor.js';
 import type { ActionRegistry } from '../shared/actions.js';
 import { defineMutation, defineQuery } from '../shared/actions.js';
-import type { PeerDispatchSyncStatus } from './action-errors.js';
-import { executeDispatch, executeInvoke } from './action-handler.js';
+import type { PeerSyncStatus } from './action-errors.js';
+import { executeRun } from './action-handler.js';
 import type { DaemonServedMount } from './types.js';
 
 type FakeDispatch = <TOutput = unknown>(
@@ -53,13 +54,12 @@ function fakeEntry({
 	};
 }
 
-describe('executeDispatch peer dispatch', () => {
+describe('executeRun peer target', () => {
 	test('rejects invalid wait budgets before creating an AbortSignal', async () => {
-		const result = await executeDispatch([fakeEntry({})], {
+		const result = await executeRun([fakeEntry({})], {
 			actionPath: 'demo.tabs_list',
 			input: undefined,
-			to: 'mac',
-			waitMs: -1,
+			peer: { to: 'mac', waitMs: -1 },
 		});
 
 		const error = expectErr(result);
@@ -80,18 +80,17 @@ describe('executeDispatch peer dispatch', () => {
 			phase: 'connecting',
 			retries: 2,
 			lastErrorType: 'connection',
-		} satisfies PeerDispatchSyncStatus;
+		} satisfies PeerSyncStatus;
 		const entry = fakeEntry({
 			syncStatus,
 			dispatch: (async () =>
 				DispatchError.RecipientOffline({ to: 'ghost' })) as FakeDispatch,
 		});
 
-		const result = await executeDispatch([entry], {
+		const result = await executeRun([entry], {
 			actionPath: 'demo.tabs_list',
 			input: undefined,
-			to: 'ghost',
-			waitMs: 25,
+			peer: { to: 'ghost', waitMs: 25 },
 		});
 
 		const error = expectErr(result);
@@ -114,11 +113,10 @@ describe('executeDispatch peer dispatch', () => {
 			}) as FakeDispatch,
 		});
 
-		const result = await executeDispatch([entry], {
+		const result = await executeRun([entry], {
 			actionPath: 'demo.tabs_list',
 			input: undefined,
-			to: 'mac',
-			waitMs: 25,
+			peer: { to: 'mac', waitMs: 25 },
 		});
 
 		expectOk(result);
@@ -135,11 +133,10 @@ describe('executeDispatch peer dispatch', () => {
 				})) as FakeDispatch,
 		});
 
-		const result = await executeDispatch([entry], {
+		const result = await executeRun([entry], {
 			actionPath: 'demo.tabs_list',
 			input: undefined,
-			to: 'mac',
-			waitMs: 25,
+			peer: { to: 'mac', waitMs: 25 },
 		});
 
 		const error = expectErr(result);
@@ -160,11 +157,10 @@ describe('executeDispatch peer dispatch', () => {
 			}) as FakeDispatch,
 		});
 
-		const result = await executeDispatch([entry], {
+		const result = await executeRun([entry], {
 			actionPath: 'demo.peer_only_action',
 			input: undefined,
-			to: 'mac',
-			waitMs: 25,
+			peer: { to: 'mac', waitMs: 25 },
 		});
 
 		expectOk(result);
@@ -172,7 +168,7 @@ describe('executeDispatch peer dispatch', () => {
 	});
 });
 
-describe('executeInvoke mount-prefixed routing', () => {
+describe('executeRun mount-prefixed routing', () => {
 	test('invokes action under the selected mount', async () => {
 		const entry = fakeEntry({
 			mount: 'notes',
@@ -183,7 +179,7 @@ describe('executeInvoke mount-prefixed routing', () => {
 			},
 		});
 
-		const result = await executeInvoke([entry], {
+		const result = await executeRun([entry], {
 			actionPath: 'notes.notes_add',
 			input: { body: 'hello' },
 		});
@@ -202,7 +198,7 @@ describe('executeInvoke mount-prefixed routing', () => {
 			},
 		});
 
-		const result = await executeInvoke([entry], {
+		const result = await executeRun([entry], {
 			actionPath: 'notes.notes',
 			input: { body: 'hello' },
 		});
@@ -216,7 +212,7 @@ describe('executeInvoke mount-prefixed routing', () => {
 	});
 
 	test('unknown mount returns available mount suggestions', async () => {
-		const result = await executeInvoke(
+		const result = await executeRun(
 			[fakeEntry({}), fakeEntry({ mount: 'tasks', actions: {} })],
 			{
 				actionPath: 'missing.actions_add',
@@ -244,7 +240,7 @@ describe('executeInvoke mount-prefixed routing', () => {
 			},
 		});
 
-		const result = await executeInvoke([entry], {
+		const result = await executeRun([entry], {
 			actionPath: 'fuji.bulk_delete',
 			input: { maxDeletes: 'lots' },
 		});

--- a/packages/workspace/src/daemon/action-handler.ts
+++ b/packages/workspace/src/daemon/action-handler.ts
@@ -1,63 +1,79 @@
 /**
- * Daemon-side action handlers for `/invoke` and `/dispatch`.
+ * Daemon-side handler for `/run`.
  *
- * Local invoke and peer dispatch stay separate here because they have
- * different authorities:
+ * One entry point, two execution targets selected by `peer`:
  *
- *   /invoke   -> this daemon's action registry decides action existence.
- *   /dispatch -> the recipient peer decides action existence.
+ *   `peer` absent  -> local run: this daemon's action registry decides action
+ *                     existence, then `invokeAction` executes the handler.
+ *   `peer` present -> peer run: the recipient peer decides action existence,
+ *                     and the relay owns reachability.
  *
- * Dispatch addresses devices by `deviceId` directly; the relay routes to the
+ * Peer runs address devices by `deviceId` directly; the relay routes to the
  * most-recently-connected socket for that device. If the relay has no live
  * socket for the target, dispatch resolves with `RecipientOffline`, surfaced
  * here as `PeerNotFound`; any other dispatch error is forwarded under
  * `RemoteCallFailed`.
  *
+ * The daemon owns the peer wait budget default ({@link DEFAULT_PEER_WAIT_MS});
+ * clients send `waitMs` only when the user overrides it.
+ *
  * Power-user automation (loops, fan-out across peers, conditional dispatch)
  * lives in vault-style TypeScript scripts that load the workspace library
  * directly. The CLI deliberately does not grow flags that shadow scripting.
  *
- * Each function returns a domain response that the route serializes verbatim.
- * Unexpected exceptions bubble to Hono's non-2xx response path and surface as
+ * Returns a domain response that the route serializes verbatim. Unexpected
+ * exceptions bubble to Hono's non-2xx response path and surface as
  * `HandlerCrashed` on the client side.
  */
 
 import { Ok, type Result } from 'wellcrafted/result';
 import type { SyncStatus } from '../document/internal/sync-supervisor.js';
 import { invokeAction, isActionInputError } from '../shared/actions.js';
-import {
-	InvokeError,
-	PeerDispatchError,
-	type PeerDispatchSyncStatus,
-} from './action-errors.js';
+import { type PeerSyncStatus, RunError } from './action-errors.js';
 import { joinDaemonActionPath, parseDaemonActionPath } from './action-path.js';
-import type { InvokeRequest, PeerDispatchRequest } from './app.js';
+import type { RunRequest } from './app.js';
 import type { DaemonServedMount } from './types.js';
 
-export async function executeInvoke(
+/** Default peer RPC deadline when the client does not send `waitMs`. */
+export const DEFAULT_PEER_WAIT_MS = 5000;
+
+export async function executeRun(
 	mounts: readonly DaemonServedMount[],
-	{ actionPath, input: actionInput }: InvokeRequest,
-): Promise<Result<unknown, InvokeError>> {
+	{ actionPath, input: actionInput, peer }: RunRequest,
+): Promise<Result<unknown, RunError>> {
 	const { mount, localPath } = parseDaemonActionPath(actionPath);
 	const mountRuntime = mounts.find((candidate) => candidate.mount === mount);
 	if (!mountRuntime) {
 		const available = mounts.map((candidate) => candidate.mount);
-		return InvokeError.UsageError({
+		return RunError.UsageError({
 			message: `No mount "${mount}". Available: ${available.join(', ')}`,
 			suggestions: available.map((name) => `  ${name}`),
 		});
 	}
 
+	if (peer === undefined) {
+		return runLocal(mountRuntime, actionPath, localPath, actionInput);
+	}
+	return runOnPeer(mountRuntime, localPath, actionInput, peer);
+}
+
+/** Local run: this daemon's registry is the authority for action existence. */
+async function runLocal(
+	mountRuntime: DaemonServedMount,
+	actionPath: string,
+	localPath: string,
+	actionInput: unknown,
+): Promise<Result<unknown, RunError>> {
 	const action = mountRuntime.runtime.collaboration.actions[localPath];
 	if (!action) {
 		const descendants = daemonActionSuggestionLines(mountRuntime, localPath);
 		if (descendants.length > 0) {
-			return InvokeError.UsageError({
+			return RunError.UsageError({
 				message: `"${actionPath}" is not a runnable action.`,
 				suggestions: descendants,
 			});
 		}
-		return InvokeError.UsageError({
+		return RunError.UsageError({
 			message: `"${actionPath}" is not defined.`,
 			suggestions: daemonActionNearestSiblingLines(mountRuntime, localPath),
 		});
@@ -69,30 +85,24 @@ export async function executeInvoke(
 		// a handler crash: surface it as a usage error (the same family as an
 		// unknown action) so the CLI exits 1, not 2.
 		if (isActionInputError(result.error)) {
-			return InvokeError.UsageError({ message: result.error.message });
+			return RunError.UsageError({ message: result.error.message });
 		}
-		return InvokeError.RuntimeError({ cause: result.error });
+		return RunError.RuntimeError({ cause: result.error });
 	}
 	return Ok(result.data);
 }
 
-export async function executeDispatch(
-	mounts: readonly DaemonServedMount[],
-	{ actionPath, input: actionInput, to, waitMs }: PeerDispatchRequest,
-): Promise<Result<unknown, PeerDispatchError>> {
-	if (!Number.isInteger(waitMs) || waitMs < 0) {
-		return PeerDispatchError.UsageError({
+/** Peer run: the recipient decides action existence, the relay reachability. */
+async function runOnPeer(
+	mountRuntime: DaemonServedMount,
+	localPath: string,
+	actionInput: unknown,
+	{ to, waitMs }: NonNullable<RunRequest['peer']>,
+): Promise<Result<unknown, RunError>> {
+	const budgetMs = waitMs ?? DEFAULT_PEER_WAIT_MS;
+	if (!Number.isInteger(budgetMs) || budgetMs < 0) {
+		return RunError.UsageError({
 			message: '`waitMs` must be a non-negative integer.',
-		});
-	}
-
-	const { mount, localPath } = parseDaemonActionPath(actionPath);
-	const mountRuntime = mounts.find((candidate) => candidate.mount === mount);
-	if (!mountRuntime) {
-		const available = mounts.map((candidate) => candidate.mount);
-		return PeerDispatchError.UsageError({
-			message: `No mount "${mount}". Available: ${available.join(', ')}`,
-			suggestions: available.map((name) => `  ${name}`),
 		});
 	}
 
@@ -102,23 +112,23 @@ export async function executeDispatch(
 		to,
 		action: localPath,
 		input: actionInput,
-		signal: AbortSignal.timeout(waitMs),
+		signal: AbortSignal.timeout(budgetMs),
 	});
 
 	if (result.error !== null) {
-		const syncStatus = toPeerDispatchSyncStatus(runtime.collaboration.status);
+		const syncStatus = toPeerSyncStatus(runtime.collaboration.status);
 		switch (result.error.name) {
 			case 'RecipientOffline':
-				return PeerDispatchError.PeerNotFound({
+				return RunError.PeerNotFound({
 					to,
-					waitMs,
+					waitMs: budgetMs,
 					syncStatus,
 				});
 			case 'ActionNotFound':
 			case 'ActionFailed':
 			case 'Cancelled':
 			case 'NetworkFailed':
-				return PeerDispatchError.RemoteCallFailed({
+				return RunError.RemoteCallFailed({
 					cause: result.error,
 					to,
 					syncStatus,
@@ -130,7 +140,7 @@ export async function executeDispatch(
 	return Ok(result.data);
 }
 
-function toPeerDispatchSyncStatus(status: SyncStatus): PeerDispatchSyncStatus {
+function toPeerSyncStatus(status: SyncStatus): PeerSyncStatus {
 	switch (status.phase) {
 		case 'offline':
 			return { phase: 'offline' };

--- a/packages/workspace/src/daemon/action-path.ts
+++ b/packages/workspace/src/daemon/action-path.ts
@@ -1,8 +1,8 @@
 /**
  * Source of truth for mount-prefixed daemon action paths.
  *
- * `/list` publishes action keys in this format, and `/invoke` / `/dispatch`
- * accept the same format from clients. Mount validation rejects dots in mount
+ * `/list` publishes action keys in this format, and `/run`
+ * accepts the same format from clients. Mount validation rejects dots in mount
  * names, so the first dot belongs to the mount boundary. Everything after it
  * is the mount-local action key. Valid action keys are snake_case, so
  * additional dots remain part of an invalid key and resolve as ActionNotFound.

--- a/packages/workspace/src/daemon/app.ts
+++ b/packages/workspace/src/daemon/app.ts
@@ -5,10 +5,10 @@
  *
  * Each route is a one-line shell shortcut for one daemon runtime primitive:
  *
- *   /peers    ->  collaboration.devices.list()                     all mounts
- *   /list     ->  flat manifest of `${mount}.${action_key}` -> meta all mounts
- *   /invoke   ->  invokeAction(...)                                 mount-routed
- *   /dispatch ->  collab.dispatch(...)                              mount-routed
+ *   /peers  ->  collaboration.devices.list()                       all mounts
+ *   /list   ->  flat manifest of `${mount}.${action_key}` -> meta  all mounts
+ *   /run    ->  invokeAction(...) locally, or collab.dispatch(...)
+ *               on a peer when `peer` is present                   mount-routed
  *
  * Each route returns the handler's `Result<T, DomainErr>` body directly.
  * Unexpected exceptions propagate to Hono's default error handler (HTTP
@@ -21,12 +21,12 @@ import { type } from 'arktype';
 import { Hono } from 'hono';
 import { Ok } from 'wellcrafted/result';
 import { type ActionManifest, toActionMeta } from '../shared/actions.js';
-import { executeDispatch, executeInvoke } from './action-handler.js';
+import { executeRun } from './action-handler.js';
 import { joinDaemonActionPath } from './action-path.js';
 import type { DaemonServedMount } from './types.js';
 
 /**
- * Wire body for `/invoke`. The schema serves two roles:
+ * Wire body for `/run`. The schema serves two roles:
  *
  *   1. Envelope validation at the daemon boundary via
  *      `@hono/standard-validator`: it checks the request shape (`actionPath`
@@ -36,28 +36,24 @@ import type { DaemonServedMount } from './types.js';
  *   2. Compile-time inference for the hand-rolled client; both sides import
  *      the exact same shape.
  *
+ * `peer` selects the execution target: absent runs the action on this
+ * daemon, present dispatches it to `peer.to`. Grouping the peer fields into
+ * one optional object makes the co-occurrence invariant structural: a
+ * `waitMs` (peer RPC deadline; the daemon owns its default) cannot exist
+ * without a peer target.
+ *
  * Naming follows arktype's idiom (one PascalCase name declares both the
  * value and the type).
  */
-
-export const InvokeRequest = type({
+export const RunRequest = type({
 	actionPath: 'string',
 	input: 'unknown',
+	'peer?': {
+		to: 'string',
+		'waitMs?': 'number',
+	},
 });
-export type InvokeRequest = typeof InvokeRequest.infer;
-
-/**
- * Wire body for `/dispatch`. Peer dispatch is deliberately separate from
- * local invoke: the recipient device is the authority for action existence,
- * and the relay owns reachability.
- */
-export const PeerDispatchRequest = type({
-	actionPath: 'string',
-	input: 'unknown',
-	to: 'string',
-	waitMs: 'number',
-});
-export type PeerDispatchRequest = typeof PeerDispatchRequest.infer;
+export type RunRequest = typeof RunRequest.infer;
 
 /**
  * Row shape returned by `/peers`. One row per `(mount, deviceId)` pair,
@@ -78,9 +74,8 @@ export type PeerSnapshot = typeof PeerSnapshot.infer;
  * Build the daemon's Hono app. Tests import this directly; production serves
  * the app through the daemon server factory.
  *
- * `/list` exposes mount-prefixed action paths. `/invoke` and `/dispatch` use
- * that same prefix to pick the hosted runtime before executing locally or
- * routing to a peer.
+ * `/list` exposes mount-prefixed action paths. `/run` uses that same prefix
+ * to pick the hosted runtime before executing locally or routing to a peer.
  */
 export function buildDaemonApp(mounts: readonly DaemonServedMount[]) {
 	return new Hono()
@@ -109,12 +104,8 @@ export function buildDaemonApp(mounts: readonly DaemonServedMount[]) {
 			}
 			return c.json(Ok(manifest));
 		})
-		.post('/invoke', sValidator('json', InvokeRequest), async (c) => {
+		.post('/run', sValidator('json', RunRequest), async (c) => {
 			const request = c.req.valid('json');
-			return c.json(await executeInvoke(mounts, request));
-		})
-		.post('/dispatch', sValidator('json', PeerDispatchRequest), async (c) => {
-			const request = c.req.valid('json');
-			return c.json(await executeDispatch(mounts, request));
+			return c.json(await executeRun(mounts, request));
 		});
 }

--- a/packages/workspace/src/daemon/attach-project-infrastructure.ts
+++ b/packages/workspace/src/daemon/attach-project-infrastructure.ts
@@ -5,7 +5,8 @@
  * persist the Y.Doc update log to disk under `yjsPath(projectDir, guid)`, join
  * the cloud room at the partitioned `roomWsUrl({ baseURL, ownerId, guid,
  * deviceId })`, and own the ordered async dispose (destroy first so writes
- * flush before sockets close, then await both `whenDisposed` promises).
+ * flush before sockets close, then await every `whenDisposed` barrier:
+ * collaboration, log, and any registered materializers).
  *
  * A cloud doc is owned by the authenticated `ownerId` and addressed by its
  * `ydoc.guid`. The daemon and browser apps build the same URL with
@@ -49,6 +50,13 @@ export type AttachProjectInfrastructureOptions<
 	actions: TActions;
 	/** Base URL of the sync server (the Epicenter cloud, or a self-hosted hub). */
 	baseURL: string;
+	/**
+	 * Materializer attachments composed around the same ydoc. Their teardown
+	 * drains are awaited alongside collaboration and log teardown, so a daemon
+	 * shutdown cannot drop projection writes mid-flight. Each drain is bounded
+	 * by the materializer's own `disposeTimeoutMs`.
+	 */
+	materializers?: ReadonlyArray<{ whenDisposed: Promise<void> }>;
 };
 
 export function attachProjectInfrastructure<TActions extends ActionRegistry>(
@@ -61,6 +69,7 @@ export function attachProjectInfrastructure<TActions extends ActionRegistry>(
 		onReconnectSignal,
 		actions,
 		baseURL,
+		materializers = [],
 	}: AttachProjectInfrastructureOptions<TActions>,
 ) {
 	const yjsLog = attachYjsLog(ydoc, {
@@ -84,10 +93,17 @@ export function attachProjectInfrastructure<TActions extends ActionRegistry>(
 		yjsLog,
 		/** Cloud sync, presence, and dispatch handle for this mount. */
 		collaboration,
-		/** Destroy the Y.Doc, then await collaboration and log teardown. */
+		/**
+		 * Destroy the Y.Doc, then await collaboration, log, and materializer
+		 * teardown (each materializer drains its pending projection writes).
+		 */
 		async [Symbol.asyncDispose]() {
 			ydoc.destroy();
-			await Promise.all([collaboration.whenDisposed, yjsLog.whenDisposed]);
+			await Promise.all([
+				collaboration.whenDisposed,
+				yjsLog.whenDisposed,
+				...materializers.map((materializer) => materializer.whenDisposed),
+			]);
 		},
 	};
 }

--- a/packages/workspace/src/daemon/client.ts
+++ b/packages/workspace/src/daemon/client.ts
@@ -7,8 +7,7 @@
  *   per route. Each method returns `Promise<Result<T, DomainErr | DaemonError>>`,
  *   merging transport and domain failures into one tagged union the
  *   renderer narrows by `error.name`.
- * - {@link getDaemon}: dispatch decision for `invoke` / `dispatch` / `list`
- *   / `peers`.
+ * - {@link getDaemon}: dispatch decision for `run` / `list` / `peers`.
  *   Returns a typed client on success, or `Required` when the project has no
  *   live daemon.
  *
@@ -27,12 +26,8 @@ import {
 } from 'wellcrafted/error';
 import { Ok, type Result, tryAsync } from 'wellcrafted/result';
 import type { ActionManifest } from '../shared/actions.js';
-import type { InvokeError, PeerDispatchError } from './action-errors.js';
-import type {
-	InvokeRequest,
-	PeerDispatchRequest,
-	PeerSnapshot,
-} from './app.js';
+import type { RunError } from './action-errors.js';
+import type { PeerSnapshot, RunRequest } from './app.js';
 import { socketPathFor } from './paths.js';
 
 /**
@@ -169,15 +164,8 @@ export function daemonClient(
 	return {
 		peers: () => call<PeerSnapshot[], never>(socketPath, timeoutMs, '/peers'),
 		list: () => call<ActionManifest, never>(socketPath, timeoutMs, '/list'),
-		invoke: (request: InvokeRequest) =>
-			call<unknown, InvokeError>(socketPath, timeoutMs, '/invoke', request),
-		dispatch: (request: PeerDispatchRequest) =>
-			call<unknown, PeerDispatchError>(
-				socketPath,
-				timeoutMs,
-				'/dispatch',
-				request,
-			),
+		run: (request: RunRequest) =>
+			call<unknown, RunError>(socketPath, timeoutMs, '/run', request),
 	};
 }
 
@@ -193,8 +181,8 @@ export type DaemonClient = ReturnType<typeof daemonClient>;
  *   - `Required`: no daemon is running. Renderer prints the
  *     start-with-`daemon up` hint.
  *
- * `invoke`, `dispatch`, `list`, and `peers` are mandatory-daemon commands; if
- * they hit no error they have a typed client to call.
+ * `run`, `list`, and `peers` are mandatory-daemon commands; if they hit no
+ * error they have a typed client to call.
  */
 export async function getDaemon(
 	projectDir: string,

--- a/packages/workspace/src/daemon/server.test.ts
+++ b/packages/workspace/src/daemon/server.test.ts
@@ -9,8 +9,8 @@
  * - valid mounts are served over the daemon client
  * - invalid mount declarations fail before binding a socket
  * - close stops the listener, removes the socket file, and can run twice
- * - /invoke executes a real action handler over the Unix socket
- * - /dispatch forwards peer calls over the Unix socket
+ * - /run executes a real action handler over the Unix socket, and
+ *   forwards peer calls when `to` is present
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
@@ -150,7 +150,7 @@ describe('startDaemonServer', () => {
 		}
 	});
 
-	test('invoke executes a real action handler over the socket', async () => {
+	test('run executes a real action handler over the socket', async () => {
 		const lease = claimTestLease();
 		const runtime = makeRuntime({
 			actions: {
@@ -165,7 +165,7 @@ describe('startDaemonServer', () => {
 		try {
 			const server = expectOk(serverResult);
 			const data = expectOk(
-				await daemonClient(server.socketPath).invoke({
+				await daemonClient(server.socketPath).run({
 					actionPath: 'demo.echo',
 					input: null,
 				}),
@@ -177,7 +177,7 @@ describe('startDaemonServer', () => {
 		}
 	});
 
-	test('dispatch forwards mount-local action keys over the socket', async () => {
+	test('run with to forwards mount-local action keys over the socket', async () => {
 		const lease = claimTestLease();
 		let invokedAction = '';
 		let invokedTo = '';
@@ -196,11 +196,10 @@ describe('startDaemonServer', () => {
 		try {
 			const server = expectOk(serverResult);
 			const data = expectOk(
-				await daemonClient(server.socketPath).dispatch({
+				await daemonClient(server.socketPath).run({
 					actionPath: 'demo.peer_only_action',
 					input: null,
-					to: 'mac',
-					waitMs: 25,
+					peer: { to: 'mac', waitMs: 25 },
 				}),
 			);
 			expect(data).toBe('remote-ok');
@@ -212,7 +211,7 @@ describe('startDaemonServer', () => {
 		}
 	});
 
-	test('dispatch rejects invalid wait budgets as a domain error', async () => {
+	test('run with to rejects invalid wait budgets as a domain error', async () => {
 		const lease = claimTestLease();
 		const serverResult = await startDaemonServer({
 			lease,
@@ -222,11 +221,10 @@ describe('startDaemonServer', () => {
 		try {
 			const server = expectOk(serverResult);
 			const error = expectErr(
-				await daemonClient(server.socketPath).dispatch({
+				await daemonClient(server.socketPath).run({
 					actionPath: 'demo.peer_only_action',
 					input: null,
-					to: 'mac',
-					waitMs: -1,
+					peer: { to: 'mac', waitMs: -1 },
 				}),
 			);
 			expect(error.name).toBe('UsageError');

--- a/packages/workspace/src/daemon/types.ts
+++ b/packages/workspace/src/daemon/types.ts
@@ -20,7 +20,7 @@ import type { MaybePromise } from '../shared/types.js';
 
 /**
  * Collaboration fields the daemon socket app reads while serving `/peers`,
- * `/list`, `/invoke`, and `/dispatch`.
+ * `/list`, and `/run`.
  */
 type DaemonServedCollaboration<
 	TActions extends ActionRegistry = ActionRegistry,

--- a/packages/workspace/src/document/column/constraint.test-d.ts
+++ b/packages/workspace/src/document/column/constraint.test-d.ts
@@ -10,12 +10,12 @@
  * assertion fails, the type error appears at the offending line during typecheck.
  */
 
+import type { field } from '@epicenter/field';
 import type { Type } from 'typebox';
 import type { Brand } from 'wellcrafted/brand';
 import type { JsonValue } from 'wellcrafted/json';
-import type { field } from '@epicenter/field';
-import type { ColumnError, FlatJsonTSchema } from './constraint';
 import type { nullable } from '../nullable';
+import type { ColumnError, FlatJsonTSchema } from './constraint';
 
 // --------------------------------------------------------------------------
 // Helpers
@@ -97,7 +97,9 @@ export type _RejectObject = Expect<
 // final Static<S> extends JsonValue clause.
 export type _AcceptArrayOfScalar = Expect<
 	Equal<
-		FlatJsonTSchema<ReturnType<typeof Type.Array<ReturnType<typeof Type.Number>>>>,
+		FlatJsonTSchema<
+			ReturnType<typeof Type.Array<ReturnType<typeof Type.Number>>>
+		>,
 		ReturnType<typeof Type.Array<ReturnType<typeof Type.Number>>>
 	>
 >;

--- a/packages/workspace/src/document/create-table.test.ts
+++ b/packages/workspace/src/document/create-table.test.ts
@@ -3,10 +3,10 @@
  */
 
 import { describe, expect, test } from 'bun:test';
+import { field } from '@epicenter/field';
 import { expectErr, expectOk } from 'wellcrafted/testing';
 import * as Y from 'yjs';
 import { createEncryptedYkvLww } from '../shared/y-keyvalue/y-keyvalue-lww-encrypted.js';
-import { field } from '@epicenter/field';
 import { defineTable } from './define-table.js';
 import { createReadonlyTable, createTable } from './table.js';
 

--- a/packages/workspace/src/document/local-only-recipe.test.ts
+++ b/packages/workspace/src/document/local-only-recipe.test.ts
@@ -16,10 +16,10 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { field } from '@epicenter/field';
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb';
 import { attachBroadcastChannel } from './attach-broadcast-channel.js';
 import { attachIndexedDb } from './attach-indexed-db.js';
-import { field } from '@epicenter/field';
 import { defineTable } from './define-table.js';
 import { createWorkspace } from './workspace.js';
 

--- a/packages/workspace/src/document/materializer/markdown/export.test.ts
+++ b/packages/workspace/src/document/materializer/markdown/export.test.ts
@@ -10,8 +10,8 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { createWorkspace, defineTable } from '../../../index.js';
 import { field } from '@epicenter/field';
+import { createWorkspace, defineTable } from '../../../index.js';
 import { attachMarkdownExport } from './export.js';
 
 const postsTable = defineTable({
@@ -118,6 +118,97 @@ describe('attachMarkdownExport', () => {
 		await expect(listDir('posts')).rejects.toThrow();
 
 		workspace[Symbol.dispose]();
+	});
+
+	describe('teardown drain', () => {
+		test('dispose immediately after seeding still writes the initial flush', async () => {
+			const workspace = createWorkspace({
+				id: 'export-drain-initial',
+				tables: tableDefinitions,
+				kv: {},
+			});
+			const exporter = attachMarkdownExport(workspace, {
+				dir: TEST_DIR,
+				tables: { posts: {} },
+			});
+
+			workspace.tables.posts.set({ id: 'a', title: 'alpha', published: true });
+			workspace[Symbol.dispose]();
+
+			await exporter.whenDisposed;
+
+			const files = await listDir('posts');
+			expect(files).toContain('a.md');
+		});
+
+		test('dispose drains an in-flight observer render', async () => {
+			const workspace = createWorkspace({
+				id: 'export-drain-observer',
+				tables: tableDefinitions,
+				kv: {},
+			});
+			const exporter = attachMarkdownExport(workspace, {
+				dir: TEST_DIR,
+				tables: { posts: {} },
+			});
+			await exporter.whenFlushed;
+
+			workspace.tables.posts.set({ id: 'b', title: 'beta', published: false });
+			workspace[Symbol.dispose]();
+
+			await exporter.whenDisposed;
+
+			const files = await listDir('posts');
+			expect(files).toContain('b.md');
+		});
+
+		test('a hung render cannot wedge teardown past the bounded timeout', async () => {
+			const workspace = createWorkspace({
+				id: 'export-drain-hung',
+				tables: tableDefinitions,
+				kv: {},
+			});
+			const exporter = attachMarkdownExport(workspace, {
+				dir: TEST_DIR,
+				disposeTimeoutMs: 50,
+				tables: {
+					posts: { toMarkdown: () => new Promise<never>(() => {}) },
+				},
+			});
+
+			workspace.tables.posts.set({ id: 'c', title: 'gamma', published: true });
+			workspace[Symbol.dispose]();
+
+			// Resolves via the bounded timeout instead of hanging on the render.
+			await exporter.whenDisposed;
+		});
+
+		test('dispose before the waitFor gate opens owes no flush', async () => {
+			const gate = Promise.withResolvers<void>();
+			const workspace = createWorkspace({
+				id: 'export-drain-gated',
+				tables: tableDefinitions,
+				kv: {},
+			});
+			const exporter = attachMarkdownExport(workspace, {
+				dir: TEST_DIR,
+				waitFor: gate.promise,
+				tables: { posts: {} },
+			});
+
+			workspace.tables.posts.set({ id: 'd', title: 'delta', published: true });
+			const start = performance.now();
+			workspace[Symbol.dispose]();
+			await exporter.whenDisposed;
+			// The flush never started, so teardown owes nothing and must not
+			// sit out the bounded timeout waiting on the unopened gate.
+			expect(performance.now() - start).toBeLessThan(1000);
+
+			// The gate opening later must not flush against the disposed doc.
+			gate.resolve();
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			await expect(listDir('posts')).rejects.toThrow();
+		});
 	});
 
 	test('markdown_rebuild removes an orphan and rewrites rows', async () => {

--- a/packages/workspace/src/document/materializer/markdown/export.ts
+++ b/packages/workspace/src/document/materializer/markdown/export.ts
@@ -7,7 +7,12 @@ import { assembleMarkdown } from '../../../markdown/assemble-markdown.js';
 import { defineActions, defineMutation } from '../../../shared/actions.js';
 import type { MaybePromise } from '../../../shared/types.js';
 import type { BaseRow, Table } from '../../table.js';
-import type { AnyTable, MaterializerInput, TablesRecord } from '../shared.js';
+import {
+	type AnyTable,
+	type MaterializerInput,
+	settledWithin,
+	type TablesRecord,
+} from '../shared.js';
 
 // ════════════════════════════════════════════════════════════════════════════
 // attachMarkdownExport: the read-only markdown projection
@@ -74,6 +79,7 @@ export function attachMarkdownExport<TTableHandles extends TablesRecord>(
 		dir,
 		tables: tablesConfig,
 		waitFor,
+		disposeTimeoutMs = 10_000,
 		log = createLogger('markdown-export'),
 	}: {
 		/** Base output directory. A string or async getter for lazy path resolution. */
@@ -86,6 +92,13 @@ export function attachMarkdownExport<TTableHandles extends TablesRecord>(
 		tables?: ExportTablesConfig<TTableHandles>;
 		/** Gate: awaited before the initial filesystem flush. Omit for no gate. */
 		waitFor?: Promise<unknown>;
+		/**
+		 * Upper bound on the teardown drain: dispose waits at most this long for
+		 * the initial flush and in-flight row renders to settle before resolving
+		 * `whenDisposed`, so a hung render (e.g. a stuck HTTP body read) cannot
+		 * wedge shutdown. Defaults to 10 seconds.
+		 */
+		disposeTimeoutMs?: number;
 		/** Logger for background write-observer failures. */
 		log?: Logger;
 	},
@@ -119,34 +132,80 @@ export function attachMarkdownExport<TTableHandles extends TablesRecord>(
 		});
 	}
 	let isDisposed = false;
+	// The `waitFor` gate has resolved, so the initial flush is underway (or
+	// done) and teardown owes it a drain. Disposing while the gate is still
+	// closed owes nothing: the flush never started, and `initialize` bails
+	// when the gate finally opens.
+	let isGateOpen = waitFor === undefined;
+	let isFlushAbandoned = false;
+
+	// In-flight observer render batches. Each batch is added when its observer
+	// fires and removed when it settles, so the teardown drain can await
+	// exactly the writes that were mid-flight at dispose time.
+	const pendingWrites = new Set<Promise<void>>();
+	function trackPendingWrite(work: Promise<void>) {
+		pendingWrites.add(work);
+		void work.finally(() => pendingWrites.delete(work));
+	}
 
 	const resolveDir = async () =>
 		typeof dir === 'function' ? await dir() : dir;
 
+	const { promise: whenDisposed, resolve: resolveDisposed } =
+		Promise.withResolvers<void>();
+
 	function dispose() {
 		if (isDisposed) return;
 		isDisposed = true;
+		isFlushAbandoned = !isGateOpen;
 		for (const entry of registered.values()) entry.unsubscribe?.();
+		void drainPendingWork().finally(resolveDisposed);
+	}
+
+	/**
+	 * Drain projection work still in flight at dispose: the initial flush
+	 * (unless its gate never opened) and any observer render batches. Bounded
+	 * by `disposeTimeoutMs` so teardown cannot wedge on a hung render.
+	 */
+	async function drainPendingWork() {
+		const pending: Promise<unknown>[] = isFlushAbandoned
+			? [...pendingWrites]
+			: [whenFlushed, ...pendingWrites];
+		if (pending.length === 0) return;
+		const didSettle = await settledWithin(
+			Promise.allSettled(pending),
+			disposeTimeoutMs,
+		);
+		if (!didSettle) {
+			log.warn(
+				MaterializerWriteError.DrainTimedOut({ timeoutMs: disposeTimeoutMs }),
+			);
+		}
 	}
 
 	ydoc.once('destroy', dispose);
 
 	async function initialize() {
 		await waitFor;
-		if (isDisposed) return;
+		isGateOpen = true;
+		if (isFlushAbandoned) return;
 
 		const baseDir = await resolveDir();
 		await mkdir(baseDir, { recursive: true });
 
 		for (const entry of registered.values()) {
-			if (isDisposed) return;
-			entry.unsubscribe = await materializeTable({
+			const unsubscribe = await materializeTable({
 				table: entry.table,
 				directory: join(baseDir, entry.subdir),
 				render: entry.render,
 				fileState: entry.fileState,
+				track: trackPendingWrite,
 				log,
 			});
+			// Disposed mid-flush: the writes above are owed (the teardown drain
+			// awaits this whole flush), but no observer may outlive teardown.
+			if (isDisposed) unsubscribe();
+			else entry.unsubscribe = unsubscribe;
 		}
 	}
 
@@ -188,6 +247,13 @@ export function attachMarkdownExport<TTableHandles extends TablesRecord>(
 
 	return {
 		whenFlushed,
+		/**
+		 * Resolves after `ydoc.destroy()` once pending projection work (the
+		 * initial flush and in-flight row renders) has drained, bounded by
+		 * `disposeTimeoutMs`. Daemon teardown awaits this before process exit
+		 * so a shutdown cannot drop markdown writes mid-flight.
+		 */
+		whenDisposed,
 		actions: defineActions({
 			markdown_rebuild: defineMutation({
 				title: 'Rebuild Markdown Export',
@@ -229,9 +295,9 @@ type RenderRow = (
 type FileState = Map<string, { filename: string; content: string }>;
 
 /**
- * Errors produced by the background write-observer (table row → .md file).
- * These run inside `.catch(...)` of a detached async task, so they ship to the
- * logger, not through a Result to the caller.
+ * Errors produced by the background write-observer (table row → .md file) and
+ * the teardown drain. These run inside `.catch(...)` of a detached async task,
+ * so they ship to the logger, not through a Result to the caller.
  */
 const MaterializerWriteError = defineErrors({
 	TableWriteFailed: ({
@@ -247,6 +313,10 @@ const MaterializerWriteError = defineErrors({
 		tableName,
 		id,
 		cause,
+	}),
+	DrainTimedOut: ({ timeoutMs }: { timeoutMs: number }) => ({
+		message: `[markdown] teardown drain did not settle within ${timeoutMs}ms; abandoning pending writes`,
+		timeoutMs,
 	}),
 });
 
@@ -292,9 +362,11 @@ async function materializeTable(opts: {
 	directory: string;
 	render: RenderRow;
 	fileState: FileState;
+	/** Register an observer batch with the attachment's teardown drain. */
+	track: (work: Promise<void>) => void;
 	log: Logger;
 }): Promise<() => void> {
-	const { table, directory, render, fileState, log } = opts;
+	const { table, directory, render, fileState, track, log } = opts;
 
 	await mkdir(directory, { recursive: true });
 
@@ -331,7 +403,7 @@ async function materializeTable(opts: {
 	// Sequential writes inside the observer avoid rename races; a parallel
 	// approach (Promise.allSettled) could delete a file another write needs.
 	return table.observe((changedIds) => {
-		void (async () => {
+		const batch = (async () => {
 			for (const id of changedIds) {
 				const { data: row, error } = table.get(id);
 
@@ -357,6 +429,7 @@ async function materializeTable(opts: {
 				}),
 			);
 		});
+		track(batch);
 	});
 }
 

--- a/packages/workspace/src/document/materializer/shared.ts
+++ b/packages/workspace/src/document/materializer/shared.ts
@@ -1,13 +1,38 @@
 /**
- * Shared types for the materializer family (sqlite + markdown). Each
- * materializer is generic over a record of materialized workspace tables;
- * `TablesRecord` is the structural bound those generics share and
- * `AnyTable` is the variance-friendly element shape they both pass around
- * internally.
+ * Shared types and teardown helpers for the materializer family (sqlite +
+ * markdown). Each materializer is generic over a record of materialized
+ * workspace tables; `TablesRecord` is the structural bound those generics
+ * share and `AnyTable` is the variance-friendly element shape they both pass
+ * around internally. `settledWithin` is the bounded wait both families use to
+ * drain pending projection work at dispose.
  */
 
 import type * as Y from 'yjs';
 import type { Table } from '../table.js';
+
+/**
+ * Await `work`, but give up after `timeoutMs` so a hung drain (e.g. a stuck
+ * HTTP body read inside a render) cannot wedge teardown. Returns whether the
+ * work settled in time. A rejection counts as settled: drain callers report
+ * failures through their own logging channels, not through this wait.
+ */
+export async function settledWithin(
+	work: Promise<unknown>,
+	timeoutMs: number,
+): Promise<boolean> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const didSettle = await Promise.race([
+		work.then(
+			() => true,
+			() => true,
+		),
+		new Promise<false>((resolve) => {
+			timer = setTimeout(() => resolve(false), timeoutMs);
+		}),
+	]);
+	clearTimeout(timer);
+	return didSettle;
+}
 
 /**
  * Variance-friendly handle for a single workspace table whose row type the

--- a/packages/workspace/src/document/materializer/sqlite/bun-sqlite.ts
+++ b/packages/workspace/src/document/materializer/sqlite/bun-sqlite.ts
@@ -67,6 +67,13 @@ export type AttachBunSqliteMaterializerOptions<
 	waitFor?: Promise<unknown>;
 
 	/**
+	 * Upper bound on the teardown drain: dispose waits at most this long for
+	 * the initial full-load and the pending row flush to settle before closing
+	 * the database. Defaults to 10 seconds.
+	 */
+	disposeTimeoutMs?: number;
+
+	/**
 	 * Logger for background failures (debounced sync flush, FTS query, WAL
 	 * pragma fallbacks). Defaults to a console-backed logger with source
 	 * `attachBunSqliteMaterializer`.
@@ -93,6 +100,7 @@ export function attachBunSqliteMaterializer<
 		fts,
 		debounceMs,
 		waitFor,
+		disposeTimeoutMs,
 		log = createLogger('attachBunSqliteMaterializer'),
 	}: AttachBunSqliteMaterializerOptions<TTables, TFts>,
 ) {
@@ -105,6 +113,7 @@ export function attachBunSqliteMaterializer<
 		fts,
 		debounceMs,
 		waitFor,
+		disposeTimeoutMs,
 		log,
 	});
 

--- a/packages/workspace/src/document/materializer/sqlite/core.test.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.test.ts
@@ -12,11 +12,12 @@
  * - Observer-based sync upserts changed rows and deletes removed rows
  * - FTS5 search returns ranked results with snippets
  * - rebuild() drops and recreates all materialized data
- * - dispose() stops observers and clears timeouts
+ * - dispose() stops observers, drains pending mirror work, then closes the db
  */
 
 import { Database, type SQLQueryBindings } from 'bun:sqlite';
 import { describe, expect, test } from 'bun:test';
+import { field } from '@epicenter/field';
 import {
 	createDisposableCache,
 	createWorkspace,
@@ -24,7 +25,6 @@ import {
 	type Tables,
 } from '../../../index.js';
 import { isAction, isMutation, isQuery } from '../../../shared/actions.js';
-import { field } from '@epicenter/field';
 import { nullable } from '../../nullable.js';
 import { attachSqliteMaterializerCore } from './core.js';
 
@@ -143,8 +143,9 @@ function hasTable(db: Database, tableName: string) {
 
 async function disposeAndYieldForClose(setupResult: ReturnType<typeof setup>) {
 	setupResult.workspace[Symbol.dispose]();
-	// In settled cleanup paths, disposal schedules close on the next microtask.
-	await Promise.resolve();
+	// Disposal drains pending mirror work before closing; await the barrier so
+	// no test leaks an open database or a late close into the next case.
+	await setupResult.workspace.sqlite.whenDisposed;
 }
 
 // ============================================================================
@@ -424,7 +425,7 @@ describe('attachSqliteMaterializerCore', () => {
 	// ============================================================================
 
 	describe('dispose', () => {
-		test('dispose cancels queued sync and ignores later writes', async () => {
+		test('dispose flushes queued sync before closing', async () => {
 			const testSetup = setup();
 			const originalClose = testSetup.db.close.bind(testSetup.db);
 			testSetup.db.close = () => {};
@@ -439,14 +440,36 @@ describe('attachSqliteMaterializerCore', () => {
 				});
 				testSetup.workspace[Symbol.dispose]();
 
-				await waitForSyncCycle();
+				await testSetup.workspace.sqlite.whenDisposed;
 
-				// The ydoc is destroyed, so further writes to tables are no-ops
-				// as far as materialization is concerned; the observer has been
-				// unsubscribed via materializer dispose.
-				await waitForSyncCycle();
+				// The row was still sitting in the debounced pending set at
+				// dispose time; teardown drains it instead of dropping it.
+				expect(getRows(testSetup.db, 'posts')).toEqual([
+					{ id: 'post-1', title: 'Queued row', published: null },
+				]);
+			} finally {
+				originalClose();
+			}
+		});
 
-				expect(getRows(testSetup.db, 'posts')).toEqual([]);
+		test('dispose immediately after seeding drains the initial full load', async () => {
+			const testSetup = setup();
+			const originalClose = testSetup.db.close.bind(testSetup.db);
+			testSetup.db.close = () => {};
+
+			try {
+				testSetup.workspace.tables.posts.set({
+					id: 'post-1',
+					title: 'Seeded row',
+					published: null,
+				});
+				testSetup.workspace[Symbol.dispose]();
+
+				await testSetup.workspace.sqlite.whenDisposed;
+
+				expect(getRows(testSetup.db, 'posts')).toEqual([
+					{ id: 'post-1', title: 'Seeded row', published: null },
+				]);
 			} finally {
 				originalClose();
 			}

--- a/packages/workspace/src/document/materializer/sqlite/core.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.ts
@@ -6,8 +6,10 @@
  * Public callers use `attachBunSqliteMaterializer`, which owns the native
  * client lifecycle and forwards the client here.
  *
- * Teardown is hooked to the ydoc via `ydoc.once('destroy', ...)`. Core closes
- * the underlying native client after queued database work drains.
+ * Teardown is hooked to the ydoc via `ydoc.once('destroy', ...)`. Core drains
+ * pending mirror work (initial full-load, debounced row flush) bounded by
+ * `disposeTimeoutMs`, then closes the underlying native client; the barrier is
+ * surfaced as `whenDisposed`.
  *
  * @internal
  * @module
@@ -21,7 +23,7 @@ import { createLogger, type Logger } from 'wellcrafted/logger';
 import type * as Y from 'yjs';
 import { defineActions, defineMutation } from '../../../shared/actions.js';
 import type { BaseRow, Table } from '../../table.js';
-import type { AnyTable, TablesRecord } from '../shared.js';
+import { type AnyTable, settledWithin, type TablesRecord } from '../shared.js';
 import { generateDdl, quoteIdentifier } from './ddl.js';
 import { createSqliteFtsLayer } from './fts.js';
 
@@ -50,6 +52,11 @@ const SqliteMaterializerError = defineErrors({
 		message: `[sqlite-materializer] Failed to dispose SQLite materializer: ${extractErrorMessage(cause)}`,
 		cause,
 	}),
+	/** Teardown drain hit its bound; the database closes with work pending. */
+	DrainTimedOut: ({ timeoutMs }: { timeoutMs: number }) => ({
+		message: `[sqlite-materializer] teardown drain did not settle within ${timeoutMs}ms; closing with work pending`,
+		timeoutMs,
+	}),
 });
 
 type RegisteredTable = {
@@ -76,6 +83,7 @@ export function attachSqliteMaterializerCore<
 		fts,
 		debounceMs = 100,
 		waitFor,
+		disposeTimeoutMs = 10_000,
 		log = createLogger('sqlite-materializer'),
 	}: {
 		db: Database;
@@ -99,6 +107,13 @@ export function attachSqliteMaterializerCore<
 		 */
 		waitFor?: Promise<unknown>;
 		/**
+		 * Upper bound on the teardown drain: dispose waits at most this long
+		 * for the initial full-load and the pending row flush to settle before
+		 * closing the database, so a hung statement cannot wedge shutdown.
+		 * Defaults to 10 seconds.
+		 */
+		disposeTimeoutMs?: number;
+		/**
 		 * Logger for background failures (debounced sync flush, FTS query).
 		 * Defaults to a console-backed logger with source `sqlite-materializer`.
 		 */
@@ -120,6 +135,12 @@ export function attachSqliteMaterializerCore<
 	let pendingSync = new Map<string, Set<string>>();
 	let dbQueue = Promise.resolve();
 	let isDisposed = false;
+	// The `waitFor` gate has resolved, so the initial DDL + full-load is
+	// underway (or done) and teardown owes it a drain. Disposing while the
+	// gate is still closed owes nothing: the load never started, and
+	// `initialize` bails when the gate finally opens.
+	let isGateOpen = waitFor === undefined;
+	let isFlushAbandoned = false;
 
 	// ── SQL primitives ───────────────────────────────────────────
 
@@ -189,8 +210,6 @@ export function attachSqliteMaterializerCore<
 	}
 
 	async function flushPendingSync() {
-		if (isDisposed) return;
-
 		const currentPending = pendingSync;
 		pendingSync = new Map<string, Set<string>>();
 
@@ -257,16 +276,41 @@ export function attachSqliteMaterializerCore<
 
 	// ── Disposal ────────────────────────────────────────────────
 
+	const { promise: whenDisposed, resolve: resolveDisposed } =
+		Promise.withResolvers<void>();
+
 	function dispose() {
 		if (isDisposed) return;
 		isDisposed = true;
+		isFlushAbandoned = !isGateOpen;
 		flushAfterDebounce.cancel();
 		for (const entry of registered.values()) entry.unsubscribe?.();
-		void dbQueue
-			.then(() => db.close())
+
+		// Drain pending projection work before closing: the initial DDL +
+		// full-load (unless its gate never opened) and any rows still sitting
+		// in the debounced pending set. Bounded so a hung statement cannot
+		// wedge shutdown; on timeout the database closes with work pending.
+		void (async () => {
+			const drain = (async () => {
+				if (!isFlushAbandoned) await whenFlushed.catch(() => {});
+				await enqueueDbWork(flushPendingSync).catch((cause: unknown) => {
+					log.error(SqliteMaterializerError.SyncFailed({ cause }));
+				});
+			})();
+			const didSettle = await settledWithin(drain, disposeTimeoutMs);
+			if (!didSettle) {
+				log.warn(
+					SqliteMaterializerError.DrainTimedOut({
+						timeoutMs: disposeTimeoutMs,
+					}),
+				);
+			}
+			await db.close();
+		})()
 			.catch((cause: unknown) => {
 				log.error(SqliteMaterializerError.DisposeFailed({ cause }));
-			});
+			})
+			.finally(resolveDisposed);
 	}
 
 	ydoc.once('destroy', dispose);
@@ -278,11 +322,10 @@ export function attachSqliteMaterializerCore<
 		// (e.g. `tables.posts.set(...)`) before the full-load reads
 		// `getAllValid()`.
 		await waitFor;
-		if (isDisposed) return;
+		isGateOpen = true;
+		if (isFlushAbandoned) return;
 
 		await enqueueDbWork(async () => {
-			if (isDisposed) return;
-
 			for (const [tableName, entry] of registered) {
 				await db.run(generateDdl(tableName, entry.table.schema));
 			}
@@ -292,8 +335,6 @@ export function attachSqliteMaterializerCore<
 				// populate `<table>_fts` through the normal INSERT triggers.
 				await ftsLayer.setupForBulkLoad();
 			}
-
-			if (isDisposed) return;
 
 			await db.run('BEGIN');
 			try {
@@ -306,6 +347,8 @@ export function attachSqliteMaterializerCore<
 			}
 		});
 
+		// Disposed mid-load: the writes above are owed (the teardown drain
+		// awaits this whole flush), but no observer may outlive teardown.
 		if (isDisposed) return;
 
 		for (const [tableName, entry] of registered) {
@@ -343,7 +386,18 @@ export function attachSqliteMaterializerCore<
 			})
 		: defineActions({ sqlite_rebuild: rebuildAction });
 
-	return { whenFlushed, actions };
+	return {
+		whenFlushed,
+		/**
+		 * Resolves after `ydoc.destroy()` once pending mirror work (the initial
+		 * full-load and the debounced row flush) has drained and the database
+		 * handle is closed, bounded by `disposeTimeoutMs`. Daemon teardown
+		 * awaits this before process exit so a shutdown cannot drop mirror
+		 * writes mid-flight.
+		 */
+		whenDisposed,
+		actions,
+	};
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/workspace/src/document/nullable.test.ts
+++ b/packages/workspace/src/document/nullable.test.ts
@@ -6,8 +6,8 @@
  * compile-time `FlatJsonTSchema` tests live in `column/constraint.test-d.ts`.
  */
 
-import { field, recognize } from '@epicenter/field';
 import { describe, expect, test } from 'bun:test';
+import { field, recognize } from '@epicenter/field';
 import { Type } from 'typebox';
 import { Value } from 'typebox/value';
 import { nullable } from './nullable';

--- a/packages/workspace/src/document/open-sqlite-reader.test.ts
+++ b/packages/workspace/src/document/open-sqlite-reader.test.ts
@@ -9,8 +9,8 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createWorkspace, defineTable } from '../index.js';
 import { field } from '@epicenter/field';
+import { createWorkspace, defineTable } from '../index.js';
 import { attachBunSqliteMaterializer } from './materializer/sqlite/bun-sqlite.js';
 import { openSqliteReader } from './open-sqlite-reader.js';
 

--- a/packages/workspace/src/document/workspace.test.ts
+++ b/packages/workspace/src/document/workspace.test.ts
@@ -7,9 +7,9 @@
 import { describe, expect, test } from 'bun:test';
 import type { Keyring } from '@epicenter/encryption';
 import { bytesToBase64 } from '@epicenter/encryption';
+import { field } from '@epicenter/field';
 import { randomBytes } from '@noble/ciphers/utils.js';
 import { Type } from 'typebox';
-import { field } from '@epicenter/field';
 import { defineKv } from './define-kv.js';
 import { defineTable } from './define-table.js';
 import { createWorkspace } from './workspace.js';

--- a/packages/workspace/src/node.ts
+++ b/packages/workspace/src/node.ts
@@ -12,15 +12,10 @@ export { findProjectRoot } from './client/find-project-root.js';
 export { ProjectConfigError } from './config/load-project-config.js';
 export { DEFAULT_PROJECT_CONFIG_SOURCE } from './config/project-config-source.js';
 export {
-	InvokeError,
-	PeerDispatchError,
-	type PeerDispatchSyncStatus,
+	type PeerSyncStatus,
+	RunError,
 } from './daemon/action-errors.js';
-export {
-	InvokeRequest,
-	PeerDispatchRequest,
-	PeerSnapshot,
-} from './daemon/app.js';
+export { PeerSnapshot, RunRequest } from './daemon/app.js';
 export {
 	type AttachProjectInfrastructureOptions,
 	attachProjectInfrastructure,

--- a/specs/20260610T193000-cli-daemon-collapse-waves.md
+++ b/specs/20260610T193000-cli-daemon-collapse-waves.md
@@ -1,0 +1,114 @@
+# CLI/daemon collapse waves
+
+Status: wave 1 implemented; wave 2 owed; wave 3 deferred with triggers.
+
+Source: greenfield clean-break consult on the CLI/daemon shape, plus a
+latency experiment for daemonless one-shot `run`.
+
+## Product sentence
+
+The lease owner runs actions; the user enters through `epicenter run`; the
+daemon's one job is staying online as a live peer (presence, inbound
+dispatch, materializer projections).
+
+## Experiment record
+
+Throwaway benchmark (`bench-oneshot.ts` at the repo root, untracked) drove
+the full one-shot path against a temp project mounting the real fuji app
+with stub signed-in auth and no relay: bun spawn, library import,
+`openProject`, invoke `entries_get_all_valid`, dispose.
+
+| Scenario                          | openProject | total wall |
+| --------------------------------- | ----------- | ---------- |
+| Empty project                     | 41-53 ms    | 0.17-0.25 s |
+| 300 entries (2.8 MB Yjs log)      | 65-69 ms    | ~0.21 s    |
+
+Latency gate for daemonless `run` was "under ~1 s"; it passes by roughly 5x.
+`attachYjsLog` hydration is synchronous, dispose is clean, and the sync
+supervisor exits gracefully offline.
+
+The experiment also surfaced a correctness bug, recorded under wave 2: a
+short-lived process drops markdown materializer work entirely. Seeding 300
+entries left 300 rows in the SQLite materializer and zero `.md` files, with
+zero body reads attempted across three subsequent opens.
+
+## Wave 1: sure collapses (implemented)
+
+- Deleted the `REMOVED_DAEMON_COMMANDS` tombstone in `packages/cli/src/cli.ts`;
+  yargs `.strict()` already rejects unknown commands.
+- Replaced the recursive tree renderer in `epicenter list` with mount-grouped
+  flat output; action paths are exactly `mount.action_key`, so the tree was
+  always two levels deep.
+- Moved project scaffolding out of `daemon up` into a new `epicenter init`.
+  `daemon up` no longer writes `epicenter.config.ts` or litters `.epicenter`
+  into non-project directories; on a missing config it fails with a hint
+  pointing at `init`. Per-dir provisioning collapsed entirely: the attach
+  primitives create their own data dirs on demand (verified by the benchmark,
+  which never provisioned and still got `sqlite/` and `yjs/`), and
+  `.epicenter/log` had no consumer (daemon logs live in the user log dir).
+  `daemon up` now only ensures `.epicenter/.gitignore` containing `*`, a
+  universal rule instead of a maintained directory list.
+- Made the socket ping the single liveness authority in `daemon ps`; the pid
+  in metadata exists only so `daemon down` can signal the process.
+- Merged `/invoke` and `/dispatch` into one `/run` route, merged
+  `InvokeError` + `PeerDispatchError` into one `RunError` union, and
+  collapsed the CLI's dual error rendering. The peer fields are grouped into
+  one optional `peer: { to, waitMs? }` object, so "waitMs without a peer
+  target" is structurally unrepresentable instead of a runtime guard. The
+  daemon owns the peer wait default (`DEFAULT_PEER_WAIT_MS`); the CLI sends
+  `waitMs` only when the user passes `--wait`. `waitMs` stays a duration, not
+  an absolute deadline: same-clock single hop over a Unix socket, and the CLI
+  flag is a duration, so a deadline would only add conversions.
+
+Wire compatibility was explicitly refused: no `/invoke` or `/dispatch`
+aliases remain. CLI and daemon ship together from this repo; there is no
+published contract that earns an alias.
+
+## Wave 2: materializer drain on teardown (owed, not yet done)
+
+`attachMarkdownExport` starts its initial flush as a fire-and-forget promise
+(`whenFlushed`, `export.ts`), and row renders triggered by observers are
+also unawaited. Nothing in the mount dispose chain drains them.
+
+This is a live bug in the current daemon: `epicenter daemon down` (SIGTERM)
+shortly after a mutation can drop markdown projection writes mid-flight. It
+is also a hard precondition for any daemonless one-shot mode.
+
+Fix shape: mount/runtime dispose awaits pending materializer work (or the
+teardown drains explicitly before `ydoc.destroy()`), with a bounded timeout
+so a hung HTTP body read cannot wedge shutdown.
+
+Trigger to do it: next time anyone touches the markdown materializer or
+daemon teardown, or before wave 3 starts; it should not wait for wave 3.
+
+## Wave 3: daemonless `run` (deferred)
+
+Candidate:
+  `epicenter run`/`list` work without a running daemon: if the project
+  socket answers, route through it; otherwise open the project in-process
+  offline, run, dispose. The daemon remains for live-peer duties; `--peer`
+  honestly requires it.
+
+Refusal (for now):
+  Latency is a green light (see experiment record), but the design is
+  blocked on three decisions, not performance:
+
+  1. Materializer policy for one-shots. Fuji's markdown export re-reads
+     every entry body over HTTP on each attach (in-memory `fileState`), so a
+     one-shot that properly drains pays O(entries) network round trips per
+     CLI invocation. Likely answer: projections are the daemon's job and
+     one-shot runs skip materializers, but that must be decided, not
+     defaulted.
+  2. Relay flush policy on exit. The WebSocket connects in the background; a
+     one-shot mutation gets only a race window to sync. Needs an explicit
+     flush-with-timeout-else-sync-later contract.
+  3. Lease contention. Socket dead but daemon mid-startup means both sides
+     contend for the SQLite lease; the loser needs a defined retry/error.
+
+User loss while deferred:
+  `run`/`list`/`peers` keep requiring `epicenter daemon up` first.
+
+Trigger to revisit:
+  Deciding to ship daemonless `run` as product direction, or recurring user
+  friction reports about the `daemon up` prerequisite. Wave 2 must land
+  first.

--- a/specs/20260610T193000-cli-daemon-collapse-waves.md
+++ b/specs/20260610T193000-cli-daemon-collapse-waves.md
@@ -1,6 +1,6 @@
 # CLI/daemon collapse waves
 
-Status: wave 1 implemented; wave 2 owed; wave 3 deferred with triggers.
+Status: waves 1-2 implemented; wave 3 deferred with triggers.
 
 Source: greenfield clean-break consult on the CLI/daemon shape, plus a
 latency experiment for daemonless one-shot `run`.
@@ -64,22 +64,35 @@ Wire compatibility was explicitly refused: no `/invoke` or `/dispatch`
 aliases remain. CLI and daemon ship together from this repo; there is no
 published contract that earns an alias.
 
-## Wave 2: materializer drain on teardown (owed, not yet done)
+## Wave 2: materializer drain on teardown (implemented)
 
-`attachMarkdownExport` starts its initial flush as a fire-and-forget promise
-(`whenFlushed`, `export.ts`), and row renders triggered by observers are
-also unawaited. Nothing in the mount dispose chain drains them.
+The bug: `attachMarkdownExport` started its initial flush as a
+fire-and-forget promise (`whenFlushed`, `export.ts`) and aborted it at the
+first dispose check; row renders triggered by observers were also unawaited.
+The SQLite materializer had the same shape: dispose cancelled the debounced
+flush (dropping `pendingSync`) and the initial DDL + full-load aborted on a
+dispose-immediately. Nothing in the mount dispose chain drained any of it,
+so `epicenter daemon down` shortly after a mutation could drop projection
+writes mid-flight.
 
-This is a live bug in the current daemon: `epicenter daemon down` (SIGTERM)
-shortly after a mutation can drop markdown projection writes mid-flight. It
-is also a hard precondition for any daemonless one-shot mode.
+The fix, in three layers:
 
-Fix shape: mount/runtime dispose awaits pending materializer work (or the
-teardown drains explicitly before `ydoc.destroy()`), with a bounded timeout
-so a hung HTTP body read cannot wedge shutdown.
-
-Trigger to do it: next time anyone touches the markdown materializer or
-daemon teardown, or before wave 3 starts; it should not wait for wave 3.
+- Both materializers now drain on dispose and expose a `whenDisposed`
+  barrier (per the attach-primitive invariant): the markdown export awaits
+  the initial flush plus in-flight observer render batches; the SQLite core
+  flushes the pending row set through its db queue before closing. Each
+  drain is bounded by a per-materializer `disposeTimeoutMs` (default 10 s)
+  so a hung HTTP body read or statement cannot wedge shutdown.
+- A `waitFor` gate that never opened owes nothing: disposing before the
+  gate resolves abandons the flush instead of sitting out the timeout, and
+  the flush bails if the gate opens after dispose. Draining after
+  `ydoc.destroy()` is safe because YKV reads come from in-memory maps that
+  survive doc destruction.
+- `attachProjectInfrastructure` takes a `materializers` list and its
+  `[Symbol.asyncDispose]` awaits their `whenDisposed` barriers alongside
+  collaboration and log teardown; the fuji, honeycrisp, and tab-manager
+  mounts register their sqlite + markdown attachments there, and the
+  daemon's teardown stack already awaits each runtime's async dispose.
 
 ## Wave 3: daemonless `run` (deferred)
 


### PR DESCRIPTION
The daemon had two overlapping action paths: invoke and dispatch. This PR collapses that into one `/run` route, then tightens the CLI around it so project setup is explicit and daemon discovery is easier to read.

The command surface now looks like this:

```bash
epicenter init
epicenter daemon up -C ~/workspace
epicenter list -C ~/workspace
epicenter run fuji.entries_update '{"id":"entry_1"}' -C ~/workspace
```

`daemon up` stops scaffolding project files as a side effect. `epicenter init` owns that setup step. `list` groups actions by mount, and `ps` trusts socket pings instead of mixing process state with daemon liveness.

The same pass also makes projection teardown wait for work that is already in flight. Markdown and SQLite materializers now expose `whenDisposed`; daemon mount teardown awaits those barriers so a quick `daemon down` after a mutation does not drop pending projection writes. Each drain is bounded, so a stuck render or statement cannot wedge shutdown forever.

## Changelog

- Added `epicenter init` for project scaffolding.
- Changed `epicenter daemon up` so it no longer creates project files implicitly.
- Collapsed daemon action invocation onto one `/run` route.
- Made daemon teardown drain pending Markdown and SQLite materializer writes before exit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783738414&installation_id=128463665&pr_number=1909&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1909&signature=197e75641f7557d3c5dab10d1ae41828d615eccf4e0988b42e259e756c6375f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->