### PR TITLE
feat(matter): add markdown live preview

### DIFF
--- a/apps/matter/package.json
+++ b/apps/matter/package.json
@@ -37,6 +37,7 @@
 		"@codemirror/state": "^6.6.0",
 		"@codemirror/view": "^6.41.0",
 		"@epicenter/field": "workspace:*",
+		"@lezer/common": "^1.5.1",
 		"@tauri-apps/api": "catalog:",
 		"@tauri-apps/plugin-dialog": "^2.3.2",
 		"typebox": "catalog:",

--- a/apps/matter/package.json
+++ b/apps/matter/package.json
@@ -38,6 +38,7 @@
 		"@codemirror/view": "^6.41.0",
 		"@epicenter/field": "workspace:*",
 		"@lezer/common": "^1.5.1",
+		"@lezer/highlight": "^1.2.3",
 		"@tauri-apps/api": "catalog:",
 		"@tauri-apps/plugin-dialog": "^2.3.2",
 		"typebox": "catalog:",

--- a/apps/matter/package.json
+++ b/apps/matter/package.json
@@ -33,6 +33,7 @@
 	"dependencies": {
 		"@codemirror/commands": "^6.10.3",
 		"@codemirror/lang-markdown": "^6.5.0",
+		"@codemirror/language": "^6.12.3",
 		"@codemirror/state": "^6.6.0",
 		"@codemirror/view": "^6.41.0",
 		"@epicenter/field": "workspace:*",

--- a/apps/matter/src/lib/components/MarkdownBodyEditor.svelte
+++ b/apps/matter/src/lib/components/MarkdownBodyEditor.svelte
@@ -8,6 +8,7 @@
 		keymap,
 		placeholder,
 	} from '@codemirror/view';
+	import { markdownLivePreview } from '$lib/editor/markdown-live-preview';
 
 	let {
 		body,
@@ -42,6 +43,7 @@
 					drawSelection(),
 					EditorView.lineWrapping,
 					markdown(),
+					markdownLivePreview(),
 					placeholder('Start writing'),
 					EditorView.updateListener.of((update) => {
 						if (update.docChanged) draft = update.state.doc.toString();

--- a/apps/matter/src/lib/editor/markdown-live-preview.test.ts
+++ b/apps/matter/src/lib/editor/markdown-live-preview.test.ts
@@ -123,6 +123,19 @@ describe('collectMarkdownLivePreviewRanges', () => {
 		expect(hiddenText).toEqual(['#']);
 	});
 
+	test('marks only the label when a link title contains "]("', () => {
+		const doc = '[x](u "a](b")\nplain';
+		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));
+		const linkText = collectMarkedText(
+			doc,
+			doc.indexOf('plain'),
+			'cm-matter-md-link',
+		);
+
+		expect(linkText).toEqual(['x']);
+		expect(hiddenText).toEqual(['[', ']', '(', 'u', '"a](b"', ')']);
+	});
+
 	test('leaves images, reference links, and autolinks raw', () => {
 		const doc = '![alt](image.png)\n[label][ref]\n<https://example.com>\nplain';
 		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));
@@ -171,5 +184,6 @@ function collectRangeText(
 		{ from: 0, to: state.doc.length },
 	])
 		.filter(matches)
+		.toSorted((left, right) => left.from - right.from || left.to - right.to)
 		.map((range) => state.doc.sliceString(range.from, range.to));
 }

--- a/apps/matter/src/lib/editor/markdown-live-preview.test.ts
+++ b/apps/matter/src/lib/editor/markdown-live-preview.test.ts
@@ -85,20 +85,11 @@ describe('collectMarkdownLivePreviewRanges', () => {
 		]);
 	});
 
-	test('splits hidden link titles at line boundaries', () => {
+	test('leaves multi-line link syntax raw', () => {
 		const doc = '[label](https://example.com "two\nline title")\nplain';
 		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));
 
-		expect(hiddenText).toEqual([
-			'[',
-			']',
-			'(',
-			'https://example.com',
-			'"two',
-			'line title"',
-			')',
-		]);
-		expect(hiddenText.every((text) => !text.includes('\n'))).toBe(true);
+		expect(hiddenText).toEqual([]);
 	});
 
 	test('leaves nested image syntax raw inside a link label', () => {

--- a/apps/matter/src/lib/editor/markdown-live-preview.test.ts
+++ b/apps/matter/src/lib/editor/markdown-live-preview.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 import { markdown } from '@codemirror/lang-markdown';
 import { EditorSelection, EditorState } from '@codemirror/state';
-import { collectMarkdownLivePreviewRanges } from './markdown-live-preview.js';
+import { collectHiddenMarkerRanges } from './markdown-live-preview.js';
 
-describe('collectMarkdownLivePreviewRanges', () => {
+describe('collectHiddenMarkerRanges', () => {
 	test('hides a heading marker on an inactive line', () => {
 		const doc = '# Heading\nplain';
 		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));
@@ -46,17 +46,6 @@ describe('collectMarkdownLivePreviewRanges', () => {
 		expect(hiddenText).toEqual(['##', '##']);
 	});
 
-	test('marks the whole heading construct including its markers', () => {
-		const doc = '# Heading\nplain';
-		const headingText = collectMarkedText(
-			doc,
-			doc.indexOf('plain'),
-			'cm-matter-md-heading',
-		);
-
-		expect(headingText).toEqual(['# Heading']);
-	});
-
 	test('does not hide setext heading markers', () => {
 		const doc = 'Title\n=====\nplain';
 		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));
@@ -95,14 +84,8 @@ describe('collectMarkdownLivePreviewRanges', () => {
 	test('leaves nested image syntax raw inside a link label', () => {
 		const doc = '[![alt](img.png)](https://example.com)\nplain';
 		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));
-		const linkText = collectMarkedText(
-			doc,
-			doc.indexOf('plain'),
-			'cm-matter-md-link',
-		);
 
 		expect(hiddenText).toEqual(['[', ']', '(', 'https://example.com', ')']);
-		expect(linkText).toEqual(['![alt](img.png)']);
 	});
 
 	test('leaves nested autolink syntax raw inside a link label', () => {
@@ -132,16 +115,10 @@ describe('collectMarkdownLivePreviewRanges', () => {
 		expect(hiddenText).toEqual(['#']);
 	});
 
-	test('marks only the label when a link title contains "]("', () => {
+	test('hides link syntax when a title contains "]("', () => {
 		const doc = '[x](u "a](b")\nplain';
 		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));
-		const linkText = collectMarkedText(
-			doc,
-			doc.indexOf('plain'),
-			'cm-matter-md-link',
-		);
 
-		expect(linkText).toEqual(['x']);
 		expect(hiddenText).toEqual(['[', ']', '(', 'u', '"a](b"', ')']);
 	});
 
@@ -157,29 +134,6 @@ function collectHiddenText(
 	doc: string,
 	selection: number | EditorSelection,
 ): string[] {
-	return collectRangeText(doc, selection, (range) => range.type === 'hide');
-}
-
-function collectMarkedText(
-	doc: string,
-	selection: number | EditorSelection,
-	className: string,
-): string[] {
-	return collectRangeText(
-		doc,
-		selection,
-		(range) =>
-			range.type === 'mark' && range.className.split(' ').includes(className),
-	);
-}
-
-function collectRangeText(
-	doc: string,
-	selection: number | EditorSelection,
-	matches: (
-		range: ReturnType<typeof collectMarkdownLivePreviewRanges>[number],
-	) => boolean,
-): string[] {
 	const state = EditorState.create({
 		doc,
 		extensions: [EditorState.allowMultipleSelections.of(true), markdown()],
@@ -189,10 +143,7 @@ function collectRangeText(
 				: selection,
 	});
 
-	return collectMarkdownLivePreviewRanges(state, [
-		{ from: 0, to: state.doc.length },
-	])
-		.filter(matches)
+	return collectHiddenMarkerRanges(state, [{ from: 0, to: state.doc.length }])
 		.toSorted((left, right) => left.from - right.from || left.to - right.to)
 		.map((range) => state.doc.sliceString(range.from, range.to));
 }

--- a/apps/matter/src/lib/editor/markdown-live-preview.test.ts
+++ b/apps/matter/src/lib/editor/markdown-live-preview.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from 'bun:test';
+import { markdown } from '@codemirror/lang-markdown';
+import { EditorSelection, EditorState } from '@codemirror/state';
+import { collectMarkdownLivePreviewRanges } from './markdown-live-preview.js';
+
+describe('collectMarkdownLivePreviewRanges', () => {
+	test('hides a heading marker on an inactive line', () => {
+		const doc = '# Heading\nplain';
+		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));
+
+		expect(hiddenText).toEqual(['#']);
+	});
+
+	test('keeps a heading marker visible when selection overlaps the line', () => {
+		const doc = '# Heading\nplain';
+		const hiddenText = collectHiddenText(doc, doc.indexOf('Heading'));
+
+		expect(hiddenText).toEqual([]);
+	});
+
+	test('hides emphasis markers on inactive lines', () => {
+		const doc = '**bold** and *em*\nplain';
+		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));
+
+		expect(hiddenText).toEqual(['**', '**', '*', '*']);
+	});
+
+	test('hides inline-code backticks on inactive lines', () => {
+		const doc = '`code`\nplain';
+		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));
+
+		expect(hiddenText).toEqual(['`', '`']);
+	});
+
+	test('does not hide fenced-code markers', () => {
+		const doc = '```js\nconst value = 1;\n```\nplain';
+		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));
+
+		expect(hiddenText).toEqual([]);
+	});
+
+	test('does not hide setext heading markers', () => {
+		const doc = 'Title\n=====\nplain';
+		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));
+
+		expect(hiddenText).toEqual([]);
+	});
+
+	test('reveals every marker in a multi-line emphasis span', () => {
+		const doc = '*foo\nbar*\nplain';
+		const hiddenText = collectHiddenText(doc, doc.indexOf('foo'));
+
+		expect(hiddenText).toEqual([]);
+	});
+
+	test('hides inline-link URL syntax on inactive lines', () => {
+		const doc = '[label](https://example.com "Title")\nplain';
+		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));
+
+		expect(hiddenText).toEqual([
+			'[',
+			']',
+			'(',
+			'https://example.com',
+			'"Title"',
+			')',
+		]);
+	});
+
+	test('splits hidden link titles at line boundaries', () => {
+		const doc = '[label](https://example.com "two\nline title")\nplain';
+		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));
+
+		expect(hiddenText).toEqual([
+			'[',
+			']',
+			'(',
+			'https://example.com',
+			'"two',
+			'line title"',
+			')',
+		]);
+		expect(hiddenText.every((text) => !text.includes('\n'))).toBe(true);
+	});
+
+	test('leaves nested image syntax raw inside a link label', () => {
+		const doc = '[![alt](img.png)](https://example.com)\nplain';
+		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));
+		const linkText = collectMarkedText(
+			doc,
+			doc.indexOf('plain'),
+			'cm-matter-md-link',
+		);
+
+		expect(hiddenText).toEqual(['[', ']', '(', 'https://example.com', ')']);
+		expect(linkText).toEqual(['![alt](img.png)']);
+	});
+
+	test('leaves nested autolink syntax raw inside a link label', () => {
+		const doc = '[<https://label.example>](https://example.com)\nplain';
+		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));
+
+		expect(hiddenText).toEqual(['[', ']', '(', 'https://example.com', ')']);
+	});
+
+	test('does not hide list bullets or blockquote markers', () => {
+		const doc = '- item\n> quote\nplain';
+		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));
+
+		expect(hiddenText).toEqual([]);
+	});
+
+	test('multi-range selection reveals every overlapped line', () => {
+		const doc = '# One\n# Two\n# Three';
+		const hiddenText = collectHiddenText(
+			doc,
+			EditorSelection.create([
+				EditorSelection.cursor(doc.indexOf('One')),
+				EditorSelection.cursor(doc.indexOf('Three')),
+			]),
+		);
+
+		expect(hiddenText).toEqual(['#']);
+	});
+
+	test('leaves images, reference links, and autolinks raw', () => {
+		const doc = '![alt](image.png)\n[label][ref]\n<https://example.com>\nplain';
+		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));
+
+		expect(hiddenText).toEqual([]);
+	});
+});
+
+function collectHiddenText(
+	doc: string,
+	selection: number | EditorSelection,
+): string[] {
+	return collectRangeText(doc, selection, (range) => range.type === 'hide');
+}
+
+function collectMarkedText(
+	doc: string,
+	selection: number | EditorSelection,
+	className: string,
+): string[] {
+	return collectRangeText(
+		doc,
+		selection,
+		(range) =>
+			range.type === 'mark' && range.className.split(' ').includes(className),
+	);
+}
+
+function collectRangeText(
+	doc: string,
+	selection: number | EditorSelection,
+	matches: (
+		range: ReturnType<typeof collectMarkdownLivePreviewRanges>[number],
+	) => boolean,
+): string[] {
+	const state = EditorState.create({
+		doc,
+		extensions: [EditorState.allowMultipleSelections.of(true), markdown()],
+		selection:
+			typeof selection === 'number'
+				? EditorSelection.cursor(selection)
+				: selection,
+	});
+
+	return collectMarkdownLivePreviewRanges(state, [
+		{ from: 0, to: state.doc.length },
+	])
+		.filter(matches)
+		.map((range) => state.doc.sliceString(range.from, range.to));
+}

--- a/apps/matter/src/lib/editor/markdown-live-preview.test.ts
+++ b/apps/matter/src/lib/editor/markdown-live-preview.test.ts
@@ -39,6 +39,24 @@ describe('collectMarkdownLivePreviewRanges', () => {
 		expect(hiddenText).toEqual([]);
 	});
 
+	test('hides closing heading marks on inactive lines', () => {
+		const doc = '## Closing ##\nplain';
+		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));
+
+		expect(hiddenText).toEqual(['##', '##']);
+	});
+
+	test('marks the whole heading construct including its markers', () => {
+		const doc = '# Heading\nplain';
+		const headingText = collectMarkedText(
+			doc,
+			doc.indexOf('plain'),
+			'cm-matter-md-heading',
+		);
+
+		expect(headingText).toEqual(['# Heading']);
+	});
+
 	test('does not hide setext heading markers', () => {
 		const doc = 'Title\n=====\nplain';
 		const hiddenText = collectHiddenText(doc, doc.indexOf('plain'));

--- a/apps/matter/src/lib/editor/markdown-live-preview.ts
+++ b/apps/matter/src/lib/editor/markdown-live-preview.ts
@@ -1,0 +1,433 @@
+import { syntaxTree } from '@codemirror/language';
+import type { EditorState, Extension } from '@codemirror/state';
+import {
+	Decoration,
+	type DecorationSet,
+	EditorView,
+	type PluginValue,
+	ViewPlugin,
+	type ViewUpdate,
+} from '@codemirror/view';
+
+type VisibleRange = {
+	from: number;
+	to: number;
+};
+
+type SyntaxContext = {
+	name: string;
+	from: number;
+	to: number;
+	isInlineLink?: boolean;
+};
+
+type MarkdownLivePreviewRange =
+	| {
+			type: 'hide';
+			from: number;
+			to: number;
+	  }
+	| {
+			type: 'mark';
+			from: number;
+			to: number;
+			className: string;
+	  };
+
+const headingPattern = /^ATXHeading([1-6])$/;
+
+export function collectMarkdownLivePreviewRanges(
+	state: EditorState,
+	visibleRanges: readonly VisibleRange[],
+): MarkdownLivePreviewRange[] {
+	const activeLines = collectActiveLines(state);
+	const ranges: MarkdownLivePreviewRange[] = [];
+
+	for (const visibleRange of visibleRanges) {
+		const contexts: SyntaxContext[] = [];
+
+		syntaxTree(state).iterate({
+			from: visibleRange.from,
+			to: visibleRange.to,
+			enter(node) {
+				const name = node.type.name;
+				const headingMatch = headingPattern.exec(name);
+				const linkInfo =
+					name === 'Link'
+						? getInlineLinkInfo(
+								state.doc.sliceString(node.from, node.to),
+								node.from,
+							)
+						: null;
+
+				if (headingMatch) {
+					const level = headingMatch[1];
+					const contentRange = getHeadingContentRange(
+						state.doc.sliceString(node.from, node.to),
+						node.from,
+						node.to,
+					);
+
+					if (contentRange) {
+						addMark(
+							ranges,
+							contentRange.from,
+							contentRange.to,
+							`cm-matter-md-heading cm-matter-md-heading-${level}`,
+						);
+					}
+				}
+
+				if (name === 'Emphasis' || name === 'StrongEmphasis') {
+					const markerLength = name === 'StrongEmphasis' ? 2 : 1;
+					addMark(
+						ranges,
+						node.from + markerLength,
+						node.to - markerLength,
+						name === 'StrongEmphasis'
+							? 'cm-matter-md-strong'
+							: 'cm-matter-md-emphasis',
+					);
+				}
+
+				if (name === 'InlineCode') {
+					const contentRange = getInlineCodeContentRange(
+						state.doc.sliceString(node.from, node.to),
+						node.from,
+						node.to,
+					);
+
+					if (contentRange) {
+						addMark(
+							ranges,
+							contentRange.from,
+							contentRange.to,
+							'cm-matter-md-inline-code',
+						);
+					}
+				}
+
+				if (linkInfo) {
+					addMark(
+						ranges,
+						linkInfo.labelFrom,
+						linkInfo.labelTo,
+						'cm-matter-md-link',
+					);
+				}
+
+				if (name === 'ListMark' || name === 'QuoteMark') {
+					addMark(ranges, node.from, node.to, 'cm-matter-md-structural-marker');
+				}
+
+				const activeRange = getHideActiveRange(name, contexts);
+				if (activeRange && !isActiveRange(state, activeLines, activeRange)) {
+					addHide(ranges, state, node.from, node.to);
+				}
+
+				contexts.push({
+					name,
+					from: node.from,
+					to: node.to,
+					isInlineLink: linkInfo !== null,
+				});
+			},
+			leave() {
+				contexts.pop();
+			},
+		});
+	}
+
+	return uniqueSortedRanges(ranges);
+}
+
+export function markdownLivePreview(): Extension {
+	return [markdownLivePreviewPlugin, markdownLivePreviewTheme];
+}
+
+const markdownLivePreviewPlugin = ViewPlugin.define(
+	(view): PluginValue & { decorations: DecorationSet } => ({
+		decorations: buildDecorations(view),
+		update(update: ViewUpdate) {
+			if (
+				update.docChanged ||
+				update.selectionSet ||
+				update.viewportChanged ||
+				syntaxTree(update.state) !== syntaxTree(update.startState)
+			) {
+				this.decorations = buildDecorations(update.view);
+			}
+		},
+	}),
+	{
+		decorations: (plugin) => plugin.decorations,
+	},
+);
+
+const markdownLivePreviewTheme = EditorView.baseTheme({
+	'.cm-matter-md-heading': {
+		fontWeight: '700',
+		color: 'hsl(var(--foreground))',
+	},
+	'.cm-matter-md-heading-1': {
+		fontSize: '1.25em',
+	},
+	'.cm-matter-md-heading-2': {
+		fontSize: '1.15em',
+	},
+	'.cm-matter-md-heading-3': {
+		fontSize: '1.08em',
+	},
+	'.cm-matter-md-heading-4, .cm-matter-md-heading-5, .cm-matter-md-heading-6': {
+		fontSize: '1em',
+	},
+	'.cm-matter-md-strong': {
+		fontWeight: '700',
+	},
+	'.cm-matter-md-emphasis': {
+		fontStyle: 'italic',
+	},
+	'.cm-matter-md-inline-code': {
+		borderRadius: '0.25rem',
+		backgroundColor: 'hsl(var(--muted))',
+		color: 'hsl(var(--foreground))',
+		padding: '0.05rem 0.25rem',
+	},
+	'.cm-matter-md-link': {
+		color: 'hsl(var(--primary))',
+		textDecoration: 'underline',
+		textDecorationColor: 'hsl(var(--primary) / 0.45)',
+		textUnderlineOffset: '0.18em',
+	},
+	'.cm-matter-md-structural-marker': {
+		color: 'hsl(var(--muted-foreground))',
+		fontWeight: '500',
+	},
+});
+
+function buildDecorations(view: EditorView): DecorationSet {
+	return Decoration.set(
+		collectMarkdownLivePreviewRanges(view.state, view.visibleRanges).map(
+			(range) => {
+				if (range.type === 'hide') {
+					return Decoration.replace({}).range(range.from, range.to);
+				}
+
+				return Decoration.mark({ class: range.className }).range(
+					range.from,
+					range.to,
+				);
+			},
+		),
+		true,
+	);
+}
+
+function collectActiveLines(state: EditorState): Set<number> {
+	const activeLines = new Set<number>();
+
+	for (const range of state.selection.ranges) {
+		const fromLine = state.doc.lineAt(range.from).number;
+		const toLine = state.doc.lineAt(range.to).number;
+
+		for (let lineNumber = fromLine; lineNumber <= toLine; lineNumber += 1) {
+			activeLines.add(lineNumber);
+		}
+	}
+
+	return activeLines;
+}
+
+function isActiveRange(
+	state: EditorState,
+	activeLines: Set<number>,
+	range: VisibleRange,
+): boolean {
+	const fromLine = state.doc.lineAt(range.from).number;
+	const toLine = state.doc.lineAt(range.to).number;
+
+	for (let lineNumber = fromLine; lineNumber <= toLine; lineNumber += 1) {
+		if (activeLines.has(lineNumber)) return true;
+	}
+
+	return false;
+}
+
+function getHideActiveRange(
+	name: string,
+	contexts: readonly SyntaxContext[],
+): VisibleRange | null {
+	if (name === 'HeaderMark') {
+		return getClosestContext(contexts, (context) =>
+			headingPattern.test(context.name),
+		);
+	}
+
+	if (name === 'EmphasisMark') {
+		return getClosestContext(
+			contexts,
+			(context) =>
+				context.name === 'Emphasis' || context.name === 'StrongEmphasis',
+		);
+	}
+
+	if (name === 'CodeMark') {
+		return getClosestContext(
+			contexts,
+			(context) => context.name === 'InlineCode',
+		);
+	}
+
+	if (name !== 'LinkMark' && name !== 'URL' && name !== 'LinkTitle') {
+		return null;
+	}
+
+	const context = getCurrentLinkContext(contexts);
+	return context?.name === 'Link' && context.isInlineLink === true
+		? context
+		: null;
+}
+
+function getClosestContext(
+	contexts: readonly SyntaxContext[],
+	matches: (context: SyntaxContext) => boolean,
+): SyntaxContext | null {
+	for (let index = contexts.length - 1; index >= 0; index -= 1) {
+		const context = contexts[index];
+		if (context && matches(context)) return context;
+	}
+
+	return null;
+}
+
+function getCurrentLinkContext(
+	contexts: readonly SyntaxContext[],
+): SyntaxContext | undefined {
+	for (let index = contexts.length - 1; index >= 0; index -= 1) {
+		const context = contexts[index];
+		if (
+			context?.name === 'Link' ||
+			context?.name === 'Image' ||
+			context?.name === 'Autolink'
+		) {
+			return context;
+		}
+	}
+}
+
+function getInlineLinkInfo(
+	text: string,
+	nodeFrom: number,
+): {
+	labelFrom: number;
+	labelTo: number;
+} | null {
+	const labelEnd = text.lastIndexOf('](');
+	if (labelEnd <= 1 || !text.endsWith(')')) return null;
+
+	return {
+		labelFrom: nodeFrom + 1,
+		labelTo: nodeFrom + labelEnd,
+	};
+}
+
+function getHeadingContentRange(
+	text: string,
+	nodeFrom: number,
+	nodeTo: number,
+): VisibleRange | null {
+	const opening = /^(#{1,6})[ \t]*/.exec(text);
+	if (!opening) return null;
+
+	const closing = /[ \t]+#{1,6}[ \t]*$/.exec(text);
+	const from = nodeFrom + opening[0].length;
+	const to = closing?.index === undefined ? nodeTo : nodeFrom + closing.index;
+
+	return from < to ? { from, to } : null;
+}
+
+function getInlineCodeContentRange(
+	text: string,
+	nodeFrom: number,
+	nodeTo: number,
+): VisibleRange | null {
+	const opening = /^`+/.exec(text);
+	const closing = /`+$/.exec(text);
+	if (!opening || !closing) return null;
+
+	const from = nodeFrom + opening[0].length;
+	const to = nodeTo - closing[0].length;
+
+	return from < to ? { from, to } : null;
+}
+
+function addHide(
+	ranges: MarkdownLivePreviewRange[],
+	state: EditorState,
+	from: number,
+	to: number,
+) {
+	let cursor = from;
+
+	while (cursor < to) {
+		const line = state.doc.lineAt(cursor);
+		const lineTo = Math.min(to, line.to);
+
+		if (cursor < lineTo) {
+			ranges.push({ type: 'hide', from: cursor, to: lineTo });
+		}
+
+		if (lineTo >= to) return;
+
+		const nextLineNumber = line.number + 1;
+		if (nextLineNumber > state.doc.lines) return;
+		cursor = state.doc.line(nextLineNumber).from;
+	}
+}
+
+function addMark(
+	ranges: MarkdownLivePreviewRange[],
+	from: number,
+	to: number,
+	className: string,
+) {
+	if (from >= to) return;
+	ranges.push({ type: 'mark', from, to, className });
+}
+
+function uniqueSortedRanges(
+	ranges: MarkdownLivePreviewRange[],
+): MarkdownLivePreviewRange[] {
+	const sortedRanges = ranges.toSorted(compareRanges);
+	const uniqueRanges: MarkdownLivePreviewRange[] = [];
+	const seen = new Set<string>();
+
+	for (const range of sortedRanges) {
+		const key =
+			range.type === 'hide'
+				? `${range.type}:${range.from}:${range.to}`
+				: `${range.type}:${range.from}:${range.to}:${range.className}`;
+
+		if (seen.has(key)) continue;
+		seen.add(key);
+		uniqueRanges.push(range);
+	}
+
+	return uniqueRanges;
+}
+
+function compareRanges(
+	left: MarkdownLivePreviewRange,
+	right: MarkdownLivePreviewRange,
+): number {
+	return (
+		left.from - right.from ||
+		left.to - right.to ||
+		left.type.localeCompare(right.type) ||
+		getRangeClassName(left).localeCompare(getRangeClassName(right))
+	);
+}
+
+function getRangeClassName(range: MarkdownLivePreviewRange): string {
+	return range.type === 'mark' ? range.className : '';
+}

--- a/apps/matter/src/lib/editor/markdown-live-preview.ts
+++ b/apps/matter/src/lib/editor/markdown-live-preview.ts
@@ -4,12 +4,11 @@ import {
 	Decoration,
 	type DecorationSet,
 	EditorView,
-	type PluginValue,
 	ViewPlugin,
 	type ViewUpdate,
 } from '@codemirror/view';
 
-type VisibleRange = {
+type Span = {
 	from: number;
 	to: number;
 };
@@ -38,7 +37,7 @@ const headingPattern = /^ATXHeading([1-6])$/;
 
 export function collectMarkdownLivePreviewRanges(
 	state: EditorState,
-	visibleRanges: readonly VisibleRange[],
+	visibleRanges: readonly Span[],
 ): MarkdownLivePreviewRange[] {
 	const activeLines = collectActiveLines(state);
 	const ranges: MarkdownLivePreviewRange[] = [];
@@ -52,13 +51,18 @@ export function collectMarkdownLivePreviewRanges(
 			enter(node) {
 				const name = node.type.name;
 				const headingMatch = headingPattern.exec(name);
-				const linkInfo =
-					name === 'Link'
-						? getInlineLinkInfo(
-								state.doc.sliceString(node.from, node.to),
-								node.from,
-							)
-						: null;
+				let linkLabel: Span | null = null;
+				if (name === 'Link') {
+					const link = node.node;
+					// Only inline links carry a URL child; reference and
+					// shortcut links carry a LinkLabel instead.
+					if (link.getChild('URL')) {
+						const [labelOpen, labelClose] = link.getChildren('LinkMark');
+						if (labelOpen && labelClose && labelOpen.to < labelClose.from) {
+							linkLabel = { from: labelOpen.to, to: labelClose.from };
+						}
+					}
+				}
 
 				if (headingMatch) {
 					const level = headingMatch[1];
@@ -107,21 +111,16 @@ export function collectMarkdownLivePreviewRanges(
 					}
 				}
 
-				if (linkInfo) {
-					addMark(
-						ranges,
-						linkInfo.labelFrom,
-						linkInfo.labelTo,
-						'cm-matter-md-link',
-					);
+				if (linkLabel) {
+					addMark(ranges, linkLabel.from, linkLabel.to, 'cm-matter-md-link');
 				}
 
 				if (name === 'ListMark' || name === 'QuoteMark') {
 					addMark(ranges, node.from, node.to, 'cm-matter-md-structural-marker');
 				}
 
-				const activeRange = getHideActiveRange(name, contexts);
-				if (activeRange && !isActiveRange(state, activeLines, activeRange)) {
+				const revealScope = getRevealScope(name, contexts);
+				if (revealScope && !isActiveRange(state, activeLines, revealScope)) {
 					addHide(ranges, state, node.from, node.to);
 				}
 
@@ -129,7 +128,7 @@ export function collectMarkdownLivePreviewRanges(
 					name,
 					from: node.from,
 					to: node.to,
-					isInlineLink: linkInfo !== null,
+					isInlineLink: linkLabel !== null,
 				});
 			},
 			leave() {
@@ -138,7 +137,7 @@ export function collectMarkdownLivePreviewRanges(
 		});
 	}
 
-	return uniqueSortedRanges(ranges);
+	return ranges;
 }
 
 export function markdownLivePreview(): Extension {
@@ -146,7 +145,7 @@ export function markdownLivePreview(): Extension {
 }
 
 const markdownLivePreviewPlugin = ViewPlugin.define(
-	(view): PluginValue & { decorations: DecorationSet } => ({
+	(view) => ({
 		decorations: buildDecorations(view),
 		update(update: ViewUpdate) {
 			if (
@@ -205,12 +204,14 @@ const markdownLivePreviewTheme = EditorView.baseTheme({
 	},
 });
 
+const hideDecoration = Decoration.replace({});
+
 function buildDecorations(view: EditorView): DecorationSet {
 	return Decoration.set(
 		collectMarkdownLivePreviewRanges(view.state, view.visibleRanges).map(
 			(range) => {
 				if (range.type === 'hide') {
-					return Decoration.replace({}).range(range.from, range.to);
+					return hideDecoration.range(range.from, range.to);
 				}
 
 				return Decoration.mark({ class: range.className }).range(
@@ -241,7 +242,7 @@ function collectActiveLines(state: EditorState): Set<number> {
 function isActiveRange(
 	state: EditorState,
 	activeLines: Set<number>,
-	range: VisibleRange,
+	range: Span,
 ): boolean {
 	const fromLine = state.doc.lineAt(range.from).number;
 	const toLine = state.doc.lineAt(range.to).number;
@@ -253,10 +254,10 @@ function isActiveRange(
 	return false;
 }
 
-function getHideActiveRange(
+function getRevealScope(
 	name: string,
 	contexts: readonly SyntaxContext[],
-): VisibleRange | null {
+): Span | null {
 	if (name === 'HeaderMark') {
 		return getClosestContext(contexts, (context) =>
 			headingPattern.test(context.name),
@@ -282,7 +283,13 @@ function getHideActiveRange(
 		return null;
 	}
 
-	const context = getCurrentLinkContext(contexts);
+	const context = getClosestContext(
+		contexts,
+		(candidate) =>
+			candidate.name === 'Link' ||
+			candidate.name === 'Image' ||
+			candidate.name === 'Autolink',
+	);
 	return context?.name === 'Link' && context.isInlineLink === true
 		? context
 		: null;
@@ -300,42 +307,11 @@ function getClosestContext(
 	return null;
 }
 
-function getCurrentLinkContext(
-	contexts: readonly SyntaxContext[],
-): SyntaxContext | undefined {
-	for (let index = contexts.length - 1; index >= 0; index -= 1) {
-		const context = contexts[index];
-		if (
-			context?.name === 'Link' ||
-			context?.name === 'Image' ||
-			context?.name === 'Autolink'
-		) {
-			return context;
-		}
-	}
-}
-
-function getInlineLinkInfo(
-	text: string,
-	nodeFrom: number,
-): {
-	labelFrom: number;
-	labelTo: number;
-} | null {
-	const labelEnd = text.lastIndexOf('](');
-	if (labelEnd <= 1 || !text.endsWith(')')) return null;
-
-	return {
-		labelFrom: nodeFrom + 1,
-		labelTo: nodeFrom + labelEnd,
-	};
-}
-
 function getHeadingContentRange(
 	text: string,
 	nodeFrom: number,
 	nodeTo: number,
-): VisibleRange | null {
+): Span | null {
 	const opening = /^(#{1,6})[ \t]*/.exec(text);
 	if (!opening) return null;
 
@@ -350,7 +326,7 @@ function getInlineCodeContentRange(
 	text: string,
 	nodeFrom: number,
 	nodeTo: number,
-): VisibleRange | null {
+): Span | null {
 	const opening = /^`+/.exec(text);
 	const closing = /`+$/.exec(text);
 	if (!opening || !closing) return null;
@@ -367,6 +343,8 @@ function addHide(
 	from: number,
 	to: number,
 ) {
+	// CodeMirror rejects plugin-provided replace decorations that span line
+	// breaks, so hidden ranges are emitted per line.
 	let cursor = from;
 
 	while (cursor < to) {
@@ -393,41 +371,4 @@ function addMark(
 ) {
 	if (from >= to) return;
 	ranges.push({ type: 'mark', from, to, className });
-}
-
-function uniqueSortedRanges(
-	ranges: MarkdownLivePreviewRange[],
-): MarkdownLivePreviewRange[] {
-	const sortedRanges = ranges.toSorted(compareRanges);
-	const uniqueRanges: MarkdownLivePreviewRange[] = [];
-	const seen = new Set<string>();
-
-	for (const range of sortedRanges) {
-		const key =
-			range.type === 'hide'
-				? `${range.type}:${range.from}:${range.to}`
-				: `${range.type}:${range.from}:${range.to}:${range.className}`;
-
-		if (seen.has(key)) continue;
-		seen.add(key);
-		uniqueRanges.push(range);
-	}
-
-	return uniqueRanges;
-}
-
-function compareRanges(
-	left: MarkdownLivePreviewRange,
-	right: MarkdownLivePreviewRange,
-): number {
-	return (
-		left.from - right.from ||
-		left.to - right.to ||
-		left.type.localeCompare(right.type) ||
-		getRangeClassName(left).localeCompare(getRangeClassName(right))
-	);
-}
-
-function getRangeClassName(range: MarkdownLivePreviewRange): string {
-	return range.type === 'mark' ? range.className : '';
 }

--- a/apps/matter/src/lib/editor/markdown-live-preview.ts
+++ b/apps/matter/src/lib/editor/markdown-live-preview.ts
@@ -1,4 +1,8 @@
-import { syntaxTree } from '@codemirror/language';
+import {
+	HighlightStyle,
+	syntaxHighlighting,
+	syntaxTree,
+} from '@codemirror/language';
 import type { EditorState, Extension } from '@codemirror/state';
 import {
 	Decoration,
@@ -7,88 +11,51 @@ import {
 	ViewPlugin,
 	type ViewUpdate,
 } from '@codemirror/view';
-import type { SyntaxNode, SyntaxNodeRef } from '@lezer/common';
+import type { SyntaxNode } from '@lezer/common';
+import { tags } from '@lezer/highlight';
 
 type Span = {
 	from: number;
 	to: number;
 };
 
-type MarkdownLivePreviewRange =
-	| {
-			type: 'hide';
-			from: number;
-			to: number;
-	  }
-	| {
-			type: 'mark';
-			from: number;
-			to: number;
-			className: string;
-	  };
-
 /**
- * Node name to mark class. The whole node is styled, markers included;
- * hiding markers on inactive lines is handled separately, so on active lines
- * the markers render in their construct's look. List and quote markers are
- * styled here but never hidden. Node names absent from this table
- * (SetextHeading, FencedCode, Image, Autolink, tables, HTML) render plain.
- */
-const markClassByNode: Record<string, string> = {
-	ATXHeading1: 'cm-matter-md-heading cm-matter-md-heading-1',
-	ATXHeading2: 'cm-matter-md-heading cm-matter-md-heading-2',
-	ATXHeading3: 'cm-matter-md-heading cm-matter-md-heading-3',
-	ATXHeading4: 'cm-matter-md-heading cm-matter-md-heading-4',
-	ATXHeading5: 'cm-matter-md-heading cm-matter-md-heading-5',
-	ATXHeading6: 'cm-matter-md-heading cm-matter-md-heading-6',
-	StrongEmphasis: 'cm-matter-md-strong',
-	Emphasis: 'cm-matter-md-emphasis',
-	InlineCode: 'cm-matter-md-inline-code',
-	ListMark: 'cm-matter-md-structural-marker',
-	QuoteMark: 'cm-matter-md-structural-marker',
-};
-
-/**
- * Marker node name to the construct parents that own its reveal. A marker is
- * hidden only when its direct parent is listed here and no selection range
- * touches the parent's lines. Markers with unlisted parents always stay raw,
- * which keeps setext underlines (HeaderMark under SetextHeading), fenced-code
- * backticks (CodeMark under FencedCode), and image, reference-link, and
- * autolink punctuation visible.
+ * Construct node name to the marker children it hides on inactive lines.
+ * Constructs absent from this table never hide anything, which keeps setext
+ * underlines, fenced-code backticks, and image, reference-link, and autolink
+ * punctuation visible.
  *
  * Hidden ranges must never span a line break: CodeMirror rejects replace
  * decorations that cross lines when they come from a view plugin. Every
  * marker here is single-line by the CommonMark grammar except LinkTitle,
- * which getRevealScope covers by leaving multi-line links raw.
+ * which isPreviewableLink covers by leaving multi-line links raw.
  */
-const revealParentsByMarker: Record<string, readonly string[]> = {
-	HeaderMark: [
-		'ATXHeading1',
-		'ATXHeading2',
-		'ATXHeading3',
-		'ATXHeading4',
-		'ATXHeading5',
-		'ATXHeading6',
-	],
-	EmphasisMark: ['Emphasis', 'StrongEmphasis'],
-	CodeMark: ['InlineCode'],
-	LinkMark: ['Link'],
-	URL: ['Link'],
-	LinkTitle: ['Link'],
+const hiddenMarkersByConstruct: Record<string, readonly string[]> = {
+	ATXHeading1: ['HeaderMark'],
+	ATXHeading2: ['HeaderMark'],
+	ATXHeading3: ['HeaderMark'],
+	ATXHeading4: ['HeaderMark'],
+	ATXHeading5: ['HeaderMark'],
+	ATXHeading6: ['HeaderMark'],
+	Emphasis: ['EmphasisMark'],
+	StrongEmphasis: ['EmphasisMark'],
+	InlineCode: ['CodeMark'],
+	Link: ['LinkMark', 'URL', 'LinkTitle'],
 };
 
 /**
- * Compute the live-preview spans for the visible ranges. Pure with respect to
- * the editor state: it reads the syntax tree and the selection and returns
+ * Compute the marker spans to hide for the visible ranges. Pure with respect
+ * to the editor state: it reads the syntax tree and the selection and returns
  * plain spans, which is the surface the tests assert on.
  *
- * A line is active when any selection range overlaps it. Markers whose
- * construct touches an active line stay raw; style marks apply everywhere.
+ * A line is active when any selection range overlaps it. A construct that
+ * touches an active line keeps all its markers raw; styling is not handled
+ * here at all, it belongs to the syntax highlighter.
  */
-export function collectMarkdownLivePreviewRanges(
+export function collectHiddenMarkerRanges(
 	state: EditorState,
 	visibleRanges: readonly Span[],
-): MarkdownLivePreviewRange[] {
+): Span[] {
 	const activeSpans = state.selection.ranges.map((range) => ({
 		from: state.doc.lineAt(range.from).from,
 		to: state.doc.lineAt(range.to).to,
@@ -98,40 +65,29 @@ export function collectMarkdownLivePreviewRanges(
 			(active) => active.from <= span.to && span.from <= active.to,
 		);
 
-	const ranges: MarkdownLivePreviewRange[] = [];
+	const tree = syntaxTree(state);
+	const ranges: Span[] = [];
 
 	for (const visibleRange of visibleRanges) {
-		syntaxTree(state).iterate({
+		tree.iterate({
 			from: visibleRange.from,
 			to: visibleRange.to,
 			enter(node) {
-				const name = node.type.name;
+				const markers = hiddenMarkersByConstruct[node.type.name];
+				if (!markers || isRevealed(node)) return;
 
-				const className = markClassByNode[name];
-				if (className) {
-					ranges.push({
-						type: 'mark',
-						from: node.from,
-						to: node.to,
-						className,
-					});
+				const construct = node.node;
+				if (
+					node.type.name === 'Link' &&
+					!isPreviewableLink(construct, state)
+				) {
+					return;
 				}
 
-				if (name === 'Link') {
-					const label = getInlineLinkLabel(node.node);
-					if (label) {
-						ranges.push({
-							type: 'mark',
-							from: label.from,
-							to: label.to,
-							className: 'cm-matter-md-link',
-						});
+				for (const markerName of markers) {
+					for (const marker of construct.getChildren(markerName)) {
+						ranges.push({ from: marker.from, to: marker.to });
 					}
-				}
-
-				const revealScope = getRevealScope(node, state);
-				if (revealScope && !isRevealed(revealScope)) {
-					ranges.push({ type: 'hide', from: node.from, to: node.to });
 				}
 			},
 		});
@@ -142,11 +98,15 @@ export function collectMarkdownLivePreviewRanges(
 
 /**
  * Live Markdown preview as pure view behavior: inactive lines hide marker
- * punctuation and style constructs, and lines touched by any selection show
- * raw Markdown. The extension never dispatches document changes.
+ * punctuation, lines touched by any selection show raw Markdown, and the
+ * syntax highlighter styles constructs independently of the selection. The
+ * extension never dispatches document changes.
  */
 export function markdownLivePreview(): Extension {
-	return [markdownLivePreviewPlugin, markdownLivePreviewTheme];
+	return [
+		markdownLivePreviewPlugin,
+		syntaxHighlighting(markdownPreviewHighlightStyle),
+	];
 }
 
 const markdownLivePreviewPlugin = ViewPlugin.define(
@@ -170,99 +130,64 @@ const markdownLivePreviewPlugin = ViewPlugin.define(
 	},
 );
 
-const markdownLivePreviewTheme = EditorView.baseTheme({
-	'.cm-matter-md-heading': {
-		fontWeight: '700',
-		color: 'hsl(var(--foreground))',
-	},
-	'.cm-matter-md-heading-1': {
-		fontSize: '1.25em',
-	},
-	'.cm-matter-md-heading-2': {
-		fontSize: '1.15em',
-	},
-	'.cm-matter-md-heading-3': {
-		fontSize: '1.08em',
-	},
-	'.cm-matter-md-heading-4, .cm-matter-md-heading-5, .cm-matter-md-heading-6': {
-		fontSize: '1em',
-	},
-	'.cm-matter-md-strong': {
-		fontWeight: '700',
-	},
-	'.cm-matter-md-emphasis': {
-		fontStyle: 'italic',
-	},
-	'.cm-matter-md-inline-code': {
+/**
+ * Styling rides the highlight tags @lezer/markdown already emits: heading
+ * tags apply through children, marker punctuation is processingInstruction,
+ * and Link applies link styling through its children, so the visible label
+ * is styled while the hidden syntax around it does not matter.
+ */
+const markdownPreviewHighlightStyle = HighlightStyle.define([
+	{ tag: tags.heading1, fontSize: '1.25em', fontWeight: '700' },
+	{ tag: tags.heading2, fontSize: '1.15em', fontWeight: '700' },
+	{ tag: tags.heading3, fontSize: '1.08em', fontWeight: '700' },
+	{ tag: tags.heading4, fontWeight: '700' },
+	{ tag: tags.heading5, fontWeight: '700' },
+	{ tag: tags.heading6, fontWeight: '700' },
+	{ tag: tags.strong, fontWeight: '700' },
+	{ tag: tags.emphasis, fontStyle: 'italic' },
+	{
+		tag: tags.monospace,
 		borderRadius: '0.25rem',
 		backgroundColor: 'hsl(var(--muted))',
-		color: 'hsl(var(--foreground))',
 		padding: '0.05rem 0.25rem',
 	},
-	'.cm-matter-md-link': {
+	{
+		tag: tags.link,
 		color: 'hsl(var(--primary))',
 		textDecoration: 'underline',
 		textDecorationColor: 'hsl(var(--primary) / 0.45)',
 		textUnderlineOffset: '0.18em',
 	},
-	'.cm-matter-md-structural-marker': {
+	{
+		tag: tags.processingInstruction,
 		color: 'hsl(var(--muted-foreground))',
-		fontWeight: '500',
 	},
-});
+]);
 
 const hideDecoration = Decoration.replace({});
 
 function buildDecorations(view: EditorView): DecorationSet {
 	return Decoration.set(
-		collectMarkdownLivePreviewRanges(view.state, view.visibleRanges).map(
-			(range) =>
-				range.type === 'hide'
-					? hideDecoration.range(range.from, range.to)
-					: Decoration.mark({ class: range.className }).range(
-							range.from,
-							range.to,
-						),
+		collectHiddenMarkerRanges(view.state, view.visibleRanges).map((range) =>
+			hideDecoration.range(range.from, range.to),
 		),
 		true,
 	);
 }
 
 /**
- * The construct whose lines decide whether this marker is revealed, or null
- * when the marker always stays raw. Markers are direct children of their
- * construct in the lezer Markdown tree, so one parent check suffices.
+ * Whether a Link's syntax should hide on inactive lines. Reference and
+ * shortcut links stay raw (they carry a LinkLabel instead of a URL child),
+ * empty labels like [](url) stay raw because they would preview as nothing,
+ * and multi-line links stay raw so no hidden range can span a line break.
  */
-function getRevealScope(node: SyntaxNodeRef, state: EditorState): Span | null {
-	const parents = revealParentsByMarker[node.type.name];
-	if (!parents) return null;
-
-	const parent = node.node.parent;
-	if (!parent || !parents.includes(parent.name)) return null;
-
-	if (parent.name === 'Link') {
-		// Links are previewed only when their syntax sits on one line; a
-		// multi-line LinkTitle could otherwise produce a hidden range that
-		// spans a line break, and half-hiding a wrapped link reads worse
-		// than showing it raw.
-		if (state.doc.lineAt(parent.from).to < parent.to) return null;
-		if (!getInlineLinkLabel(parent)) return null;
-	}
-
-	return parent;
-}
-
-/**
- * The label span of an inline link, or null for anything that should stay
- * raw: reference and shortcut links (they carry a LinkLabel instead of a URL
- * child) and empty labels like [](url), which would otherwise preview as
- * nothing at all.
- */
-function getInlineLinkLabel(link: SyntaxNode): Span | null {
-	if (!link.getChild('URL')) return null;
+function isPreviewableLink(link: SyntaxNode, state: EditorState): boolean {
+	if (!link.getChild('URL')) return false;
 
 	const [labelOpen, labelClose] = link.getChildren('LinkMark');
-	return labelOpen && labelClose && labelOpen.to < labelClose.from
-		? { from: labelOpen.to, to: labelClose.from }
-		: null;
+	if (!labelOpen || !labelClose || labelOpen.to >= labelClose.from) {
+		return false;
+	}
+
+	return state.doc.lineAt(link.from).to >= link.to;
 }

--- a/apps/matter/src/lib/editor/markdown-live-preview.ts
+++ b/apps/matter/src/lib/editor/markdown-live-preview.ts
@@ -7,17 +7,11 @@ import {
 	ViewPlugin,
 	type ViewUpdate,
 } from '@codemirror/view';
+import type { SyntaxNode, SyntaxNodeRef } from '@lezer/common';
 
 type Span = {
 	from: number;
 	to: number;
-};
-
-type SyntaxContext = {
-	name: string;
-	from: number;
-	to: number;
-	isInlineLink?: boolean;
 };
 
 type MarkdownLivePreviewRange =
@@ -43,51 +37,27 @@ export function collectMarkdownLivePreviewRanges(
 	const ranges: MarkdownLivePreviewRange[] = [];
 
 	for (const visibleRange of visibleRanges) {
-		const contexts: SyntaxContext[] = [];
-
 		syntaxTree(state).iterate({
 			from: visibleRange.from,
 			to: visibleRange.to,
 			enter(node) {
 				const name = node.type.name;
 				const headingMatch = headingPattern.exec(name);
-				let linkLabel: Span | null = null;
-				if (name === 'Link') {
-					const link = node.node;
-					// Only inline links carry a URL child; reference and
-					// shortcut links carry a LinkLabel instead.
-					if (link.getChild('URL')) {
-						const [labelOpen, labelClose] = link.getChildren('LinkMark');
-						if (labelOpen && labelClose && labelOpen.to < labelClose.from) {
-							linkLabel = { from: labelOpen.to, to: labelClose.from };
-						}
-					}
-				}
 
 				if (headingMatch) {
-					const level = headingMatch[1];
-					const contentRange = getHeadingContentRange(
-						state.doc.sliceString(node.from, node.to),
+					addMark(
+						ranges,
 						node.from,
 						node.to,
+						`cm-matter-md-heading cm-matter-md-heading-${headingMatch[1]}`,
 					);
-
-					if (contentRange) {
-						addMark(
-							ranges,
-							contentRange.from,
-							contentRange.to,
-							`cm-matter-md-heading cm-matter-md-heading-${level}`,
-						);
-					}
 				}
 
 				if (name === 'Emphasis' || name === 'StrongEmphasis') {
-					const markerLength = name === 'StrongEmphasis' ? 2 : 1;
 					addMark(
 						ranges,
-						node.from + markerLength,
-						node.to - markerLength,
+						node.from,
+						node.to,
 						name === 'StrongEmphasis'
 							? 'cm-matter-md-strong'
 							: 'cm-matter-md-emphasis',
@@ -95,44 +65,24 @@ export function collectMarkdownLivePreviewRanges(
 				}
 
 				if (name === 'InlineCode') {
-					const contentRange = getInlineCodeContentRange(
-						state.doc.sliceString(node.from, node.to),
-						node.from,
-						node.to,
-					);
-
-					if (contentRange) {
-						addMark(
-							ranges,
-							contentRange.from,
-							contentRange.to,
-							'cm-matter-md-inline-code',
-						);
-					}
+					addMark(ranges, node.from, node.to, 'cm-matter-md-inline-code');
 				}
 
-				if (linkLabel) {
-					addMark(ranges, linkLabel.from, linkLabel.to, 'cm-matter-md-link');
+				if (name === 'Link') {
+					const label = getInlineLinkLabel(node.node);
+					if (label) {
+						addMark(ranges, label.from, label.to, 'cm-matter-md-link');
+					}
 				}
 
 				if (name === 'ListMark' || name === 'QuoteMark') {
 					addMark(ranges, node.from, node.to, 'cm-matter-md-structural-marker');
 				}
 
-				const revealScope = getRevealScope(name, contexts);
+				const revealScope = getRevealScope(node);
 				if (revealScope && !isActiveRange(state, activeLines, revealScope)) {
 					addHide(ranges, state, node.from, node.to);
 				}
-
-				contexts.push({
-					name,
-					from: node.from,
-					to: node.to,
-					isInlineLink: linkLabel !== null,
-				});
-			},
-			leave() {
-				contexts.pop();
 			},
 		});
 	}
@@ -254,87 +204,48 @@ function isActiveRange(
 	return false;
 }
 
-function getRevealScope(
-	name: string,
-	contexts: readonly SyntaxContext[],
-): Span | null {
-	if (name === 'HeaderMark') {
-		return getClosestContext(contexts, (context) =>
-			headingPattern.test(context.name),
-		);
-	}
-
-	if (name === 'EmphasisMark') {
-		return getClosestContext(
-			contexts,
-			(context) =>
-				context.name === 'Emphasis' || context.name === 'StrongEmphasis',
-		);
-	}
-
-	if (name === 'CodeMark') {
-		return getClosestContext(
-			contexts,
-			(context) => context.name === 'InlineCode',
-		);
-	}
-
-	if (name !== 'LinkMark' && name !== 'URL' && name !== 'LinkTitle') {
+function getRevealScope(node: SyntaxNodeRef): Span | null {
+	const name = node.type.name;
+	if (
+		name !== 'HeaderMark' &&
+		name !== 'EmphasisMark' &&
+		name !== 'CodeMark' &&
+		name !== 'LinkMark' &&
+		name !== 'URL' &&
+		name !== 'LinkTitle'
+	) {
 		return null;
 	}
 
-	const context = getClosestContext(
-		contexts,
-		(candidate) =>
-			candidate.name === 'Link' ||
-			candidate.name === 'Image' ||
-			candidate.name === 'Autolink',
-	);
-	return context?.name === 'Link' && context.isInlineLink === true
-		? context
-		: null;
-}
+	const parent = node.node.parent;
+	if (!parent) return null;
 
-function getClosestContext(
-	contexts: readonly SyntaxContext[],
-	matches: (context: SyntaxContext) => boolean,
-): SyntaxContext | null {
-	for (let index = contexts.length - 1; index >= 0; index -= 1) {
-		const context = contexts[index];
-		if (context && matches(context)) return context;
+	if (name === 'HeaderMark') {
+		return headingPattern.test(parent.name) ? parent : null;
 	}
 
-	return null;
+	if (name === 'EmphasisMark') {
+		return parent.name === 'Emphasis' || parent.name === 'StrongEmphasis'
+			? parent
+			: null;
+	}
+
+	if (name === 'CodeMark') {
+		return parent.name === 'InlineCode' ? parent : null;
+	}
+
+	return parent.name === 'Link' && getInlineLinkLabel(parent) ? parent : null;
 }
 
-function getHeadingContentRange(
-	text: string,
-	nodeFrom: number,
-	nodeTo: number,
-): Span | null {
-	const opening = /^(#{1,6})[ \t]*/.exec(text);
-	if (!opening) return null;
+function getInlineLinkLabel(link: SyntaxNode): Span | null {
+	// Only inline links carry a URL child; reference and shortcut links
+	// carry a LinkLabel instead.
+	if (!link.getChild('URL')) return null;
 
-	const closing = /[ \t]+#{1,6}[ \t]*$/.exec(text);
-	const from = nodeFrom + opening[0].length;
-	const to = closing?.index === undefined ? nodeTo : nodeFrom + closing.index;
-
-	return from < to ? { from, to } : null;
-}
-
-function getInlineCodeContentRange(
-	text: string,
-	nodeFrom: number,
-	nodeTo: number,
-): Span | null {
-	const opening = /^`+/.exec(text);
-	const closing = /`+$/.exec(text);
-	if (!opening || !closing) return null;
-
-	const from = nodeFrom + opening[0].length;
-	const to = nodeTo - closing[0].length;
-
-	return from < to ? { from, to } : null;
+	const [labelOpen, labelClose] = link.getChildren('LinkMark');
+	return labelOpen && labelClose && labelOpen.to < labelClose.from
+		? { from: labelOpen.to, to: labelClose.from }
+		: null;
 }
 
 function addHide(

--- a/apps/matter/src/lib/editor/markdown-live-preview.ts
+++ b/apps/matter/src/lib/editor/markdown-live-preview.ts
@@ -77,10 +77,7 @@ export function collectHiddenMarkerRanges(
 				if (!markers || isRevealed(node)) return;
 
 				const construct = node.node;
-				if (
-					node.type.name === 'Link' &&
-					!isPreviewableLink(construct, state)
-				) {
+				if (node.type.name === 'Link' && !isPreviewableLink(construct, state)) {
 					return;
 				}
 

--- a/apps/matter/src/lib/editor/markdown-live-preview.ts
+++ b/apps/matter/src/lib/editor/markdown-live-preview.ts
@@ -27,13 +27,77 @@ type MarkdownLivePreviewRange =
 			className: string;
 	  };
 
-const headingPattern = /^ATXHeading([1-6])$/;
+/**
+ * Node name to mark class. The whole node is styled, markers included;
+ * hiding markers on inactive lines is handled separately, so on active lines
+ * the markers render in their construct's look. List and quote markers are
+ * styled here but never hidden. Node names absent from this table
+ * (SetextHeading, FencedCode, Image, Autolink, tables, HTML) render plain.
+ */
+const markClassByNode: Record<string, string> = {
+	ATXHeading1: 'cm-matter-md-heading cm-matter-md-heading-1',
+	ATXHeading2: 'cm-matter-md-heading cm-matter-md-heading-2',
+	ATXHeading3: 'cm-matter-md-heading cm-matter-md-heading-3',
+	ATXHeading4: 'cm-matter-md-heading cm-matter-md-heading-4',
+	ATXHeading5: 'cm-matter-md-heading cm-matter-md-heading-5',
+	ATXHeading6: 'cm-matter-md-heading cm-matter-md-heading-6',
+	StrongEmphasis: 'cm-matter-md-strong',
+	Emphasis: 'cm-matter-md-emphasis',
+	InlineCode: 'cm-matter-md-inline-code',
+	ListMark: 'cm-matter-md-structural-marker',
+	QuoteMark: 'cm-matter-md-structural-marker',
+};
 
+/**
+ * Marker node name to the construct parents that own its reveal. A marker is
+ * hidden only when its direct parent is listed here and no selection range
+ * touches the parent's lines. Markers with unlisted parents always stay raw,
+ * which keeps setext underlines (HeaderMark under SetextHeading), fenced-code
+ * backticks (CodeMark under FencedCode), and image, reference-link, and
+ * autolink punctuation visible.
+ *
+ * Hidden ranges must never span a line break: CodeMirror rejects replace
+ * decorations that cross lines when they come from a view plugin. Every
+ * marker here is single-line by the CommonMark grammar except LinkTitle,
+ * which getRevealScope covers by leaving multi-line links raw.
+ */
+const revealParentsByMarker: Record<string, readonly string[]> = {
+	HeaderMark: [
+		'ATXHeading1',
+		'ATXHeading2',
+		'ATXHeading3',
+		'ATXHeading4',
+		'ATXHeading5',
+		'ATXHeading6',
+	],
+	EmphasisMark: ['Emphasis', 'StrongEmphasis'],
+	CodeMark: ['InlineCode'],
+	LinkMark: ['Link'],
+	URL: ['Link'],
+	LinkTitle: ['Link'],
+};
+
+/**
+ * Compute the live-preview spans for the visible ranges. Pure with respect to
+ * the editor state: it reads the syntax tree and the selection and returns
+ * plain spans, which is the surface the tests assert on.
+ *
+ * A line is active when any selection range overlaps it. Markers whose
+ * construct touches an active line stay raw; style marks apply everywhere.
+ */
 export function collectMarkdownLivePreviewRanges(
 	state: EditorState,
 	visibleRanges: readonly Span[],
 ): MarkdownLivePreviewRange[] {
-	const activeLines = collectActiveLines(state);
+	const activeSpans = state.selection.ranges.map((range) => ({
+		from: state.doc.lineAt(range.from).from,
+		to: state.doc.lineAt(range.to).to,
+	}));
+	const isRevealed = (span: Span) =>
+		activeSpans.some(
+			(active) => active.from <= span.to && span.from <= active.to,
+		);
+
 	const ranges: MarkdownLivePreviewRange[] = [];
 
 	for (const visibleRange of visibleRanges) {
@@ -42,46 +106,32 @@ export function collectMarkdownLivePreviewRanges(
 			to: visibleRange.to,
 			enter(node) {
 				const name = node.type.name;
-				const headingMatch = headingPattern.exec(name);
 
-				if (headingMatch) {
-					addMark(
-						ranges,
-						node.from,
-						node.to,
-						`cm-matter-md-heading cm-matter-md-heading-${headingMatch[1]}`,
-					);
-				}
-
-				if (name === 'Emphasis' || name === 'StrongEmphasis') {
-					addMark(
-						ranges,
-						node.from,
-						node.to,
-						name === 'StrongEmphasis'
-							? 'cm-matter-md-strong'
-							: 'cm-matter-md-emphasis',
-					);
-				}
-
-				if (name === 'InlineCode') {
-					addMark(ranges, node.from, node.to, 'cm-matter-md-inline-code');
+				const className = markClassByNode[name];
+				if (className) {
+					ranges.push({
+						type: 'mark',
+						from: node.from,
+						to: node.to,
+						className,
+					});
 				}
 
 				if (name === 'Link') {
 					const label = getInlineLinkLabel(node.node);
 					if (label) {
-						addMark(ranges, label.from, label.to, 'cm-matter-md-link');
+						ranges.push({
+							type: 'mark',
+							from: label.from,
+							to: label.to,
+							className: 'cm-matter-md-link',
+						});
 					}
 				}
 
-				if (name === 'ListMark' || name === 'QuoteMark') {
-					addMark(ranges, node.from, node.to, 'cm-matter-md-structural-marker');
-				}
-
-				const revealScope = getRevealScope(node);
-				if (revealScope && !isActiveRange(state, activeLines, revealScope)) {
-					addHide(ranges, state, node.from, node.to);
+				const revealScope = getRevealScope(node, state);
+				if (revealScope && !isRevealed(revealScope)) {
+					ranges.push({ type: 'hide', from: node.from, to: node.to });
 				}
 			},
 		});
@@ -90,6 +140,11 @@ export function collectMarkdownLivePreviewRanges(
 	return ranges;
 }
 
+/**
+ * Live Markdown preview as pure view behavior: inactive lines hide marker
+ * punctuation and style constructs, and lines touched by any selection show
+ * raw Markdown. The extension never dispatches document changes.
+ */
 export function markdownLivePreview(): Extension {
 	return [markdownLivePreviewPlugin, markdownLivePreviewTheme];
 }
@@ -102,6 +157,8 @@ const markdownLivePreviewPlugin = ViewPlugin.define(
 				update.docChanged ||
 				update.selectionSet ||
 				update.viewportChanged ||
+				// Background parsing dispatches updates as the tree grows; a
+				// changed tree identity means new nodes may need decorating.
 				syntaxTree(update.state) !== syntaxTree(update.startState)
 			) {
 				this.decorations = buildDecorations(update.view);
@@ -159,127 +216,53 @@ const hideDecoration = Decoration.replace({});
 function buildDecorations(view: EditorView): DecorationSet {
 	return Decoration.set(
 		collectMarkdownLivePreviewRanges(view.state, view.visibleRanges).map(
-			(range) => {
-				if (range.type === 'hide') {
-					return hideDecoration.range(range.from, range.to);
-				}
-
-				return Decoration.mark({ class: range.className }).range(
-					range.from,
-					range.to,
-				);
-			},
+			(range) =>
+				range.type === 'hide'
+					? hideDecoration.range(range.from, range.to)
+					: Decoration.mark({ class: range.className }).range(
+							range.from,
+							range.to,
+						),
 		),
 		true,
 	);
 }
 
-function collectActiveLines(state: EditorState): Set<number> {
-	const activeLines = new Set<number>();
-
-	for (const range of state.selection.ranges) {
-		const fromLine = state.doc.lineAt(range.from).number;
-		const toLine = state.doc.lineAt(range.to).number;
-
-		for (let lineNumber = fromLine; lineNumber <= toLine; lineNumber += 1) {
-			activeLines.add(lineNumber);
-		}
-	}
-
-	return activeLines;
-}
-
-function isActiveRange(
-	state: EditorState,
-	activeLines: Set<number>,
-	range: Span,
-): boolean {
-	const fromLine = state.doc.lineAt(range.from).number;
-	const toLine = state.doc.lineAt(range.to).number;
-
-	for (let lineNumber = fromLine; lineNumber <= toLine; lineNumber += 1) {
-		if (activeLines.has(lineNumber)) return true;
-	}
-
-	return false;
-}
-
-function getRevealScope(node: SyntaxNodeRef): Span | null {
-	const name = node.type.name;
-	if (
-		name !== 'HeaderMark' &&
-		name !== 'EmphasisMark' &&
-		name !== 'CodeMark' &&
-		name !== 'LinkMark' &&
-		name !== 'URL' &&
-		name !== 'LinkTitle'
-	) {
-		return null;
-	}
+/**
+ * The construct whose lines decide whether this marker is revealed, or null
+ * when the marker always stays raw. Markers are direct children of their
+ * construct in the lezer Markdown tree, so one parent check suffices.
+ */
+function getRevealScope(node: SyntaxNodeRef, state: EditorState): Span | null {
+	const parents = revealParentsByMarker[node.type.name];
+	if (!parents) return null;
 
 	const parent = node.node.parent;
-	if (!parent) return null;
+	if (!parent || !parents.includes(parent.name)) return null;
 
-	if (name === 'HeaderMark') {
-		return headingPattern.test(parent.name) ? parent : null;
+	if (parent.name === 'Link') {
+		// Links are previewed only when their syntax sits on one line; a
+		// multi-line LinkTitle could otherwise produce a hidden range that
+		// spans a line break, and half-hiding a wrapped link reads worse
+		// than showing it raw.
+		if (state.doc.lineAt(parent.from).to < parent.to) return null;
+		if (!getInlineLinkLabel(parent)) return null;
 	}
 
-	if (name === 'EmphasisMark') {
-		return parent.name === 'Emphasis' || parent.name === 'StrongEmphasis'
-			? parent
-			: null;
-	}
-
-	if (name === 'CodeMark') {
-		return parent.name === 'InlineCode' ? parent : null;
-	}
-
-	return parent.name === 'Link' && getInlineLinkLabel(parent) ? parent : null;
+	return parent;
 }
 
+/**
+ * The label span of an inline link, or null for anything that should stay
+ * raw: reference and shortcut links (they carry a LinkLabel instead of a URL
+ * child) and empty labels like [](url), which would otherwise preview as
+ * nothing at all.
+ */
 function getInlineLinkLabel(link: SyntaxNode): Span | null {
-	// Only inline links carry a URL child; reference and shortcut links
-	// carry a LinkLabel instead.
 	if (!link.getChild('URL')) return null;
 
 	const [labelOpen, labelClose] = link.getChildren('LinkMark');
 	return labelOpen && labelClose && labelOpen.to < labelClose.from
 		? { from: labelOpen.to, to: labelClose.from }
 		: null;
-}
-
-function addHide(
-	ranges: MarkdownLivePreviewRange[],
-	state: EditorState,
-	from: number,
-	to: number,
-) {
-	// CodeMirror rejects plugin-provided replace decorations that span line
-	// breaks, so hidden ranges are emitted per line.
-	let cursor = from;
-
-	while (cursor < to) {
-		const line = state.doc.lineAt(cursor);
-		const lineTo = Math.min(to, line.to);
-
-		if (cursor < lineTo) {
-			ranges.push({ type: 'hide', from: cursor, to: lineTo });
-		}
-
-		if (lineTo >= to) return;
-
-		const nextLineNumber = line.number + 1;
-		if (nextLineNumber > state.doc.lines) return;
-		cursor = state.doc.line(nextLineNumber).from;
-	}
-}
-
-function addMark(
-	ranges: MarkdownLivePreviewRange[],
-	from: number,
-	to: number,
-	className: string,
-) {
-	if (from >= to) return;
-	ranges.push({ type: 'mark', from, to, className });
 }

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",
@@ -220,6 +221,7 @@
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.41.0",
         "@epicenter/field": "workspace:*",
+        "@lezer/common": "^1.5.1",
         "@tauri-apps/api": "catalog:",
         "@tauri-apps/plugin-dialog": "^2.3.2",
         "typebox": "catalog:",

--- a/bun.lock
+++ b/bun.lock
@@ -216,6 +216,7 @@
       "dependencies": {
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/language": "^6.12.3",
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.41.0",
         "@epicenter/field": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -222,6 +222,7 @@
         "@codemirror/view": "^6.41.0",
         "@epicenter/field": "workspace:*",
         "@lezer/common": "^1.5.1",
+        "@lezer/highlight": "^1.2.3",
         "@tauri-apps/api": "catalog:",
         "@tauri-apps/plugin-dialog": "^2.3.2",
         "typebox": "catalog:",


### PR DESCRIPTION
Matter's body editor now has a view-only CodeMirror Markdown live preview. Inactive lines hide marker punctuation for headings, emphasis, inline code, and inline links, while any line touched by a selection shows raw Markdown for editing. The Svelte editor keeps owning the body draft and commit lifecycle; the extension is one extra entry in its extension list:

```ts
extensions: [
	markdown(),
	markdownLivePreview(),
]
```

The extension never dispatches document changes. That invariant is the V1 boundary, and the rest of the design is arranged around it.

---

**Styling and hiding are different jobs, and only one needs custom code.** Styling rides CodeMirror's syntax highlighter over the tags `@lezer/markdown` already emits (heading1-6 through children, emphasis and strong, monospace, link, and processingInstruction for marker punctuation), so it is declarative config that recomputes incrementally and never depends on the selection. The view plugin owns only the selection-dependent half: one table maps each construct to the marker children it hides on inactive lines, and a construct touching any selected line keeps all its markers raw.

```ts
const hiddenMarkersByConstruct: Record<string, readonly string[]> = {
	ATXHeading1: ['HeaderMark'],
	Emphasis: ['EmphasisMark'],
	StrongEmphasis: ['EmphasisMark'],
	InlineCode: ['CodeMark'],
	Link: ['LinkMark', 'URL', 'LinkTitle'],
	// ...
};
```

Constructs absent from the table never hide anything, which is how setext underlines, fenced code, images, reference links, and autolinks stay raw. List bullets and blockquote markers are styled muted but never hidden, avoiding horizontal line jumps when the cursor enters a line.

---

**One refused feature keeps every hidden range single-line by construction.** CodeMirror rejects plugin replace decorations that span line breaks, and the only marker that can contain one is a multi-line link title. Links whose syntax spans lines stay raw instead of half-hiding around a line break, so the constraint holds without any per-line range-splitting machinery. The trade-off is that a hard-wrapped inline link shows raw Markdown on inactive lines; the old splitting approach rendered those with a dangling blank line anyway.

Tests pin the hide decisions on the pure collector (`collectHiddenMarkerRanges`): closing ATX hashes, multi-line emphasis reveal, multi-cursor reveal, link titles containing `](`, and the raw-by-omission cases above.

## Changelog

- Add Matter Markdown live preview for inactive editor lines.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783836004&installation_id=128463665&pr_number=1914&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1914&signature=596b1472fd338f5882d5ffab4ec51bcffec7b91dd7650d82d00c56470d97fd72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
