### PR TITLE
refactor(whispering): move local model lifecycle behind factory boundaries

### DIFF
--- a/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
@@ -7,27 +7,16 @@
 	import CheckIcon from '@lucide/svelte/icons/check';
 	import Download from '@lucide/svelte/icons/download';
 	import X from '@lucide/svelte/icons/x';
-	import { join } from '@tauri-apps/api/path';
-	import {
-		exists,
-		mkdir,
-		remove,
-		stat,
-		writeFile,
-	} from '@tauri-apps/plugin-fs';
-	import { fetch } from '@tauri-apps/plugin-http';
-	import { extractErrorMessage } from 'wellcrafted/error';
-	import { Ok, tryAsync } from 'wellcrafted/result';
 	import { type LocalModelConfig } from '$lib/constants/local-models';
-	import { isModelFileSizeValid } from '$lib/services/transcription/model-file';
-	import { PATHS } from '$lib/services/fs-paths';
-	import { deviceConfig } from '$lib/state/device-config.svelte';
+	import { createPrebuiltModel } from '$lib/operations/local-models';
 
 	let {
 		model,
 	}: {
 		model: LocalModelConfig;
 	} = $props();
+
+	const prebuiltModel = $derived(createPrebuiltModel(model));
 
 	type ModelState =
 		| { type: 'not-downloaded' }
@@ -37,131 +26,17 @@
 
 	let modelState = $state<ModelState>({ type: 'not-downloaded' });
 
-	/**
-	 * Calculates the destination path where this model will be downloaded and stored,
-	 * and ensures that the parent directory structure exists.
-	 *
-	 * @returns The full path where the model should be stored:
-	 * - For Whisper models: `{appDataDir}/models/whisper/{filename}` (a single file)
-	 * - For Parakeet models: `{appDataDir}/models/parakeet/{directoryName}/` (a directory containing multiple files)
-	 * - For Moonshine models: `{appDataDir}/models/moonshine/{directoryName}/` (a directory containing multiple files)
-	 */
-	async function ensureModelDestinationPath(): Promise<string> {
-		switch (model.engine) {
-			case 'whispercpp': {
-				const modelsDir = await PATHS.MODELS.WHISPER();
-				// Ensure directory exists
-				if (!(await exists(modelsDir))) {
-					await mkdir(modelsDir, { recursive: true });
-				}
-				return join(modelsDir, model.file.filename);
-			}
-			case 'parakeet': {
-				// Parakeet models are stored in a directory
-				const parakeetModelsDir = await PATHS.MODELS.PARAKEET();
-				// Ensure directory exists
-				if (!(await exists(parakeetModelsDir))) {
-					await mkdir(parakeetModelsDir, { recursive: true });
-				}
-				return join(parakeetModelsDir, model.directoryName);
-			}
-			case 'moonshine': {
-				// Moonshine models are stored in a directory
-				const moonshineModelsDir = await PATHS.MODELS.MOONSHINE();
-				// Ensure directory exists
-				if (!(await exists(moonshineModelsDir))) {
-					await mkdir(moonshineModelsDir, { recursive: true });
-				}
-				return join(moonshineModelsDir, model.directoryName);
-			}
-		}
-	}
-
-	/**
-	 * Validates if a model is properly installed at the given path.
-	 */
-	async function isModelValid(path: string): Promise<boolean> {
-		switch (model.engine) {
-			case 'whispercpp': {
-				if (!(await exists(path))) return false;
-				// Check file size to detect corrupted/incomplete downloads
-				const { data: stats } = await tryAsync({
-					try: () => stat(path),
-					catch: () => Ok(null),
-				});
-				if (!stats) return false;
-				if (!isModelFileSizeValid(stats.size, model.sizeBytes)) {
-					console.warn(
-						`Model file appears corrupted: ${Math.round(stats.size / 1_000_000)}MB, expected ~${Math.round(model.sizeBytes / 1_000_000)}MB`,
-					);
-					return false;
-				}
-				return true;
-			}
-			case 'parakeet':
-			case 'moonshine': {
-				if (!(await exists(path))) return false;
-				// For multi-file models, path must be a directory containing all files
-				const { data: dirStats } = await tryAsync({
-					try: () => stat(path),
-					catch: () => Ok(null),
-				});
-				if (!dirStats?.isDirectory) return false;
-
-				// Check that all required files exist and have valid sizes
-				for (const file of model.files) {
-					const filePath = await join(path, file.filename);
-					if (!(await exists(filePath))) return false;
-					// Check file size to detect corrupted/incomplete downloads
-					const { data: fileStats } = await tryAsync({
-						try: () => stat(filePath),
-						catch: () => Ok(null),
-					});
-					if (!fileStats) return false;
-					if (!isModelFileSizeValid(fileStats.size, file.sizeBytes)) {
-						console.warn(
-							`${model.engine} file "${file.filename}" appears corrupted: ${Math.round(fileStats.size / 1_000_000)}MB, expected ~${Math.round(file.sizeBytes / 1_000_000)}MB`,
-						);
-						return false;
-					}
-				}
-				return true;
-			}
-		}
-	}
-
-	// Check model status on mount and when settings change
+	// Check model status on mount and whenever the engine's active model
+	// path changes (the getter reads deviceConfig, so this effect tracks it).
 	$effect(() => {
-		// React to settings changes for this engine
-		const settingsKey = `transcription.${model.engine}.modelPath` as const;
-		const currentPath = deviceConfig.get(settingsKey);
-		// Trigger refresh when settings change (currentPath is a dependency)
+		void prebuiltModel.activeModelPath;
 		refreshStatus();
 	});
 
 	async function refreshStatus() {
-		await tryAsync({
-			try: async () => {
-				const path = await ensureModelDestinationPath();
-				const isValid = await isModelValid(path);
-
-				if (!isValid) {
-					modelState = { type: 'not-downloaded' };
-					return;
-				}
-
-				// Check if this model is active in settings
-				const settingsKey = `transcription.${model.engine}.modelPath` as const;
-				const currentPath = deviceConfig.get(settingsKey);
-				const isActive = currentPath === path;
-
-				modelState = isActive ? { type: 'active' } : { type: 'ready' };
-			},
-			catch: () => {
-				modelState = { type: 'not-downloaded' };
-				return Ok(undefined);
-			},
-		});
+		// While downloading, the download handler owns the state machine.
+		if (modelState.type === 'downloading') return;
+		modelState = { type: await prebuiltModel.getStatus() };
 	}
 
 	async function downloadModel() {
@@ -169,167 +44,43 @@
 
 		modelState = { type: 'downloading', progress: 0 };
 
-		await tryAsync({
-			try: async () => {
-				const downloadFileContent = async (
-					url: string,
-					sizeBytes: number,
-					filePath: string,
-					onProgress: (progress: number) => void,
-				): Promise<void> => {
-					const response = await fetch(url);
-					if (!response.ok) {
-						throw new Error(`Failed to download: ${response.status}`);
-					}
-
-					const contentLength = response.headers.get('content-length');
-					const totalBytes = contentLength
-						? Number.parseInt(contentLength, 10)
-						: sizeBytes;
-
-					const reader = response.body?.getReader();
-					if (!reader) {
-						throw new Error('Failed to read response body');
-					}
-
-					// Create or truncate the file first
-					await writeFile(filePath, new Uint8Array());
-
-					let downloadedBytes = 0;
-
-					while (true) {
-						const { done, value } = await reader.read();
-						if (done) break;
-
-						// Write each chunk directly to disk using append mode
-						await writeFile(filePath, value, { append: true });
-
-						downloadedBytes += value.length;
-						const progress = Math.round((downloadedBytes / totalBytes) * 100);
-						onProgress(progress);
-					}
-
-					// Validate download completeness
-					if (downloadedBytes < totalBytes) {
-						await remove(filePath);
-						const downloadedMB = Math.round(downloadedBytes / 1_000_000);
-						const expectedMB = Math.round(totalBytes / 1_000_000);
-						throw new Error(
-							`Download incomplete: received ${downloadedMB}MB but expected ${expectedMB}MB. Please check your network connection and try again.`,
-						);
-					}
-				};
-
-				const path = await ensureModelDestinationPath();
-
-				// Check if already exists
-				await refreshStatus();
-				if (modelState.type === 'ready' || modelState.type === 'active') {
-					if (modelState.type === 'ready') {
-						await activateModel();
-					}
-					toast.success('Model already downloaded and activated');
-					return;
-				}
-
-				switch (model.engine) {
-					case 'whispercpp': {
-						// Single file download for Whisper
-						await downloadFileContent(
-							model.file.url,
-							model.sizeBytes,
-							path,
-							(progress) => {
-								modelState = { type: 'downloading', progress };
-							},
-						);
-						break;
-					}
-					case 'parakeet':
-					case 'moonshine': {
-						// Multiple file downloads for multi-file models
-						const totalBytes = model.sizeBytes;
-						let downloadedBytes = 0;
-
-						// Create directory for model files
-						await mkdir(path, { recursive: true });
-
-						for (const file of model.files) {
-							const filePath = await join(path, file.filename);
-							await downloadFileContent(
-								file.url,
-								file.sizeBytes,
-								filePath,
-								(fileProgress) => {
-									const overallProgress = Math.round(
-										((downloadedBytes + (file.sizeBytes * fileProgress) / 100) /
-											totalBytes) *
-											100,
-									);
-									modelState = {
-										type: 'downloading',
-										progress: overallProgress,
-									};
-								},
-							);
-							downloadedBytes += file.sizeBytes;
-						}
-						break;
-					}
-				}
-
-				// After download, activate the model
-				await activateModel();
-				modelState = { type: 'active' };
-				toast.success('Model downloaded and activated successfully');
-			},
-			catch: (error) => {
-				console.error('Download failed:', error);
-				toast.error('Failed to download model', {
-					description: extractErrorMessage(error),
-				});
-				modelState = { type: 'not-downloaded' };
-				return Ok(undefined);
+		const { data, error } = await prebuiltModel.downloadAndActivate({
+			onProgress: (progress) => {
+				modelState = { type: 'downloading', progress };
 			},
 		});
+		if (error) {
+			toast.error('Failed to download model', {
+				description: error.message,
+			});
+			modelState = { type: 'not-downloaded' };
+			return;
+		}
+
+		modelState = { type: 'active' };
+		toast.success(
+			data.outcome === 'already-installed'
+				? 'Model already downloaded and activated'
+				: 'Model downloaded and activated successfully',
+		);
 	}
 
 	async function activateModel() {
-		const path = await ensureModelDestinationPath();
-		const settingsKey = `transcription.${model.engine}.modelPath` as const;
-
-		deviceConfig.set(settingsKey, path);
+		await prebuiltModel.activate();
 		// The settings watcher will update modelState to 'active'
 		toast.success('Model activated');
 	}
 
 	async function deleteModel() {
-		await tryAsync({
-			try: async () => {
-				const path = await ensureModelDestinationPath();
-				if (await exists(path)) {
-					const isDirectory =
-						model.engine === 'parakeet' || model.engine === 'moonshine';
-					await remove(path, { recursive: isDirectory });
-				}
-
-				// Clear settings if this was the active model
-				const settingsKey = `transcription.${model.engine}.modelPath` as const;
-
-				if (deviceConfig.get(settingsKey) === path) {
-					deviceConfig.set(settingsKey, '');
-				}
-
-				modelState = { type: 'not-downloaded' };
-				toast.success('Model deleted');
-			},
-			catch: (error) => {
-				toast.error('Failed to delete model', {
-					description: extractErrorMessage(error),
-				});
-				return Ok(undefined);
-			},
-		});
+		const { error } = await prebuiltModel.delete();
+		if (error) {
+			toast.error('Failed to delete model', {
+				description: error.message,
+			});
+			return;
+		}
+		modelState = { type: 'not-downloaded' };
+		toast.success('Model deleted');
 	}
 </script>
 

--- a/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
@@ -34,9 +34,11 @@
 	});
 
 	async function refreshStatus() {
-		// While downloading, the download handler owns the state machine.
+		const status = await prebuiltModel.getStatus();
+		// While downloading, the download handler owns the state machine; a
+		// download may also have started while we were checking the disk.
 		if (modelState.type === 'downloading') return;
-		modelState = { type: await prebuiltModel.getStatus() };
+		modelState = { type: status };
 	}
 
 	async function downloadModel() {

--- a/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
@@ -15,6 +15,7 @@
 		importModelDirectory,
 		importModelFile,
 	} from '$lib/services/transcription/local-model-storage';
+	import { PROVIDERS } from '$lib/services/transcription/providers';
 	import { tauri } from '#platform/tauri';
 	import LocalModelDownloadCard from './LocalModelDownloadCard.svelte';
 
@@ -35,9 +36,6 @@
 		/** Component description displayed below the title */
 		description: string;
 
-		/** Whether to select files or directories */
-		fileSelectionMode: 'file' | 'directory';
-
 		/** File extensions to filter (for file mode only) */
 		fileExtensions?: string[];
 
@@ -55,12 +53,18 @@
 		models,
 		title,
 		description,
-		fileSelectionMode,
 		fileExtensions = [],
 		value = $bindable(),
 		prebuiltFooter,
 		manualInstructions,
 	}: LocalModelSelectorProps = $props();
+
+	const engine = $derived(models[0].engine);
+
+	// Not a free choice: an imported path must match what the engine's
+	// preflight accepts (a file for Whisper, a directory for Parakeet and
+	// Moonshine), so the mode comes from the provider registry.
+	const fileSelectionMode = $derived(PROVIDERS[engine].preflightKind);
 
 	// Extract the model name from the current path
 	const modelName = $derived.by(async () => {
@@ -89,8 +93,6 @@
 	 */
 	async function selectModel() {
 		if (!tauri) return;
-
-		const engine = models[0].engine;
 
 		if (fileSelectionMode === 'directory') {
 			const selected = await open({

--- a/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
@@ -7,14 +7,14 @@
 	import FolderOpen from '@lucide/svelte/icons/folder-open';
 	import Paperclip from '@lucide/svelte/icons/paperclip';
 	import X from '@lucide/svelte/icons/x';
-	import { basename, join } from '@tauri-apps/api/path';
+	import { basename } from '@tauri-apps/api/path';
 	import { open } from '@tauri-apps/plugin-dialog';
-	import { copyFile, mkdir, readDir } from '@tauri-apps/plugin-fs';
 	import type { Snippet } from 'svelte';
-	import { extractErrorMessage } from 'wellcrafted/error';
-	import { Ok, tryAsync } from 'wellcrafted/result';
 	import type { LocalModelConfig } from '$lib/constants/local-models';
-	import { PATHS } from '$lib/services/fs-paths';
+	import {
+		importModelDirectory,
+		importModelFile,
+	} from '$lib/services/transcription/local-model-storage';
 	import { tauri } from '#platform/tauri';
 	import LocalModelDownloadCard from './LocalModelDownloadCard.svelte';
 
@@ -22,8 +22,12 @@
 	 * Props for the LocalModelSelector component
 	 */
 	type LocalModelSelectorProps = {
-		/** Array of pre-built models available for download */
-		models: readonly LocalModelConfig[];
+		/**
+		 * Pre-built models available for download. All entries share one
+		 * engine; at least one is required because the engine decides where
+		 * manual imports land.
+		 */
+		models: readonly [LocalModelConfig, ...LocalModelConfig[]];
 
 		/** Component title displayed in the card header */
 		title: string;
@@ -80,100 +84,65 @@
 	);
 	const isPrebuiltModel = $derived(!!prebuiltModelInfo);
 
-	async function getModelRoot() {
-		const engine = models[0]?.engine;
-		switch (engine) {
-			case 'whispercpp':
-				return PATHS.MODELS.WHISPER();
-			case 'parakeet':
-				return PATHS.MODELS.PARAKEET();
-			case 'moonshine':
-				return PATHS.MODELS.MOONSHINE();
-			default:
-				throw new Error('No local model engine configured');
-		}
-	}
-
-	async function copyDirectory(sourceDir: string, destinationDir: string) {
-		await mkdir(destinationDir, { recursive: true });
-		const entries = await readDir(sourceDir);
-
-		for (const entry of entries) {
-			const sourcePath = await join(sourceDir, entry.name);
-			const destinationPath = await join(destinationDir, entry.name);
-
-			if (entry.isDirectory) {
-				await copyDirectory(sourcePath, destinationPath);
-			} else if (entry.isFile) {
-				await copyFile(sourcePath, destinationPath);
-			} else {
-				throw new Error('Selected model directory cannot include symlinks');
-			}
-		}
-	}
-
 	/**
 	 * Open file/folder browser for manual model selection
 	 */
 	async function selectModel() {
 		if (!tauri) return;
 
-		await tryAsync({
-			try: async () => {
-				const modelRoot = await getModelRoot();
-				await mkdir(modelRoot, { recursive: true });
+		const engine = models[0].engine;
 
-				if (fileSelectionMode === 'directory') {
-					const selected = await open({
-						directory: true,
-						multiple: false,
-						title: `Select ${title} Directory`,
-					});
+		if (fileSelectionMode === 'directory') {
+			const selected = await open({
+				directory: true,
+				multiple: false,
+				title: `Select ${title} Directory`,
+			});
+			if (!selected) return;
 
-					if (selected) {
-						const entries = await readDir(selected);
-						if (entries.length === 0) {
-							throw new Error('Selected directory appears to be empty');
-						}
-						const directoryName = await basename(selected);
-						const importedPath = await join(modelRoot, directoryName);
-						await copyDirectory(selected, importedPath);
-						value = importedPath;
-						toast.success('Model directory imported');
-					}
-				} else {
-					const filters =
-						fileExtensions.length > 0
-							? [
-									{
-										name: `${title} Files`,
-										extensions: fileExtensions,
-									},
-								]
-							: [];
-
-					const selected = await open({
-						multiple: false,
-						filters,
-						title: `Select ${title} File`,
-					});
-
-					if (selected) {
-						const fileName = await basename(selected);
-						const importedPath = await join(modelRoot, fileName);
-						await copyFile(selected, importedPath);
-						value = importedPath;
-						toast.success('Model file imported');
-					}
-				}
-			},
-			catch: (error) => {
+			const { data, error } = await importModelDirectory({
+				engine,
+				sourceDir: selected,
+			});
+			if (error) {
 				toast.error('Failed to select model', {
-					description: extractErrorMessage(error),
+					description: error.message,
 				});
-				return Ok(undefined);
-			},
-		});
+				return;
+			}
+			value = data.path;
+			toast.success('Model directory imported');
+		} else {
+			const filters =
+				fileExtensions.length > 0
+					? [
+							{
+								name: `${title} Files`,
+								extensions: fileExtensions,
+							},
+						]
+					: [];
+
+			const selected = await open({
+				multiple: false,
+				filters,
+				title: `Select ${title} File`,
+			});
+			if (!selected) return;
+
+			const { data, error } = await importModelFile({
+				engine,
+				sourcePath: selected,
+			});
+			if (error) {
+				toast.error('Failed to select model', {
+					description: error.message,
+				});
+				return;
+			}
+			value = data.path;
+			toast.success('Model file imported');
+		}
 	}
 
 	/**

--- a/apps/whispering/src/lib/components/settings/README.md
+++ b/apps/whispering/src/lib/components/settings/README.md
@@ -45,7 +45,9 @@ settings/
 │   ├── TransformationSelector.svelte
 │   ├── TranscriptionSelector.svelte
 │   └── RecordingModeSelector.svelte
+├── LocalModelSelector.svelte
 ├── LocalModelDownloadCard.svelte
+├── TranscriptionServiceSelect.svelte
 └── README.md               # This file
 ```
 

--- a/apps/whispering/src/lib/operations/local-models.ts
+++ b/apps/whispering/src/lib/operations/local-models.ts
@@ -1,0 +1,97 @@
+/**
+ * Lifecycle orchestration for one pre-built local transcription model:
+ * combines its on-disk storage handle with the engine's model path setting
+ * in `deviceConfig` (the key comes from the provider registry). A model is
+ * "active" when that setting points at its canonical install path.
+ */
+import { Err, Ok, type Result } from 'wellcrafted/result';
+import type { LocalModelConfig } from '$lib/constants/local-models';
+import {
+	createModelStorage,
+	type LocalModelStorageError,
+} from '$lib/services/transcription/local-model-storage';
+import { PROVIDERS } from '$lib/services/transcription/providers';
+import { deviceConfig } from '$lib/state/device-config.svelte';
+
+/**
+ * Per-model handle the settings UI drives. Stateless; safe to recreate
+ * freely (the download card derives one from its `model` prop).
+ */
+export function createPrebuiltModel(model: LocalModelConfig) {
+	const storage = createModelStorage(model);
+	const settingsKey = PROVIDERS[model.engine].modelPathKey;
+
+	return {
+		/**
+		 * The engine's currently selected model path. Reads `deviceConfig`,
+		 * so reading it inside `$effect` or `$derived` tracks changes.
+		 */
+		get activeModelPath() {
+			return deviceConfig.get(settingsKey);
+		},
+
+		/**
+		 * Where the model stands on this device: missing or corrupted
+		 * (`not-downloaded`), installed (`ready`), or installed and selected
+		 * as the engine's model path (`active`). Never rejects.
+		 */
+		async getStatus(): Promise<'not-downloaded' | 'ready' | 'active'> {
+			const installedPath = await storage.getInstalledPath();
+			if (!installedPath) return 'not-downloaded';
+			const isActive = deviceConfig.get(settingsKey) === installedPath;
+			return isActive ? 'active' : 'ready';
+		},
+
+		/**
+		 * Point the engine's model path setting at this model's canonical
+		 * install path.
+		 */
+		async activate(): Promise<void> {
+			deviceConfig.set(settingsKey, await storage.getPath());
+		},
+
+		/**
+		 * Download the model (skipping the download when a valid install
+		 * already exists) and activate it. The `outcome` tells callers which
+		 * happened so they can phrase confirmation accordingly.
+		 */
+		async downloadAndActivate({
+			onProgress,
+		}: {
+			onProgress: (progress: number) => void;
+		}): Promise<
+			Result<
+				{ outcome: 'downloaded' | 'already-installed' },
+				LocalModelStorageError
+			>
+		> {
+			const installedPath = await storage.getInstalledPath();
+			if (installedPath) {
+				deviceConfig.set(settingsKey, installedPath);
+				return Ok({ outcome: 'already-installed' });
+			}
+
+			const { data, error: downloadError } = await storage.download({
+				onProgress,
+			});
+			if (downloadError) return Err(downloadError);
+
+			deviceConfig.set(settingsKey, data.path);
+			return Ok({ outcome: 'downloaded' });
+		},
+
+		/**
+		 * Remove the model from disk and, when it was the engine's active
+		 * model, clear the engine's model path setting.
+		 */
+		async delete(): Promise<Result<void, LocalModelStorageError>> {
+			const { data, error: deleteError } = await storage.delete();
+			if (deleteError) return Err(deleteError);
+
+			if (deviceConfig.get(settingsKey) === data.path) {
+				deviceConfig.set(settingsKey, '');
+			}
+			return Ok(undefined);
+		},
+	};
+}

--- a/apps/whispering/src/lib/services/fs-paths.ts
+++ b/apps/whispering/src/lib/services/fs-paths.ts
@@ -25,15 +25,20 @@ async function appDataPath(...segments: string[]) {
 }
 
 export const PATHS = {
-	/** Local transcription model directories under `models/`. */
+	/**
+	 * Local transcription model directories under `models/`, keyed by engine
+	 * id so consumers can index with `PATHS.MODELS[engine]()`. The directory
+	 * names are durable on-disk contracts (existing installs and saved model
+	 * paths point at them), which is why `whispercpp` maps to `whisper`.
+	 */
 	MODELS: {
-		async WHISPER() {
+		async whispercpp() {
 			return appDataPath('models', 'whisper');
 		},
-		async PARAKEET() {
+		async parakeet() {
 			return appDataPath('models', 'parakeet');
 		},
-		async MOONSHINE() {
+		async moonshine() {
 			return appDataPath('models', 'moonshine');
 		},
 	},

--- a/apps/whispering/src/lib/services/transcription/README.md
+++ b/apps/whispering/src/lib/services/transcription/README.md
@@ -6,4 +6,4 @@ This directory organizes transcription providers (service implementations):
 
 **`/self-hosted`**: Services that connect to servers you deploy yourself on your own machine. You provide the base URL of your own instance.
 
-**Local engines (whispercpp / parakeet / moonshine)** do not have JS service files. Rust owns model loading, caching, and inference via the `transcribe_recording` Tauri command. Dispatch is inlined as one switch in `$lib/operations/transcribe.ts`, sharing the preflight + error mapping in `./local-transcription.ts`. Download catalogs live in `$lib/constants/local-models.ts`.
+**Local engines (whispercpp / parakeet / moonshine)** have no JS transcription services. Rust owns model loading, caching, and inference via the `transcribe_recording` Tauri command. Dispatch is inlined as one switch in `$lib/operations/transcribe.ts`, sharing the preflight in `./local-preflight.ts`. Download catalogs live in `$lib/constants/local-models.ts`; on-disk model storage (download, import, delete) lives in `./local-model-storage.ts`, orchestrated per model by `createPrebuiltModel` in `$lib/operations/local-models.ts`.

--- a/apps/whispering/src/lib/services/transcription/local-model-storage.ts
+++ b/apps/whispering/src/lib/services/transcription/local-model-storage.ts
@@ -1,0 +1,376 @@
+/**
+ * On-disk storage for pre-built local transcription models: resolve where a
+ * model lives, verify an install, stream downloads from the catalog URLs,
+ * import user-selected files or directories, and delete installs.
+ *
+ * UI-free and settings-free. Activation (writing the model path into
+ * `deviceConfig`) lives in `$lib/operations/local-models.ts`.
+ *
+ * Layout under the appdata root (see `$lib/services/fs-paths`):
+ * - Whisper:   `models/whisper/{filename}` (a single .bin file)
+ * - Parakeet:  `models/parakeet/{directoryName}/` (multiple ONNX files)
+ * - Moonshine: `models/moonshine/{directoryName}/` (multiple ONNX files)
+ */
+import { basename, join } from '@tauri-apps/api/path';
+import {
+	copyFile,
+	exists,
+	mkdir,
+	readDir,
+	remove,
+	stat,
+	writeFile,
+} from '@tauri-apps/plugin-fs';
+import { fetch } from '@tauri-apps/plugin-http';
+import {
+	defineErrors,
+	extractErrorMessage,
+	type InferErrors,
+} from 'wellcrafted/error';
+import { Err, Ok, type Result, tryAsync } from 'wellcrafted/result';
+import type { LocalModelConfig } from '$lib/constants/local-models';
+import { PATHS } from '$lib/services/fs-paths';
+import { isModelFileSizeValid } from '$lib/services/transcription/model-file';
+
+export const LocalModelStorageError = defineErrors({
+	DownloadRequestFailed: ({
+		url,
+		status,
+	}: {
+		url: string;
+		status: number;
+	}) => ({
+		message: `Failed to download: ${status}`,
+		url,
+		status,
+	}),
+	DownloadIncomplete: ({
+		downloadedMb,
+		expectedMb,
+	}: {
+		downloadedMb: number;
+		expectedMb: number;
+	}) => ({
+		message: `Download incomplete: received ${downloadedMb}MB but expected ${expectedMb}MB. Please check your network connection and try again.`,
+		downloadedMb,
+		expectedMb,
+	}),
+	DownloadFailed: ({ cause }: { cause: unknown }) => ({
+		message: extractErrorMessage(cause),
+		cause,
+	}),
+	DeleteFailed: ({ cause }: { cause: unknown }) => ({
+		message: extractErrorMessage(cause),
+		cause,
+	}),
+	ImportFailed: ({ cause }: { cause: unknown }) => ({
+		message: extractErrorMessage(cause),
+		cause,
+	}),
+	EmptyModelDirectory: () => ({
+		message: 'Selected directory appears to be empty',
+	}),
+});
+export type LocalModelStorageError = InferErrors<typeof LocalModelStorageError>;
+
+type Engine = LocalModelConfig['engine'];
+
+/**
+ * Stream one file to disk, appending chunk by chunk so large models never
+ * buffer fully in memory. Reports whole-file progress as 0-100.
+ */
+async function downloadFileTo({
+	url,
+	sizeBytes,
+	filePath,
+	onProgress,
+}: {
+	url: string;
+	/** Catalog size, used when the response has no content-length header. */
+	sizeBytes: number;
+	filePath: string;
+	onProgress: (progress: number) => void;
+}): Promise<Result<void, LocalModelStorageError>> {
+	const { data: response, error: fetchError } = await tryAsync({
+		try: () => fetch(url),
+		catch: (error) => LocalModelStorageError.DownloadFailed({ cause: error }),
+	});
+	if (fetchError) return Err(fetchError);
+	if (!response.ok) {
+		return LocalModelStorageError.DownloadRequestFailed({
+			url,
+			status: response.status,
+		});
+	}
+
+	const contentLength = response.headers.get('content-length');
+	const totalBytes = contentLength
+		? Number.parseInt(contentLength, 10)
+		: sizeBytes;
+
+	const { data: downloadedBytes, error: streamError } = await tryAsync({
+		try: async () => {
+			const reader = response.body?.getReader();
+			if (!reader) {
+				throw new Error('Failed to read response body');
+			}
+
+			// Create or truncate the file first
+			await writeFile(filePath, new Uint8Array());
+
+			let bytes = 0;
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+
+				// Write each chunk directly to disk using append mode
+				await writeFile(filePath, value, { append: true });
+
+				bytes += value.length;
+				onProgress(Math.round((bytes / totalBytes) * 100));
+			}
+			return bytes;
+		},
+		catch: (error) => LocalModelStorageError.DownloadFailed({ cause: error }),
+	});
+	if (streamError) return Err(streamError);
+
+	if (downloadedBytes < totalBytes) {
+		await tryAsync({
+			try: () => remove(filePath),
+			catch: () => Ok(undefined),
+		});
+		return LocalModelStorageError.DownloadIncomplete({
+			downloadedMb: Math.round(downloadedBytes / 1_000_000),
+			expectedMb: Math.round(totalBytes / 1_000_000),
+		});
+	}
+	return Ok(undefined);
+}
+
+/**
+ * Per-model handle over the model's on-disk install. Stateless; safe to
+ * recreate freely.
+ */
+export function createModelStorage(model: LocalModelConfig) {
+	async function getPath(): Promise<string> {
+		const dir = await PATHS.MODELS[model.engine]();
+		switch (model.engine) {
+			case 'whispercpp':
+				return join(dir, model.file.filename);
+			case 'parakeet':
+			case 'moonshine':
+				return join(dir, model.directoryName);
+		}
+	}
+
+	return {
+		/**
+		 * The canonical install path: a file for Whisper, a directory for
+		 * Parakeet and Moonshine. Pure path math; does not touch disk.
+		 */
+		getPath,
+
+		/**
+		 * The canonical path when a valid install exists there, else null.
+		 * Every expected file must exist with a plausible size (at least 90%
+		 * of the catalog size), so interrupted downloads read as missing.
+		 * Never rejects; any filesystem or path error reads as missing.
+		 */
+		async getInstalledPath(): Promise<string | null> {
+			const { data: installedPath } = await tryAsync({
+				try: async (): Promise<string | null> => {
+					const path = await getPath();
+					if (!(await exists(path))) return null;
+					switch (model.engine) {
+						case 'whispercpp': {
+							const stats = await stat(path);
+							return isModelFileSizeValid(stats.size, model.sizeBytes)
+								? path
+								: null;
+						}
+						case 'parakeet':
+						case 'moonshine': {
+							const dirStats = await stat(path);
+							if (!dirStats.isDirectory) return null;
+							for (const file of model.files) {
+								const filePath = await join(path, file.filename);
+								if (!(await exists(filePath))) return null;
+								const fileStats = await stat(filePath);
+								if (!isModelFileSizeValid(fileStats.size, file.sizeBytes)) {
+									return null;
+								}
+							}
+							return path;
+						}
+					}
+				},
+				catch: () => Ok(null),
+			});
+			return installedPath ?? null;
+		},
+
+		/**
+		 * Download the model to its canonical path. `onProgress` receives
+		 * overall progress as 0-100, aggregated across files for multi-file
+		 * models. Does not check for an existing install; callers decide
+		 * whether to skip.
+		 */
+		async download({
+			onProgress,
+		}: {
+			onProgress: (progress: number) => void;
+		}): Promise<Result<{ path: string }, LocalModelStorageError>> {
+			const { data: path, error: prepareError } = await tryAsync({
+				try: async () => {
+					await mkdir(await PATHS.MODELS[model.engine](), { recursive: true });
+					const destination = await getPath();
+					if (model.engine !== 'whispercpp') {
+						await mkdir(destination, { recursive: true });
+					}
+					return destination;
+				},
+				catch: (error) =>
+					LocalModelStorageError.DownloadFailed({ cause: error }),
+			});
+			if (prepareError) return Err(prepareError);
+
+			switch (model.engine) {
+				case 'whispercpp': {
+					const { error } = await downloadFileTo({
+						url: model.file.url,
+						sizeBytes: model.sizeBytes,
+						filePath: path,
+						onProgress,
+					});
+					if (error) return Err(error);
+					break;
+				}
+				case 'parakeet':
+				case 'moonshine': {
+					const totalBytes = model.sizeBytes;
+					let completedBytes = 0;
+					for (const file of model.files) {
+						const { data: filePath, error: joinError } = await tryAsync({
+							try: () => join(path, file.filename),
+							catch: (error) =>
+								LocalModelStorageError.DownloadFailed({ cause: error }),
+						});
+						if (joinError) return Err(joinError);
+						const { error } = await downloadFileTo({
+							url: file.url,
+							sizeBytes: file.sizeBytes,
+							filePath,
+							onProgress: (fileProgress) => {
+								onProgress(
+									Math.round(
+										((completedBytes + (file.sizeBytes * fileProgress) / 100) /
+											totalBytes) *
+											100,
+									),
+								);
+							},
+						});
+						if (error) return Err(error);
+						completedBytes += file.sizeBytes;
+					}
+					break;
+				}
+			}
+			return Ok({ path });
+		},
+
+		/**
+		 * Remove the model's files from disk. Succeeds (and returns the
+		 * canonical path) even when nothing is installed, so callers can
+		 * always reconcile settings against the returned path.
+		 */
+		async delete(): Promise<Result<{ path: string }, LocalModelStorageError>> {
+			return tryAsync({
+				try: async () => {
+					const path = await getPath();
+					if (await exists(path)) {
+						const isDirectory = model.engine !== 'whispercpp';
+						await remove(path, { recursive: isDirectory });
+					}
+					return { path };
+				},
+				catch: (error) => LocalModelStorageError.DeleteFailed({ cause: error }),
+			});
+		},
+	};
+}
+
+/** Copy a user-selected model file into the engine's models directory. */
+export async function importModelFile({
+	engine,
+	sourcePath,
+}: {
+	engine: Engine;
+	sourcePath: string;
+}): Promise<Result<{ path: string }, LocalModelStorageError>> {
+	return tryAsync({
+		try: async () => {
+			const modelsDir = await PATHS.MODELS[engine]();
+			await mkdir(modelsDir, { recursive: true });
+			const destination = await join(modelsDir, await basename(sourcePath));
+			await copyFile(sourcePath, destination);
+			return { path: destination };
+		},
+		catch: (error) => LocalModelStorageError.ImportFailed({ cause: error }),
+	});
+}
+
+async function copyDirectoryRecursive(
+	sourceDir: string,
+	destinationDir: string,
+): Promise<void> {
+	await mkdir(destinationDir, { recursive: true });
+	const entries = await readDir(sourceDir);
+
+	for (const entry of entries) {
+		const sourcePath = await join(sourceDir, entry.name);
+		const destinationPath = await join(destinationDir, entry.name);
+
+		if (entry.isDirectory) {
+			await copyDirectoryRecursive(sourcePath, destinationPath);
+		} else if (entry.isFile) {
+			await copyFile(sourcePath, destinationPath);
+		} else {
+			throw new Error('Selected model directory cannot include symlinks');
+		}
+	}
+}
+
+/**
+ * Copy a user-selected model directory into the engine's models directory,
+ * keeping the source directory's name. Rejects empty directories and
+ * directories containing symlinks.
+ */
+export async function importModelDirectory({
+	engine,
+	sourceDir,
+}: {
+	engine: Engine;
+	sourceDir: string;
+}): Promise<Result<{ path: string }, LocalModelStorageError>> {
+	const { data: entries, error: readError } = await tryAsync({
+		try: () => readDir(sourceDir),
+		catch: (error) => LocalModelStorageError.ImportFailed({ cause: error }),
+	});
+	if (readError) return Err(readError);
+	if (entries.length === 0) {
+		return LocalModelStorageError.EmptyModelDirectory();
+	}
+
+	return tryAsync({
+		try: async () => {
+			const modelsDir = await PATHS.MODELS[engine]();
+			await mkdir(modelsDir, { recursive: true });
+			const destination = await join(modelsDir, await basename(sourceDir));
+			await copyDirectoryRecursive(sourceDir, destination);
+			return { path: destination };
+		},
+		catch: (error) => LocalModelStorageError.ImportFailed({ cause: error }),
+	});
+}

--- a/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
@@ -447,7 +447,6 @@
 						models={WHISPER_MODELS}
 						title="Whisper Model"
 						description="Select a pre-built model or browse for your own. Models run locally for private, offline transcription."
-						fileSelectionMode="file"
 						fileExtensions={['bin', 'gguf', 'ggml']}
 						bind:value={() => deviceConfig.get('transcription.whispercpp.modelPath'),
 							(v) => deviceConfig.set('transcription.whispercpp.modelPath', v)}
@@ -506,7 +505,6 @@
 						models={PARAKEET_MODELS}
 						title="Parakeet Model"
 						description="Parakeet is an NVIDIA NeMo model optimized for fast local transcription. It automatically detects the language and doesn't support manual language selection."
-						fileSelectionMode="directory"
 						bind:value={() => deviceConfig.get('transcription.parakeet.modelPath'),
 						(v) => deviceConfig.set('transcription.parakeet.modelPath', v)}
 					>
@@ -580,7 +578,6 @@
 						models={MOONSHINE_MODELS}
 						title="Moonshine Model"
 						description="Moonshine is an efficient ONNX model by UsefulSensors. English-only with fast inference and small model sizes (~30 MB)."
-						fileSelectionMode="directory"
 						bind:value={() => deviceConfig.get('transcription.moonshine.modelPath'),
 						(v) => deviceConfig.set('transcription.moonshine.modelPath', v)}
 					>

--- a/apps/whispering/src/routes/(app)/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/+layout.svelte
@@ -7,6 +7,7 @@
 	import { migrateOldSettings } from '$lib/migration/migrate-settings';
 	import { analytics } from '$lib/operations/analytics';
 	import { services } from '$lib/services';
+	import { PROVIDERS } from '$lib/services/transcription/providers';
 	import { deviceConfig } from '$lib/state/device-config.svelte';
 	import { localModel } from '$lib/state/local-model.svelte';
 	import { settings } from '$lib/state/settings.svelte';
@@ -28,10 +29,6 @@
 	const LOCAL_ENGINES = new Set<Engine>(['whispercpp', 'parakeet', 'moonshine']);
 	function isLocalEngine(serviceId: string): serviceId is Engine {
 		return LOCAL_ENGINES.has(serviceId as Engine);
-	}
-
-	function modelPathKey(engine: Engine) {
-		return `transcription.${engine}.modelPath` as const;
 	}
 
 	// Sidebar when wide, bottom bar on narrow viewports (phone, small window).
@@ -59,7 +56,7 @@
 		const service = settings.get('transcription.service');
 		if (!isLocalEngine(service)) return;
 
-		const modelPath = deviceConfig.get(modelPathKey(service));
+		const modelPath = deviceConfig.get(PROVIDERS[service].modelPathKey);
 		if (!modelPath) return;
 
 		const language = settings.get('transcription.language');


### PR DESCRIPTION
`LocalModelDownloadCard.svelte` was the whole local model platform in one component: it computed install paths, created directories, streamed HTTP downloads chunk by chunk to disk, validated file sizes, wrote the active model into `deviceConfig`, deleted installs, and fired toasts. `LocalModelSelector.svelte` duplicated another slice of the same filesystem logic for manual imports. None of it was reachable outside those two components, and Whispering's architecture says components don't own business logic.

The lifecycle now flows through two per-model factories, one per layer. The service layer owns disk and network, returns `Result` everywhere, and never touches settings; the operations layer binds that storage handle to the engine's model path setting:

```ts
// services/transcription/local-model-storage.ts
const storage = createModelStorage(model);
await storage.getInstalledPath();          // canonical path when validly installed, else null
await storage.download({ onProgress });    // Result<{ path }, LocalModelStorageError>
await storage.delete();

// operations/local-models.ts
const prebuiltModel = createPrebuiltModel(model);
prebuiltModel.activeModelPath;             // reactive read, tracks deviceConfig in $effect
await prebuiltModel.getStatus();           // 'not-downloaded' | 'ready' | 'active'
await prebuiltModel.downloadAndActivate({ onProgress });
```

The card derives one handle from its prop (`const prebuiltModel = $derived(createPrebuiltModel(model))`) and keeps only its download-progress state machine plus toast copy. The selector keeps the native dialog (it builds titles from the `title` prop) and hands the chosen path to `importModelFile` / `importModelDirectory`.

```txt
constants/local-models.ts            catalog: urls, sizes, directory names
services/fs-paths.ts                 PATHS.MODELS[engine]() model directories
services/transcription/
  local-model-storage.ts             disk: download, verify, import, delete
  providers.ts                       modelPathKey, the one owner of the settings key
operations/local-models.ts           status, activate, download-and-activate, delete
components/settings/*                render state, fire toasts
```

**The engine-to-settings-key mapping now has one owner.** `PROVIDERS` already published `modelPathKey` per local provider, but the root layout re-derived the key with a private template helper and the components spelled it a third way. Operations and the layout now both index `PROVIDERS[engine].modelPathKey`; the template spellings are gone. Similarly, `PATHS.MODELS` is keyed by engine id (`whispercpp`/`parakeet`/`moonshine`) so consumers index it directly instead of switching through a second vocabulary; the on-disk directory names are byte-identical.

**A few behavior fixes fell out of the move.** `download()` returns the path it wrote, so activation is a plain `deviceConfig.set` and can no longer throw from inside a `Result`-typed flow. The double toast on a fresh download ("Model activated" followed by "Model downloaded and activated successfully") is gone; each flow fires exactly one. Opening the settings page no longer `mkdir`s model directories as a side effect of checking status. And a `deviceConfig` change mid-download can no longer clobber the progress UI back to "not-downloaded". Everything durable is untouched: install paths (`models/whisper/{file}`, `models/{parakeet,moonshine}/{dir}`), the `transcription.{engine}.modelPath` keys, and all user-facing copy except one unreachable error toast that the selector's non-empty `models` tuple type now forbids.

Review path: start with `createModelStorage` in `local-model-storage.ts`, then `createPrebuiltModel` in `operations/local-models.ts`, then skim the card as proof the components shrank to rendering. Verified with `bun run --cwd apps/whispering typecheck` (0 errors, no new warnings) and biome. Net: the two components dropped from ~680 lines of mixed concerns to ~420 lines that mostly render.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783865177&installation_id=128463665&pr_number=1918&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1918&signature=ebc0ac162ed61593146c2499ce9473b2c0d65dcffc42d2630e39451fa0c6dd69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->