### PR TITLE
fix: make AI provider house keys optional for self-host deployments

### DIFF
--- a/apps/api/worker/index.ts
+++ b/apps/api/worker/index.ts
@@ -25,6 +25,7 @@ import {
 	Room,
 	requireBearerUser,
 	requireCookieOrBearerUser,
+	type ServerBindings,
 } from '@epicenter/server';
 import { describeRoute } from 'hono-openapi';
 import {
@@ -33,6 +34,11 @@ import {
 } from './billing/policies.js';
 import { mountBillingApi } from './billing/routes.js';
 import { buildEpicenterTrustedOrigins } from './trusted-origins.js';
+
+// Compile-time proof that this worker's generated Env provides every
+// binding the library reads. A missing or mistyped binding fails here,
+// not deep inside library files compiled in this program.
+({}) as Cloudflare.Env satisfies ServerBindings;
 
 const ownership = personal();
 

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -69,6 +69,9 @@
 			// "2:newBase64,1:oldBase64"). Generate each secret with: openssl rand -base64 32
 			"ENCRYPTION_SECRETS",
 			"GOOGLE_CLIENT_SECRET",
+			// House AI keys are required here even though the library types them
+			// as optional bindings: hosted credits are billed against house-key
+			// usage, so a deploy without them would 503 paying users.
 			"OPENAI_API_KEY",
 			"AUTUMN_SECRET_KEY",
 			"GEMINI_API_KEY"

--- a/apps/self-host/README.md
+++ b/apps/self-host/README.md
@@ -41,10 +41,15 @@ wrangler secret put ...
 ## Deploy
 
 ```bash
-bun run --cwd apps/self-host typegen      # generate worker-configuration.d.ts
 bun run --cwd apps/self-host typecheck
 bun run --cwd apps/self-host deploy
 ```
+
+`worker-configuration.d.ts` is hand-written: it inherits the library's
+binding contract (`ServerBindings`) and declares only deployment-owned
+vars, so there is no typegen step. If you add bindings of your own, declare
+them there (or regenerate with `bun run typegen` and re-add the `extends`
+clause).
 
 ## Composition
 

--- a/apps/self-host/README.md
+++ b/apps/self-host/README.md
@@ -34,8 +34,8 @@ wrangler secret put ...
   BETTER_AUTH_SECRET       openssl rand -base64 32
   ENCRYPTION_SECRETS       "1:$(openssl rand -base64 32)"  (versioned)
   GOOGLE_CLIENT_SECRET     your Google OAuth client secret
-  OPENAI_API_KEY           your provider key (or omit and BYOK)
-  GEMINI_API_KEY           your provider key (or omit and BYOK)
+  OPENAI_API_KEY           optional house key; omit and members BYOK
+  GEMINI_API_KEY           optional house key; omit and members BYOK
 ```
 
 ## Deploy

--- a/apps/self-host/worker-configuration.d.ts
+++ b/apps/self-host/worker-configuration.d.ts
@@ -38,8 +38,12 @@ declare namespace Cloudflare {
 		ENCRYPTION_SECRETS: string;
 		GOOGLE_CLIENT_SECRET: string;
 		GITHUB_CLIENT_SECRET?: string;
-		OPENAI_API_KEY: string;
-		GEMINI_API_KEY: string;
+		// AI provider house keys are optional: omit one and members must bring
+		// their own key (BYOK) for that provider; a house-key request gets 503
+		// ProviderNotConfigured. Mirrors the optional bindings in
+		// @epicenter/server's cloudflare-bindings.d.ts.
+		OPENAI_API_KEY?: string;
+		GEMINI_API_KEY?: string;
 	}
 }
 

--- a/apps/self-host/worker-configuration.d.ts
+++ b/apps/self-host/worker-configuration.d.ts
@@ -2,48 +2,30 @@
  * Cloudflare bindings for apps/self-host.
  *
  * Hand-written so this reference deployable typechecks without requiring a
- * Cloudflare account or a `wrangler types` run. Deployers should regenerate
- * via `bun run typegen` after customizing `wrangler.jsonc`.
+ * Cloudflare account or a `wrangler types` run. The library's binding
+ * contract is inherited from `ServerBindings`, so this file declares only
+ * what the deployment itself owns. If you replace it with `wrangler types`
+ * output, re-add the `extends` clause so the inherited bindings (GitHub
+ * OAuth, AI provider house keys) survive the regeneration.
  *
- * Bindings mirror those declared in `wrangler.jsonc` and the cloudflare
- * bindings the `@epicenter/server` library reads from `c.env`. Hosted-only
- * bindings (Autumn, ASSETS, ADMIN_USER_IDS) are deliberately absent: the
- * shared-wiki reference has no billing surface and no dashboard SPA.
+ * Hosted-only bindings (Autumn, ASSETS, ADMIN_USER_IDS) are deliberately
+ * absent: the shared-wiki reference has no billing surface and no
+ * dashboard SPA.
  */
 
 /// <reference types="@cloudflare/workers-types" />
 
 declare namespace Cloudflare {
-	interface Env {
-		// KV: Better Auth secondary storage
-		SESSION_KV: KVNamespace;
-		// R2: Asset storage
-		ASSETS_BUCKET: R2Bucket;
-		// Hyperdrive: Postgres connection pool
-		HYPERDRIVE: Hyperdrive;
-		// Durable Object: Yjs sync rooms
-		ROOM: DurableObjectNamespace<import('./worker/index').Room>;
-		// vars (wrangler.jsonc)
+	// Heritage clauses cannot contain import() type expressions (TS2499),
+	// so the library contract is aliased before the extends.
+	type ServerBindings = import('@epicenter/server').ServerBindings;
+
+	interface Env extends ServerBindings {
+		// Deployment-owned vars (wrangler.jsonc): this deployment's public
+		// origin and the shared() admission allowlist. The library never
+		// reads these by name; they flow through deployment callbacks.
 		API_PUBLIC_ORIGIN: string;
 		ALLOWED_MEMBER_EMAILS: string;
-		GOOGLE_CLIENT_ID: string;
-		// GitHub OAuth is optional: a deployment that has not registered a
-		// GitHub app simply does not offer GitHub sign-in. The provider and its
-		// sign-in button are both gated on these being present (see the server's
-		// create-auth.ts and the /sign-in route). Mirrors the optional binding
-		// in @epicenter/server's cloudflare-bindings.d.ts.
-		GITHUB_CLIENT_ID?: string;
-		// secrets (wrangler secret put)
-		BETTER_AUTH_SECRET: string;
-		ENCRYPTION_SECRETS: string;
-		GOOGLE_CLIENT_SECRET: string;
-		GITHUB_CLIENT_SECRET?: string;
-		// AI provider house keys are optional: omit one and members must bring
-		// their own key (BYOK) for that provider; a house-key request gets 503
-		// ProviderNotConfigured. Mirrors the optional bindings in
-		// @epicenter/server's cloudflare-bindings.d.ts.
-		OPENAI_API_KEY?: string;
-		GEMINI_API_KEY?: string;
 	}
 }
 

--- a/apps/self-host/worker/index.ts
+++ b/apps/self-host/worker/index.ts
@@ -31,11 +31,9 @@ import {
 
 const ownership = shared({
 	admit: (c) => {
-		const raw = (c.env.ALLOWED_MEMBER_EMAILS ?? '') as string;
 		const allowed = new Set(
-			raw
-				.split(',')
-				.map((s: string) => s.trim())
+			c.env.ALLOWED_MEMBER_EMAILS.split(',')
+				.map((s) => s.trim())
 				.filter(Boolean),
 		);
 		return allowed.has(c.var.user.email);

--- a/apps/self-host/wrangler.jsonc
+++ b/apps/self-host/wrangler.jsonc
@@ -23,13 +23,16 @@
 	// boundary: it lives only in this deployment's environment, so Epicenter
 	// cannot decrypt anything stored here. Self-hosted = functionally
 	// zero-knowledge against Epicenter.
+	//
+	// AI provider house keys (OPENAI_API_KEY, GEMINI_API_KEY) are optional:
+	// `wrangler secret put` one to serve that provider to all members, or
+	// omit it and members bring their own key per request (BYOK). A house-key
+	// request for a missing key gets 503 ProviderNotConfigured.
 	"secrets": {
 		"required": [
 			"BETTER_AUTH_SECRET",
 			"ENCRYPTION_SECRETS",
-			"GOOGLE_CLIENT_SECRET",
-			"OPENAI_API_KEY",
-			"GEMINI_API_KEY"
+			"GOOGLE_CLIENT_SECRET"
 		]
 	},
 

--- a/packages/server/src/cloudflare-bindings.d.ts
+++ b/packages/server/src/cloudflare-bindings.d.ts
@@ -1,49 +1,21 @@
 /**
- * Cloudflare bindings the `@epicenter/server` library reads from `c.env`.
+ * Ambient shim for the library's own TS program only: applies the
+ * `ServerBindings` contract to `Cloudflare.Env` so library code can read
+ * `c.env` without a deployment present.
  *
- * This file is only in the library's own TS program. Each consuming
- * deployment declares `Cloudflare.Env` from exactly one source of its own:
- * apps/api via `wrangler types`, apps/self-host via its hand-written
- * worker-configuration.d.ts. The declarations are never merged across
- * packages, and must not be: `wrangler types` emits literal-typed vars and
- * required secrets that would conflict with the `string`/optional members
- * here. Keep this file and the deployments' Env declarations in agreement
- * by hand. Cloud-only bindings (Autumn, admin IDs, dashboard ASSETS
- * fetcher) live in apps/api's generated file and never appear here.
+ * Deliberately never imported. Each deployment's program resolves
+ * `Cloudflare.Env` from exactly one source of its own (apps/api via
+ * `wrangler types`, apps/self-host via its hand-written
+ * worker-configuration.d.ts) and proves it against `ServerBindings`
+ * itself. Importing this shim from a module would leak the augmentation
+ * into deployment programs and merge with their declarations.
  */
+
+import type { ServerBindings } from './server-bindings.js';
+
 declare global {
 	namespace Cloudflare {
-		interface Env {
-			// The deployment's public origin is NOT read from `c.env` here. The
-			// hosted cloud bakes a constant while a self-host reads operator
-			// config, so each deployment hands `createServerApp` its own
-			// `resolveOrigin(env)` instead of the library reaching for a shared
-			// var name. See server-app.ts.
-			HYPERDRIVE: Hyperdrive;
-			ROOM: DurableObjectNamespace<
-				import('./room/backends/cloudflare/durable-object.js').Room
-			>;
-			ASSETS_BUCKET: R2Bucket;
-			SESSION_KV: KVNamespace;
-			ENCRYPTION_SECRETS: string;
-			BETTER_AUTH_SECRET: string;
-			GOOGLE_CLIENT_ID: string;
-			GOOGLE_CLIENT_SECRET: string;
-			// GitHub is optional: a deployment that has not registered a GitHub
-			// OAuth app simply does not offer GitHub sign-in. The provider and its
-			// sign-in button are both gated on these being present (see
-			// create-auth.ts and the `/sign-in` route).
-			GITHUB_CLIENT_ID?: string;
-			GITHUB_CLIENT_SECRET?: string;
-			// AI provider house keys are optional: a deployment that omits one
-			// serves only BYOK requests for that provider, and /api/ai/chat
-			// returns 503 ProviderNotConfigured when neither a caller key nor a
-			// house key exists (see routes/ai.ts). The hosted cloud requires
-			// both in apps/api/wrangler.jsonc because credits are billed
-			// against house-key usage.
-			OPENAI_API_KEY?: string;
-			GEMINI_API_KEY?: string;
-		}
+		interface Env extends ServerBindings {}
 	}
 }
 

--- a/packages/server/src/cloudflare-bindings.d.ts
+++ b/packages/server/src/cloudflare-bindings.d.ts
@@ -1,13 +1,15 @@
 /**
  * Cloudflare bindings the `@epicenter/server` library reads from `c.env`.
  *
- * Each consuming deployment (apps/api for hosted personal cloud,
- * apps/self-host for self-hosted shared wiki) merges its own `Cloudflare.Env`
- * via `wrangler types`. This
- * declaration teaches the library compiler that the names it reads are
- * required to exist on `Cloudflare.Env`. Optional cloud-only bindings
- * (Autumn, admin IDs, dashboard ASSETS fetcher) live in apps/api's
- * generated worker-configuration.d.ts and never appear here.
+ * This file is only in the library's own TS program. Each consuming
+ * deployment declares `Cloudflare.Env` from exactly one source of its own:
+ * apps/api via `wrangler types`, apps/self-host via its hand-written
+ * worker-configuration.d.ts. The declarations are never merged across
+ * packages, and must not be: `wrangler types` emits literal-typed vars and
+ * required secrets that would conflict with the `string`/optional members
+ * here. Keep this file and the deployments' Env declarations in agreement
+ * by hand. Cloud-only bindings (Autumn, admin IDs, dashboard ASSETS
+ * fetcher) live in apps/api's generated file and never appear here.
  */
 declare global {
 	namespace Cloudflare {
@@ -33,8 +35,14 @@ declare global {
 			// create-auth.ts and the `/sign-in` route).
 			GITHUB_CLIENT_ID?: string;
 			GITHUB_CLIENT_SECRET?: string;
-			OPENAI_API_KEY: string;
-			GEMINI_API_KEY: string;
+			// AI provider house keys are optional: a deployment that omits one
+			// serves only BYOK requests for that provider, and /api/ai/chat
+			// returns 503 ProviderNotConfigured when neither a caller key nor a
+			// house key exists (see routes/ai.ts). The hosted cloud requires
+			// both in apps/api/wrangler.jsonc because credits are billed
+			// against house-key usage.
+			OPENAI_API_KEY?: string;
+			GEMINI_API_KEY?: string;
 		}
 	}
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -55,6 +55,10 @@ export { mountSessionApp } from './routes/session.js';
 // app via the `mount*` primitives.
 export { createServerApp } from './server-app.js';
 
+// Binding contract: the Cloudflare bindings the library reads from
+// `c.env`. Each deployment proves its own Env declaration against it
+// (extends in apps/self-host, satisfies in apps/api).
+export type { ServerBindings } from './server-bindings.js';
 // Public Hono context type the deployment composes around library
 // middleware.
 export type { Env } from './types.js';

--- a/packages/server/src/routes/ai.ts
+++ b/packages/server/src/routes/ai.ts
@@ -12,9 +12,8 @@
  *
  * House keys (`OPENAI_API_KEY`, `GEMINI_API_KEY`) are optional bindings: a
  * deployment that omits one serves only BYOK requests for that provider,
- * and a house-key request gets 503 ProviderNotConfigured. The hosted cloud
- * requires both in its wrangler config because credits are billed against
- * house-key usage.
+ * and a house-key request gets 503 ProviderNotConfigured. Hosted requires
+ * both at deploy time; see apps/api/wrangler.jsonc for why.
  */
 
 import {

--- a/packages/server/src/routes/ai.ts
+++ b/packages/server/src/routes/ai.ts
@@ -9,6 +9,12 @@
  * BYOK: callers may pass `apiKey` in the request body, in which case the
  * deployment's provider key is ignored. No billing implications; the
  * library treats BYOK and house-key the same.
+ *
+ * House keys (`OPENAI_API_KEY`, `GEMINI_API_KEY`) are optional bindings: a
+ * deployment that omits one serves only BYOK requests for that provider,
+ * and a house-key request gets 503 ProviderNotConfigured. The hosted cloud
+ * requires both in its wrangler config because credits are billed against
+ * house-key usage.
  */
 
 import {

--- a/packages/server/src/server-bindings.ts
+++ b/packages/server/src/server-bindings.ts
@@ -1,0 +1,45 @@
+/**
+ * Cloudflare bindings the `@epicenter/server` library reads from `c.env`.
+ *
+ * Single source of truth for the library's binding contract. The library's
+ * own program applies it to `Cloudflare.Env` through the ambient shim in
+ * cloudflare-bindings.d.ts; each deployment proves its own Env declaration
+ * against it (apps/self-host extends it in worker-configuration.d.ts,
+ * apps/api asserts `satisfies` in its worker entry). Assignability lets a
+ * deployment strengthen the contract (a required `string` satisfies an
+ * optional member), never weaken it.
+ *
+ * Cloud-only bindings (Autumn, admin IDs, dashboard ASSETS fetcher) live in
+ * apps/api's generated worker-configuration.d.ts and never appear here.
+ */
+
+import type { Room } from './room/backends/cloudflare/durable-object.js';
+
+export interface ServerBindings {
+	// The deployment's public origin is NOT read from `c.env` here. The
+	// hosted cloud bakes a constant while a self-host reads operator
+	// config, so each deployment hands `createServerApp` its own
+	// `resolveOrigin(env)` instead of the library reaching for a shared
+	// var name. See server-app.ts.
+	HYPERDRIVE: Hyperdrive;
+	ROOM: DurableObjectNamespace<Room>;
+	ASSETS_BUCKET: R2Bucket;
+	SESSION_KV: KVNamespace;
+	ENCRYPTION_SECRETS: string;
+	BETTER_AUTH_SECRET: string;
+	GOOGLE_CLIENT_ID: string;
+	GOOGLE_CLIENT_SECRET: string;
+	// GitHub is optional: a deployment that has not registered a GitHub
+	// OAuth app simply does not offer GitHub sign-in. The provider and its
+	// sign-in button are both gated on these being present (see
+	// create-auth.ts and the `/sign-in` route).
+	GITHUB_CLIENT_ID?: string;
+	GITHUB_CLIENT_SECRET?: string;
+	// AI provider house keys are optional: a deployment that omits one
+	// serves only BYOK requests for that provider, and /api/ai/chat
+	// returns 503 ProviderNotConfigured when neither a caller key nor a
+	// house key exists (see routes/ai.ts). Hosted requires both at deploy
+	// time; see apps/api/wrangler.jsonc for why.
+	OPENAI_API_KEY?: string;
+	GEMINI_API_KEY?: string;
+}

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -47,11 +47,11 @@ export type Connection = {
 /**
  * Hono context type for every library sub-app.
  *
- * `Bindings` is `Cloudflare.Env`, augmented by each deployment with the
+ * `Bindings` is `Cloudflare.Env`, declared by each deployment with the
  * exact set of bindings it provides. The library declares the bindings it
- * reads via {@link cloudflare-bindings.d.ts}; cloud-only bindings such as
- * `AUTUMN_SECRET_KEY` are declared in apps/api's generated types and never
- * appear in the library's required set.
+ * reads in the exported `ServerBindings` interface (see
+ * server-bindings.ts); cloud-only bindings such as `AUTUMN_SECRET_KEY` are
+ * declared in apps/api's generated types and never appear there.
  *
  * `Variables` are populated by request-scoped middleware: database client,
  * auth instance, resolved user, after-response queue, and the runtime-


### PR DESCRIPTION
The self-host README promises "your provider key (or omit and BYOK)", and the `/api/ai/chat` route delivers on it: a request with a caller-supplied `apiKey` never touches the deployment's keys, and a house-key request without one gets a clean 503 ProviderNotConfigured. But the config and types said otherwise. `apps/self-host/wrangler.jsonc` listed `OPENAI_API_KEY` and `GEMINI_API_KEY` in `secrets.required`, forcing every operator to provision keys they may never use, and both the library's `Cloudflare.Env` declaration and self-host's hand-written Env typed them as required strings. This PR aligns everything with the contract the runtime already implements: AI provider house keys are optional bindings, and a deployment that omits one serves only BYOK requests for that provider.

The library types now match the route's guard, following the same pattern as the optional GitHub OAuth bindings:

```ts
// Before
OPENAI_API_KEY: string;
GEMINI_API_KEY: string;

// After
OPENAI_API_KEY?: string;
GEMINI_API_KEY?: string;
```

The hosted cloud is deliberately asymmetric. `apps/api/wrangler.jsonc` keeps both keys in `secrets.required` because credits are billed against house-key usage; a hosted deploy without them would 503 paying users.

```txt
                    library types     wrangler secrets.required
apps/api            optional          required  (billing is house-key metered)
apps/self-host      optional          omitted   (omit a key, members BYOK)
```

---

**The binding contract is now a single exported interface instead of three hand-agreed declarations.** Reconciling the key types exposed the deeper problem: the bindings the library reads were stated in its own ambient d.ts, restated in self-host's hand-written `worker-configuration.d.ts`, and stated a third time in apps/api's generated types, with nothing but a comment asking maintainers to keep them aligned. The library now exports the contract:

```ts
// packages/server/src/server-bindings.ts
export interface ServerBindings {
	HYPERDRIVE: Hyperdrive;
	ROOM: DurableObjectNamespace<Room>;
	// ...
	OPENAI_API_KEY?: string;
	GEMINI_API_KEY?: string;
}
```

Each program then proves its own Env against it with the mechanism that fits. The library's ambient shim applies it globally for its own compile. Self-host's hand-written Env inherits it, which deleted the entire mirrored block and left only what the deployment owns:

```ts
// apps/self-host/worker-configuration.d.ts
declare namespace Cloudflare {
	type ServerBindings = import('@epicenter/server').ServerBindings;
	interface Env extends ServerBindings {
		API_PUBLIC_ORIGIN: string;
		ALLOWED_MEMBER_EMAILS: string;
	}
}
```

And apps/api, whose Env is wrangler-generated and regenerated, asserts compatibility in its worker entry:

```ts
({}) as Cloudflare.Env satisfies ServerBindings;
```

The reason this works where sharing the global declaration would not: `extends` and `satisfies` are assignability checks, not declaration merging. Hosted's required `OPENAI_API_KEY: string` satisfies the library's optional member, and a wrangler-generated literal var satisfies `string`; merging the same declarations would conflict on modifiers and literal types. Required-satisfies-optional is the type-level mirror of the product rule: a deployment may strengthen the binding contract, never weaken it. Dropping a binding apps/api needs now fails at the one-line check (`Type 'Omit<Env, "SESSION_KV">' does not satisfy 'ServerBindings'`) instead of as scattered property errors deep inside library files.

A small adjacent cleanup rode along: the self-host `admit` callback cast `c.env.ALLOWED_MEMBER_EMAILS` to `string` and guarded it with `?? ''`, but the binding is already typed `string` in that program, so the cast, the fallback, and an explicit parameter annotation were all dead. The self-host deploy docs also drop their typegen step, since the hand-written Env (now three lines of deployment-owned vars) is canonical.

## Changelog
- Self-host deployments no longer require OpenAI and Gemini API keys; omit either and members bring their own key per request