### PR TITLE
feat(whispering): redesign local model settings around recommended defaults

### DIFF
--- a/.agents/skills/comparable-apps/SKILL.md
+++ b/.agents/skills/comparable-apps/SKILL.md
@@ -100,6 +100,22 @@ Implication: Epicenter is local-first; the closest references (Obsidian, Logseq)
 
 Asymmetric win surfaced: refusing the feature of "email in chrome" lets the runtime state stop carrying email at all. Email becomes a fetched query at the one surface that wants to display it. See `specs/20260514T210000-profile-as-application-data.md` for the resulting design.
 
+## Worked example: local model pickers (Whispering)
+
+Question: how should a settings screen present downloadable local models (Whisper, Parakeet, Moonshine) when each is a 0.03 to 1.6 GB download?
+
+| App | Category | Picker pattern | Size on action? |
+| --- | --- | --- | --- |
+| Ollama desktop | Local LLM runtime | Picks a default model, downloads on first use; library is secondary | Yes |
+| LM Studio | Local LLM catalog | Full catalog browser with search; "Staff pick" badge | Yes, on every download button |
+| Jan | Local LLM app | Hub with "Recommended" tags | Yes |
+| superwhisper | Local dictation | Onboarding recommends one model with its size; others in a secondary list | Yes |
+| MacWhisper | Local dictation | Model tiers with sizes; recommended default | Yes |
+| Handy | Local dictation (OSS) | Flat model list, recommended default preselected | Yes |
+| Wispr Flow | Dictation (cloud) | No model picker at all; the surface does not exist | n/a |
+
+Implication: local-model apps converge on default-first (one recommended model per engine, size visible on the download action, full catalog secondary). Whispering borrowed default-first plus size-on-action and refused LM Studio's catalog browser, since its largest catalog is four models. Wispr Flow is the refusal boundary: going cloud deletes the surface entirely, which is not Whispering's category. Resulting design: PR #1922 (status hero plus one "All models" disclosure, manual path picker one level deeper).
+
 ## Other questions this lens answers well
 
 ```

--- a/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
@@ -2,13 +2,12 @@
 	import { Badge } from '@epicenter/ui/badge';
 	import { Button } from '@epicenter/ui/button';
 	import { Progress } from '@epicenter/ui/progress';
-	import { toast } from '@epicenter/ui/sonner';
 	import { Spinner } from '@epicenter/ui/spinner';
 	import CheckIcon from '@lucide/svelte/icons/check';
 	import Download from '@lucide/svelte/icons/download';
 	import X from '@lucide/svelte/icons/x';
 	import { type LocalModelConfig } from '$lib/constants/local-models';
-	import { createPrebuiltModel } from '$lib/operations/local-models';
+	import { localModelDownloads } from '$lib/state/local-model-downloads.svelte';
 
 	let {
 		model,
@@ -16,79 +15,14 @@
 		model: LocalModelConfig;
 	} = $props();
 
-	const prebuiltModel = $derived(createPrebuiltModel(model));
+	const download = $derived(localModelDownloads.get(model));
 
-	type ModelState =
-		| { type: 'not-downloaded' }
-		| { type: 'downloading'; progress: number }
-		| { type: 'ready' }
-		| { type: 'active' };
-
-	let modelState = $state<ModelState>({ type: 'not-downloaded' });
-
-	// Check model status on mount and whenever the engine's active model
-	// path changes (the getter reads deviceConfig, so this effect tracks it).
-	$effect(() => {
-		void prebuiltModel.activeModelPath;
-		refreshStatus();
-	});
-
-	async function refreshStatus() {
-		const status = await prebuiltModel.getStatus();
-		// While downloading, the download handler owns the state machine; a
-		// download may also have started while we were checking the disk.
-		if (modelState.type === 'downloading') return;
-		modelState = { type: status };
-	}
-
-	async function downloadModel() {
-		if (modelState.type === 'downloading') return;
-
-		modelState = { type: 'downloading', progress: 0 };
-
-		const { data, error } = await prebuiltModel.downloadAndActivate({
-			onProgress: (progress) => {
-				modelState = { type: 'downloading', progress };
-			},
-		});
-		if (error) {
-			toast.error('Failed to download model', {
-				description: error.message,
-			});
-			modelState = { type: 'not-downloaded' };
-			return;
-		}
-
-		modelState = { type: 'active' };
-		toast.success(
-			data.outcome === 'already-installed'
-				? 'Model already downloaded and activated'
-				: 'Model downloaded and activated successfully',
-		);
-	}
-
-	async function activateModel() {
-		await prebuiltModel.activate();
-		// The settings watcher will update modelState to 'active'
-		toast.success('Model activated');
-	}
-
-	async function deleteModel() {
-		const { error } = await prebuiltModel.delete();
-		if (error) {
-			toast.error('Failed to delete model', {
-				description: error.message,
-			});
-			return;
-		}
-		modelState = { type: 'not-downloaded' };
-		toast.success('Model deleted');
-	}
+	// Aliased so the template narrows the union per branch.
+	const state = $derived(download.state);
 </script>
 
 <div
-	class="flex items-center gap-3 p-3 rounded-lg border {modelState.type ===
-	'active'
+	class="flex items-center gap-3 p-3 rounded-lg border {state.type === 'active'
 		? 'border-primary bg-primary/5'
 		: ''}"
 >
@@ -98,9 +32,9 @@
 			{#if model.recommended}
 				<Badge variant="outline" class="text-xs">Recommended</Badge>
 			{/if}
-			{#if modelState.type === 'active'}
+			{#if state.type === 'active'}
 				<Badge variant="default" class="text-xs">Active</Badge>
-			{:else if modelState.type === 'ready'}
+			{:else if state.type === 'ready'}
 				<Badge variant="secondary" class="text-xs">Downloaded</Badge>
 			{/if}
 		</div>
@@ -109,28 +43,28 @@
 	</div>
 
 	<div class="flex items-center gap-2">
-		{#if modelState.type === 'downloading'}
+		{#if state.type === 'downloading'}
 			<div class="flex items-center gap-2 min-w-[120px]">
 				<Spinner />
-				<span class="text-sm font-medium">{modelState.progress}%</span>
+				<span class="text-sm font-medium">{state.progress}%</span>
 			</div>
-		{:else if modelState.type === 'ready'}
-			<Button size="sm" variant="outline" onclick={activateModel}>
+		{:else if state.type === 'ready'}
+			<Button size="sm" variant="outline" onclick={() => download.activate()}>
 				Activate
 			</Button>
-			<Button size="sm" variant="ghost" onclick={deleteModel}>
+			<Button size="sm" variant="ghost" onclick={() => download.delete()}>
 				<X class="size-4" />
 			</Button>
-		{:else if modelState.type === 'active'}
+		{:else if state.type === 'active'}
 			<Button size="sm" variant="default" disabled>
 				<CheckIcon class="size-4 mr-1" />
 				Activated
 			</Button>
-			<Button size="sm" variant="ghost" onclick={deleteModel}>
+			<Button size="sm" variant="ghost" onclick={() => download.delete()}>
 				<X class="size-4" />
 			</Button>
 		{:else}
-			<Button size="sm" variant="outline" onclick={downloadModel}>
+			<Button size="sm" variant="outline" onclick={() => download.download()}>
 				<Download class="size-4" />
 				Download
 			</Button>
@@ -138,6 +72,6 @@
 	</div>
 </div>
 
-{#if modelState.type === 'downloading' && modelState.progress > 0}
-	<Progress value={modelState.progress} class="mt-2 h-2" />
+{#if state.type === 'downloading' && state.progress > 0}
+	<Progress value={state.progress} class="mt-2 h-2" />
 {/if}

--- a/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
@@ -95,6 +95,9 @@
 	<div class="flex-1">
 		<div class="flex items-center gap-2">
 			<span class="font-medium">{model.name}</span>
+			{#if model.recommended}
+				<Badge variant="outline" class="text-xs">Recommended</Badge>
+			{/if}
 			{#if modelState.type === 'active'}
 				<Badge variant="default" class="text-xs">Active</Badge>
 			{:else if modelState.type === 'ready'}

--- a/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
@@ -1,16 +1,25 @@
 <script lang="ts">
+	import { Badge } from '@epicenter/ui/badge';
 	import { Button } from '@epicenter/ui/button';
 	import * as Card from '@epicenter/ui/card';
+	import * as Collapsible from '@epicenter/ui/collapsible';
+	import * as Empty from '@epicenter/ui/empty';
 	import { Input } from '@epicenter/ui/input';
+	import * as Item from '@epicenter/ui/item';
+	import { Progress } from '@epicenter/ui/progress';
 	import { toast } from '@epicenter/ui/sonner';
-	import * as Tabs from '@epicenter/ui/tabs';
+	import ChevronDown from '@lucide/svelte/icons/chevron-down';
+	import ChevronRight from '@lucide/svelte/icons/chevron-right';
+	import Download from '@lucide/svelte/icons/download';
 	import FolderOpen from '@lucide/svelte/icons/folder-open';
+	import HardDriveDownload from '@lucide/svelte/icons/hard-drive-download';
 	import Paperclip from '@lucide/svelte/icons/paperclip';
 	import X from '@lucide/svelte/icons/x';
 	import { basename } from '@tauri-apps/api/path';
 	import { open } from '@tauri-apps/plugin-dialog';
 	import type { Snippet } from 'svelte';
 	import type { LocalModelConfig } from '$lib/constants/local-models';
+	import { createPrebuiltModel } from '$lib/operations/local-models';
 	import {
 		importModelDirectory,
 		importModelFile,
@@ -42,11 +51,11 @@
 		/** Bindable value with getter/setter for the model path */
 		value: string;
 
-		/** Optional footer content for pre-built models tab */
-		prebuiltFooter?: Snippet;
+		/** Optional footer content for the expanded model catalog */
+		catalogFooter?: Snippet;
 
-		/** Custom instructions for manual selection tab */
-		manualInstructions?: Snippet;
+		/** Help text shown above the bring-your-own-model path picker */
+		manualHelp?: Snippet;
 	};
 
 	let {
@@ -55,8 +64,8 @@
 		description,
 		fileExtensions = [],
 		value = $bindable(),
-		prebuiltFooter,
-		manualInstructions,
+		catalogFooter,
+		manualHelp,
 	}: LocalModelSelectorProps = $props();
 
 	const engine = $derived(models[0].engine);
@@ -86,7 +95,65 @@
 			}
 		}) ?? null,
 	);
-	const isPrebuiltModel = $derived(!!prebuiltModelInfo);
+
+	/** Whether the full catalog (and the manual picker inside it) is expanded. */
+	let allModelsOpen = $state(false);
+
+	// The engine's default download. The catalog marks exactly one model as
+	// recommended; falling back to the first entry keeps the primary action
+	// rendering even if the catalog ever loses the flag.
+	const recommended = $derived(models.find((m) => m.recommended) ?? models[0]);
+	const recommendedModel = $derived(createPrebuiltModel(recommended));
+
+	type RecommendedState =
+		| { type: 'not-downloaded' }
+		| { type: 'downloading'; progress: number }
+		| { type: 'ready' }
+		| { type: 'active' };
+
+	let recommendedState = $state<RecommendedState>({ type: 'not-downloaded' });
+
+	// Check the recommended model's status on mount and whenever the engine's
+	// active model path changes (the getter reads deviceConfig, so this effect
+	// tracks it).
+	$effect(() => {
+		void recommendedModel.activeModelPath;
+		refreshRecommendedStatus();
+	});
+
+	async function refreshRecommendedStatus() {
+		const status = await recommendedModel.getStatus();
+		// While downloading, the download handler owns the state machine; a
+		// download may also have started while we were checking the disk.
+		if (recommendedState.type === 'downloading') return;
+		recommendedState = { type: status };
+	}
+
+	async function downloadRecommended() {
+		if (recommendedState.type === 'downloading') return;
+
+		recommendedState = { type: 'downloading', progress: 0 };
+
+		const { data, error } = await recommendedModel.downloadAndActivate({
+			onProgress: (progress) => {
+				recommendedState = { type: 'downloading', progress };
+			},
+		});
+		if (error) {
+			toast.error('Failed to download model', {
+				description: error.message,
+			});
+			recommendedState = { type: 'not-downloaded' };
+			return;
+		}
+
+		recommendedState = { type: 'active' };
+		toast.success(
+			data.outcome === 'already-installed'
+				? 'Model already downloaded and activated'
+				: 'Model downloaded and activated successfully',
+		);
+	}
 
 	/**
 	 * Open file/folder browser for manual model selection
@@ -161,103 +228,129 @@
 		<Card.Title class="text-lg">{title}</Card.Title>
 		<Card.Description>{description}</Card.Description>
 	</Card.Header>
-	<Card.Content class="space-y-6">
-		<Tabs.Root value="prebuilt" class="w-full">
-			<Tabs.List class="grid w-full grid-cols-2">
-				<Tabs.Trigger value="prebuilt">Pre-built Models</Tabs.Trigger>
-				<Tabs.Trigger value="manual">Manual Selection</Tabs.Trigger>
-			</Tabs.List>
+	<Card.Content class="space-y-3">
+		{#if value}
+			<Item.Root variant="outline">
+				<Item.Content>
+					<Item.Title>
+						{#if prebuiltModelInfo}
+							{prebuiltModelInfo.name}
+						{:else}
+							{#await modelName then name}
+								{name || 'Your own model'}
+							{/await}
+						{/if}
+					</Item.Title>
+					<Item.Description>
+						{prebuiltModelInfo ? prebuiltModelInfo.size : 'Your own model'}
+					</Item.Description>
+				</Item.Content>
+				<Item.Actions>
+					<Badge class="text-xs">Active</Badge>
+					<Button
+						variant="outline"
+						size="sm"
+						onclick={() => (allModelsOpen = !allModelsOpen)}
+					>
+						Change
+					</Button>
+				</Item.Actions>
+			</Item.Root>
+		{:else}
+			<Empty.Root class="py-8">
+				<Empty.Media variant="icon">
+					<HardDriveDownload class="size-5" />
+				</Empty.Media>
+				<Empty.Title>No model installed</Empty.Title>
+				<Empty.Description>
+					Download the recommended model to start transcribing on this
+					device.
+				</Empty.Description>
+				<Empty.Content>
+					{#if recommendedState.type === 'downloading'}
+						<div class="flex w-full max-w-xs flex-col items-center gap-2">
+							<Progress value={recommendedState.progress} class="h-2" />
+							<span class="text-sm text-muted-foreground">
+								Downloading {recommended.name}: {recommendedState.progress}%
+							</span>
+						</div>
+					{:else if recommendedState.type === 'ready'}
+						<Button onclick={downloadRecommended}>
+							Activate {recommended.name}
+						</Button>
+					{:else}
+						<Button onclick={downloadRecommended}>
+							<Download class="size-4" />
+							Download {recommended.name} ({recommended.size})
+						</Button>
+					{/if}
+				</Empty.Content>
+			</Empty.Root>
+		{/if}
 
-			<!-- Pre-built Models Tab -->
-			<Tabs.Content value="prebuilt" class="mt-4 space-y-3">
-				{#each models as model}
+		<Collapsible.Root bind:open={allModelsOpen}>
+			<Collapsible.Trigger
+				class="flex w-full items-center justify-between rounded-lg border px-4 py-3 text-sm font-medium transition-colors hover:bg-muted/50 [&[data-state=open]>svg]:rotate-180"
+			>
+				All models ({models.length})
+				<ChevronDown
+					class="size-4 shrink-0 text-muted-foreground transition-transform"
+				/>
+			</Collapsible.Trigger>
+			<Collapsible.Content class="space-y-3 pt-3">
+				{#each models as model (model.id)}
 					<LocalModelDownloadCard {model} />
 				{/each}
 
-				{#if prebuiltFooter}
+				{#if catalogFooter}
 					<div class="rounded-lg border bg-muted/50 p-4">
-						{@render prebuiltFooter()}
+						{@render catalogFooter()}
 					</div>
 				{/if}
-			</Tabs.Content>
 
-			<!-- Manual Selection Tab -->
-			<Tabs.Content value="manual" class="mt-4 space-y-4">
-				{#if manualInstructions}
-					{@render manualInstructions()}
-				{/if}
+				<Collapsible.Root>
+					<Collapsible.Trigger
+						class="flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground [&[data-state=open]>svg]:rotate-90"
+					>
+						<ChevronRight class="size-4 transition-transform" />
+						Use your own model
+					</Collapsible.Trigger>
+					<Collapsible.Content class="space-y-3 pt-3">
+						{#if manualHelp}
+							{@render manualHelp()}
+						{/if}
 
-				<!-- Model Selection Input -->
-				<div>
-					<p class="text-sm font-medium mb-2">
-						{#if manualInstructions}
-							<span class="text-muted-foreground">Step 2:</span>
-							Select the model
-							{fileSelectionMode === 'directory' ? 'directory' : 'file'}
-						{:else}
-							Select the model
-							{fileSelectionMode === 'directory' ? 'directory' : 'file'}
-						{/if}
-					</p>
-					<div class="flex items-center gap-2">
-						<Input
-							type="text"
-							{value}
-							readonly
-							placeholder="No model selected"
-							class="flex-1"
-						/>
-						{#if value}
-							<Button
-								variant="outline"
-								size="icon"
-								onclick={clearModel}
-								title="Clear model path"
-							>
-								<X class="size-4" />
-							</Button>
-						{/if}
-						<Button
-							variant="outline"
-							size="icon"
-							onclick={selectModel}
-							title={fileSelectionMode === 'directory'
-								? 'Browse for model directory'
-								: 'Browse for model file'}
-						>
-							{#if fileSelectionMode === 'directory'}
-								<FolderOpen class="size-4" />
-							{:else}
-								<Paperclip class="size-4" />
+						<div class="flex items-center gap-2">
+							<Input
+								type="text"
+								{value}
+								readonly
+								placeholder="No model selected"
+								class="flex-1"
+							/>
+							{#if value}
+								<Button
+									variant="outline"
+									size="icon"
+									onclick={clearModel}
+									title="Clear model path"
+								>
+									<X class="size-4" />
+								</Button>
 							{/if}
-						</Button>
-					</div>
-
-					<!-- Display selected model info -->
-					{#if value}
-						<div class="mt-2 space-y-1">
-							{#await modelName then name}
-								{#if name}
-									<p class="text-sm text-muted-foreground">
-										<span class="font-medium">Selected:</span>
-										{name}
-									</p>
+							<Button variant="outline" onclick={selectModel}>
+								{#if fileSelectionMode === 'directory'}
+									<FolderOpen class="size-4" />
+									Choose folder
+								{:else}
+									<Paperclip class="size-4" />
+									Choose file
 								{/if}
-							{/await}
-
-							{#if isPrebuiltModel && prebuiltModelInfo}
-								<p class="text-sm text-muted-foreground">
-									<span class="font-medium">Size:</span>
-									{prebuiltModelInfo.size}
-									{#if fileSelectionMode === 'directory'}
-										(directory with model files)
-									{/if}
-								</p>
-							{/if}
+							</Button>
 						</div>
-					{/if}
-				</div>
-			</Tabs.Content>
-		</Tabs.Root>
+					</Collapsible.Content>
+				</Collapsible.Root>
+			</Collapsible.Content>
+		</Collapsible.Root>
 	</Card.Content>
 </Card.Root>

--- a/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
@@ -19,12 +19,12 @@
 	import { open } from '@tauri-apps/plugin-dialog';
 	import type { Snippet } from 'svelte';
 	import type { LocalModelConfig } from '$lib/constants/local-models';
-	import { createPrebuiltModel } from '$lib/operations/local-models';
 	import {
 		importModelDirectory,
 		importModelFile,
 	} from '$lib/services/transcription/local-model-storage';
 	import { PROVIDERS } from '$lib/services/transcription/providers';
+	import { localModelDownloads } from '$lib/state/local-model-downloads.svelte';
 	import { tauri } from '#platform/tauri';
 	import LocalModelDownloadCard from './LocalModelDownloadCard.svelte';
 
@@ -103,57 +103,12 @@
 	// recommended; falling back to the first entry keeps the primary action
 	// rendering even if the catalog ever loses the flag.
 	const recommended = $derived(models.find((m) => m.recommended) ?? models[0]);
-	const recommendedModel = $derived(createPrebuiltModel(recommended));
+	const recommendedDownload = $derived(localModelDownloads.get(recommended));
 
-	type RecommendedState =
-		| { type: 'not-downloaded' }
-		| { type: 'downloading'; progress: number }
-		| { type: 'ready' }
-		| { type: 'active' };
-
-	let recommendedState = $state<RecommendedState>({ type: 'not-downloaded' });
-
-	// Check the recommended model's status on mount and whenever the engine's
-	// active model path changes (the getter reads deviceConfig, so this effect
-	// tracks it).
-	$effect(() => {
-		void recommendedModel.activeModelPath;
-		refreshRecommendedStatus();
-	});
-
-	async function refreshRecommendedStatus() {
-		const status = await recommendedModel.getStatus();
-		// While downloading, the download handler owns the state machine; a
-		// download may also have started while we were checking the disk.
-		if (recommendedState.type === 'downloading') return;
-		recommendedState = { type: status };
-	}
-
-	async function downloadRecommended() {
-		if (recommendedState.type === 'downloading') return;
-
-		recommendedState = { type: 'downloading', progress: 0 };
-
-		const { data, error } = await recommendedModel.downloadAndActivate({
-			onProgress: (progress) => {
-				recommendedState = { type: 'downloading', progress };
-			},
-		});
-		if (error) {
-			toast.error('Failed to download model', {
-				description: error.message,
-			});
-			recommendedState = { type: 'not-downloaded' };
-			return;
-		}
-
-		recommendedState = { type: 'active' };
-		toast.success(
-			data.outcome === 'already-installed'
-				? 'Model already downloaded and activated'
-				: 'Model downloaded and activated successfully',
-		);
-	}
+	// Aliased so the template narrows the union per branch. Shared with the
+	// catalog row for the same model, so a download started here shows its
+	// progress there too.
+	const recommendedState = $derived(recommendedDownload.state);
 
 	/**
 	 * Open file/folder browser for manual model selection
@@ -275,11 +230,11 @@
 							</span>
 						</div>
 					{:else if recommendedState.type === 'ready'}
-						<Button onclick={downloadRecommended}>
+						<Button onclick={() => recommendedDownload.activate()}>
 							Activate {recommended.name}
 						</Button>
 					{:else}
-						<Button onclick={downloadRecommended}>
+						<Button onclick={() => recommendedDownload.download()}>
 							<Download class="size-4" />
 							Download {recommended.name} ({recommended.size})
 						</Button>

--- a/apps/whispering/src/lib/constants/local-models.ts
+++ b/apps/whispering/src/lib/constants/local-models.ts
@@ -59,6 +59,11 @@ type BaseModelConfig = {
 	size: string;
 	/** Exact size in bytes for progress tracking */
 	sizeBytes: number;
+	/**
+	 * The engine's default download. Exactly one model per engine carries
+	 * this; the settings UI builds its primary action around it.
+	 */
+	recommended?: true;
 };
 
 /** Whisper models are a single .bin file. */
@@ -137,6 +142,7 @@ export const WHISPER_MODELS = [
 		description: 'Fast, good accuracy',
 		size: '488 MB',
 		sizeBytes: 487_601_967,
+		recommended: true,
 		engine: 'whispercpp',
 		file: {
 			url: 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin',
@@ -180,6 +186,7 @@ export const PARAKEET_MODELS = [
 		description: 'Fast and accurate NVIDIA NeMo model',
 		size: '~670 MB',
 		sizeBytes: 670_619_803,
+		recommended: true,
 		engine: 'parakeet',
 		directoryName: 'parakeet-tdt-0.6b-v3-int8',
 		files: [
@@ -230,7 +237,7 @@ export const MOONSHINE_MODELS = [
 	{
 		id: 'moonshine-tiny-en',
 		name: 'Moonshine Tiny (English)',
-		description: 'Fast and efficient English transcription (~28 MB)',
+		description: 'Fast and efficient English transcription',
 		size: '~30 MB',
 		sizeBytes: 30_166_481,
 		engine: 'moonshine',
@@ -257,9 +264,10 @@ export const MOONSHINE_MODELS = [
 	{
 		id: 'moonshine-base-en',
 		name: 'Moonshine Base (English)',
-		description: 'Higher accuracy English transcription (~65 MB)',
+		description: 'Higher accuracy English transcription',
 		size: '~65 MB',
 		sizeBytes: 64_997_467,
+		recommended: true,
 		engine: 'moonshine',
 		language: 'en',
 		directoryName: 'moonshine-base-en',

--- a/apps/whispering/src/lib/state/local-model-downloads.svelte.ts
+++ b/apps/whispering/src/lib/state/local-model-downloads.svelte.ts
@@ -1,0 +1,133 @@
+/**
+ * Shared download state for pre-built local transcription models, keyed by
+ * model id. Every surface that renders a model (catalog row, recommended
+ * model callout) reads the same handle, so a download started in one place
+ * shows its progress everywhere.
+ *
+ * The state machine is computed, not stored: `downloading` while a download
+ * owns the handle, otherwise disk truth (`installedPath`) plus the engine's
+ * reactive model path setting decide between not-downloaded, ready, and
+ * active. Disk is checked once when the handle is first used and kept
+ * current by `download()` and `delete()`; nothing else inside the app can
+ * change the install, so activation changes never need a disk re-check.
+ *
+ * Shape mirrors `local-model.svelte.ts`: factory function with `$state`
+ * closure variables and a return object exposing a reactive getter plus
+ * operations.
+ */
+import { toast } from '@epicenter/ui/sonner';
+import type { LocalModelConfig } from '$lib/constants/local-models';
+import { createPrebuiltModel } from '$lib/operations/local-models';
+import { createModelStorage } from '$lib/services/transcription/local-model-storage';
+
+export type ModelDownloadState =
+	| { type: 'not-downloaded' }
+	| { type: 'downloading'; progress: number }
+	| { type: 'ready' }
+	| { type: 'active' };
+
+function createModelDownload(model: LocalModelConfig) {
+	const storage = createModelStorage(model);
+	const prebuiltModel = createPrebuiltModel(model);
+
+	/** Disk truth: the canonical install path when a valid install exists. */
+	let installedPath = $state<string | null>(null);
+
+	/** Progress 0-100 while this handle owns a download, else null. */
+	let progress = $state<number | null>(null);
+
+	void refreshInstalledPath();
+
+	async function refreshInstalledPath() {
+		installedPath = await storage.getInstalledPath();
+	}
+
+	return {
+		/**
+		 * Where this model stands on this device. A getter, not a `$derived`:
+		 * handles are created lazily from whichever component touches them
+		 * first, and a derived created inside a component's effect context
+		 * goes inert when that component is destroyed (`derived_inert`). The
+		 * computation is two comparisons; consumers that need caching or
+		 * narrowing alias it with a component-local `$derived`.
+		 */
+		get state(): ModelDownloadState {
+			if (progress !== null) return { type: 'downloading', progress };
+			if (!installedPath) return { type: 'not-downloaded' };
+			return prebuiltModel.activeModelPath === installedPath
+				? { type: 'active' }
+				: { type: 'ready' };
+		},
+
+		/**
+		 * Download the model (skipping the download when a valid install
+		 * already exists) and activate it.
+		 */
+		async download() {
+			if (progress !== null) return;
+			progress = 0;
+
+			const { data, error } = await prebuiltModel.downloadAndActivate({
+				onProgress: (value) => {
+					progress = value;
+				},
+			});
+			if (error) {
+				progress = null;
+				toast.error('Failed to download model', {
+					description: error.message,
+				});
+				return;
+			}
+
+			// Refresh disk truth before releasing the downloading state so the
+			// derived machine lands directly on active.
+			await refreshInstalledPath();
+			progress = null;
+			toast.success(
+				data.outcome === 'already-installed'
+					? 'Model already downloaded and activated'
+					: 'Model downloaded and activated successfully',
+			);
+		},
+
+		/** Point the engine's model path setting at this model. */
+		async activate() {
+			await prebuiltModel.activate();
+			toast.success('Model activated');
+		},
+
+		/**
+		 * Remove the model from disk and, when it was the engine's active
+		 * model, clear the engine's model path setting.
+		 */
+		async delete() {
+			const { error } = await prebuiltModel.delete();
+			if (error) {
+				toast.error('Failed to delete model', {
+					description: error.message,
+				});
+				return;
+			}
+			installedPath = null;
+			toast.success('Model deleted');
+		},
+	};
+}
+
+function createLocalModelDownloads() {
+	const handles = new Map<string, ReturnType<typeof createModelDownload>>();
+
+	return {
+		/** The shared download handle for a catalog model, created on first use. */
+		get(model: LocalModelConfig) {
+			const existing = handles.get(model.id);
+			if (existing) return existing;
+			const handle = createModelDownload(model);
+			handles.set(model.id, handle);
+			return handle;
+		},
+	};
+}
+
+export const localModelDownloads = createLocalModelDownloads();

--- a/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
@@ -446,12 +446,12 @@
 					<LocalModelSelector
 						models={WHISPER_MODELS}
 						title="Whisper Model"
-						description="Select a pre-built model or browse for your own. Models run locally for private, offline transcription."
+						description="Models run on this device for private, offline transcription."
 						fileExtensions={['bin', 'gguf', 'ggml']}
 						bind:value={() => deviceConfig.get('transcription.whispercpp.modelPath'),
 							(v) => deviceConfig.set('transcription.whispercpp.modelPath', v)}
 					>
-						{#snippet prebuiltFooter()}
+						{#snippet catalogFooter()}
 							<Field.Description>
 								Models are downloaded from{' '}
 								<Link
@@ -461,38 +461,24 @@
 								>
 									Hugging Face
 								</Link>
-								{' '}and stored locally in your app data directory. Quantized
-								models offer smaller sizes with minimal quality loss.
+								{' '}and stored in your app data directory.
 							</Field.Description>
 						{/snippet}
 
-						{#snippet manualInstructions()}
-							<div>
-								<p class="text-sm font-medium mb-2">
-									<span class="text-muted-foreground">Step 1:</span>
-									Download a Whisper model
-								</p>
-								<ul class="ml-6 mt-2 space-y-2 text-sm text-muted-foreground">
-									<li class="list-disc">
-										Visit the{' '}
-										<Link
-											href="https://huggingface.co/ggerganov/whisper.cpp/tree/main"
-											target="_blank"
-											rel="noopener noreferrer"
-										>
-											model repository
-										</Link>
-									</li>
-									<li class="list-disc">
-										Download any model file (e.g., ggml-base.en.bin for
-										English-only)
-									</li>
-									<li class="list-disc">
-										Quantized models (q5_0, q8_0) offer smaller sizes with
-										minimal quality loss
-									</li>
-								</ul>
-							</div>
+						{#snippet manualHelp()}
+							<Field.Description>
+								Works with any whisper.cpp model file (.bin, .gguf, or .ggml).
+								Browse the{' '}
+								<Link
+									href="https://huggingface.co/ggerganov/whisper.cpp/tree/main"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									model repository
+								</Link>
+								{' '}for more options; quantized models (q5_0, q8_0) are
+								smaller with little quality loss.
+							</Field.Description>
 						{/snippet}
 					</LocalModelSelector>
 				{/if}
@@ -508,7 +494,7 @@
 						bind:value={() => deviceConfig.get('transcription.parakeet.modelPath'),
 						(v) => deviceConfig.set('transcription.parakeet.modelPath', v)}
 					>
-						{#snippet prebuiltFooter()}
+						{#snippet catalogFooter()}
 							<Field.Description>
 								Models are downloaded from{' '}
 								<Link
@@ -524,48 +510,19 @@
 							</Field.Description>
 						{/snippet}
 
-						{#snippet manualInstructions()}
-							<Card.Root class="bg-muted/50">
-								<Card.Content class="p-4">
-									<Field.Legend variant="label">
-										Getting Parakeet Models
-									</Field.Legend>
-									<ul class="space-y-2 text-sm text-muted-foreground">
-										<li class="flex items-start gap-2">
-											<span
-												class="mt-0.5 block size-1.5 rounded-full bg-muted-foreground/50"
-											/>
-											<span>
-												Download pre-built models from the "Pre-built Models"
-												tab
-											</span>
-										</li>
-										<li class="flex items-start gap-2">
-											<span
-												class="mt-0.5 block size-1.5 rounded-full bg-muted-foreground/50"
-											/>
-											<span>
-												Or download from{' '}
-												<Link
-													href="https://github.com/NVIDIA/NeMo"
-													target="_blank"
-													rel="noopener noreferrer"
-												>
-													NVIDIA NeMo
-												</Link>
-											</span>
-										</li>
-										<li class="flex items-start gap-2">
-											<span
-												class="mt-0.5 block size-1.5 rounded-full bg-muted-foreground/50"
-											/>
-											<span>
-												Parakeet models are directories containing ONNX files
-											</span>
-										</li>
-									</ul>
-								</Card.Content>
-							</Card.Root>
+						{#snippet manualHelp()}
+							<Field.Description>
+								Select a directory of Parakeet ONNX files, such as a model
+								exported from{' '}
+								<Link
+									href="https://github.com/NVIDIA/NeMo"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									NVIDIA NeMo
+								</Link>
+								.
+							</Field.Description>
 						{/snippet}
 					</LocalModelSelector>
 				{/if}
@@ -581,7 +538,7 @@
 						bind:value={() => deviceConfig.get('transcription.moonshine.modelPath'),
 						(v) => deviceConfig.set('transcription.moonshine.modelPath', v)}
 					>
-						{#snippet prebuiltFooter()}
+						{#snippet catalogFooter()}
 							<Field.Description>
 								Models are downloaded from{' '}
 								<Link
@@ -596,72 +553,26 @@
 							</Field.Description>
 						{/snippet}
 
-						{#snippet manualInstructions()}
-							<Card.Root class="bg-muted/50">
-								<Card.Content class="p-4">
-									<Field.Legend variant="label">
-										Getting Moonshine Models
-									</Field.Legend>
-									<ul class="space-y-2 text-sm text-muted-foreground">
-										<li class="flex items-start gap-2">
-											<span
-												class="mt-0.5 block size-1.5 rounded-full bg-muted-foreground/50"
-											/>
-											<span>
-												Download pre-built models from the "Pre-built Models"
-												tab
-											</span>
-										</li>
-										<li class="flex items-start gap-2">
-											<span
-												class="mt-0.5 block size-1.5 rounded-full bg-muted-foreground/50"
-											/>
-											<span>
-												Or download from{' '}
-												<Link
-													href="https://huggingface.co/UsefulSensors/moonshine"
-													target="_blank"
-													rel="noopener noreferrer"
-												>
-													UsefulSensors on Hugging Face
-												</Link>
-											</span>
-										</li>
-										<li class="flex items-start gap-2">
-											<span
-												class="mt-0.5 block size-1.5 rounded-full bg-muted-foreground/50"
-											/>
-											<span>
-												Moonshine models are directories containing ONNX files
-												and tokenizer
-											</span>
-										</li>
-									</ul>
-									<div
-										class="mt-3 rounded border border-amber-500/20 bg-amber-500/5 p-3"
-									>
-										<p
-											class="text-xs font-medium text-amber-600 dark:text-amber-400"
-										>
-											Directory Naming Requirement
-										</p>
-										<p class="mt-1 text-xs text-muted-foreground">
-											The model directory must be named{' '}
-											<code class="rounded bg-muted px-1 py-0.5 font-mono"
-												>moonshine-&#123;variant&#125;-&#123;lang&#125;</code
-											>
-											{' '}(e.g.,
-											<code class="rounded bg-muted px-1 py-0.5 font-mono"
-												>moonshine-tiny-en</code
-											>,
-											{' '}
-											<code class="rounded bg-muted px-1 py-0.5 font-mono"
-												>moonshine-base-en</code
-											>). The variant (tiny/base) determines model architecture.
-										</p>
-									</div>
-								</Card.Content>
-							</Card.Root>
+						{#snippet manualHelp()}
+							<Field.Description>
+								Select a directory containing Moonshine ONNX files and a
+								tokenizer, such as a model from{' '}
+								<Link
+									href="https://huggingface.co/UsefulSensors/moonshine"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									UsefulSensors on Hugging Face
+								</Link>
+								. The directory must be named{' '}
+								<code class="rounded bg-muted px-1 py-0.5 font-mono"
+									>moonshine-&#123;variant&#125;-&#123;lang&#125;</code
+								>
+								{' '}(for example{' '}
+								<code class="rounded bg-muted px-1 py-0.5 font-mono"
+									>moonshine-base-en</code
+								>); the variant tells Whispering which architecture to load.
+							</Field.Description>
 						{/snippet}
 					</LocalModelSelector>
 				{/if}


### PR DESCRIPTION
The local-engine section of the transcription settings screen handed the user every decision at once: a two-tab layout per engine, every catalog model as a peer row, and a path picker with step-by-step instructions, all visible before the user had made the only choice that matters (get a working model). This PR rebuilds each engine's card around one obvious happy path: a single prominent action when nothing is installed, the active model's name when one is, and everything else behind progressive disclosure.

The catalog now marks exactly one model per engine as `recommended: true` (Whisper Small for the best size-to-accuracy default, Parakeet TDT 0.6B v3 as the only option, Moonshine Base). Recommended is catalog data, not a user preference; no settings keys changed, and services, operations, and the Rust side are untouched.

Chosen direction (status hero plus one disclosure):

```
+ Whisper Model ------------------------------------+
| Models run on this device...                      |
|                                                   |
|  [empty]   No model installed                     |
|            Download the recommended model...      |
|            [ Download Small (488 MB) ]            |
|            (progress bar while downloading)       |
|                                                   |
|  [active]  | Small          [Active]  (Change) |  |
|            |   488 MB                          |  |
|                                                   |
|  > All models (4)                  [collapsed]    |
|      catalog rows w/ Recommended badge, footer    |
|      > Use your own model          [collapsed]    |
|          help text + path picker                  |
+---------------------------------------------------+
```

Rejected alternatives: a select-like row that expands in place (hides the download CTA behind a click in the empty state, which is exactly the state that needs the strongest affordance), and keeping the flat list with only the recommended row visible plus a "show N more" tail (shows the wrong model at a glance whenever a non-recommended or custom model is active).

The direction matches how comparable local-model apps behave. Ollama's desktop app picks a default model and treats the library as secondary; LM Studio badges a staff pick and puts the size on every download button; superwhisper and MacWhisper recommend one model with its size during onboarding and keep the rest in a secondary list; Handy preselects a recommended default; Wispr Flow goes cloud and deletes the surface entirely. We borrow default-first plus size-on-action and refuse LM Studio's full catalog browser, since our largest catalog is four models. The comparison table now lives in the comparable-apps skill as a worked example for future design passes.

Concretely: `LocalModelSelector` loses its two-tab layout. The empty state is an `Empty.*` block whose primary button reads "Download Small (488 MB)" (sizes stay visible because these are 0.5 to 1.6 GB downloads, possibly on metered connections) and shows a `Progress` bar while downloading; when the recommended model is already on disk but inactive, the button becomes "Activate Small". The active state is an `Item.*` row with the model name, its size (or "Your own model" for manual paths), an Active badge, and a Change button that expands the "All models" `Collapsible`. The catalog rows still use `LocalModelDownloadCard` as the row primitive, now with a Recommended badge. Manual selection lives one level deeper inside "All models" as a "Use your own model" collapsible: a short help paragraph and the same import-on-pick path picker, with the browse button now labeled "Choose file" or "Choose folder" instead of a bare icon.

The page-side snippets shrank to match: `prebuiltFooter` became `catalogFooter`, and the step-by-step `manualInstructions` cards became one-paragraph `manualHelp` descriptions. Moonshine's directory naming requirement (`moonshine-{variant}-{lang}`) survives in its help text since Rust parses the variant out of the directory name; the amber callout styling did not. Moonshine catalog descriptions also dropped their "(~28 MB)" suffixes because size is already its own visible field.

---

**Download state is now shared, not duplicated.** The first cut of this PR gave the recommended-model hero its own private copy of `LocalModelDownloadCard`'s state machine, which meant a download started in one surface was invisible in the other. A follow-up commit lifts that machine into `$lib/state/local-model-downloads.svelte.ts`, a state module keyed by model id (same factory-plus-getter shape as `local-model.svelte.ts`): the module owns disk truth and download progress as `$state`, and the four-state machine (not-downloaded, downloading, ready, active) is computed from those plus the engine's reactive model path. Both components collapsed to a handle lookup and template reads; every `$effect` in this area is gone. Two grounded decisions worth knowing: the state accessor is a plain getter rather than a `$derived` because handles are created lazily from whichever component touches them first, and a derived created inside a component's effect context goes inert when that component is destroyed (Svelte's `derived_inert` warning); and the "All models" expansion stays a component-local `bind:open` boolean, which is the controlled-collapsible pattern shadcn-svelte itself uses in `CodeCollapsibleWrapper`.

Flagged per the brief, controls that survive mainly because they existed before: the "Unload Model When Idle" select still renders below every local engine at top level (it is a real deviceConfig setting, but it predates this pass and was not redesigned), and the X-to-clear button in the path picker remains the only way to deactivate a model without deleting it. One behavior delta from the refactor: disk state is checked once per model handle (first use) and maintained by download and delete, instead of re-checked on every mount; files deleted outside the app mid-session show as installed until the next action.

Verification: `bun run --cwd apps/whispering typecheck` passes with 0 errors (remaining warnings are pre-existing and in untouched files). Not verified in a running Tauri build; the local-engine cards only render under `#if tauri`, so a quick visual pass on the three engines before merge would be worthwhile.

Net effect on the default view per engine: from roughly 12 simultaneous controls down to 3.