### PR TITLE
feat(whispering): rebuild local model settings around recommended defaults

### DIFF
--- a/.agents/skills/comparable-apps/SKILL.md
+++ b/.agents/skills/comparable-apps/SKILL.md
@@ -100,6 +100,22 @@ Implication: Epicenter is local-first; the closest references (Obsidian, Logseq)
 
 Asymmetric win surfaced: refusing the feature of "email in chrome" lets the runtime state stop carrying email at all. Email becomes a fetched query at the one surface that wants to display it. See `specs/20260514T210000-profile-as-application-data.md` for the resulting design.
 
+## Worked example: local model pickers (Whispering)
+
+Question: how should a settings screen present downloadable local models (Whisper, Parakeet, Moonshine) when each is a 0.03 to 1.6 GB download?
+
+| App | Category | Picker pattern | Size on action? |
+| --- | --- | --- | --- |
+| Ollama desktop | Local LLM runtime | Picks a default model, downloads on first use; library is secondary | Yes |
+| LM Studio | Local LLM catalog | Full catalog browser with search; "Staff pick" badge | Yes, on every download button |
+| Jan | Local LLM app | Hub with "Recommended" tags | Yes |
+| superwhisper | Local dictation | Onboarding recommends one model with its size; others in a secondary list | Yes |
+| MacWhisper | Local dictation | Model tiers with sizes; recommended default | Yes |
+| Handy | Local dictation (OSS) | Flat model list, recommended default preselected | Yes |
+| Wispr Flow | Dictation (cloud) | No model picker at all; the surface does not exist | n/a |
+
+Implication: local-model apps converge on default-first (one recommended model per engine, size visible on the download action, full catalog secondary). Whispering borrowed default-first plus size-on-action and refused LM Studio's catalog browser, since its largest catalog is four models. Wispr Flow is the refusal boundary: going cloud deletes the surface entirely, which is not Whispering's category. Resulting design: a status hero plus one "All models" disclosure (first built in PR #1922, then rebuilt on the folder-backed selector from PR #1923; see `specs/20260612T164300-local-model-recommended-defaults-rebuild.md`).
+
 ## Other questions this lens answers well
 
 ```

--- a/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
@@ -11,8 +11,11 @@
 
 	let {
 		model,
+		recommended = false,
 	}: {
 		model: LocalModelConfig;
+		/** Show the Recommended badge; the selector decides when it guides a choice. */
+		recommended?: boolean;
 	} = $props();
 
 	// Shared per-model handle: the selector hero reads the same one, so a
@@ -32,7 +35,7 @@
 	<div class="flex-1">
 		<div class="flex items-center gap-2">
 			<span class="font-medium">{model.name}</span>
-			{#if model.recommended}
+			{#if recommended}
 				<Badge variant="outline" class="text-xs">Recommended</Badge>
 			{/if}
 			{#if modelState.type === 'active'}

--- a/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
@@ -2,13 +2,12 @@
 	import { Badge } from '@epicenter/ui/badge';
 	import { Button } from '@epicenter/ui/button';
 	import { Progress } from '@epicenter/ui/progress';
-	import { toast } from '@epicenter/ui/sonner';
 	import { Spinner } from '@epicenter/ui/spinner';
 	import CheckIcon from '@lucide/svelte/icons/check';
 	import Download from '@lucide/svelte/icons/download';
 	import X from '@lucide/svelte/icons/x';
 	import { type LocalModelConfig } from '$lib/constants/local-models';
-	import { createPrebuiltModel } from '$lib/operations/local-models';
+	import { localModelDownloads } from '$lib/state/local-model-downloads.svelte';
 
 	let {
 		model,
@@ -16,74 +15,12 @@
 		model: LocalModelConfig;
 	} = $props();
 
-	const prebuiltModel = $derived(createPrebuiltModel(model));
+	// Shared per-model handle: the selector hero reads the same one, so a
+	// download started in either place shows its progress in both.
+	const download = $derived(localModelDownloads.get(model));
 
-	type ModelState =
-		| { type: 'not-downloaded' }
-		| { type: 'downloading'; progress: number }
-		| { type: 'ready' }
-		| { type: 'active' };
-
-	let modelState = $state<ModelState>({ type: 'not-downloaded' });
-
-	// Check model status on mount and whenever the engine's active model
-	// changes (the getter reads deviceConfig, so this effect tracks it).
-	$effect(() => {
-		void prebuiltModel.activeModelName;
-		refreshStatus();
-	});
-
-	async function refreshStatus() {
-		const status = await prebuiltModel.getStatus();
-		// While downloading, the download handler owns the state machine; a
-		// download may also have started while we were checking the disk.
-		if (modelState.type === 'downloading') return;
-		modelState = { type: status };
-	}
-
-	async function downloadModel() {
-		if (modelState.type === 'downloading') return;
-
-		modelState = { type: 'downloading', progress: 0 };
-
-		const { data, error } = await prebuiltModel.downloadAndActivate({
-			onProgress: (progress) => {
-				modelState = { type: 'downloading', progress };
-			},
-		});
-		if (error) {
-			toast.error('Failed to download model', {
-				description: error.message,
-			});
-			modelState = { type: 'not-downloaded' };
-			return;
-		}
-
-		modelState = { type: 'active' };
-		toast.success(
-			data.outcome === 'already-installed'
-				? 'Model already downloaded and activated'
-				: 'Model downloaded and activated successfully',
-		);
-	}
-
-	function activateModel() {
-		prebuiltModel.activate();
-		// The settings watcher will update modelState to 'active'
-		toast.success('Model activated');
-	}
-
-	async function deleteModel() {
-		const { error } = await prebuiltModel.delete();
-		if (error) {
-			toast.error('Failed to delete model', {
-				description: error.message,
-			});
-			return;
-		}
-		modelState = { type: 'not-downloaded' };
-		toast.success('Model deleted');
-	}
+	// Aliased so the template narrows the union per branch.
+	const modelState = $derived(download.state);
 </script>
 
 <div
@@ -95,6 +32,9 @@
 	<div class="flex-1">
 		<div class="flex items-center gap-2">
 			<span class="font-medium">{model.name}</span>
+			{#if model.recommended}
+				<Badge variant="outline" class="text-xs">Recommended</Badge>
+			{/if}
 			{#if modelState.type === 'active'}
 				<Badge variant="default" class="text-xs">Active</Badge>
 			{:else if modelState.type === 'ready'}
@@ -112,10 +52,10 @@
 				<span class="text-sm font-medium">{modelState.progress}%</span>
 			</div>
 		{:else if modelState.type === 'ready'}
-			<Button size="sm" variant="outline" onclick={activateModel}>
+			<Button size="sm" variant="outline" onclick={() => download.activate()}>
 				Activate
 			</Button>
-			<Button size="sm" variant="ghost" onclick={deleteModel}>
+			<Button size="sm" variant="ghost" onclick={() => download.delete()}>
 				<X class="size-4" />
 			</Button>
 		{:else if modelState.type === 'active'}
@@ -123,11 +63,11 @@
 				<CheckIcon class="size-4 mr-1" />
 				Activated
 			</Button>
-			<Button size="sm" variant="ghost" onclick={deleteModel}>
+			<Button size="sm" variant="ghost" onclick={() => download.delete()}>
 				<X class="size-4" />
 			</Button>
 		{:else}
-			<Button size="sm" variant="outline" onclick={downloadModel}>
+			<Button size="sm" variant="outline" onclick={() => download.download()}>
 				<Download class="size-4" />
 				Download
 			</Button>

--- a/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
@@ -21,6 +21,7 @@
 	import {
 		type LocalModelConfig,
 		modelEntryName,
+		RECOMMENDED_MODELS,
 	} from '$lib/constants/local-models';
 	import { PATHS } from '$lib/services/fs-paths';
 	import {
@@ -95,10 +96,8 @@
 		customEntries.find((entry) => entry.name === value) ?? null,
 	);
 
-	// The engine's default download. The catalog marks exactly one model as
-	// recommended; falling back to the first entry keeps the primary action
-	// rendering even if the catalog ever loses the flag.
-	const recommended = $derived(models.find((m) => m.recommended) ?? models[0]);
+	/** The engine's default download; the hero builds its action around it. */
+	const recommended = $derived(RECOMMENDED_MODELS[engine]);
 	const recommendedDownload = $derived(localModelDownloads.get(recommended));
 
 	// Aliased so the template narrows the union per branch. Shared with the
@@ -264,7 +263,10 @@
 			</Collapsible.Trigger>
 			<Collapsible.Content class="space-y-3 pt-3">
 				{#each models as model (model.id)}
-					<LocalModelDownloadCard {model} />
+					<LocalModelDownloadCard
+						{model}
+						recommended={models.length > 1 && model.id === recommended.id}
+					/>
 				{/each}
 
 				{#each customEntries as entry (entry.name)}

--- a/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
@@ -203,7 +203,7 @@
 					<Button
 						variant="outline"
 						size="sm"
-						onclick={() => (allModelsOpen = !allModelsOpen)}
+						onclick={() => (allModelsOpen = true)}
 					>
 						Change
 					</Button>

--- a/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
@@ -2,10 +2,17 @@
 	import { Badge } from '@epicenter/ui/badge';
 	import { Button } from '@epicenter/ui/button';
 	import * as Card from '@epicenter/ui/card';
+	import * as Collapsible from '@epicenter/ui/collapsible';
+	import * as Empty from '@epicenter/ui/empty';
 	import * as Field from '@epicenter/ui/field';
+	import * as Item from '@epicenter/ui/item';
+	import { Progress } from '@epicenter/ui/progress';
 	import { toast } from '@epicenter/ui/sonner';
 	import CheckIcon from '@lucide/svelte/icons/check';
+	import ChevronDown from '@lucide/svelte/icons/chevron-down';
+	import Download from '@lucide/svelte/icons/download';
 	import FolderOpen from '@lucide/svelte/icons/folder-open';
+	import HardDriveDownload from '@lucide/svelte/icons/hard-drive-download';
 	import X from '@lucide/svelte/icons/x';
 	import { mkdir } from '@tauri-apps/plugin-fs';
 	import type { Snippet } from 'svelte';
@@ -22,14 +29,16 @@
 		type LocalModelEntry,
 	} from '$lib/services/transcription/local-model-folder';
 	import { PROVIDERS } from '$lib/services/transcription/providers';
+	import { localModelDownloads } from '$lib/state/local-model-downloads.svelte';
 	import { tauri } from '#platform/tauri';
 	import LocalModelDownloadCard from './LocalModelDownloadCard.svelte';
 
 	/**
-	 * One list backed by the engine's models folder: catalog models render as
-	 * download cards, and every other folder entry (dropped in or symlinked
-	 * by the user) renders as a selectable row. The bindable value is the
-	 * active entry's name.
+	 * One happy path per engine: an empty-state hero that downloads the
+	 * recommended model, or a summary row showing the active one. The full
+	 * list (catalog download cards, custom folder entries, the folder help
+	 * box) collapses behind "All models". The list is backed by the engine's
+	 * models folder; the bindable value is the active entry's name.
 	 */
 	type LocalModelSelectorProps = {
 		/**
@@ -63,7 +72,7 @@
 	const engine = $derived(models[0].engine);
 	const modelKind = $derived(PROVIDERS[engine].modelKind);
 
-	/** Folder entry names the catalog cards above already represent. */
+	/** Folder entry names the catalog cards already represent. */
 	const catalogNames = $derived(new Set(models.map(modelEntryName)));
 
 	let entries = $state<LocalModelEntry[] | null>(null);
@@ -77,9 +86,49 @@
 		!!value && entries !== null && !entries.some((e) => e.name === value),
 	);
 
+	/** The catalog model behind the active entry, when it is a catalog one. */
+	const activeCatalogModel = $derived(
+		models.find((model) => modelEntryName(model) === value) ?? null,
+	);
+
+	const activeCustomEntry = $derived(
+		customEntries.find((entry) => entry.name === value) ?? null,
+	);
+
+	// The engine's default download. The catalog marks exactly one model as
+	// recommended; falling back to the first entry keeps the primary action
+	// rendering even if the catalog ever loses the flag.
+	const recommended = $derived(models.find((m) => m.recommended) ?? models[0]);
+	const recommendedDownload = $derived(localModelDownloads.get(recommended));
+
+	// Aliased so the template narrows the union per branch. Shared with the
+	// catalog row for the same model, so a download started here shows its
+	// progress there too.
+	const recommendedState = $derived(recommendedDownload.state);
+
+	/** Whether the full list behind "All models" is expanded. */
+	let allModelsOpen = $state(false);
+
+	// Plain variable, not $state: refreshEntries runs inside the rescan
+	// effect, and a reactive read here would make the effect track entries
+	// and re-run on its own assignment.
+	let hasDecidedInitialOpen = false;
+
 	async function refreshEntries() {
 		if (!tauri) return;
 		entries = await listModelEntries(engine);
+		// The folder is user-editable truth, so the catalog handles re-check
+		// disk on the same signal that rescans the folder.
+		for (const model of models) {
+			localModelDownloads.get(model).refresh();
+		}
+		// A user who already brought their own model gets the list, not a
+		// download pitch: when nothing is active and the first scan finds
+		// custom entries, start with the list open instead of the hero.
+		if (!hasDecidedInitialOpen) {
+			hasDecidedInitialOpen = true;
+			if (!value && customEntries.length > 0) allModelsOpen = true;
+		}
 	}
 
 	// Rescan on mount, when the engine changes, and whenever the active model
@@ -134,50 +183,63 @@
 		<Card.Description>{description}</Card.Description>
 	</Card.Header>
 	<Card.Content class="space-y-3">
-		{#each models as model}
-			<LocalModelDownloadCard {model} />
-		{/each}
-
-		{#each customEntries as entry (entry.name)}
-			{@const isActive = value === entry.name}
-			<div
-				class="flex items-center gap-3 p-3 rounded-lg border {isActive
-					? 'border-primary bg-primary/5'
-					: ''}"
-			>
-				<div class="flex-1">
-					<div class="flex items-center gap-2">
-						<span class="font-medium">{entry.name}</span>
-						{#if isActive}
-							<Badge variant="default" class="text-xs">Active</Badge>
+		{#if value && !isSelectionMissing}
+			<Item.Root variant="outline">
+				<Item.Content>
+					<Item.Title>
+						{activeCatalogModel ? activeCatalogModel.name : value}
+					</Item.Title>
+					<Item.Description>
+						{#if activeCatalogModel}
+							{activeCatalogModel.size}
+						{:else if activeCustomEntry?.isSymlink}
+							Your model (linked)
+						{:else}
+							Your model
 						{/if}
-					</div>
-					<div class="text-sm text-muted-foreground">
-						{entry.isSymlink ? 'Your model (linked)' : 'Your model'}
-					</div>
-				</div>
-
-				<div class="flex items-center gap-2">
-					{#if isActive}
-						<Button size="sm" variant="default" disabled>
-							<CheckIcon class="size-4 mr-1" />
-							Activated
+					</Item.Description>
+				</Item.Content>
+				<Item.Actions>
+					<Badge class="text-xs">Active</Badge>
+					<Button
+						variant="outline"
+						size="sm"
+						onclick={() => (allModelsOpen = !allModelsOpen)}
+					>
+						Change
+					</Button>
+				</Item.Actions>
+			</Item.Root>
+		{:else if !value && customEntries.length === 0}
+			<Empty.Root class="py-8">
+				<Empty.Media variant="icon">
+					<HardDriveDownload class="size-5" />
+				</Empty.Media>
+				<Empty.Title>No model installed</Empty.Title>
+				<Empty.Description>
+					Download the recommended model to start transcribing on this device.
+				</Empty.Description>
+				<Empty.Content>
+					{#if recommendedState.type === 'downloading'}
+						<div class="flex w-full max-w-xs flex-col items-center gap-2">
+							<Progress value={recommendedState.progress} class="h-2" />
+							<span class="text-sm text-muted-foreground">
+								Downloading {recommended.name}: {recommendedState.progress}%
+							</span>
+						</div>
+					{:else if recommendedState.type === 'ready'}
+						<Button onclick={() => recommendedDownload.activate()}>
+							Activate {recommended.name}
 						</Button>
 					{:else}
-						<Button
-							size="sm"
-							variant="outline"
-							onclick={() => activateEntry(entry)}
-						>
-							Activate
+						<Button onclick={() => recommendedDownload.download()}>
+							<Download class="size-4" />
+							Download {recommended.name} ({recommended.size})
 						</Button>
 					{/if}
-					<Button size="sm" variant="ghost" onclick={() => removeEntry(entry)}>
-						<X class="size-4" />
-					</Button>
-				</div>
-			</div>
-		{/each}
+				</Empty.Content>
+			</Empty.Root>
+		{/if}
 
 		{#if isSelectionMissing}
 			<div class="rounded-lg border border-amber-500/20 bg-amber-500/5 p-3">
@@ -185,27 +247,88 @@
 					Selected model is missing
 				</p>
 				<p class="mt-1 text-sm text-muted-foreground">
-					"{value}" is no longer in the models folder. Download a model above
-					or add yours back, then activate it.
+					"{value}" is no longer in the models folder. Pick another model under
+					All models, or add yours back and activate it.
 				</p>
 			</div>
 		{/if}
 
-		<div class="rounded-lg border bg-muted/50 p-4 space-y-3">
-			<Field.Description>
-				Have your own model? Put a model {modelKind === 'directory'
-					? 'directory'
-					: 'file (.bin, .gguf, or .ggml)'} in the models folder and it appears
-				in this list. A symlink works too if you'd rather not keep a second
-				copy.
-			</Field.Description>
-			<Button variant="outline" size="sm" onclick={openModelsFolder}>
-				<FolderOpen class="size-4 mr-2" />
-				Open Models Folder
-			</Button>
-			{#if footer}
-				{@render footer()}
-			{/if}
-		</div>
+		<Collapsible.Root bind:open={allModelsOpen}>
+			<Collapsible.Trigger
+				class="flex w-full items-center justify-between rounded-lg border px-4 py-3 text-sm font-medium transition-colors hover:bg-muted/50 [&[data-state=open]>svg]:rotate-180"
+			>
+				All models ({models.length + customEntries.length})
+				<ChevronDown
+					class="size-4 shrink-0 text-muted-foreground transition-transform"
+				/>
+			</Collapsible.Trigger>
+			<Collapsible.Content class="space-y-3 pt-3">
+				{#each models as model (model.id)}
+					<LocalModelDownloadCard {model} />
+				{/each}
+
+				{#each customEntries as entry (entry.name)}
+					{@const isActive = value === entry.name}
+					<div
+						class="flex items-center gap-3 p-3 rounded-lg border {isActive
+							? 'border-primary bg-primary/5'
+							: ''}"
+					>
+						<div class="flex-1">
+							<div class="flex items-center gap-2">
+								<span class="font-medium">{entry.name}</span>
+								{#if isActive}
+									<Badge variant="default" class="text-xs">Active</Badge>
+								{/if}
+							</div>
+							<div class="text-sm text-muted-foreground">
+								{entry.isSymlink ? 'Your model (linked)' : 'Your model'}
+							</div>
+						</div>
+
+						<div class="flex items-center gap-2">
+							{#if isActive}
+								<Button size="sm" variant="default" disabled>
+									<CheckIcon class="size-4 mr-1" />
+									Activated
+								</Button>
+							{:else}
+								<Button
+									size="sm"
+									variant="outline"
+									onclick={() => activateEntry(entry)}
+								>
+									Activate
+								</Button>
+							{/if}
+							<Button
+								size="sm"
+								variant="ghost"
+								onclick={() => removeEntry(entry)}
+							>
+								<X class="size-4" />
+							</Button>
+						</div>
+					</div>
+				{/each}
+
+				<div class="rounded-lg border bg-muted/50 p-4 space-y-3">
+					<Field.Description>
+						Have your own model? Put a model {modelKind === 'directory'
+							? 'directory'
+							: 'file (.bin, .gguf, or .ggml)'} in the models folder and it appears
+						in this list. A symlink works too if you'd rather not keep a second
+						copy.
+					</Field.Description>
+					<Button variant="outline" size="sm" onclick={openModelsFolder}>
+						<FolderOpen class="size-4 mr-2" />
+						Open Models Folder
+					</Button>
+					{#if footer}
+						{@render footer()}
+					{/if}
+				</div>
+			</Collapsible.Content>
+		</Collapsible.Root>
 	</Card.Content>
 </Card.Root>

--- a/apps/whispering/src/lib/constants/local-models.ts
+++ b/apps/whispering/src/lib/constants/local-models.ts
@@ -59,11 +59,6 @@ type BaseModelConfig = {
 	size: string;
 	/** Exact size in bytes for progress tracking */
 	sizeBytes: number;
-	/**
-	 * The engine's default download. Exactly one model per engine carries
-	 * this; the settings UI builds its primary action around it.
-	 */
-	recommended?: true;
 };
 
 /** Whisper models are a single .bin file. */
@@ -119,6 +114,19 @@ export type LocalModelConfig =
 	| ParakeetModelConfig
 	| MoonshineModelConfig;
 
+const WHISPER_SMALL = {
+	id: 'small',
+	name: 'Small',
+	description: 'Fast, good accuracy',
+	size: '488 MB',
+	sizeBytes: 487_601_967,
+	engine: 'whispercpp',
+	file: {
+		url: 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin',
+		filename: 'ggml-small.bin',
+	},
+} as const satisfies WhisperModelConfig;
+
 /**
  * Pre-built Whisper models available for download from Hugging Face.
  * These are ggml-format models compatible with whisper.cpp.
@@ -136,19 +144,7 @@ export const WHISPER_MODELS = [
 			filename: 'ggml-tiny.bin',
 		},
 	},
-	{
-		id: 'small',
-		name: 'Small',
-		description: 'Fast, good accuracy',
-		size: '488 MB',
-		sizeBytes: 487_601_967,
-		recommended: true,
-		engine: 'whispercpp',
-		file: {
-			url: 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin',
-			filename: 'ggml-small.bin',
-		},
-	},
+	WHISPER_SMALL,
 	{
 		id: 'medium',
 		name: 'Medium',
@@ -175,48 +171,49 @@ export const WHISPER_MODELS = [
 	},
 ] as const satisfies readonly WhisperModelConfig[];
 
+const PARAKEET_TDT_06B_V3_INT8 = {
+	id: 'parakeet-tdt-0.6b-v3-int8',
+	name: 'Parakeet TDT 0.6B v3 (INT8)',
+	description: 'Fast and accurate NVIDIA NeMo model',
+	size: '~670 MB',
+	sizeBytes: 670_619_803,
+	engine: 'parakeet',
+	directoryName: 'parakeet-tdt-0.6b-v3-int8',
+	files: [
+		{
+			url: 'https://github.com/EpicenterHQ/epicenter/releases/download/models/parakeet-tdt-0.6b-v3-int8/config.json',
+			filename: 'config.json',
+			sizeBytes: 97,
+		},
+		{
+			url: 'https://github.com/EpicenterHQ/epicenter/releases/download/models/parakeet-tdt-0.6b-v3-int8/decoder_joint-model.int8.onnx',
+			filename: 'decoder_joint-model.int8.onnx',
+			sizeBytes: 18_202_004,
+		},
+		{
+			url: 'https://github.com/EpicenterHQ/epicenter/releases/download/models/parakeet-tdt-0.6b-v3-int8/encoder-model.int8.onnx',
+			filename: 'encoder-model.int8.onnx',
+			sizeBytes: 652_183_999,
+		},
+		{
+			url: 'https://github.com/EpicenterHQ/epicenter/releases/download/models/parakeet-tdt-0.6b-v3-int8/nemo128.onnx',
+			filename: 'nemo128.onnx',
+			sizeBytes: 139_764,
+		},
+		{
+			url: 'https://github.com/EpicenterHQ/epicenter/releases/download/models/parakeet-tdt-0.6b-v3-int8/vocab.txt',
+			filename: 'vocab.txt',
+			sizeBytes: 93_939,
+		},
+	],
+} as const satisfies ParakeetModelConfig;
+
 /**
  * Pre-built Parakeet models available for download from GitHub releases.
  * These are NVIDIA NeMo models consisting of multiple ONNX files.
  */
 export const PARAKEET_MODELS = [
-	{
-		id: 'parakeet-tdt-0.6b-v3-int8',
-		name: 'Parakeet TDT 0.6B v3 (INT8)',
-		description: 'Fast and accurate NVIDIA NeMo model',
-		size: '~670 MB',
-		sizeBytes: 670_619_803,
-		recommended: true,
-		engine: 'parakeet',
-		directoryName: 'parakeet-tdt-0.6b-v3-int8',
-		files: [
-			{
-				url: 'https://github.com/EpicenterHQ/epicenter/releases/download/models/parakeet-tdt-0.6b-v3-int8/config.json',
-				filename: 'config.json',
-				sizeBytes: 97,
-			},
-			{
-				url: 'https://github.com/EpicenterHQ/epicenter/releases/download/models/parakeet-tdt-0.6b-v3-int8/decoder_joint-model.int8.onnx',
-				filename: 'decoder_joint-model.int8.onnx',
-				sizeBytes: 18_202_004,
-			},
-			{
-				url: 'https://github.com/EpicenterHQ/epicenter/releases/download/models/parakeet-tdt-0.6b-v3-int8/encoder-model.int8.onnx',
-				filename: 'encoder-model.int8.onnx',
-				sizeBytes: 652_183_999,
-			},
-			{
-				url: 'https://github.com/EpicenterHQ/epicenter/releases/download/models/parakeet-tdt-0.6b-v3-int8/nemo128.onnx',
-				filename: 'nemo128.onnx',
-				sizeBytes: 139_764,
-			},
-			{
-				url: 'https://github.com/EpicenterHQ/epicenter/releases/download/models/parakeet-tdt-0.6b-v3-int8/vocab.txt',
-				filename: 'vocab.txt',
-				sizeBytes: 93_939,
-			},
-		],
-	},
+	PARAKEET_TDT_06B_V3_INT8,
 ] as const satisfies readonly ParakeetModelConfig[];
 
 /**
@@ -232,6 +229,34 @@ export const PARAKEET_MODELS = [
  * since they offer the best size/performance tradeoff.
  */
 const HF_BASE = 'https://huggingface.co/UsefulSensors/moonshine/resolve/main';
+
+const MOONSHINE_BASE_EN = {
+	id: 'moonshine-base-en',
+	name: 'Moonshine Base (English)',
+	description: 'Higher accuracy English transcription',
+	size: '~65 MB',
+	sizeBytes: 64_997_467,
+	engine: 'moonshine',
+	language: 'en',
+	directoryName: 'moonshine-base-en',
+	files: [
+		{
+			url: `${HF_BASE}/onnx/merged/base/quantized/encoder_model.onnx`,
+			filename: 'encoder_model.onnx',
+			sizeBytes: 20_513_063,
+		},
+		{
+			url: `${HF_BASE}/onnx/merged/base/quantized/decoder_model_merged.onnx`,
+			filename: 'decoder_model_merged.onnx',
+			sizeBytes: 42_498_870,
+		},
+		{
+			url: `${HF_BASE}/ctranslate2/tiny/tokenizer.json`,
+			filename: 'tokenizer.json',
+			sizeBytes: 1_985_534,
+		},
+	],
+} as const satisfies MoonshineModelConfig;
 
 export const MOONSHINE_MODELS = [
 	{
@@ -261,35 +286,21 @@ export const MOONSHINE_MODELS = [
 			},
 		],
 	},
-	{
-		id: 'moonshine-base-en',
-		name: 'Moonshine Base (English)',
-		description: 'Higher accuracy English transcription',
-		size: '~65 MB',
-		sizeBytes: 64_997_467,
-		recommended: true,
-		engine: 'moonshine',
-		language: 'en',
-		directoryName: 'moonshine-base-en',
-		files: [
-			{
-				url: `${HF_BASE}/onnx/merged/base/quantized/encoder_model.onnx`,
-				filename: 'encoder_model.onnx',
-				sizeBytes: 20_513_063,
-			},
-			{
-				url: `${HF_BASE}/onnx/merged/base/quantized/decoder_model_merged.onnx`,
-				filename: 'decoder_model_merged.onnx',
-				sizeBytes: 42_498_870,
-			},
-			{
-				url: `${HF_BASE}/ctranslate2/tiny/tokenizer.json`,
-				filename: 'tokenizer.json',
-				sizeBytes: 1_985_534,
-			},
-		],
-	},
+	MOONSHINE_BASE_EN,
 ] as const satisfies readonly MoonshineModelConfig[];
+
+/**
+ * Each engine's default download: the model the settings UI builds its
+ * primary action around. The mapped type guarantees every engine names
+ * exactly one recommendation and that it belongs to that engine.
+ */
+export const RECOMMENDED_MODELS = {
+	whispercpp: WHISPER_SMALL,
+	parakeet: PARAKEET_TDT_06B_V3_INT8,
+	moonshine: MOONSHINE_BASE_EN,
+} satisfies {
+	[E in LocalModelConfig['engine']]: Extract<LocalModelConfig, { engine: E }>;
+};
 
 /**
  * The model's entry name inside its engine's models folder: the filename

--- a/apps/whispering/src/lib/constants/local-models.ts
+++ b/apps/whispering/src/lib/constants/local-models.ts
@@ -59,6 +59,11 @@ type BaseModelConfig = {
 	size: string;
 	/** Exact size in bytes for progress tracking */
 	sizeBytes: number;
+	/**
+	 * The engine's default download. Exactly one model per engine carries
+	 * this; the settings UI builds its primary action around it.
+	 */
+	recommended?: true;
 };
 
 /** Whisper models are a single .bin file. */
@@ -137,6 +142,7 @@ export const WHISPER_MODELS = [
 		description: 'Fast, good accuracy',
 		size: '488 MB',
 		sizeBytes: 487_601_967,
+		recommended: true,
 		engine: 'whispercpp',
 		file: {
 			url: 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin',
@@ -180,6 +186,7 @@ export const PARAKEET_MODELS = [
 		description: 'Fast and accurate NVIDIA NeMo model',
 		size: '~670 MB',
 		sizeBytes: 670_619_803,
+		recommended: true,
 		engine: 'parakeet',
 		directoryName: 'parakeet-tdt-0.6b-v3-int8',
 		files: [
@@ -230,7 +237,7 @@ export const MOONSHINE_MODELS = [
 	{
 		id: 'moonshine-tiny-en',
 		name: 'Moonshine Tiny (English)',
-		description: 'Fast and efficient English transcription (~28 MB)',
+		description: 'Fast and efficient English transcription',
 		size: '~30 MB',
 		sizeBytes: 30_166_481,
 		engine: 'moonshine',
@@ -257,9 +264,10 @@ export const MOONSHINE_MODELS = [
 	{
 		id: 'moonshine-base-en',
 		name: 'Moonshine Base (English)',
-		description: 'Higher accuracy English transcription (~65 MB)',
+		description: 'Higher accuracy English transcription',
 		size: '~65 MB',
 		sizeBytes: 64_997_467,
+		recommended: true,
 		engine: 'moonshine',
 		language: 'en',
 		directoryName: 'moonshine-base-en',

--- a/apps/whispering/src/lib/operations/local-models.ts
+++ b/apps/whispering/src/lib/operations/local-models.ts
@@ -17,8 +17,9 @@ import { PROVIDERS } from '$lib/services/transcription/providers';
 import { deviceConfig } from '$lib/state/device-config.svelte';
 
 /**
- * Per-model handle the settings UI drives. Stateless; safe to recreate
- * freely (the download card derives one from its `model` prop).
+ * Per-model handle the settings UI drives, through the shared download
+ * handles in `$lib/state/local-model-downloads.svelte.ts`. Stateless;
+ * safe to recreate freely.
  */
 export function createPrebuiltModel(model: LocalModelConfig) {
 	const storage = createModelStorage(model);
@@ -32,17 +33,6 @@ export function createPrebuiltModel(model: LocalModelConfig) {
 		 */
 		get activeModelName() {
 			return deviceConfig.get(settingsKey);
-		},
-
-		/**
-		 * Where the model stands on this device: missing or corrupted
-		 * (`not-downloaded`), installed (`ready`), or installed and selected
-		 * as the engine's model (`active`). Never rejects.
-		 */
-		async getStatus(): Promise<'not-downloaded' | 'ready' | 'active'> {
-			const installedPath = await storage.getInstalledPath();
-			if (!installedPath) return 'not-downloaded';
-			return deviceConfig.get(settingsKey) === entryName ? 'active' : 'ready';
 		},
 
 		/** Point the engine's model setting at this model's entry name. */

--- a/apps/whispering/src/lib/state/local-model-downloads.svelte.ts
+++ b/apps/whispering/src/lib/state/local-model-downloads.svelte.ts
@@ -1,8 +1,8 @@
 /**
  * Shared download state for pre-built local transcription models, keyed by
- * model id. Every surface that renders a model (recommended-model hero,
- * catalog row) reads the same handle, so a download started in one place
- * shows its progress everywhere.
+ * engine and model id. Every surface that renders a model (recommended-model
+ * hero, catalog row) reads the same handle, so a download started in one
+ * place shows its progress everywhere.
  *
  * The state machine is computed, not stored: `downloading` while a download
  * owns the handle, otherwise disk truth (`isInstalled`) plus the engine's
@@ -127,6 +127,10 @@ function createModelDownload(model: LocalModelConfig) {
 	};
 }
 
+function modelDownloadKey(model: LocalModelConfig) {
+	return `${model.engine}:${model.id}`;
+}
+
 function createLocalModelDownloads() {
 	const handles = new Map<string, ReturnType<typeof createModelDownload>>();
 
@@ -140,10 +144,11 @@ function createLocalModelDownloads() {
 		 * reads its state in one expression would never update.
 		 */
 		get(model: LocalModelConfig) {
-			const existing = handles.get(model.id);
+			const key = modelDownloadKey(model);
+			const existing = handles.get(key);
 			if (existing) return existing;
 			const handle = createModelDownload(model);
-			handles.set(model.id, handle);
+			handles.set(key, handle);
 			return handle;
 		},
 	};

--- a/apps/whispering/src/lib/state/local-model-downloads.svelte.ts
+++ b/apps/whispering/src/lib/state/local-model-downloads.svelte.ts
@@ -1,0 +1,145 @@
+/**
+ * Shared download state for pre-built local transcription models, keyed by
+ * model id. Every surface that renders a model (recommended-model hero,
+ * catalog row) reads the same handle, so a download started in one place
+ * shows its progress everywhere.
+ *
+ * The state machine is computed, not stored: `downloading` while a download
+ * owns the handle, otherwise disk truth (`isInstalled`) plus the engine's
+ * reactive model setting decide between not-downloaded, ready, and active.
+ * The models folder is user-editable truth (entries can be dropped in or
+ * deleted outside the app), so `refresh()` re-checks disk; the selector
+ * calls it from the same window-focus rescan that refreshes folder entries.
+ *
+ * Shape mirrors `local-model.svelte.ts`: factory function with `$state`
+ * closure variables and a return object exposing a reactive getter plus
+ * operations.
+ */
+import { toast } from '@epicenter/ui/sonner';
+import {
+	type LocalModelConfig,
+	modelEntryName,
+} from '$lib/constants/local-models';
+import { createPrebuiltModel } from '$lib/operations/local-models';
+import { createModelStorage } from '$lib/services/transcription/local-model-folder';
+
+export type ModelDownloadState =
+	| { type: 'not-downloaded' }
+	| { type: 'downloading'; progress: number }
+	| { type: 'ready' }
+	| { type: 'active' };
+
+function createModelDownload(model: LocalModelConfig) {
+	const storage = createModelStorage(model);
+	const prebuiltModel = createPrebuiltModel(model);
+	const entryName = modelEntryName(model);
+
+	/** Disk truth: whether a valid install exists in the models folder. */
+	let isInstalled = $state(false);
+
+	/** Progress 0-100 while this handle owns a download, else null. */
+	let progress = $state<number | null>(null);
+
+	async function refresh() {
+		isInstalled = (await storage.getInstalledPath()) !== null;
+	}
+
+	void refresh();
+
+	return {
+		/**
+		 * Where this model stands on this device. A getter, not a `$derived`:
+		 * handles are created lazily from whichever component touches them
+		 * first, and a derived created inside a component's effect context
+		 * goes inert when that component is destroyed (`derived_inert`). The
+		 * computation is two comparisons; consumers that need caching or
+		 * narrowing alias it with a component-local `$derived`.
+		 */
+		get state(): ModelDownloadState {
+			if (progress !== null) return { type: 'downloading', progress };
+			if (!isInstalled) return { type: 'not-downloaded' };
+			return prebuiltModel.activeModelName === entryName
+				? { type: 'active' }
+				: { type: 'ready' };
+		},
+
+		/**
+		 * Re-check disk truth. The models folder can change outside the app
+		 * (entries deleted, a partial download cleaned up), so callers invoke
+		 * this on the same signal they use to rescan the folder, typically
+		 * window focus.
+		 */
+		refresh,
+
+		/**
+		 * Download the model (skipping the download when a valid install
+		 * already exists) and activate it.
+		 */
+		async download() {
+			if (progress !== null) return;
+			progress = 0;
+
+			const { data, error } = await prebuiltModel.downloadAndActivate({
+				onProgress: (value) => {
+					progress = value;
+				},
+			});
+			if (error) {
+				progress = null;
+				toast.error('Failed to download model', {
+					description: error.message,
+				});
+				return;
+			}
+
+			// Refresh disk truth before releasing the downloading state so the
+			// computed machine lands directly on active.
+			await refresh();
+			progress = null;
+			toast.success(
+				data.outcome === 'already-installed'
+					? 'Model already downloaded and activated'
+					: 'Model downloaded and activated successfully',
+			);
+		},
+
+		/** Point the engine's model setting at this model's entry name. */
+		activate() {
+			prebuiltModel.activate();
+			toast.success('Model activated');
+		},
+
+		/**
+		 * Remove the model from disk and, when it was the engine's active
+		 * model, clear the engine's model setting.
+		 */
+		async delete() {
+			const { error } = await prebuiltModel.delete();
+			if (error) {
+				toast.error('Failed to delete model', {
+					description: error.message,
+				});
+				return;
+			}
+			isInstalled = false;
+			toast.success('Model deleted');
+		},
+	};
+}
+
+function createLocalModelDownloads() {
+	const handles = new Map<string, ReturnType<typeof createModelDownload>>();
+
+	return {
+		/** The shared download handle for a catalog model, created on first use. */
+		get(model: LocalModelConfig) {
+			const existing = handles.get(model.id);
+			if (existing) return existing;
+			const handle = createModelDownload(model);
+			handles.set(model.id, handle);
+			return handle;
+		},
+	};
+}
+
+export const localModelDownloads = createLocalModelDownloads();

--- a/apps/whispering/src/lib/state/local-model-downloads.svelte.ts
+++ b/apps/whispering/src/lib/state/local-model-downloads.svelte.ts
@@ -131,7 +131,14 @@ function createLocalModelDownloads() {
 	const handles = new Map<string, ReturnType<typeof createModelDownload>>();
 
 	return {
-		/** The shared download handle for a catalog model, created on first use. */
+		/**
+		 * The shared download handle for a catalog model, created on first
+		 * use. Acquire the handle and read its `state` in separate deriveds
+		 * (`$derived(localModelDownloads.get(model))`, then
+		 * `$derived(handle.state)`): a derived does not depend on state it
+		 * created itself, so a single derived that creates the handle and
+		 * reads its state in one expression would never update.
+		 */
 		get(model: LocalModelConfig) {
 			const existing = handles.get(model.id);
 			if (existing) return existing;

--- a/apps/whispering/src/lib/state/local-model-downloads.svelte.ts
+++ b/apps/whispering/src/lib/state/local-model-downloads.svelte.ts
@@ -23,7 +23,7 @@ import {
 import { createPrebuiltModel } from '$lib/operations/local-models';
 import { createModelStorage } from '$lib/services/transcription/local-model-folder';
 
-export type ModelDownloadState =
+type ModelDownloadState =
 	| { type: 'not-downloaded' }
 	| { type: 'downloading'; progress: number }
 	| { type: 'ready' }

--- a/specs/20260612T164300-local-model-recommended-defaults-rebuild.md
+++ b/specs/20260612T164300-local-model-recommended-defaults-rebuild.md
@@ -1,0 +1,80 @@
+# Rebuild local model recommended defaults on the folder-backed selector
+
+Date: 2026-06-12. Owner: Braden. Supersedes the implementation in PR #1922 (branch `feat/local-model-defaults`, closed unmerged).
+
+## Goal
+
+Rebuild the recommended-defaults UX from PR #1922 on top of main as it stands after PR #1923. The old branch cannot rebase: every commit except its docs commit targets APIs that #1923 deleted (absolute model paths in settings, the file picker import flow, `local-preflight.ts`). The design intent survives; this spec carries it to a fresh implementation.
+
+## What happened
+
+Two parallel passes rewrote the same surface. PR #1922 redesigned the local engine cards around one recommended model per engine (status hero, progressive disclosure, shared download state). PR #1923 replaced the storage model underneath: the engine's models folder under app data became the single source of truth, settings store a folder entry name instead of a path, and the manual file picker died in favor of "drop or symlink a file into the folder". #1923 merged first. #1922 was closed and its docs commit re-landed separately (the comparable-apps worked example, `.agents/skills/comparable-apps/SKILL.md`).
+
+## The intent to preserve
+
+The local-engine section handed the user every decision at once: every catalog model as a peer row plus bring-your-own affordances, all visible before the user made the only choice that matters (get a working model). Rebuild each engine's card around one obvious happy path:
+
+```txt
++ Whisper Model ------------------------------------+
+| Models run on this device...                      |
+|                                                   |
+|  [empty]   No model installed                     |
+|            Download the recommended model...      |
+|            [ Download Small (488 MB) ]            |
+|            (progress bar while downloading)       |
+|                                                   |
+|  [active]  | Small          [Active]  (Change) |  |
+|            |   488 MB                          |  |
+|                                                   |
+|  > All models (4)                  [collapsed]    |
+|      catalog download cards w/ Recommended badge  |
+|      custom folder entries as selectable rows     |
+|      folder help box + Open Models Folder         |
++---------------------------------------------------+
+```
+
+Sizes stay on download buttons; these are 0.03 to 1.6 GB downloads, possibly on metered connections. When the recommended model is on disk but not active, the hero button reads "Activate" instead of "Download". The active summary shows the catalog name and size, or the entry name with "Your model" for a custom folder entry. The Change button expands the "All models" collapsible.
+
+Alternatives already rejected in #1922's design pass, do not reopen: a select-like row that expands in place (hides the download CTA in the empty state, exactly where the affordance must be strongest), and a flat list showing only the recommended row plus a "show N more" tail (shows the wrong model at a glance whenever a non-recommended or custom model is active). The comparable-apps grounding (Ollama, LM Studio, Jan, superwhisper, MacWhisper, Handy, Wispr Flow) lives in the skill's worked example.
+
+## What main looks like now
+
+Read these before writing anything:
+
+- `apps/whispering/src/lib/components/settings/LocalModelSelector.svelte`: one flat list backed by the engine's models folder. Catalog models render as `LocalModelDownloadCard`; every other folder entry renders as a selectable "Your model" row with activate and delete. A missing-selection notice appears when the active name is no longer in the folder. A help box explains drop-or-symlink and an Open Models Folder button opens it. `svelte:window onfocus` rescans the folder. The bindable `value` is an entry name, never a path.
+- `apps/whispering/src/lib/operations/local-models.ts`: `createPrebuiltModel` exposes `activeModelName` (reactive via `deviceConfig`), `getStatus()`, `activate()`, `downloadAndActivate()`, `delete()`. Activeness is `deviceConfig.get(settingsKey) === modelEntryName(model)`.
+- `apps/whispering/src/lib/services/transcription/local-model-folder.ts`: renamed from `local-model-storage.ts`; `createModelStorage` still exists, plus `listModelEntries` and `deleteModelEntry`.
+- `apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte`: still owns a private per-component state machine with an `$effect`. Only one surface per model exists today, so the duplicate-state bug has no trigger until the hero returns.
+
+## Decisions already made, with grounding
+
+- Recommended is catalog data, not a user preference: `recommended?: true` on `BaseModelConfig`, exactly one per engine (whisper-small, parakeet-tdt-0.6b-v3, moonshine-base-en). Commit `d9d7ea9fc` on the old branch re-applies nearly clean; the only conflict is textual (#1923 added `modelEntryName` at the end of `constants/local-models.ts`, keep both).
+- Shared download state lives in a `$lib/state` module keyed by model id, factory-plus-getter shape like `local-model.svelte.ts`. The state accessor must be a plain getter, not `$derived`: handles are created lazily by whichever component touches them first and outlive it, and a derived created inside a component's effect context goes inert when that component is destroyed (Svelte's `derived_inert`; verified against sveltejs/svelte via DeepWiki). Components alias the getter with their own `$derived` for union narrowing.
+- The "All models" expansion is a component-local `$state` boolean with `bind:open`; this is the controlled-collapsible pattern shadcn-svelte itself uses (`CodeCollapsibleWrapper`; verified via DeepWiki).
+
+## Port notes for the state module
+
+The old branch's `apps/whispering/src/lib/state/local-model-downloads.svelte.ts` (commit `c21131c16` on `feat/local-model-defaults`) is the right shape but needs three changes:
+
+1. Import `createModelStorage` from `local-model-folder.ts`, not the deleted `local-model-storage.ts`.
+2. Activeness check becomes name equality: `activeModelName === modelEntryName(model)`, not `activeModelPath === installedPath`.
+3. Its disk-caching decision is now wrong in direction, not just detail. The old module checked disk once per handle and let download/delete maintain it, accepting staleness if files changed outside the app. #1923 made the folder user-editable truth and rescans on window focus precisely to catch external edits. The handle must refresh its installed state on the same signal (expose a `refresh()` the selector calls from its existing `onfocus` rescan, or subscribe in the module).
+
+Then collapse `LocalModelDownloadCard` onto the shared handle and delete its `$effect`, which is what makes a download started in the hero show progress in the catalog row and vice versa.
+
+## Plan
+
+1. Branch off main. Cherry-pick `d9d7ea9fc` (recommended flags), resolve the constants conflict.
+2. Port the state module per the notes above.
+3. Rebuild the hero inside main's `LocalModelSelector.svelte`: empty state when `!value` (Empty block, recommended download with size, progress bar, Activate when ready), active summary row, and the existing list (catalog cards, custom entries, folder help box) behind "All models (N)". Keep the missing-model notice always visible, not inside the collapsible; it is an error state.
+4. Typecheck: `bun run --cwd apps/whispering typecheck` (0 errors; 5 warnings were pre-existing at time of writing).
+5. Visual pass in a running Tauri build: empty, downloading, ready, and active on all three engines, plus a custom dropped-in entry and the missing-model notice. Neither #1922 nor #1923 was runtime-verified; this is the first change that should be.
+
+## Open questions (owner: Braden)
+
+- Deactivate without delete: before #1923 the path input's clear button was the only way to deactivate a model without deleting it. #1923 removed that input, so today the only ways out are deleting the model or activating a different one. Does the rebuilt card need an explicit deactivate, or is that a non-goal?
+- Scope check: #1923 already removed the tabs and the picker, so the surface is smaller than the one #1922 redesigned. The empty-state hero is clearly still worth it (one obvious action instead of N peer download buttons). Confirm the active-summary-plus-collapse half still pays for itself with the now-shorter list, or whether collapsing only the catalog (leaving custom entries visible) reads better.
+
+## Constraints
+
+Repo rules that bit this work before: bun only, no em or en dashes anywhere, `writing-voice` skill for UI strings, stage specific files, no AI attribution in commits, `post-implementation-review` before handoff.

--- a/specs/20260612T164300-local-model-recommended-defaults-rebuild.md
+++ b/specs/20260612T164300-local-model-recommended-defaults-rebuild.md
@@ -42,7 +42,7 @@ Alternatives already rejected in #1922's design pass, do not reopen: a select-li
 Read these before writing anything:
 
 - `apps/whispering/src/lib/components/settings/LocalModelSelector.svelte`: one flat list backed by the engine's models folder. Catalog models render as `LocalModelDownloadCard`; every other folder entry renders as a selectable "Your model" row with activate and delete. A missing-selection notice appears when the active name is no longer in the folder. A help box explains drop-or-symlink and an Open Models Folder button opens it. `svelte:window onfocus` rescans the folder. The bindable `value` is an entry name, never a path.
-- `apps/whispering/src/lib/operations/local-models.ts`: `createPrebuiltModel` exposes `activeModelName` (reactive via `deviceConfig`), `getStatus()`, `activate()`, `downloadAndActivate()`, `delete()`. Activeness is `deviceConfig.get(settingsKey) === modelEntryName(model)`.
+- `apps/whispering/src/lib/operations/local-models.ts`: `createPrebuiltModel` exposes `activeModelName` (reactive via `deviceConfig`), `activate()`, `downloadAndActivate()`, and `delete()`. Activeness is `deviceConfig.get(settingsKey) === modelEntryName(model)`.
 - `apps/whispering/src/lib/services/transcription/local-model-folder.ts`: renamed from `local-model-storage.ts`; `createModelStorage` still exists, plus `listModelEntries` and `deleteModelEntry`.
 - `apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte`: still owns a private per-component state machine with an `$effect`. Only one surface per model exists today, so the duplicate-state bug has no trigger until the hero returns.
 

--- a/specs/20260612T164300-local-model-recommended-defaults-rebuild.md
+++ b/specs/20260612T164300-local-model-recommended-defaults-rebuild.md
@@ -66,14 +66,15 @@ Then collapse `LocalModelDownloadCard` onto the shared handle and delete its `$e
 
 1. Branch off main. Cherry-pick `d9d7ea9fc` (recommended flags), resolve the constants conflict.
 2. Port the state module per the notes above.
-3. Rebuild the hero inside main's `LocalModelSelector.svelte`: empty state when `!value` (Empty block, recommended download with size, progress bar, Activate when ready), active summary row, and the existing list (catalog cards, custom entries, folder help box) behind "All models (N)". Keep the missing-model notice always visible, not inside the collapsible; it is an error state.
+3. Rebuild the hero inside main's `LocalModelSelector.svelte`. The hero renders when nothing is active and the folder holds no custom entries (`!value && customEntries.length === 0`): an Empty block whose button derives from the recommended model's handle state (Download with size, progress bar while downloading, Activate when on disk). When custom entries exist but nothing is active, skip the hero and default "All models" open; that user already brought their own model, and a "Download Small (488 MB)" pitch would ignore it. When a model is active, show the summary row (catalog name and size, or entry name with "Your model") with the Change button. Everything else (catalog cards, custom entry rows, folder help box) collapses behind "All models (N)" where N counts catalog plus custom entries. Keep the missing-model notice always visible, not inside the collapsible; it is an error state.
 4. Typecheck: `bun run --cwd apps/whispering typecheck` (0 errors; 5 warnings were pre-existing at time of writing).
 5. Visual pass in a running Tauri build: empty, downloading, ready, and active on all three engines, plus a custom dropped-in entry and the missing-model notice. Neither #1922 nor #1923 was runtime-verified; this is the first change that should be.
 
-## Open questions (owner: Braden)
+## Scoping decisions (resolved 2026-06-12, do not reopen)
 
-- Deactivate without delete: before #1923 the path input's clear button was the only way to deactivate a model without deleting it. #1923 removed that input, so today the only ways out are deleting the model or activating a different one. Does the rebuilt card need an explicit deactivate, or is that a non-goal?
-- Scope check: #1923 already removed the tabs and the picker, so the surface is smaller than the one #1922 redesigned. The empty-state hero is clearly still worth it (one obvious action instead of N peer download buttons). Confirm the active-summary-plus-collapse half still pays for itself with the now-shorter list, or whether collapsing only the catalog (leaving custom entries visible) reads better.
+- No deactivate affordance. Deactivating leaves the engine selected with no model, a broken configuration that fails preflight until something is picked. Not wanting this model means activating another; not wanting local transcription means switching provider above the card. The old X-to-clear was an artifact of the path input, and #1923 deleted the input.
+- The active-summary-plus-collapse half stays. The summary row is what answers "what is running" at a glance, which was the reason the flat-list alternative was rejected, and that reason did not shrink with the surface. Custom entries collapse along with the catalog; the hero-skip rule above covers the one case where hiding them would mislead.
+- This work stacks on the `whispering/local-model-defaults-handoff` branch (PR #1926) rather than waiting for a docs merge. Retitle and rewrite the PR description when the implementation lands. The two docs commits are standalone; if the rebuild stalls, split them out and merge them alone.
 
 ## Constraints
 


### PR DESCRIPTION
This rebuilds local model settings around a default-first path. The old screen presented every catalog model, custom-entry affordance, and folder instruction at once; now each engine answers one question first: what gets me to a working local model on this device?

When nothing is selected and no custom model is present, the card shows a focused empty state for the engine's recommended model, with the download size on the action. If that model is already on disk, the action becomes Activate; while it downloads, the hero and catalog row share the same progress. When a model is active, the card starts with a compact summary and moves catalog rows, custom entries, and folder help behind All models.

---

**Recommendation is engine policy, not a per-model flag.**

`RECOMMENDED_MODELS` names one default for each local engine. The selector decides whether to show a Recommended badge, so Parakeet's single catalog model does not claim to be recommended over nothing.

---

**Download state now belongs to a shared per-model handle.**

`LocalModelDownloadCard` used to own a private status machine, which worked while each model had one surface. The recommended hero adds a second surface for the same model, so `$lib/state/local-model-downloads.svelte.ts` caches one handle per catalog model, keyed by engine and model id. Components read that shared handle and alias `handle.state` locally for Svelte union narrowing.

The handle uses a plain getter rather than a cached `$derived`, because handles are created lazily by whichever component touches them first and can outlive that component.

---

**The folder remains the source of truth.**

`refresh()` rechecks disk state on the same window-focus scan that reloads folder entries. Custom entries skip the download hero when nothing is active, because that user already brought a model.

## Changelog

- Add a recommended local model path in Whispering settings
- Show local model download progress consistently across the recommended model card and catalog rows
