### PR TITLE
docs(specs): resolve custom backends decisions, add pipelines boundary spec

### DIFF
--- a/specs/20260612T091000-whispering-custom-backend-profiles.md
+++ b/specs/20260612T091000-whispering-custom-backend-profiles.md
@@ -1,15 +1,23 @@
-# Whispering Custom Backend Profiles
+# Whispering Custom Backends
 
-**Date**: 2026-06-12
+**Date**: 2026-06-12 (decisions resolved 2026-06-12)
 **Status**: Draft
 **Owner**: Braden
 **Branch**: (future; builds on the providers clean break)
 
 ## One Sentence
 
-Users define named OpenAI-compatible backend profiles (name, endpoint, API key,
-default model), and a transformation step targets a profile instead of the single
-global Custom slot.
+Users define named OpenAI-compatible backends in a `customBackends` workspace
+table (name + endpoint), authenticate them per device through a
+`providers.custom.apiKeys` map, and a transformation step targets a backend by
+id instead of the single global Custom slot.
+
+## Overview
+
+Replaces the single `providers.custom.*` device-config slot with as many named
+backends as the user wants. Backend identity lives in the workspace next to the
+steps that reference it; API keys stay device-bound. Two steps in one
+transformation can hit two different local servers.
 
 ## Motivation
 
@@ -18,61 +26,120 @@ as you want." Today the app supports exactly one custom backend globally
 (`providers.custom.endpoint`). The per-step `customBaseUrl` deleted by the
 endpoint consolidation was, awkwardly, the only multi-backend support the app
 ever had: a user running Ollama and LM Studio side by side could point different
-steps at different servers. Named profiles are the deliberate version of that
+steps at different servers. Named backends are the deliberate version of that
 accident.
 
-## Design Sketch (to be hardened before implementation)
+## Design Decisions
+
+All four open questions from the original draft are resolved. The load-bearing
+one was storage domain: transformation steps live in the workspace (the thing
+that syncs when sync ships), so a step field referencing backends stored in
+deviceConfig would be a foreign key from the synced domain into the unsynced
+domain. Every synced transformation would arrive on other devices with dangling
+nanoid references the user cannot recreate. And "split later" means a data
+migration later, which this branch just refused forever.
+
+| Decision | Class | Choice | Rationale |
+| --- | --- | --- | --- |
+| Single custom slot survives? | Product (Braden) | Replace entirely; delete `providers.custom.{apiKey,endpoint}` | Two shapes for one concept is the smell the clean break removed. |
+| Storage domain for backend identity | 2 coherence | Workspace table `customBackends` (id, name, endpoint), same workspace as `transformationSteps` | Reference and referent share a fate. Costs nothing today (no cloud sync is wired; workspace behaves device-local) and avoids a future migration, which the project has sworn off. |
+| API keys | Product (Braden) | Device-bound map `providers.custom.apiKeys: Record<backendId, string>` in deviceConfig | "API keys are secrets and never sync" stays a clean rule. Workspace encryption is server-trusted, not end to end; third-party credentials should not be operator-readable in principle. Empty key is valid for local servers, so synced backends work immediately on new devices in the common case. |
+| First-run seed | 2 coherence | No seed; empty state with an add dialog prefilled with Ollama defaults (`http://localhost:11434/v1`, empty key) | Per-device seeding of a synced table duplicates on merge (two devices each seed "Default", workspace unions them). Empty state is honest and costs one click. |
+| Who owns the model | 2 coherence | The step; `customModel` stays per-step, unchanged | Symmetry with every other provider's per-step model column. Two steps on the same backend with different models is a real case (llama3 for cleanup, qwen for summarization, one Ollama). |
+| `defaultModel` on the backend | 3 taste | Drop it | Pure prefill sugar that cannot be load-bearing, and it forecloses transcription reuse (a backend's chat model and transcription model differ). Adding an optional field later is additive. Revisit when: users report friction re-typing model names when adding steps. |
+| Table naming | 2 coherence | `customBackends`, not anything completion-flavored | A backend is "an OpenAI-compatible server this workspace knows how to reach." Completions are its first consumer, transcription a plausible second. |
+| Transcription targeting backends | Product (Braden) | Out of scope for v1; do not foreclose | Speaches is already an OpenAI-compatible server with its own special-case keys (`providers.speaches.*`) that could fold into backends in v2 via a `transcription.customBackendId` KV. Neutral naming and no completion-only fields keep that additive. |
+
+## Architecture
 
 ```txt
-deviceConfig (device-bound: profiles carry secrets)
-  providers.custom.profiles   Array<{
-    id: string                 nanoid, referenced by steps
-    name: string               user label, e.g. "LM Studio"
-    endpoint: string
-    apiKey: string             '' when the server needs none
-    defaultModel: string
-  }>                           stored as one JSON entry (createPersistedMap
-                               supports arbitrary arktype schemas per key)
+workspace (syncs when sync ships; co-located with the steps that reference it)
+  customBackends table
+    id        nanoid
+    name      'LM Studio'
+    endpoint  'http://localhost:1234/v1'
+
+deviceConfig (secrets never sync)
+  providers.custom.apiKeys    Record<backendId, string>, one JSON entry
+                              (createPersistedMap supports arbitrary arktype
+                              schemas per key)
 
 transformationSteps (flat row)
-  customProfileId: field.string()   '' = first profile / legacy single slot
+  customBackendId   field.string()   references customBackends.id
+  customModel       unchanged; the step owns the model
 
 editor
-  Provider select grows a "Custom backends" group listing profiles by name;
-  managing profiles (add/edit/delete) lives on the api-keys settings page.
+  Provider select grows a "Custom backends" group listing backends by name.
+  Empty state shows "Add a custom backend..." opening the prefilled dialog.
+  Managing backends (add/edit/delete) lives on the api-keys settings page;
+  the key field per backend writes the device map, not the table.
 
 transform.ts
-  Custom entry resolves { endpoint, apiKey, model } from the profile;
-  a step pointing at a deleted profile fails with a named error.
+  Custom entry resolves endpoint from the table row and apiKey from the device
+  map. A step pointing at a missing backend, or an authed backend with no key
+  on this device, fails with a named step error.
 ```
+
+**Invariant**: `customBackends` lives in the same workspace as
+`transformationSteps`, wherever that workspace ends up. If transformation
+definitions move to a library workspace later (see the pipelines boundary
+spec), the backends table moves with them. The schema above is unchanged under
+that move.
+
+## Edge Cases
+
+### Synced backend arrives on a device with no key
+
+1. Backend row syncs; `providers.custom.apiKeys` on the new device has no entry.
+2. Local servers (Ollama, LM Studio) accept empty keys: works immediately.
+3. Authed backends fail the step with "backend X has no API key on this
+   device", a one-field fix on the api-keys page.
+
+### Deleting a backend that steps reference
+
+1. Delete UI counts referencing steps ("2 steps use this backend") since the
+   check is a cheap same-workspace query.
+2. If deleted anyway, referencing steps fail with a named error, never a
+   silent fallback.
+
+### Duplicate names after a future sync merge
+
+Two devices independently create "Ollama"; the workspace unions them into two
+rows. Acceptable; the user deletes one. Ids stay distinct so no step dangles.
 
 ## Open Questions
 
-1. Does the single `providers.custom.*` record stay as a fallback, or do
-   profiles replace it entirely (first-run seed: one "Default" profile)?
-   Leaning replace: two shapes for the same concept is the smell the clean
-   break just removed.
-2. Should profiles sync? Endpoints are shareable, keys are not. Either split
-   the record (workspace endpoint list + device-bound key map by profile id)
-   or keep the whole profile device-bound. Leaning device-bound first; split
-   later only if users ask for sync.
-3. Transcription support: OpenAI-compatible `/audio/transcriptions` servers
-   (Speaches is one) could target profiles too. Out of scope for v1.
-4. Step UX: does the model field prefill from `defaultModel` and stay
-   per-step, or does the profile own the model outright?
+1. **Provider select presentation**: inline group of backends in the existing
+   select, or a submenu? Recommendation: inline group while backend counts are
+   small; revisit past ~5.
+2. **Orphaned key map entries**: when a backend row is deleted, its key map
+   entry lingers in deviceConfig. Harmless. Sweep on delete, or leave?
+   Recommendation: delete the entry in the same mutation when the delete
+   happens on this device; accept lingering entries from remote deletes.
 
 ## Success Criteria (v1)
 
-- [ ] Two profiles pointing at different local servers can be used by two steps
+- [ ] Two backends pointing at different local servers can be used by two steps
       of the same transformation.
-- [ ] Deleting a profile that steps reference produces a clear step error, not
-      a silent fallback.
-- [ ] No second "single custom slot" shape survives.
+- [ ] Deleting a referenced backend produces a clear step error, not a silent
+      fallback; the delete UI warns with a referencing-step count.
+- [ ] No second "single custom slot" shape survives:
+      `providers.custom.apiKey` and `providers.custom.endpoint` are gone.
+- [ ] API keys never appear in the workspace document (grep the Yjs/IndexedDB
+      write path; keys exist only under `whispering.device.` localStorage).
+- [ ] Fresh profile: selecting Custom with zero backends lands in the add
+      dialog with Ollama defaults prefilled.
 
 ## References
 
 - `specs/20260612T090000-whispering-providers-clean-break.md` - the namespace
   this builds on
+- `specs/20260612T110000-whispering-pipelines-workspace-boundary.md` - the
+  future boundary this design stays invariant under
+- `apps/whispering/src/lib/workspace/definition.ts` - tables and KV; where
+  `customBackends` and `customBackendId` land
+- `apps/whispering/src/lib/state/device-config.svelte.ts` - where the key map
+  lands and the single custom slot dies
 - `apps/whispering/src/lib/operations/transform.ts` - COMPLETION_PROVIDERS map
 - `apps/whispering/src/lib/components/settings/ProviderConfigFields.svelte` -
-  where profile management UI would live
+  where backend management UI would live

--- a/specs/20260612T110000-whispering-pipelines-workspace-boundary.md
+++ b/specs/20260612T110000-whispering-pipelines-workspace-boundary.md
@@ -1,0 +1,180 @@
+# Whispering Pipelines Workspace Boundary and Selection Picker
+
+**Date**: 2026-06-12
+**Status**: Draft (future; sequenced after custom backends v1)
+**Owner**: Braden
+**Branch**: none yet
+
+## One Sentence
+
+Transformation definitions (transformations, steps, custom backends) become a
+library workspace separable from Whispering's recording data, and a
+select-text-anywhere picker that fans one input through multiple
+transformations and shows candidate outputs becomes the engine's second
+consumer.
+
+## How to read this spec
+
+```txt
+Read first:      One Sentence, Coupling Map, Target Boundary, Sequencing
+Read if designing the picker:   Selection Picker, Comparables
+Historical context:             the custom-backends spec this builds on
+```
+
+## Overview
+
+Whispering quietly grew a general text-pipeline runner with a dictation app
+attached. This spec names the boundary that makes the runner a product surface
+of its own (run pipelines on any selected text, pick among candidates) and the
+workspace split that makes pipeline definitions a shareable library, without
+committing to either until the prerequisites land.
+
+## Coupling Map (verified 2026-06-12)
+
+The execution core is already decoupled. `runTransformation({ input: string,
+transformation, recordingId: string | null })` takes arbitrary text;
+`recordingId` is a write-only bookkeeping tag on the run row, nullable, and
+already null in two of the four call paths.
+
+Recording coupling lives in exactly four seams:
+
+| # | Seam | File | Nature |
+| --- | --- | --- | --- |
+| 1 | Post-transcription hook | `operations/pipeline.ts` | Feeds transcript into `runTransformation` when the `transformation.selectedId` KV is set. The only automatic coupling. |
+| 2 | Recording hydration | `rpc/transformer.ts` (`transformRecording`) | Reads `recordings.get(id).transcript` as input. |
+| 3 | Row-action picker | `recordings/row-actions/TransformationPicker.svelte` | Passes a `recordingId`. |
+| 4 | Delivery notice | `operations/delivery.ts` | Hardcodes a "go to recordings" action on every success notice, even clipboard runs. Small bug; fix opportunistically. |
+
+Already recording-free: the `/transform-clipboard` Tauri window (polls
+clipboard, runs `transformInput` with `recordingId: null`), the transformations
+editor and its Test pane, `TransformationPickerBody`, and the global shortcuts
+that open both.
+
+## Target Boundary
+
+The split is a workspace boundary, not an app rewrite. Definitions are a
+library; runs are history.
+
+```txt
+pipelines workspace (library: small, shareable, syncs as a unit)
+  transformations         title, description
+  transformationSteps     prompt_transform + find_replace rows
+  customBackends          id, name, endpoint   (moves WITH the steps;
+                                               invariant from the backends spec)
+
+whispering workspace (data: stays with the app that produced it)
+  recordings, transcripts
+  transformationRuns      recordingId already nullable bookkeeping
+  transformationStepRuns
+  transformation.selectedId KV   cross-boundary soft ref; dangles with the
+                                 same named-error treatment as backends
+
+deviceConfig (never syncs, regardless of boundary)
+  providers.*.apiKey, providers.custom.apiKeys
+```
+
+Cross-boundary references degrade gracefully by construction: `recordingId` on
+a run is nullable, `transformationId` on a run may dangle after a library-side
+delete (runs are history; render "deleted transformation"), and
+`transformation.selectedId` already has not-found handling that clears itself.
+
+**Why not now**: no cloud sync is wired for any Whispering workspace yet, so
+the split changes zero behavior today. Its value (sync the library, share
+pipelines, mount them in other apps) arrives with sync. The custom-backends
+spec was shaped so its schema is invariant under this move; the move becomes
+"these three tables relocate together," not a schema migration.
+
+## Selection Picker (the engine's second consumer)
+
+You select text in any app and hit a global shortcut. A small always-on-top
+window (the existing picker window pattern) fans the input through k
+transformations in parallel, or one transformation sampled n times, and renders
+candidate cards diffed against the original. Arrow through, hit enter, and the
+existing delivery path applies it (`writeToCursor`, clipboard, optional enter
+keystroke).
+
+```txt
+selection capture            NEW primitive: simulate Cmd+C, read clipboard,
+                             restore prior clipboard after; the polling
+                             /transform-clipboard window sidesteps this today
+parallel fan-out             NEW: today's runner is strictly sequential per run
+candidate cards UI           NEW: original on top, candidates diffed below,
+                             each candidate is just a transformationRun row
+picker window, shortcuts,    EXISTS
+delivery, run history        EXISTS
+```
+
+### Comparables
+
+Reference set for selection-capture, candidate-card picking, and paste-back
+delivery (also recorded in the comparable-apps skill):
+
+| App | What it proves |
+| --- | --- |
+| Apple Writing Tools | System-wide select-text surface invoked from any app; candidate replacements with accept/replace flow. |
+| Raycast AI Commands | Global-shortcut launcher; user-defined prompt commands on selection/clipboard; the command library is user-editable, which is exactly the "definitions as library" framing. |
+| Grammarly suggestion cards | Inline candidates diffed against the original, accept/dismiss per card, multiple alternatives for one span. |
+
+## Design Decisions
+
+| Decision | Class | Choice | Rationale |
+| --- | --- | --- | --- |
+| Split is workspace boundary, not new app | 2 coherence | Same engine, second consumer; definitions move, runs stay | Coupling map shows four narrow seams; the exciting product is reachable from the existing engine. |
+| Definitions vs runs split | 2 coherence | Library workspace gets transformations, steps, customBackends; runs stay app-side | Library is what you sync and share; history belongs to the app that executed it. |
+| Keep `find_replace` and `useRegex` | Product (Braden) | Keep, unchanged; do not grow | The only deterministic, free, offline, key-less step type. Load-bearing in dictation ("new paragraph" to newline, filler stripping) and runs after LLM steps to enforce what prompts cannot. More valuable in a shared library: the part that works with zero API keys. Revisit growth (capture-group templating, multi-pattern lists) only on user demand. |
+| Defer the split until sync ships | Product (Braden) | Spec now, implement later | Zero behavior change before sync; prerequisite shaping (backends co-location, nullable refs) is already done. |
+| Picker before split | 2 coherence | Build the selection picker on the current single workspace | Needs none of the boundary; needs the engine plus three new pieces. |
+
+## Sequencing
+
+```txt
+1. Land the providers clean break        (current branch; foundation)
+2. Custom backends v1                    (own spec; stacks on 1)
+3. Selection picker                      (feature on the engine; fold in the
+                                          delivery.ts goToRecordings fix, seam 4)
+4. Pipelines workspace split             (this spec; when sync ships)
+```
+
+Each step is invariant under the later ones: backend schema survives the
+boundary move; the picker is an engine consumer and moves with it.
+
+## Open Questions
+
+1. **Product naming**: "pipelines," "polish," or keep "transformations"?
+   The library framing suggests a noun users would share. Recommendation:
+   decide at picker time, when the surface gets marketing-visible.
+2. **Selection capture mechanics**: simulated copy is lossy (clipboard
+   managers, non-text selections, apps blocking synthetic keys). Acceptable
+   v1? Recommendation: yes, with clipboard restore; macOS Accessibility API
+   selection reading is a later upgrade.
+3. **Candidate fan-out semantics**: k different transformations, n samples of
+   one, or both? Recommendation: both, but ship k-transformations first; it
+   reuses the picker's existing mental model.
+4. **Separate app vs mounted workspace**: if other Epicenter apps mount the
+   pipelines library, is there ever a standalone pipelines app, or is the
+   library plus per-app surfaces enough? Defer until a second app wants it.
+
+## Success Criteria
+
+- [ ] Boundary: pipeline definitions sync/share as a unit with no recording
+      data attached; runs stay app-side; a library-side delete renders as a
+      named state app-side, never a crash or silent fallback.
+- [ ] Picker: select text in a third-party app, invoke by global shortcut, see
+      2+ candidates diffed against the original, accept one, and it replaces
+      the selection; each candidate exists as a transformationRun row.
+- [ ] Seam 4 is gone: clipboard and selection runs do not offer
+      "go to recordings."
+
+## References
+
+- `specs/20260612T091000-whispering-custom-backend-profiles.md` - custom
+  backends; its co-location invariant is this spec's prerequisite shaping
+- `apps/whispering/src/lib/operations/transform.ts` - the engine
+  (`runTransformation`)
+- `apps/whispering/src/lib/operations/pipeline.ts` - seam 1
+- `apps/whispering/src/lib/rpc/transformer.ts` - seams 2 and the recording-free
+  `transformInput`
+- `apps/whispering/src/lib/operations/delivery.ts` - seam 4, the hardcoded
+  recordings action
+- `apps/whispering/src/routes/transform-clipboard/` - the existing
+  recording-free picker window the selection picker grows from


### PR DESCRIPTION
The custom backends spec landed in #1925 as a draft with open questions. This resolves them so the implementation session can run against settled decisions: backend identity is a `customBackends` workspace table co-located with `transformationSteps`, API keys stay device-local in `deviceConfig` as `providers.custom.apiKeys` keyed by backend id, steps fail with named errors (missing backend, missing key) instead of falling back silently, there is no first-run seed, and deleting a backend warns with the count of steps that reference it. The co-location invariant is written down explicitly because the second spec depends on it.

That second spec is new: it names the workspace boundary between pipeline definitions and Whispering's recording data. Transformations, steps, and custom backends become a library workspace that can sync as a unit; runs and the selected-transformation KV stay behind as history. The spec carries a coupling map verified against the code today (the execution core is already recording-free; coupling lives in four named seams), the sequencing constraint that the split waits for workspace sync, and a selection picker design sketch (fan one selection through k transformations, pick among candidate outputs) as the engine's second consumer. Nothing in it is scheduled yet; it exists so the backends implementation does not accidentally close the door on the boundary.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783906387&installation_id=128463665&pr_number=1927&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1927&signature=7a0f0f91bc7794e911824f8a61ae698802e1e8d975c00408ec402f41cc85d788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->