### PR TITLE
refactor(whispering): make provider registries own key names and config UI

### DIFF
--- a/apps/whispering/README.md
+++ b/apps/whispering/README.md
@@ -767,6 +767,10 @@ Local engines (whisper.cpp, Parakeet, Moonshine) are implemented in Rust behind 
 	apiKeyConfigKey: 'providers.yourservice.apiKey',
 	modelSettingKey: 'transcription.yourservice.model',
 	endpointConfigKey: null, // or a 'providers.yourservice.endpoint' override key
+	modelsDoc: {
+		label: 'Your Service docs',
+		href: 'https://yourservice.com/docs/speech-to-text',
+	},
 	defaultModel: 'model-v1',
 	models: [
 		{
@@ -786,9 +790,7 @@ Local engines (whisper.cpp, Parakeet, Moonshine) are implemented in Rust behind 
    - `PROVIDER_ICONS` in `src/lib/services/transcription/provider-ui.ts`: add your SVG icon.
    - `PROVIDER_FIELDS` in `src/lib/components/settings/ProviderConfigFields.svelte`: declare the API key (and optional endpoint) fields with their labels, placeholders, and docs links. This is where provider-specific copy lives, like where to find the API key.
 
-5. **Add the model picker** to `src/routes/(app)/(config)/settings/transcription/+page.svelte`: a branch for your service with a model `Select` bound to `transcription.yourservice.model`, followed by `<ProviderConfigFields provider="YourService" />`.
-
-That's the whole integration. The quick-pick selector, the configuration warning badge, and the dispatcher need no edits; they resolve `apiKeyConfigKey`, `modelSettingKey`, and `endpointConfigKey` through the registry.
+That's the whole integration. The transcription settings page, the quick-pick selector, the configuration warning badge, and the dispatcher need no edits; they all render and resolve through the registry entry. Only self-hosted and local providers get bespoke sections in `src/routes/(app)/(config)/settings/transcription/+page.svelte`, because their setup instructions are the product copy.
 
 ##### Adding an AI Transformation Adapter
 

--- a/apps/whispering/README.md
+++ b/apps/whispering/README.md
@@ -680,18 +680,20 @@ We'd love to expand Whispering's capabilities with more transcription and AI ser
 
 **Overview of the adapter system:**
 
-1. **Transcription services** (`services/transcription/`): Convert audio to text
-2. **Completion services** (`services/completion/`): Power AI transformations in the transformation pipeline
-3. **Query layer** (`query/`): Provides reactive state management and runtime dependency injection
-4. **Settings layer**: Stores API keys and user preferences
+1. **Transcription services** (`src/lib/services/transcription/`): Convert audio to text
+2. **Completion services** (`src/lib/services/completion/`): Power AI transformations in the transformation pipeline
+3. **Provider registries** (`src/lib/services/transcription/providers.ts`, `src/lib/constants/inference.ts`): Own every provider fact, including the names of the config keys that hold its credentials and selections
+4. **Stores**: Own the values behind those keys. `src/lib/state/device-config.svelte.ts` holds device-local values like API keys; `src/lib/workspace/definition.ts` holds synced settings like model selections
+5. **Operations** (`src/lib/operations/transcribe.ts`, `src/lib/operations/transform.ts`): Dispatch tables that resolve registry pointers against the stores and call your service
 
 ##### Adding a Transcription Service Adapter
 
-Adding a new transcription service involves four main steps:
+The provider registry owns every provider fact, including the names of the config keys that hold its credentials and model selection. The stores own the values. The dispatcher and the settings UI resolve those pointers through the registry, so most of the integration is compile-error driven: once your provider is in the registry, the type checker points at every table that still needs an entry.
 
-1. **Create the service implementation** in the appropriate transcription subdirectory:
-   - **Cloud services**: `src/lib/services/transcription/cloud/` (OpenAI, Groq, Deepgram, ElevenLabs)
-   - **Local services**: `src/lib/services/transcription/local/` (WhisperCpp, Parakeet)
+Local engines (whisper.cpp, Parakeet, Moonshine) are implemented in Rust behind Tauri commands, so this guide covers cloud and self-hosted services, which live in TypeScript.
+
+1. **Create the service implementation**:
+   - **Cloud services**: `src/lib/services/transcription/cloud/` (OpenAI, Groq, Deepgram, ElevenLabs, Mistral)
    - **Self-hosted services**: `src/lib/services/transcription/self-hosted/` (Speaches)
 
    ```typescript
@@ -713,17 +715,6 @@ Adding a new transcription service involves four main steps:
    });
    export type YourServiceError = InferErrors<typeof YourServiceError>;
 
-   // Define your models directly in the service file
-   export const YOUR_SERVICE_MODELS = [
-	{
-		name: 'model-v1',
-		description: 'Description of what makes this model special',
-		cost: '$0.XX/hour',
-	},
-   ] as const;
-
-   export type YourServiceModel = (typeof YOUR_SERVICE_MODELS)[number];
-
    export const YourServiceTranscriptionServiceLive = {
 	async transcribe(
 		audioBlob: Blob,
@@ -731,7 +722,8 @@ Adding a new transcription service involves four main steps:
 			prompt: string;
 			outputLanguage: string;
 			apiKey: string;
-			modelName: (string & {}) | YourServiceModel['name'];
+			modelName: string;
+			baseURL?: string;
 		},
 	): Promise<Result<string, YourServiceError>> {
 		if (!options.apiKey) return YourServiceError.MissingApiKey();
@@ -749,153 +741,58 @@ Adding a new transcription service involves four main steps:
 
    The call site in `src/lib/operations/transcribe.ts` decides how to present any error from the service: by default `report.error({ cause: error })` auto-derives a title from the variant name and a description from the message. Override inline only when context-specific copy or an action helps.
 
-   Don't forget to export your service in `src/lib/services/transcription/index.ts`:
+2. **Add the config keys the registry will point at.** API keys and endpoints are device-local and never sync. Add them to `src/lib/state/device-config.svelte.ts`:
 
    ```typescript
-   import { YourServiceTranscriptionServiceLive } from './cloud/your-service';
-
-   export {
-	// ... existing exports
-	YourServiceTranscriptionServiceLive as yourservice,
-   };
+   'providers.yourservice.apiKey': defineEntry(type('string'), ''),
    ```
 
-   And add the API key field to the settings schema in `src/lib/settings/settings.ts`:
+   The model selection syncs across devices. Add it to the transcription section of `src/lib/workspace/definition.ts`:
 
    ```typescript
-   'apiKeys.yourservice': z.string().default(''),
+   'transcription.yourservice.model': defineKv(
+	field.string(),
+	() => PROVIDERS.YourService.defaultModel as string,
+   ),
    ```
 
-2. **Update the service registry** in `src/lib/services/transcription/registry.ts`:
+3. **Register the provider facts** in `PROVIDERS` in `src/lib/services/transcription/providers.ts`:
 
    ```typescript
-   // Add import for your service icon (as SVG)
-   import yourServiceIcon from '$lib/constants/icons/your-service.svg?raw';
-
-   // Add import for your models
-   import {
-	YOUR_SERVICE_MODELS,
-	type YourServiceModel,
-   } from './cloud/your-service';
-
-   // Add to the TranscriptionModel union type
-   type TranscriptionModel =
-	| OpenAIModel
-	| GroqModel
-	| ElevenLabsModel
-	| DeepgramModel
-	| YourServiceModel;
-
-   // Add to TRANSCRIPTION_SERVICE_IDS array
-   export const TRANSCRIPTION_SERVICE_IDS = [
-	'whispercpp',
-	'parakeet',
-	'Groq',
-	'OpenAI',
-	'ElevenLabs',
-	'Deepgram',
-	'speaches',
-	'YourService', // Add your service here
-   ] as const;
-
-   // Add to TRANSCRIPTION_SERVICES array (in the appropriate section)
-   export const TRANSCRIPTION_SERVICES = [
-	// ... existing services
-	// Add in the cloud services section:
-	{
-		id: 'YourService',
-		name: 'Your Service Name',
-		icon: yourServiceIcon,
-		invertInDarkMode: true, // or false, depending on your icon
-		description: 'Description of what makes your service special',
-		models: YOUR_SERVICE_MODELS,
-		defaultModel: YOUR_SERVICE_MODELS[0],
-		modelSettingKey: 'transcription.yourservice.model',
-		apiKeyField: 'apiKeys.yourservice',
-		location: 'cloud', // or 'local' or 'self-hosted'
-	},
-	// ... rest of services
-   ] as const satisfies SatisfiedTranscriptionService[];
+   YourService: {
+	location: 'cloud',
+	label: 'Your Service',
+	description: 'What makes this service worth picking',
+	capabilities: { supportsPrompt: true, supportsLanguage: true },
+	apiKeyConfigKey: 'providers.yourservice.apiKey',
+	modelSettingKey: 'transcription.yourservice.model',
+	endpointConfigKey: null, // or a 'providers.yourservice.endpoint' override key
+	defaultModel: 'model-v1',
+	models: [
+		{
+			name: 'model-v1',
+			description: 'What makes this model special',
+			cost: '$0.XX/hour',
+		},
+	],
+   },
    ```
 
-3. **Wire up the rpc layer** in `src/lib/rpc/transcription.ts`:
+   The suffix names the store: `*ConfigKey` fields hold `deviceConfig` key names, `*SettingKey` fields hold synced `settings` key names. Everything downstream resolves these pointers instead of hardcoding keys.
 
-   ```typescript
-   // Add to the switch statement in transcribeBlob function
-   case 'YourService':
-     return services.transcriptions.yourservice.transcribe(blob, {
-       outputLanguage: settings.value['transcription.outputLanguage'],
-       prompt: settings.value['transcription.prompt'],
-       apiKey: settings.value['apiKeys.yourservice'],
-       modelName: settings.value['transcription.yourservice.model'],
-     });
-   ```
+4. **Fix the compile errors the registry entry creates.** Each of these tables is exhaustive over the provider ids, so the type checker walks you to them:
 
-4. **Update the settings UI** in `src/routes/(config)/settings/transcription/+page.svelte`:
+   - `CLOUD_TRANSCRIBERS` in `src/lib/operations/transcribe.ts`: map your id to `YourServiceTranscriptionServiceLive.transcribe`.
+   - `PROVIDER_ICONS` in `src/lib/services/transcription/provider-ui.ts`: add your SVG icon.
+   - `PROVIDER_FIELDS` in `src/lib/components/settings/ProviderConfigFields.svelte`: declare the API key (and optional endpoint) fields with their labels, placeholders, and docs links. This is where provider-specific copy lives, like where to find the API key.
 
-   ```svelte
-   <!-- Add after other service conditionals -->
-   {:else if settings.value['transcription.selectedTranscriptionService'] === 'YourService'}
-     <LabeledSelect
-       id="yourservice-model"
-       label="YourService Model"
-       items={YOUR_SERVICE_MODELS.map((model) => ({
-         value: model.name,
-         label: model.name,
-         ...model,
-       }))}
-       bind:selected={
-         () => settings.value['transcription.yourservice.model'],
-         (selected) => settings.updateKey('transcription.yourservice.model', selected)
-       }
-       renderOption={renderModelOption}
-     />
-     <YourServiceApiKeyInput />
-   {/if}
-   ```
+5. **Add the model picker** to `src/routes/(app)/(config)/settings/transcription/+page.svelte`: a branch for your service with a model `Select` bound to `transcription.yourservice.model`, followed by `<ProviderConfigFields provider="YourService" />`.
 
-   Create the API key input component in `src/lib/components/settings/api-key-inputs/YourServiceApiKeyInput.svelte`:
-
-   ```svelte
-   <script lang="ts">
-	import { LabeledInput } from '$lib/components/labeled/index.js';
-	import { Button } from '$lib/components/ui/button/index.js';
-	import { settings } from '$lib/state/settings.svelte';
-   </script>
-
-   <LabeledInput
-	id="yourservice-api-key"
-	label="YourService API Key"
-	type="password"
-	placeholder="Your YourService API Key"
-	value={settings.value['apiKeys.yourservice']}
-	oninput={({ currentTarget: { value } }) => {
-		settings.updateKey('apiKeys.yourservice', value);
-	}}
-   >
-	{#snippet description()}
-		<p class="text-muted-foreground text-sm">
-			You can find your YourService API key in your <Link
-				href="https://yourservice.com/api-keys"
-				target="_blank"
-				rel="noopener noreferrer"
-			>
-				YourService dashboard
-			</Link>.
-		</p>
-	{/snippet}
-   </LabeledInput>
-   ```
-
-   And export it from `src/lib/components/settings/index.ts`:
-
-   ```typescript
-   export { default as YourServiceApiKeyInput } from './api-key-inputs/YourServiceApiKeyInput.svelte';
-   ```
+That's the whole integration. The quick-pick selector, the configuration warning badge, and the dispatcher need no edits; they resolve `apiKeyConfigKey`, `modelSettingKey`, and `endpointConfigKey` through the registry.
 
 ##### Adding an AI Transformation Adapter
 
-AI transformations in Whispering use completion services that can be integrated into transformation workflows. Here's how to add a new AI provider:
+AI transformations use completion services. The same registry scheme applies: `INFERENCE` in `src/lib/constants/inference.ts` owns the provider facts, `COMPLETION_PROVIDERS` in `src/lib/operations/transform.ts` owns the service wiring and config-key pointers, and `deviceConfig` owns the credential values.
 
 1. **Create the completion service** in `src/lib/services/completion/`:
 
@@ -919,7 +816,7 @@ AI transformations in Whispering use completion services that can be integrated 
 		model: string;
 		systemPrompt: string;
 		userPrompt: string;
-		temperature?: number;
+		baseUrl?: string;
 	}): Promise<Result<string, YourProviderError>> {
 		if (!options.apiKey) return YourProviderError.MissingApiKey();
 
@@ -945,34 +842,20 @@ AI transformations in Whispering use completion services that can be integrated 
    };
    ```
 
-3. **Wire up the transformation handler** in `src/lib/rpc/transformer.ts`:
+3. **Add the API key** to `src/lib/state/device-config.svelte.ts`:
 
    ```typescript
-   // Add a new case in the handleStep function's prompt_transform switch statement
-   case 'YourProvider': {
-     const { data: completionResponse, error: completionError } =
-       await services.completions.yourprovider.complete({
-         apiKey: settings.value['apiKeys.yourprovider'],
-         model: step['prompt_transform.inference.provider.YourProvider.model'],
-         systemPrompt,
-         userPrompt,
-       });
-
-     if (completionError) {
-       return Err(completionError.message);
-     }
-
-     return Ok(completionResponse);
-   }
+   'providers.yourprovider.apiKey': defineEntry(type('string'), ''),
    ```
 
-4. **Add API key to settings** in `src/lib/settings/settings.ts`:
+4. **Register the provider** in `INFERENCE` in `src/lib/constants/inference.ts` (label, `stepModelField`, models), and add the matching step model field (for example `yourproviderModel: field.string()`) to the transformation step schema in `src/lib/workspace/definition.ts`.
 
-   ```typescript
-   'apiKeys.yourprovider': z.string().default(''),
-   ```
+5. **Fix the compile errors the `INFERENCE` entry creates**:
 
-5. **Update transformation types** to include your provider models and configuration
+   - `COMPLETION_PROVIDERS` in `src/lib/operations/transform.ts`: your service plus its `apiKeyConfigKey` and `endpointConfigKey` pointers.
+   - `PROVIDER_FIELDS` in `src/lib/components/settings/ProviderConfigFields.svelte`: the API key field with its label and docs link.
+
+   The transformation step editor reads providers and models from `INFERENCE`; no UI switch statements to extend.
 
 ##### Error Handling Best Practices
 
@@ -1013,7 +896,7 @@ Create a test file alongside your service:
 ```typescript
 // Example: src/lib/services/transcription/cloud/your-service.test.ts
 import { describe, it, expect } from 'vitest';
-import { createYourServiceTranscriptionService } from './your-service';
+import { YourServiceTranscriptionServiceLive } from './your-service';
 
 describe('YourService Transcription', () => {
 	it('should handle missing API key', async () => {
@@ -1035,9 +918,8 @@ describe('YourService Transcription', () => {
 When submitting a PR for a new adapter, include:
 
 - The service implementation with comprehensive error handling
-- All type definitions and constants
-- Query layer integration
-- Settings UI components
+- The registry entry plus the dispatcher, icon, and `PROVIDER_FIELDS` entries it demands
+- The config keys in `deviceConfig` and, for transcription, the synced model key
 - Tests covering success and error cases
 - Documentation of any special requirements or limitations
 - Example `.env` entries if needed

--- a/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
@@ -32,50 +32,12 @@
 
 	function getSelectedModelNameOrUrl(service: TranscriptionProviderEntry) {
 		switch (service.location) {
-			case 'cloud': {
-				switch (service.id) {
-					case 'Groq':
-						return settings.get('transcription.groq.model');
-					case 'OpenAI':
-						return settings.get('transcription.openai.model');
-					case 'ElevenLabs':
-						return settings.get('transcription.elevenlabs.model');
-					case 'Deepgram':
-						return settings.get('transcription.deepgram.model');
-					case 'Mistral':
-						return settings.get('transcription.mistral.model');
-				}
-				break;
-			}
+			case 'cloud':
+				return settings.get(service.modelSettingKey);
 			case 'self-hosted':
-				return deviceConfig.get('providers.speaches.endpoint');
+				return deviceConfig.get(service.endpointConfigKey);
 			case 'local':
-				return deviceConfig.get(service.modelKey);
-		}
-
-		return '';
-	}
-
-	function setSelectedCloudModel(
-		service: TranscriptionProviderEntry,
-		modelName: string,
-	) {
-		switch (service.id) {
-			case 'Groq':
-				settings.set('transcription.groq.model', modelName);
-				return;
-			case 'OpenAI':
-				settings.set('transcription.openai.model', modelName);
-				return;
-			case 'ElevenLabs':
-				settings.set('transcription.elevenlabs.model', modelName);
-				return;
-			case 'Deepgram':
-				settings.set('transcription.deepgram.model', modelName);
-				return;
-			case 'Mistral':
-				settings.set('transcription.mistral.model', modelName);
-				return;
+				return deviceConfig.get(service.modelConfigKey);
 		}
 	}
 
@@ -264,7 +226,7 @@
 											'transcription.service',
 											service.id,
 										);
-										setSelectedCloudModel(service, model.name);
+										settings.set(service.modelSettingKey, model.name);
 										combobox.closeAndFocusTrigger();
 									}}
 									class="flex items-center gap-2 px-2 py-1.5 pl-11"

--- a/apps/whispering/src/lib/operations/local-models.ts
+++ b/apps/whispering/src/lib/operations/local-models.ts
@@ -1,8 +1,8 @@
 /**
  * Lifecycle orchestration for one pre-built local transcription model:
- * combines its catalog storage handle with the engine's model setting in
+ * combines its catalog storage handle with the engine's model config in
  * `deviceConfig` (the key comes from the provider registry). A model is
- * "active" when that setting holds its folder entry name.
+ * "active" when that config holds its folder entry name.
  */
 import { Err, Ok, type Result } from 'wellcrafted/result';
 import {
@@ -23,7 +23,7 @@ import { deviceConfig } from '$lib/state/device-config.svelte';
  */
 export function createPrebuiltModel(model: LocalModelConfig) {
 	const storage = createModelStorage(model);
-	const settingsKey = PROVIDERS[model.engine].modelKey;
+	const modelConfigKey = PROVIDERS[model.engine].modelConfigKey;
 	const entryName = modelEntryName(model);
 
 	return {
@@ -32,12 +32,12 @@ export function createPrebuiltModel(model: LocalModelConfig) {
 		 * so reading it inside `$effect` or `$derived` tracks changes.
 		 */
 		get activeModelName() {
-			return deviceConfig.get(settingsKey);
+			return deviceConfig.get(modelConfigKey);
 		},
 
-		/** Point the engine's model setting at this model's entry name. */
+		/** Point the engine's model config at this model's entry name. */
 		activate(): void {
-			deviceConfig.set(settingsKey, entryName);
+			deviceConfig.set(modelConfigKey, entryName);
 		},
 
 		/**
@@ -57,27 +57,27 @@ export function createPrebuiltModel(model: LocalModelConfig) {
 		> {
 			const installedPath = await storage.getInstalledPath();
 			if (installedPath) {
-				deviceConfig.set(settingsKey, entryName);
+				deviceConfig.set(modelConfigKey, entryName);
 				return Ok({ outcome: 'already-installed' });
 			}
 
 			const { error: downloadError } = await storage.download({ onProgress });
 			if (downloadError) return Err(downloadError);
 
-			deviceConfig.set(settingsKey, entryName);
+			deviceConfig.set(modelConfigKey, entryName);
 			return Ok({ outcome: 'downloaded' });
 		},
 
 		/**
 		 * Remove the model from disk and, when it was the engine's active
-		 * model, clear the engine's model setting.
+		 * model, clear the engine's model config.
 		 */
 		async delete(): Promise<Result<void, LocalModelFolderError>> {
 			const { error: deleteError } = await storage.delete();
 			if (deleteError) return Err(deleteError);
 
-			if (deviceConfig.get(settingsKey) === entryName) {
-				deviceConfig.set(settingsKey, '');
+			if (deviceConfig.get(modelConfigKey) === entryName) {
+				deviceConfig.set(modelConfigKey, '');
 			}
 			return Ok(undefined);
 		},

--- a/apps/whispering/src/lib/operations/transcribe.ts
+++ b/apps/whispering/src/lib/operations/transcribe.ts
@@ -226,7 +226,7 @@ async function dispatchLocalTranscription(
 	// user-facing messages. The FE keeps two checks Rust cannot make as well:
 	// "nothing selected yet" (instant, no IPC) and the catalog-size truncation
 	// check (the expected sizes live in the JS catalog).
-	const modelName = deviceConfig.get(provider.modelKey);
+	const modelName = deviceConfig.get(provider.modelConfigKey);
 	if (!modelName) {
 		return TranscriptionOperationError.LocalModelNotSelected({
 			engineDisplayName: provider.label,
@@ -261,8 +261,8 @@ async function dispatchUploadTranscription(
 		return SpeachesTranscriptionServiceLive.transcribe(audio, {
 			outputLanguage,
 			prompt,
-			modelId: deviceConfig.get(provider.modelIdKey),
-			baseUrl: deviceConfig.get(provider.endpointKey),
+			modelId: deviceConfig.get(provider.modelIdConfigKey),
+			baseUrl: deviceConfig.get(provider.endpointConfigKey),
 		});
 	}
 
@@ -270,10 +270,10 @@ async function dispatchUploadTranscription(
 		return CLOUD_TRANSCRIBERS[selectedService](audio, {
 			outputLanguage,
 			prompt,
-			apiKey: deviceConfig.get(provider.apiKeyKey),
-			modelName: settings.get(provider.modelKey),
-			baseURL: provider.endpointKey
-				? deviceConfig.get(provider.endpointKey) || undefined
+			apiKey: deviceConfig.get(provider.apiKeyConfigKey),
+			modelName: settings.get(provider.modelSettingKey),
+			baseURL: provider.endpointConfigKey
+				? deviceConfig.get(provider.endpointConfigKey) || undefined
 				: undefined,
 		});
 	}

--- a/apps/whispering/src/lib/operations/transform.ts
+++ b/apps/whispering/src/lib/operations/transform.ts
@@ -25,38 +25,40 @@ import type {
  * `{ apiKey, model, baseUrl?, systemPrompt, userPrompt }` call signature.
  * Exhaustive over InferenceProviderId: adding a provider to INFERENCE is a
  * compile error here until its entry exists. The custom service owns the
- * "endpoint is required" invariant via its validateParams.
+ * "endpoint is required" invariant via its validateParams. `*ConfigKey`
+ * fields hold deviceConfig key names, same convention as the transcription
+ * registry in `services/transcription/providers.ts`.
  */
 const COMPLETION_PROVIDERS = {
 	OpenAI: {
 		service: services.completions.openai,
-		apiKeyKey: 'providers.openai.apiKey',
-		endpointKey: 'providers.openai.endpoint',
+		apiKeyConfigKey: 'providers.openai.apiKey',
+		endpointConfigKey: 'providers.openai.endpoint',
 	},
 	Groq: {
 		service: services.completions.groq,
-		apiKeyKey: 'providers.groq.apiKey',
-		endpointKey: 'providers.groq.endpoint',
+		apiKeyConfigKey: 'providers.groq.apiKey',
+		endpointConfigKey: 'providers.groq.endpoint',
 	},
 	Anthropic: {
 		service: services.completions.anthropic,
-		apiKeyKey: 'providers.anthropic.apiKey',
-		endpointKey: null,
+		apiKeyConfigKey: 'providers.anthropic.apiKey',
+		endpointConfigKey: null,
 	},
 	Google: {
 		service: services.completions.google,
-		apiKeyKey: 'providers.google.apiKey',
-		endpointKey: null,
+		apiKeyConfigKey: 'providers.google.apiKey',
+		endpointConfigKey: null,
 	},
 	OpenRouter: {
 		service: services.completions.openrouter,
-		apiKeyKey: 'providers.openrouter.apiKey',
-		endpointKey: null,
+		apiKeyConfigKey: 'providers.openrouter.apiKey',
+		endpointConfigKey: null,
 	},
 	Custom: {
 		service: services.completions.custom,
-		apiKeyKey: 'providers.custom.apiKey',
-		endpointKey: 'providers.custom.endpoint',
+		apiKeyConfigKey: 'providers.custom.apiKey',
+		endpointConfigKey: 'providers.custom.endpoint',
 	},
 } as const satisfies Record<
 	InferenceProviderId,
@@ -70,9 +72,9 @@ const COMPLETION_PROVIDERS = {
 				baseUrl?: string;
 			}) => Promise<Result<string, { message: string }>>;
 		};
-		apiKeyKey: DeviceConfigKey;
+		apiKeyConfigKey: DeviceConfigKey;
 		/** Device config key for the endpoint; null when not configurable. */
-		endpointKey: DeviceConfigKey | null;
+		endpointConfigKey: DeviceConfigKey | null;
 	}
 >;
 
@@ -125,10 +127,10 @@ async function handleStep({
 			// Trim everything once here: keys, model names, and URLs are
 			// pasted strings, and a trailing space fails the request opaquely.
 			return config.service.complete({
-				apiKey: deviceConfig.get(config.apiKeyKey).trim(),
+				apiKey: deviceConfig.get(config.apiKeyConfigKey).trim(),
 				model: step[INFERENCE[inferenceProvider].stepModelField].trim(),
-				baseUrl: config.endpointKey
-					? deviceConfig.get(config.endpointKey).trim() || undefined
+				baseUrl: config.endpointConfigKey
+					? deviceConfig.get(config.endpointConfigKey).trim() || undefined
 					: undefined,
 				systemPrompt,
 				userPrompt,

--- a/apps/whispering/src/lib/services/transcription/provider-ui.ts
+++ b/apps/whispering/src/lib/services/transcription/provider-ui.ts
@@ -32,13 +32,26 @@ export const PROVIDER_ICONS = {
 	{ icon: string; invertInDarkMode: boolean }
 >;
 
+/**
+ * One provider's registry data joined with its icon, discriminated by id:
+ * narrowing on `location` (or `id`) narrows every field together, `id`
+ * included. A plain `Object.entries(...).map(...)` type would cross the full
+ * id union with the full provider union, so narrowing `location` would leave
+ * `id` broad; the mapped type keeps each id paired with its own shape.
+ */
+export type TranscriptionProviderEntry = {
+	[K in TranscriptionServiceId]: { id: K } & (typeof PROVIDERS)[K] &
+		(typeof PROVIDER_ICONS)[K];
+}[TranscriptionServiceId];
+
 /** UI-facing list: each provider's data joined with its icon, in declaration order. */
 export const TRANSCRIPTION_PROVIDERS = (
 	Object.entries(PROVIDERS) as [
 		TranscriptionServiceId,
 		(typeof PROVIDERS)[TranscriptionServiceId],
 	][]
-).map(([id, provider]) => ({ id, ...provider, ...PROVIDER_ICONS[id] }));
-
-export type TranscriptionProviderEntry =
-	(typeof TRANSCRIPTION_PROVIDERS)[number];
+).map(([id, provider]) => ({
+	id,
+	...provider,
+	...PROVIDER_ICONS[id],
+})) as TranscriptionProviderEntry[];

--- a/apps/whispering/src/lib/services/transcription/providers.ts
+++ b/apps/whispering/src/lib/services/transcription/providers.ts
@@ -41,6 +41,12 @@ type CloudProvider = {
 	modelSettingKey: `transcription.${string}.model`;
 	/** Device config key for the endpoint override; null when not configurable. */
 	endpointConfigKey: DeviceConfigKey | null;
+	/**
+	 * Where this provider documents its transcription models; null when the
+	 * provider has no good page to link. The settings page renders this under
+	 * the model picker.
+	 */
+	modelsDoc: { label: string; href: string } | null;
 };
 
 type LocalProvider = {
@@ -77,6 +83,10 @@ export const PROVIDERS = {
 		apiKeyConfigKey: 'providers.openai.apiKey',
 		modelSettingKey: 'transcription.openai.model',
 		endpointConfigKey: 'providers.openai.endpoint',
+		modelsDoc: {
+			label: 'OpenAI docs',
+			href: 'https://platform.openai.com/docs/guides/speech-to-text',
+		},
 		defaultModel: 'whisper-1',
 		models: [
 			{
@@ -107,6 +117,10 @@ export const PROVIDERS = {
 		apiKeyConfigKey: 'providers.groq.apiKey',
 		modelSettingKey: 'transcription.groq.model',
 		endpointConfigKey: 'providers.groq.endpoint',
+		modelsDoc: {
+			label: 'Groq docs',
+			href: 'https://console.groq.com/docs/speech-to-text',
+		},
 		defaultModel: 'whisper-large-v3-turbo',
 		models: [
 			{
@@ -131,6 +145,10 @@ export const PROVIDERS = {
 		apiKeyConfigKey: 'providers.elevenlabs.apiKey',
 		endpointConfigKey: null,
 		modelSettingKey: 'transcription.elevenlabs.model',
+		modelsDoc: {
+			label: 'ElevenLabs docs',
+			href: 'https://elevenlabs.io/docs/capabilities/speech-to-text',
+		},
 		defaultModel: 'scribe_v2',
 		models: [
 			{
@@ -161,6 +179,7 @@ export const PROVIDERS = {
 		apiKeyConfigKey: 'providers.deepgram.apiKey',
 		endpointConfigKey: null,
 		modelSettingKey: 'transcription.deepgram.model',
+		modelsDoc: null,
 		defaultModel: 'nova-3',
 		models: [
 			{
@@ -202,6 +221,10 @@ export const PROVIDERS = {
 		apiKeyConfigKey: 'providers.mistral.apiKey',
 		endpointConfigKey: null,
 		modelSettingKey: 'transcription.mistral.model',
+		modelsDoc: {
+			label: 'Mistral docs',
+			href: 'https://mistral.ai/news/voxtral/',
+		},
 		defaultModel: 'voxtral-mini-latest',
 		models: [
 			{

--- a/apps/whispering/src/lib/services/transcription/providers.ts
+++ b/apps/whispering/src/lib/services/transcription/providers.ts
@@ -4,6 +4,11 @@
  * deviceConfig/settings key NAMES used to read its config (never the values,
  * which the dispatcher in `operations/transcribe.ts` reads).
  *
+ * Pointer-field naming: the suffix names the store. A `*ConfigKey` field
+ * holds the name of a `deviceConfig` entry (device-local, never synced); a
+ * `*SettingKey` field holds the name of a `settings` entry (synced workspace
+ * KV). Dispatchers resolve the pointer against the matching store.
+ *
  * Behavior is deliberately not here. The `id -> transcribe` wiring lives as a
  * static table in the dispatcher, where the provider SDKs already load. That
  * keeps this record free of SDK imports so the workspace schema can import
@@ -23,19 +28,19 @@ type CloudProvider = {
 	capabilities: Capabilities;
 	models: readonly CloudModel[];
 	defaultModel: string;
-	apiKeyKey: DeviceConfigKey;
+	apiKeyConfigKey: DeviceConfigKey;
 	/**
 	 * The settings key holding this provider's model selection. Constrained to
 	 * the leaf shape `transcription.${string}.model`, not a precise union of the
 	 * cloud keys: a precise union here would make `typeof PROVIDERS` reference a
 	 * type derived from itself (`satisfies Record<..., TranscriptionProvider>`
 	 * closes the loop). The real guard is the call site
-	 * `settings.get(provider.modelKey)`, which rejects keys absent from the
-	 * settings schema.
+	 * `settings.get(provider.modelSettingKey)`, which rejects keys absent from
+	 * the settings schema.
 	 */
-	modelKey: `transcription.${string}.model`;
+	modelSettingKey: `transcription.${string}.model`;
 	/** Device config key for the endpoint override; null when not configurable. */
-	endpointKey: DeviceConfigKey | null;
+	endpointConfigKey: DeviceConfigKey | null;
 };
 
 type LocalProvider = {
@@ -44,10 +49,10 @@ type LocalProvider = {
 	description: string;
 	capabilities: Capabilities;
 	/**
-	 * The settings key holding the engine's selected model: a folder entry
-	 * name inside the engine's models folder, never a path.
+	 * The device config key holding the engine's selected model: a folder
+	 * entry name inside the engine's models folder, never a path.
 	 */
-	modelKey: DeviceConfigKey;
+	modelConfigKey: DeviceConfigKey;
 	/** Whether the engine's model is a single file or a directory. */
 	modelKind: 'file' | 'directory';
 };
@@ -57,8 +62,8 @@ type SelfHostedProvider = {
 	label: string;
 	description: string;
 	capabilities: Capabilities;
-	endpointKey: DeviceConfigKey;
-	modelIdKey: DeviceConfigKey;
+	endpointConfigKey: DeviceConfigKey;
+	modelIdConfigKey: DeviceConfigKey;
 };
 
 type TranscriptionProvider = CloudProvider | LocalProvider | SelfHostedProvider;
@@ -69,9 +74,9 @@ export const PROVIDERS = {
 		label: 'OpenAI',
 		description: 'Industry-standard Whisper API',
 		capabilities: { supportsPrompt: true, supportsLanguage: true },
-		apiKeyKey: 'providers.openai.apiKey',
-		modelKey: 'transcription.openai.model',
-		endpointKey: 'providers.openai.endpoint',
+		apiKeyConfigKey: 'providers.openai.apiKey',
+		modelSettingKey: 'transcription.openai.model',
+		endpointConfigKey: 'providers.openai.endpoint',
 		defaultModel: 'whisper-1',
 		models: [
 			{
@@ -99,9 +104,9 @@ export const PROVIDERS = {
 		label: 'Groq',
 		description: 'Lightning-fast cloud transcription',
 		capabilities: { supportsPrompt: true, supportsLanguage: true },
-		apiKeyKey: 'providers.groq.apiKey',
-		modelKey: 'transcription.groq.model',
-		endpointKey: 'providers.groq.endpoint',
+		apiKeyConfigKey: 'providers.groq.apiKey',
+		modelSettingKey: 'transcription.groq.model',
+		endpointConfigKey: 'providers.groq.endpoint',
 		defaultModel: 'whisper-large-v3-turbo',
 		models: [
 			{
@@ -123,9 +128,9 @@ export const PROVIDERS = {
 		label: 'ElevenLabs',
 		description: 'Voice AI platform with transcription',
 		capabilities: { supportsPrompt: true, supportsLanguage: true },
-		apiKeyKey: 'providers.elevenlabs.apiKey',
-		endpointKey: null,
-		modelKey: 'transcription.elevenlabs.model',
+		apiKeyConfigKey: 'providers.elevenlabs.apiKey',
+		endpointConfigKey: null,
+		modelSettingKey: 'transcription.elevenlabs.model',
 		defaultModel: 'scribe_v2',
 		models: [
 			{
@@ -153,9 +158,9 @@ export const PROVIDERS = {
 		label: 'Deepgram',
 		description: 'Real-time speech recognition API',
 		capabilities: { supportsPrompt: true, supportsLanguage: true },
-		apiKeyKey: 'providers.deepgram.apiKey',
-		endpointKey: null,
-		modelKey: 'transcription.deepgram.model',
+		apiKeyConfigKey: 'providers.deepgram.apiKey',
+		endpointConfigKey: null,
+		modelSettingKey: 'transcription.deepgram.model',
 		defaultModel: 'nova-3',
 		models: [
 			{
@@ -194,9 +199,9 @@ export const PROVIDERS = {
 		label: 'Mistral AI',
 		description: 'Advanced Voxtral speech understanding',
 		capabilities: { supportsPrompt: true, supportsLanguage: true },
-		apiKeyKey: 'providers.mistral.apiKey',
-		endpointKey: null,
-		modelKey: 'transcription.mistral.model',
+		apiKeyConfigKey: 'providers.mistral.apiKey',
+		endpointConfigKey: null,
+		modelSettingKey: 'transcription.mistral.model',
 		defaultModel: 'voxtral-mini-latest',
 		models: [
 			{
@@ -219,7 +224,7 @@ export const PROVIDERS = {
 		label: 'Whisper C++',
 		description: 'Fast local transcription with no internet required',
 		capabilities: { supportsPrompt: true, supportsLanguage: true },
-		modelKey: 'transcription.whispercpp.model',
+		modelConfigKey: 'transcription.whispercpp.model',
 		modelKind: 'file',
 	},
 	parakeet: {
@@ -227,7 +232,7 @@ export const PROVIDERS = {
 		label: 'Parakeet',
 		description: 'NVIDIA NeMo model for fast local transcription',
 		capabilities: { supportsPrompt: false, supportsLanguage: false },
-		modelKey: 'transcription.parakeet.model',
+		modelConfigKey: 'transcription.parakeet.model',
 		modelKind: 'directory',
 	},
 	moonshine: {
@@ -235,7 +240,7 @@ export const PROVIDERS = {
 		label: 'Moonshine',
 		description: 'Efficient ONNX model by UsefulSensors',
 		capabilities: { supportsPrompt: false, supportsLanguage: false },
-		modelKey: 'transcription.moonshine.model',
+		modelConfigKey: 'transcription.moonshine.model',
 		modelKind: 'directory',
 	},
 
@@ -244,8 +249,8 @@ export const PROVIDERS = {
 		label: 'Speaches',
 		description: 'Self-hosted transcription server',
 		capabilities: { supportsPrompt: true, supportsLanguage: true },
-		endpointKey: 'providers.speaches.endpoint',
-		modelIdKey: 'providers.speaches.modelId',
+		endpointConfigKey: 'providers.speaches.endpoint',
+		modelIdConfigKey: 'providers.speaches.modelId',
 	},
 } as const satisfies Record<string, TranscriptionProvider>;
 

--- a/apps/whispering/src/lib/settings/transcription-validation.ts
+++ b/apps/whispering/src/lib/settings/transcription-validation.ts
@@ -36,10 +36,10 @@ export function isTranscriptionServiceConfigured(
 ): boolean {
 	switch (service.location) {
 		case 'cloud':
-			return deviceConfig.get(service.apiKeyKey) !== '';
+			return deviceConfig.get(service.apiKeyConfigKey) !== '';
 		case 'self-hosted':
-			return deviceConfig.get(service.endpointKey) !== '';
+			return deviceConfig.get(service.endpointConfigKey) !== '';
 		case 'local':
-			return deviceConfig.get(service.modelKey) !== '';
+			return deviceConfig.get(service.modelConfigKey) !== '';
 	}
 }

--- a/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
@@ -18,6 +18,7 @@
 		PARAKEET_MODELS,
 		WHISPER_MODELS,
 	} from '$lib/constants/local-models';
+	import { TRANSCRIPTION_PROVIDERS } from '$lib/services/transcription/provider-ui';
 	import { PROVIDERS } from '$lib/services/transcription/providers';
 	import {
 		LOCAL_MODEL_UNLOAD_POLICY_OPTIONS,
@@ -36,67 +37,17 @@
 		PROVIDERS[settings.get('transcription.service')].capabilities,
 	);
 
-	// Model options arrays derived from the single PROVIDERS record
-	const openaiModelItems = PROVIDERS.OpenAI.models.map((model) => ({
-		value: model.name,
-		label: model.name,
-		...model,
-	}));
-
-	const groqModelItems = PROVIDERS.Groq.models.map((model) => ({
-		value: model.name,
-		label: model.name,
-		...model,
-	}));
-
-	const deepgramModelItems = PROVIDERS.Deepgram.models.map((model) => ({
-		value: model.name,
-		label: model.name,
-		...model,
-	}));
-
-	const mistralModelItems = PROVIDERS.Mistral.models.map((model) => ({
-		value: model.name,
-		label: model.name,
-		...model,
-	}));
-
-	const elevenlabsModelItems = PROVIDERS.ElevenLabs.models.map((model) => ({
-		value: model.name,
-		label: model.name,
-		...model,
-	}));
-
-	// Selected labels for select triggers
-	const openaiModelLabel = $derived(
-		openaiModelItems.find(
-			(i) => i.value === settings.get('transcription.openai.model'),
-		)?.label,
-	);
-
-	const groqModelLabel = $derived(
-		groqModelItems.find(
-			(i) => i.value === settings.get('transcription.groq.model'),
-		)?.label,
-	);
-
-	const deepgramModelLabel = $derived(
-		deepgramModelItems.find(
-			(i) => i.value === settings.get('transcription.deepgram.model'),
-		)?.label,
-	);
-
-	const mistralModelLabel = $derived(
-		mistralModelItems.find(
-			(i) => i.value === settings.get('transcription.mistral.model'),
-		)?.label,
-	);
-
-	const elevenlabsModelLabel = $derived(
-		elevenlabsModelItems.find(
-			(i) => i.value === settings.get('transcription.elevenlabs.model'),
-		)?.label,
-	);
+	/**
+	 * The selected service's registry entry when it is a cloud provider. The
+	 * cloud section below renders entirely from this entry (models, docs
+	 * link, config fields), so cloud providers need no per-provider branch.
+	 */
+	const cloudProvider = $derived.by(() => {
+		const entry = TRANSCRIPTION_PROVIDERS.find(
+			(provider) => provider.id === settings.get('transcription.service'),
+		);
+		return entry?.location === 'cloud' ? entry : null;
+	});
 
 	const outputLanguageLabel = $derived(
 		SUPPORTED_LANGUAGES_OPTIONS.find(
@@ -133,151 +84,47 @@
 					settings.set('transcription.service', selected)}
 		/>
 
-		{#if settings.get('transcription.service') === 'OpenAI'}
+		{#if cloudProvider}
+			{@const cloud = cloudProvider}
+			{@const modelItems = cloud.models.map((model) => ({
+				value: model.name,
+				label: model.name,
+				...model,
+			}))}
 			<Field.Field>
-				<Field.Label for="openai-model">OpenAI Model</Field.Label>
+				<Field.Label for="cloud-model">{cloud.label} Model</Field.Label>
 				<Select.Root
 					type="single"
-					bind:value={() => settings.get('transcription.openai.model'),
-						(v) => settings.set('transcription.openai.model', v)}
+					bind:value={() => settings.get(cloud.modelSettingKey),
+						(v) => settings.set(cloud.modelSettingKey, v)}
 				>
-					<Select.Trigger id="openai-model" class="w-full">
-						{openaiModelLabel ?? 'Select a model'}
+					<Select.Trigger id="cloud-model" class="w-full">
+						{modelItems.find(
+							(item) => item.value === settings.get(cloud.modelSettingKey),
+						)?.label ?? 'Select a model'}
 					</Select.Trigger>
 					<Select.Content>
-						{#each openaiModelItems as item}
+						{#each modelItems as item}
 							<Select.Item value={item.value} label={item.label}>
 								{@render renderModelOption({ item })}
 							</Select.Item>
 						{/each}
 					</Select.Content>
 				</Select.Root>
-				<Field.Description>
-					You can find more details about the models in the <Link
-						href="https://platform.openai.com/docs/guides/speech-to-text"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						OpenAI docs
-					</Link>
-					.
-				</Field.Description>
+				{#if cloud.modelsDoc}
+					<Field.Description>
+						You can find more details about the models in the <Link
+							href={cloud.modelsDoc.href}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							{cloud.modelsDoc.label}
+						</Link>
+						.
+					</Field.Description>
+				{/if}
 			</Field.Field>
-			<ProviderConfigFields provider="OpenAI" />
-		{:else if settings.get('transcription.service') === 'Groq'}
-			<Field.Field>
-				<Field.Label for="groq-model">Groq Model</Field.Label>
-				<Select.Root
-					type="single"
-					bind:value={() => settings.get('transcription.groq.model'),
-						(v) => settings.set('transcription.groq.model', v)}
-				>
-					<Select.Trigger id="groq-model" class="w-full">
-						{groqModelLabel ?? 'Select a model'}
-					</Select.Trigger>
-					<Select.Content>
-						{#each groqModelItems as item}
-							<Select.Item value={item.value} label={item.label}>
-								{@render renderModelOption({ item })}
-							</Select.Item>
-						{/each}
-					</Select.Content>
-				</Select.Root>
-				<Field.Description>
-					You can find more details about the models in the <Link
-						href="https://console.groq.com/docs/speech-to-text"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						Groq docs
-					</Link>
-					.
-				</Field.Description>
-			</Field.Field>
-			<ProviderConfigFields provider="Groq" />
-		{:else if settings.get('transcription.service') === 'Deepgram'}
-			<Field.Field>
-				<Field.Label for="deepgram-model">Deepgram Model</Field.Label>
-				<Select.Root
-					type="single"
-					bind:value={() => settings.get('transcription.deepgram.model'),
-						(v) => settings.set('transcription.deepgram.model', v)}
-				>
-					<Select.Trigger id="deepgram-model" class="w-full">
-						{deepgramModelLabel ?? 'Select a model'}
-					</Select.Trigger>
-					<Select.Content>
-						{#each deepgramModelItems as item}
-							<Select.Item value={item.value} label={item.label}>
-								{@render renderModelOption({ item })}
-							</Select.Item>
-						{/each}
-					</Select.Content>
-				</Select.Root>
-			</Field.Field>
-			<ProviderConfigFields provider="Deepgram" />
-		{:else if settings.get('transcription.service') === 'Mistral'}
-			<Field.Field>
-				<Field.Label for="mistral-model">Mistral Model</Field.Label>
-				<Select.Root
-					type="single"
-					bind:value={() => settings.get('transcription.mistral.model'),
-						(v) => settings.set('transcription.mistral.model', v)}
-				>
-					<Select.Trigger id="mistral-model" class="w-full">
-						{mistralModelLabel ?? 'Select a model'}
-					</Select.Trigger>
-					<Select.Content>
-						{#each mistralModelItems as item}
-							<Select.Item value={item.value} label={item.label}>
-								{@render renderModelOption({ item })}
-							</Select.Item>
-						{/each}
-					</Select.Content>
-				</Select.Root>
-				<Field.Description>
-					You can find more details about Voxtral speech understanding in the <Link
-						href="https://mistral.ai/news/voxtral/"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						Mistral docs
-					</Link>
-					.
-				</Field.Description>
-			</Field.Field>
-			<ProviderConfigFields provider="Mistral" />
-		{:else if settings.get('transcription.service') === 'ElevenLabs'}
-			<Field.Field>
-				<Field.Label for="elevenlabs-model">ElevenLabs Model</Field.Label>
-				<Select.Root
-					type="single"
-					bind:value={() => settings.get('transcription.elevenlabs.model'),
-						(v) => settings.set('transcription.elevenlabs.model', v)}
-				>
-					<Select.Trigger id="elevenlabs-model" class="w-full">
-						{elevenlabsModelLabel ?? 'Select a model'}
-					</Select.Trigger>
-					<Select.Content>
-						{#each elevenlabsModelItems as item}
-							<Select.Item value={item.value} label={item.label}>
-								{@render renderModelOption({ item })}
-							</Select.Item>
-						{/each}
-					</Select.Content>
-				</Select.Root>
-				<Field.Description>
-					You can find more details about the models in the <Link
-						href="https://elevenlabs.io/docs/capabilities/speech-to-text"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						ElevenLabs docs
-					</Link>
-					.
-				</Field.Description>
-			</Field.Field>
-			<ProviderConfigFields provider="ElevenLabs" />
+			<ProviderConfigFields provider={cloud.id} />
 		{:else if settings.get('transcription.service') === 'speaches'}
 			<div class="space-y-4">
 				<Card.Root>

--- a/apps/whispering/src/routes/(app)/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/+layout.svelte
@@ -51,7 +51,7 @@
 		const service = settings.get('transcription.service');
 		if (!isLocalProviderId(service)) return;
 
-		const modelName = deviceConfig.get(PROVIDERS[service].modelKey);
+		const modelName = deviceConfig.get(PROVIDERS[service].modelConfigKey);
 		if (!modelName) return;
 
 		const language = settings.get('transcription.language');

--- a/specs/20260612T090000-whispering-providers-clean-break.md
+++ b/specs/20260612T090000-whispering-providers-clean-break.md
@@ -68,7 +68,10 @@ deviceConfig (one provider namespace, 14 keys)
 
 lib/migration/               does not exist
 transform.ts                 Custom is a map entry; no special branch
-registries                   apiKeyKey / endpointKey / modelIdKey everywhere
+registries                   apiKeyConfigKey / endpointConfigKey / modelIdConfigKey
+                             for deviceConfig pointers; modelSettingKey for the
+                             synced model selection; modelConfigKey for local
+                             model selection
 ProviderConfigFields         renders one provider's fields; ApiKeyInput is gone
 ```
 
@@ -83,7 +86,7 @@ ProviderConfigFields         renders one provider's fields; ApiKeyInput is gone
 | No endpoint keys for Anthropic/Google/OpenRouter | Product | Keep refusing | Unchanged from prior spec Open Question 1; add on demand. |
 | Uniform `endpointKey: null` in `STANDARD_PROVIDER_CONFIG` | 3 taste | Explicit null over optional | Kills the `'endpointPath' in config` narrowing trick; every entry has the same shape. |
 | Fold Custom into `STANDARD_PROVIDER_CONFIG` | 2 coherence | Map entry + delete branch | `stepModelField` covers Custom. Trim once at the call site for all providers (keys and models are pasted strings). The required-endpoint invariant stays owned by the custom service's `validateParams`. |
-| Suffix unification: `*Key` | 2 coherence | `apiKeyKey`, `endpointKey` | The values are `DeviceConfigKey`s; `Path` implies filesystem. `serverUrlKey` dies with the speaches re-key. |
+| Suffix unification: pointer fields name their store | 2 coherence | `apiKeyConfigKey`, `endpointConfigKey`, `modelIdConfigKey` (deviceConfig); `modelSettingKey` (synced settings); `modelConfigKey` (local model in deviceConfig) | The values are store key names; the suffix says which store resolves them. `Path` implies filesystem. `serverUrlKey` dies with the speaches re-key. Landed in two passes: `*Key` first, then the post-merge store-suffix pass (see Review). |
 | Rename `ApiKeyInput` to `ProviderConfigFields` | 2 coherence | Rename component + `ApiKeyProvider` type to `ProviderConfigId` | The component renders key and endpoint fields per provider; the name should say so. |
 | Leave orphaned localStorage in place | Product | No cleanup sweep | The old blob, migration state keys, and dev-machine per-key entries linger harmlessly. Cleanup code is migration code; refusal means refusal. |
 
@@ -193,7 +196,9 @@ harmlessly. No cleanup.
 - [ ] `lib/migration/` does not exist; no boot migration call; no nav dialog.
 - [ ] Every provider credential and endpoint reads from `providers.<id>.*`.
 - [ ] `transform.ts` has no Custom special case; one config map, uniform shape.
-- [ ] One vocabulary: `apiKeyKey` / `endpointKey` / `modelIdKey`.
+- [ ] One vocabulary: `apiKeyConfigKey` / `endpointConfigKey` / `modelIdConfigKey`
+      for deviceConfig pointers, `modelSettingKey` for synced settings,
+      `modelConfigKey` for local model selection.
 - [ ] `ProviderConfigFields` exists; `ApiKeyInput` does not.
 - [ ] Phase 5 greps pass; typecheck clean.
 
@@ -206,8 +211,10 @@ harmlessly. No cleanup.
 
 Four commits: the migration apparatus is gone (1018 lines deleted, 7 added),
 provider config lives in `providers.<id>.*` records, the config-key vocabulary
-is `apiKeyKey`/`endpointKey` everywhere with explicit null for non-configurable
-endpoints, and `ProviderConfigFields` replaces `ApiKeyInput`.
+is unified with explicit null for non-configurable endpoints (the suffixes
+landed as `*Key` in these commits and were refined to store-naming suffixes in
+the post-merge pass noted below), and `ProviderConfigFields` replaces
+`ApiKeyInput`.
 
 ### Deviations and Discoveries
 
@@ -238,6 +245,13 @@ endpoints, and `ProviderConfigFields` replaces `ApiKeyInput`.
   endpoints too; rename is a UX call, not taken here.
 - `specs/20260612T091000-whispering-custom-backend-profiles.md` holds the
   multi-backend product follow-up.
+- Done (post-merge naming pass, 2026-06-12): pointer fields now name their
+  store. `apiKeyKey`/`endpointKey`/`modelIdKey` became `apiKeyConfigKey`/
+  `endpointConfigKey`/`modelIdConfigKey` (deviceConfig pointers), and the
+  cloud vs local `modelKey` collision split into `modelSettingKey` (synced
+  settings) and `modelConfigKey` (deviceConfig). Persisted localStorage key
+  strings are unchanged; the convention is documented at the top of
+  `services/transcription/providers.ts`.
 
 ## References
 


### PR DESCRIPTION
The providers clean break gave each provider a record in a registry, but the generic UI and the dispatcher still restated provider facts by hand: the quick-pick selector carried two five-way switches mapping ids to model keys, the transcription settings page had five near-identical cloud branches, and the contributor docs still taught the deleted `apiKeys.*` / `TRANSCRIPTION_SERVICES` architecture. Every new provider meant editing those switches and that page. This pass moves the last per-provider knowledge into the registry so one sentence holds: provider registries own provider facts and the names of their config keys; stores own the values; operations and generic UI resolve every pointer through the registry, and the only per-provider code left is real product copy.

---

**Pointer fields now name their store.** A field suffix tells you which store resolves it, so a reader never has to trace a key back to its definition to know whether it syncs.

```ts
// before: the suffix told you nothing about where the value lives
apiKeyKey, endpointKey, modelIdKey, modelKey

// after: the suffix names the store
apiKeyConfigKey      // deviceConfig (device-local, never synced)
endpointConfigKey    // deviceConfig
modelIdConfigKey     // deviceConfig
modelConfigKey       // deviceConfig (local engine model selection)
modelSettingKey      // synced settings (cloud model selection)
```

The persisted localStorage key strings are unchanged; only the field names that point at them moved.

---

**Generic UI stops switching on provider id.** The quick-pick selector used to resolve the selected model and server URL through two hand-maintained switches. It now reads the registry pointer.

```ts
// before
switch (service.id) {
  case 'Groq': return settings.get('transcription.groq.model');
  case 'OpenAI': return settings.get('transcription.openai.model');
  // ...three more, plus a parallel setter switch
}

// after
switch (service.location) {
  case 'cloud': return settings.get(service.modelSettingKey);
  case 'self-hosted': return deviceConfig.get(service.endpointConfigKey);
  case 'local': return deviceConfig.get(service.modelConfigKey);
}
```

---

**The five cloud settings branches collapse into one.** Each cloud provider had its own block: a model `Select`, a docs `Link`, and `ProviderConfigFields`. The only fact not already in the registry was the documentation link, so that becomes a provider fact (`modelsDoc`), and the five branches plus their ten derived label and item helpers become a single block that renders from the selected cloud entry. `TranscriptionProviderEntry` is now a discriminated union (each id paired with its own provider shape), so narrowing on `location` narrows `id` too and the block can pass `cloud.id` straight to `ProviderConfigFields`. The speaches and local engine sections stay bespoke on purpose: their setup instructions are the product, not boilerplate.

That collapse alone removes about 200 lines from the transcription settings page.

---

**The contributor guide teaches the real flow.** The README adapter sections described `registry.ts`, `TRANSCRIPTION_SERVICES`, `apiKeys.*` settings keys, per-provider API key input components, and rpc switch statements, none of which still exist; a contributor following them would rebuild the architecture the clean break removed. They now walk the actual path (create the service, add the config keys, register the provider facts) and lean on the exhaustive tables (`CLOUD_TRANSCRIBERS`, `PROVIDER_ICONS`, `PROVIDER_FIELDS`, `COMPLETION_PROVIDERS`) to surface the remaining integration points as compile errors. The spec's final-state sections are unified on the store-suffix vocabulary too; the historical sections that record the break from the old names are left intact.

No runtime behavior changes: the same keys are read and written, just resolved through the registry instead of by hand. Net of about 250 lines, almost all deletion.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783909584&installation_id=128463665&pr_number=1928&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1928&signature=fb51bee08d0a14e854a17e799ae6e4b2377c142b41eb9e1826b733ba9da5ad98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->