### PR TITLE
docs: document the nullable-column migration rule and refresh the deleted column.* vocabulary

### DIFF
--- a/.agents/skills/specification-writing/SKILL.md
+++ b/.agents/skills/specification-writing/SKILL.md
@@ -273,19 +273,19 @@ When the spec introduces a coherent set of new primitives (column types, action 
 Catalogs let a reader scan the entire surface in one glance before diving into any single primitive.
 
 ````markdown
-## The column.* catalog
+## The field.* catalog
 
 ```ts
-column.string<TBrand?>(s?)              // TEXT (TBrand for branded strings)
-column.number(s?)                       // REAL
-column.integer(s?)                      // INTEGER
-column.boolean()                        // INTEGER 0/1
-column.literal(value)                   // TEXT (single literal)
-column.enum([...])                      // TEXT + CHECK constraint
-column.json<S extends TSchema>(schema)  // TEXT JSON-encoded, schema required
-column.nullable(inner)                  // Type.Union([inner, Type.Null()])
-column.dateTime(s?)                     // RFC 3339 string, branded DateTimeString
-column.ianaTimeZone(s?)                 // IANA zone string, branded IanaTimeZone
+field.string<TBrand?>(s?)               // TEXT (TBrand for branded strings)
+field.number(s?)                        // REAL
+field.integer(s?)                       // INTEGER
+field.boolean()                         // INTEGER 0/1
+field.select([value])                   // TEXT (single-element set)
+field.select([...])                     // TEXT + CHECK constraint
+field.json<S extends TSchema>(schema)   // TEXT JSON-encoded, schema required
+nullable(inner)                         // Type.Union([inner, Type.Null()]) (standalone)
+field.datetime(s?)                      // RFC 3339 string, branded DateTimeString
+field.string<IanaTimeZone>()            // IANA zone string, branded IanaTimeZone
 ```
 
 Every primitive justified by N+ existing call sites in the audit.
@@ -294,8 +294,8 @@ Every primitive justified by N+ existing call sites in the audit.
 
 | Candidate | Why rejected |
 |---|---|
-| `column.id()` | Subsumed by `column.string<IdBrand>()` + a co-located `generate*` factory |
-| `column.array(of)` | Subsumed by `column.json(Type.Array(of))` |
+| `field.id()` | Subsumed by `field.string<IdBrand>()` + a co-located `generate*` factory |
+| `field.array(of)` | Subsumed by `field.json(Type.Array(of))` |
 | Declaring `_v` as a column | Library-managed; positional in `defineTable(v1, v2, ...)` |
 ````
 
@@ -325,11 +325,11 @@ const notesTable = defineTable(
 
 ```ts
 const notesTable = defineTable(
-  { id: column.string<NoteId>(), title: column.string() },
+  { id: field.string<NoteId>(), title: field.string() },
   {
-    id: column.string<NoteId>(),
-    title: column.string(),
-    wordCount: column.nullable(column.number()),
+    id: field.string<NoteId>(),
+    title: field.string(),
+    wordCount: nullable(field.number()),
   },
 ).migrate(({ value, version }) => {
   switch (version) {

--- a/.agents/skills/testing/references/setup-pattern.md
+++ b/.agents/skills/testing/references/setup-pattern.md
@@ -144,9 +144,9 @@ Table definitions used across multiple tests should be defined at module level, 
 
 ```typescript
 const filesTable = defineTable({
-	id: column.string<FileId>(),
-	name: column.string(),
-	updatedAt: column.integer(),
+	id: field.string<FileId>(),
+	name: field.string(),
+	updatedAt: field.integer(),
 });
 
 function setup() {

--- a/.agents/skills/typescript/references/runtime-schema-patterns.md
+++ b/.agents/skills/typescript/references/runtime-schema-patterns.md
@@ -46,16 +46,17 @@ Both behave similarly in TypeScript, but only the `?` syntax converts correctly 
 
 Two shapes coexist in the codebase, picked by what owns the brand at runtime:
 
-- **Workspace table IDs**: pure type alias + `generate*` factory. The brand lives only in the type system; `column.string<Id>()` carries it through the TypeBox schema. No runtime validator object.
+- **Workspace table IDs**: pure type alias + `generate*` factory. The brand lives only in the type system; `field.string<Id>()` carries it through the TypeBox schema. No runtime validator object.
 - **Arktype-validated IDs** (auth user IDs, persisted-state schemas, HTTP route inputs): validator-first + `as*` helper. The arktype `Type` and the inferred type share one PascalCase name.
 
 ## Workspace Table IDs: Pure Type Alias + Generator
 
-For any ID that lives in a `defineTable` schema, declare the brand as a **type alias** and pair it with a `generate*` factory that wraps `generateId<T>()`. The brand is never a runtime value; `column.string<T>()` propagates it through the TypeBox schema.
+For any ID that lives in a `defineTable` schema, declare the brand as a **type alias** and pair it with a `generate*` factory that wraps `generateId<T>()`. The brand is never a runtime value; `field.string<T>()` propagates it through the TypeBox schema.
 
 ```typescript
 import type { Brand } from 'wellcrafted/brand';
-import { column, defineTable, generateId } from '@epicenter/workspace';
+import { field } from '@epicenter/field';
+import { defineTable, generateId, nullable } from '@epicenter/workspace';
 
 // 1. Type alias: brand-only, no runtime symbol
 export type SavedTabId = string & Brand<'SavedTabId'>;
@@ -63,11 +64,11 @@ export type SavedTabId = string & Brand<'SavedTabId'>;
 // 2. Generator: wraps generateId<T>() so the cast lives in one place
 export const generateSavedTabId = (): SavedTabId => generateId<SavedTabId>();
 
-// 3. Use in defineTable via column.string<>()
+// 3. Use in defineTable via field.string<>()
 const savedTabsTable = defineTable({
-	id: column.string<SavedTabId>(),
-	url: column.string(),
-	parentId: column.nullable(column.string<SavedTabId>()),
+	id: field.string<SavedTabId>(),
+	url: field.string(),
+	parentId: nullable(field.string<SavedTabId>()),
 });
 ```
 

--- a/.agents/skills/typescript/references/testing-patterns.md
+++ b/.agents/skills/typescript/references/testing-patterns.md
@@ -13,7 +13,7 @@ When a schema, builder, or configuration is only used once in a test, inline it 
 
 ```typescript
 test('builds a workspace bundle', () => {
-	const posts = defineTable({ id: column.string<PostId>(), title: column.string() });
+	const posts = defineTable({ id: field.string<PostId>(), title: field.string() });
 
 	const theme = defineKv(Type.Union([Type.Literal('light'), Type.Literal('dark')]), () => 'light');
 
@@ -34,7 +34,7 @@ test('builds a workspace bundle', () => {
 	const workspace = createWorkspace({
 		id: 'test-app',
 		tables: {
-			posts: defineTable({ id: column.string<PostId>(), title: column.string() }),
+			posts: defineTable({ id: field.string<PostId>(), title: field.string() }),
 		},
 		kv: {
 			theme: defineKv(
@@ -68,7 +68,7 @@ Extract to a variable when:
 
 - `defineTable()`, `defineKv()`, `createDisposableCache()` builders
 - `createWorkspace()` factory calls
-- Schema definitions (TypeBox `column.*` / `Type.*`, arktype, zod, etc.)
+- Schema definitions (TypeBox `field.*` / `Type.*`, arktype, zod, etc.)
 - Configuration objects passed to factories
 - Mock functions used only once
 

--- a/.agents/skills/workspace-api/SKILL.md
+++ b/.agents/skills/workspace-api/SKILL.md
@@ -26,7 +26,7 @@ Skip DeepWiki for Epicenter schema, action, migration, and attachment convention
 - `yjs`: Yjs CRDT patterns and shared types
 - `svelte`: reactive wrappers such as `fromTable` and `fromKv`, plus commit-on-blur workspace inputs
 - `attach-primitive`: the full contract and invariants every `attach*` function must follow
-- `typebox`: TypeBox primitives used by `column.*`, `defineKv`, and action input schemas
+- `typebox`: TypeBox primitives used by `field.*`, `defineKv`, and action input schemas
 
 ## When To Apply This Skill
 
@@ -45,7 +45,7 @@ Use this skill when you are:
 
 - Workspace action `defineQuery` / `defineMutation` factories are not Whispering `$lib/rpc` adapters from `wellcrafted/query`. Do not apply workspace action input-schema rules to Whispering RPC modules.
 - `_v` is library-managed. Never declare it as a column, never set it on a write, never read it off a row. Single-version tables drop the versioning surface entirely; multi-version tables expose it only inside the `migrate` function as `({ value, version })`.
-- Columns are TypeBox schemas. Prefer the `column.*` sugar (`column.string`, `column.number`, `column.boolean`, `column.enum`, `column.json`, `column.nullable`, `column.dateTime`, `column.ianaTimeZone`); raw `Type.X()` is allowed and the `FlatJsonTSchema` constraint enforces SQLite-mappable shapes either way.
+- Columns are TypeBox schemas. Prefer the `field.*` builders from `@epicenter/field` (`field.string`, `field.number`, `field.boolean`, `field.select`, `field.json`, `field.datetime`) plus the standalone `nullable` wrapper from `@epicenter/workspace` for the emptiness axis (an IANA timezone is just `field.string<IanaTimeZone>()`, no bespoke builder); raw `Type.X()` is allowed and the `FlatJsonTSchema` constraint enforces SQLite-mappable shapes either way.
 - Derive row types with `InferTableRow<typeof tableDefinition>` in the same module that defines the table. Consumers import the type from the workspace definition module.
 - Do not re-derive row types from runtime table methods or relay them through state files.
 - KV stores use `defineKv(schema, defaultValue)` where `defaultValue` is a **factory** `() => Static<S>`. Prefer one scalar per dot-namespaced key unless the value is a true atomic object.

--- a/.agents/skills/workspace-api/references/primitive-api.md
+++ b/.agents/skills/workspace-api/references/primitive-api.md
@@ -89,7 +89,7 @@ export function createWhisperingWorkspace() {
     id: 'whispering',
     tables: { recordings },
     kv: {
-      'ui.alwaysOnTop': defineKv(column.boolean(), () => false),
+      'ui.alwaysOnTop': defineKv(field.boolean(), () => false),
     },
   });
 

--- a/.agents/skills/workspace-api/references/schema-definition-patterns.md
+++ b/.agents/skills/workspace-api/references/schema-definition-patterns.md
@@ -4,7 +4,7 @@ Detailed guidance for `defineTable`, `defineKv`, row type inference, scalar KV d
 
 ## Tables
 
-Tables are built from TypeBox column schemas. Use the `column.*` sugar from `@epicenter/workspace` for the SQLite-safe constructor menu; raw `Type.X()` from `typebox` is interchangeable. The `FlatJsonTSchema` constraint enforces "one column maps 1:1 to a SQLite column" regardless of which side built the schema.
+Tables are built from TypeBox column schemas. Use the `field.*` builders from `@epicenter/field` for the SQLite-safe constructor menu (with the standalone `nullable` wrapper from `@epicenter/workspace` for the emptiness axis); raw `Type.X()` from `typebox` is interchangeable. The `FlatJsonTSchema` constraint enforces "one column maps 1:1 to a SQLite column" regardless of which side built the schema.
 
 `_v` is library-managed end-to-end. Never declare it as a column key (it's a compile error), never set it on a write, never read it off a row. The library stamps it on every stored row, routes by it on read, and strips it before handing the row back.
 
@@ -13,17 +13,18 @@ Tables are built from TypeBox column schemas. Use the `column.*` sugar from `@ep
 Use when a table has only one version. There is no migrate step:
 
 ```typescript
+import { field } from '@epicenter/field';
 import {
-  column,
   defineTable,
+  nullable,
   type InferTableRow,
 } from '@epicenter/workspace';
 
 const notesTable = defineTable({
-  id: column.string<NoteId>(),
-  title: column.string({ minLength: 1, maxLength: 200 }),
-  body: column.nullable(column.string()),
-  createdAt: column.dateTime(),
+  id: field.string<NoteId>(),
+  title: field.string({ minLength: 1, maxLength: 200 }),
+  body: nullable(field.string()),
+  createdAt: field.datetime(),
 });
 export type Note = InferTableRow<typeof notesTable>;
 ```
@@ -36,14 +37,14 @@ Use when you need to evolve a schema over time. Each positional argument is a ve
 const notesTable = defineTable(
   // v1
   {
-    id: column.string<NoteId>(),
-    title: column.string(),
+    id: field.string<NoteId>(),
+    title: field.string(),
   },
   // v2
   {
-    id: column.string<NoteId>(),
-    title: column.string(),
-    pinned: column.boolean(),
+    id: field.string<NoteId>(),
+    title: field.string(),
+    pinned: field.boolean(),
   },
 ).migrate(({ value, version }) => {
   switch (version) {
@@ -101,18 +102,19 @@ KV stores use `defineKv(schema, defaultValue)`. No versioning, no migration: inv
 `defaultValue` is always a **factory function**, not a bare value. The library calls it on every default firing so each call returns a fresh, mutation-safe value.
 
 ```typescript
-import { column, defineKv } from '@epicenter/workspace';
+import { field } from '@epicenter/field';
+import { defineKv } from '@epicenter/workspace';
 import { Type } from 'typebox';
 
 const sidebar = defineKv(
   Type.Object({ collapsed: Type.Boolean(), width: Type.Number() }),
   () => ({ collapsed: false, width: 300 }),
 );
-const fontSize = defineKv(column.number(), () => 14);
-const enabled = defineKv(column.boolean(), () => true);
+const fontSize = defineKv(field.number(), () => 14);
+const enabled = defineKv(field.boolean(), () => true);
 ```
 
-KV accepts any TypeBox `TSchema`: the `column.*` sugar, raw `Type.X()`, or composed unions. There is no `FlatJsonTSchema` constraint on KV values (no SQLite materialization layer for KV).
+KV accepts any TypeBox `TSchema`: the `field.*` builders, raw `Type.X()`, or composed unions. There is no `FlatJsonTSchema` constraint on KV values (no SQLite materialization layer for KV).
 
 ### KV Design Convention: One Scalar Per Key
 
@@ -121,15 +123,15 @@ Use dot-namespaced keys for logical groupings of scalar values:
 ```typescript
 // Good: each preference is an independent scalar
 'theme.mode': defineKv(
-  column.enum(['light', 'dark', 'system']),
+  field.select(['light', 'dark', 'system']),
   () => 'light' as const,
 ),
-'theme.fontSize': defineKv(column.number(), () => 14),
+'theme.fontSize': defineKv(field.number(), () => 14),
 
 // Bad: structured object invites migration needs
 'theme': defineKv(
   Type.Object({
-    mode: column.enum(['light', 'dark']),
+    mode: field.select(['light', 'dark']),
     fontSize: Type.Number(),
   }),
   () => ({ mode: 'light' as const, fontSize: 14 }),
@@ -146,14 +148,15 @@ Every table's `id` field and every string foreign key field MUST use a branded t
 
 ### Pattern
 
-Define a branded type as a **pure type alias** and a co-located `generate*` factory. There is no runtime validator object: the brand is type-only, and `column.string<NoteId>()` carries the brand through the schema.
+Define a branded type as a **pure type alias** and a co-located `generate*` factory. There is no runtime validator object: the brand is type-only, and `field.string<NoteId>()` carries the brand through the schema.
 
 ```typescript
 import type { Brand } from 'wellcrafted/brand';
+import { field } from '@epicenter/field';
 import {
-  column,
   defineTable,
   generateId,
+  nullable,
   type InferTableRow,
 } from '@epicenter/workspace';
 
@@ -164,11 +167,11 @@ export type ConversationId = string & Brand<'ConversationId'>;
 export const generateConversationId = (): ConversationId =>
   generateId<ConversationId>();
 
-// 3. Use the brand inside column.string<>() to propagate it through the schema
+// 3. Use the brand inside field.string<>() to propagate it through the schema
 const conversationsTable = defineTable({
-  id: column.string<ConversationId>(),              // Primary key: branded
-  title: column.string(),
-  parentId: column.nullable(column.string<ConversationId>()),  // Self-FK
+  id: field.string<ConversationId>(),              // Primary key: branded
+  title: field.string(),
+  parentId: nullable(field.string<ConversationId>()),  // Self-FK
 });
 export type Conversation = InferTableRow<typeof conversationsTable>;
 
@@ -177,7 +180,7 @@ const newId = generateConversationId();  // Good
 // const newId = 'abc' as ConversationId;  // Bad
 ```
 
-`column.string<T>()` accepts a brand-extended string type as its sole generic. Passing a non-branded literal subtype (e.g. `column.string<'draft'>()`) is a compile error: literal-subtype pretending isn't enforced at runtime, so the type system refuses it. Use `column.literal('draft')` for that case instead.
+`field.string<T>()` accepts a brand-extended string type as its sole generic. Passing a non-branded literal subtype (e.g. `field.string<'draft'>()`) is a compile error: literal-subtype pretending isn't enforced at runtime, so the type system refuses it. Use `field.select(['draft'])` for that case instead.
 
 ### `as*` Helper Variant for External-Source IDs
 
@@ -202,4 +205,4 @@ Pick the variant by ID origin:
 | Received as a typed string                  | `asXxx(value: string)` syntactic-sugar helper    |
 | Received as `unknown` at a network boundary | Validate with the action's TypeBox input schema  |
 
-Type aliases are PascalCase; functions are camelCase. Schema bodies read `column.string<ConversationId>()` / `column.string<UserId>()` with no `Schema` suffix anywhere.
+Type aliases are PascalCase; functions are camelCase. Schema bodies read `field.string<ConversationId>()` / `field.string<UserId>()` with no `Schema` suffix anywhere.

--- a/.agents/skills/workspace-api/references/table-migrations.md
+++ b/.agents/skills/workspace-api/references/table-migrations.md
@@ -2,7 +2,7 @@
 
 ## When to Read This
 
-Read when adding table versions, writing `.migrate()` functions, or validating migration style and anti-patterns.
+Read when adding table versions, writing `.migrate()` functions, deciding whether a schema change needs a new version at all, or validating migration style and anti-patterns.
 
 ## Migrate Function Contract
 
@@ -28,6 +28,49 @@ Rules:
 5. Always migrate directly to latest. Don't chain v1 → v2 → v3 incrementally.
 
 `_v` is never present on `value`, never returned from the function, and never appears in user-facing row types. The library stamps it on storage and routes by it before calling migrate.
+
+## When a Change Needs a New Version
+
+A stored row is a fixed-shape JSON blob, validated on every read against the schema of its own stored `_v` (see `parseRow` in `packages/workspace/src/document/table.ts`). There is no field-level merge and no read-time default-fill: every column the matched version declares must be **present** on the row. So any change that makes existing stored rows stop matching their version's schema needs a new version plus a `.migrate()` that produces the new shape. Adding a column is such a change, even a nullable one.
+
+### Adding a nullable column is not free
+
+`nullable(x)` is `Type.Union([x, Type.Null()])`: the key must be **present** with value `x | null`. A missing key fails validation, because `null` is a VALUE, not absence (a CRDT row has a fixed shape and cannot omit a key, see `packages/workspace/src/document/nullable.ts`):
+
+```typescript
+const schema = Type.Object({ id: field.string(), note: nullable(field.string()) });
+Value.Check(schema, { id: 'r1' });             // false: absent key is invalid
+Value.Check(schema, { id: 'r1', note: null }); // true: null is a value
+```
+
+So adding a nullable column **in place** to a single-version table makes every pre-existing row fail validation: those rows silently drop out of `getAllValid()` and surface in `getAllInvalid()`. They do NOT read as `null`. To add any column to a table that may already hold rows, keep the prior shape as an earlier version and write a `.migrate()` that fills the new column for every older version, including setting nullable columns to `null` explicitly:
+
+```typescript
+const notes = defineTable(
+  { id: field.string<NoteId>(), title: field.string() },                     // v1
+  {
+    id: field.string<NoteId>(),
+    title: field.string(),
+    archivedAt: nullable(field.string()),
+  },                                                                          // v2
+).migrate(({ value, version }) => {
+  switch (version) {
+    case 1: return { ...value, archivedAt: null }; // must set it: absence != null
+    case 2: return value;
+  }
+});
+```
+
+### Migrate output is not re-validated, so fill every column
+
+`parseRow` validates the stored row against its own version, then returns the migrate result as-is, with no second check against the latest schema. A migrate that forgets a column returns a row whose field is `undefined` at runtime while the type claims `x | null`. It often "works" because `undefined` is falsy, but it is a type lie waiting to break a `=== null` check or a materializer that expects the column. Always return the complete latest-version row.
+
+### When you genuinely do not need a migrate
+
+- A single-version table with no stored data to read: a pre-launch app that resets dev data per the schema-collapse convention. Redefine the one version at its terminal shape; there is nothing to migrate.
+- A brand-new table that has never been written.
+
+If stored rows exist and you cannot reset them, you need a version plus a migrate. Nothing in the read path coerces an absent column into `null`.
 
 ## Anti-Patterns
 
@@ -57,15 +100,15 @@ Rules:
 ```typescript
 // BAD: `_v` is library-managed. The defineTable parameter type refuses it.
 defineTable({
-  id: column.string<NoteId>(),
-  title: column.string(),
-  _v: column.literal(1),   // compile error: "_v is library-managed; remove it from the column record"
+  id: field.string<NoteId>(),
+  title: field.string(),
+  _v: field.number(),   // compile error: "_v is library-managed; remove it from the column record"
 });
 
 // GOOD: just declare your columns.
 defineTable({
-  id: column.string<NoteId>(),
-  title: column.string(),
+  id: field.string<NoteId>(),
+  title: field.string(),
 });
 ```
 
@@ -84,8 +127,8 @@ tables.notes.update(id, { title });
 ## Branded ID Rules
 
 1. **Every table gets its own ID type**: `DeviceId`, `SavedTabId`, `ConversationId`, `ChatMessageId`, etc.
-2. **Foreign keys use the referenced table's ID type**: `chatMessages.conversationId` uses `column.string<ConversationId>()`, not `column.string()`.
-3. **Optional FKs use `column.nullable(...)`**: `parentId: column.nullable(column.string<ConversationId>())`.
+2. **Foreign keys use the referenced table's ID type**: `chatMessages.conversationId` uses `field.string<ConversationId>()`, not `field.string()`.
+3. **Optional FKs use `nullable(...)`**: `parentId: nullable(field.string<ConversationId>())`.
 4. **Composite IDs are also branded**: `TabCompositeId`, `WindowCompositeId`, `GroupCompositeId`.
 5. **Use generator functions**: When IDs are generated at runtime, use a `generate*` factory that calls `generateId<X>()`. Never scatter casts across call sites.
 6. **Functions accept branded types**: `function switchConversation(id: ConversationId)` not `(id: string)`.
@@ -105,14 +148,14 @@ deleteConversation(message.id);  // Error: ChatMessageId is not ConversationId
 ### Reference Implementations
 
 See `apps/honeycrisp/workspace.ts` and `apps/fuji/src/lib/workspace.ts` for the canonical co-located pattern (brand type + `generate*` / `as*` + table + `InferTableRow` export).
-See `apps/whispering/src/lib/workspace/definition.ts` for a multi-table example including a multi-version migration and `column.json(Type.Union([...]))` for discriminated JSON results.
+See `apps/whispering/src/lib/workspace/definition.ts` for a multi-table example including a multi-version migration and `field.json(Type.Union([...]))` for discriminated JSON results.
 
 ### Pattern
 
 ```typescript
 import type { Brand } from 'wellcrafted/brand';
+import { field } from '@epicenter/field';
 import {
-  column,
   createWorkspace,
   defineTable,
   generateId,
@@ -130,15 +173,15 @@ export const generatePostId = (): PostId => generateId<PostId>();
 // ─── Tables (each followed by its type export) ──────────────────────────
 
 const usersTable = defineTable({
-  id: column.string<UserId>(),
-  email: column.string(),
+  id: field.string<UserId>(),
+  email: field.string(),
 });
 export type User = InferTableRow<typeof usersTable>;
 
 const postsTable = defineTable({
-  id: column.string<PostId>(),
-  authorId: column.string<UserId>(),
-  title: column.string(),
+  id: field.string<PostId>(),
+  authorId: field.string<UserId>(),
+  title: field.string(),
 });
 export type Post = InferTableRow<typeof postsTable>;
 
@@ -172,7 +215,7 @@ export function createMyAppWorkspace() {
   return createWorkspace({
     id: 'my-workspace',
     tables: {
-      users: defineTable({ id: column.string<UserId>(), email: column.string() }),
+      users: defineTable({ id: field.string<UserId>(), email: field.string() }),
     },
     kv: {},
   });
@@ -182,8 +225,8 @@ export type User = InferTableRow<Tables['users']>;
 
 // GOOD: Extract table, co-locate type, reference it in createWorkspace
 const usersTable = defineTable({
-  id: column.string<UserId>(),
-  email: column.string(),
+  id: field.string<UserId>(),
+  email: field.string(),
 });
 export type User = InferTableRow<typeof usersTable>;
 

--- a/README.md
+++ b/README.md
@@ -66,12 +66,13 @@ The hard problem with local-first apps is synchronization. If each device has it
 Alongside typed tables, local persistence, collaboration hooks, and validated actions, the package gives apps materializers, the writers that project state to disk.
 
 ```typescript
-import { column, createWorkspace, defineTable } from '@epicenter/workspace';
+import { field } from '@epicenter/field';
+import { createWorkspace, defineTable } from '@epicenter/workspace';
 
 const notes = defineTable({
-  id: column.string(),
-  title: column.string(),
-  body: column.string(),
+  id: field.string(),
+  title: field.string(),
+  body: field.string(),
 });
 
 const workspace = createWorkspace({

--- a/apps/wiki/src/lib/workspace/index.ts
+++ b/apps/wiki/src/lib/workspace/index.ts
@@ -51,7 +51,7 @@ export const WikiActionError = defineErrors({
 		typeId: string;
 		columnId: string;
 	}) => ({
-		message: `Type "${typeId}" column "${columnId}" schema must be a TSchema object (a column.* result)`,
+		message: `Type "${typeId}" column "${columnId}" schema must be a TSchema object (a field.* result)`,
 		typeId,
 		columnId,
 	}),
@@ -62,7 +62,7 @@ const columnSpecInput = Type.Object({
 	id: Type.String(),
 	name: Type.String(),
 	schema: Type.Unknown({
-		description: 'A column.* result (a TypeBox TSchema)',
+		description: 'A field.* result (a TypeBox TSchema)',
 	}),
 });
 

--- a/apps/wiki/src/lib/workspace/schema.ts
+++ b/apps/wiki/src/lib/workspace/schema.ts
@@ -40,7 +40,7 @@ export const asPageId = (value: string): PageId => value as PageId;
 /** A type id is a stable slug; it also becomes a SQL table-name segment. */
 export const TYPE_ID_PATTERN = /^[a-z0-9_]+$/;
 
-/** A column.* result is a non-null JSON object; a string/array/primitive is not. */
+/** A field.* result is a non-null JSON object; a string/array/primitive is not. */
 export function isTSchemaObject(value: unknown): boolean {
 	return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -51,7 +51,7 @@ export function isTSchemaObject(value: unknown): boolean {
  * - `id` is the stable physical id. A rename never touches it, which is what
  *   makes a display rename metadata-only (no SQL DDL).
  * - `name` is the display name; free to change.
- * - `schema` is the column's TypeBox schema, authored with the real `column.*`
+ * - `schema` is the column's TypeBox schema, authored with the real `field.*`
  *   builders (`field.url()`, `nullable(field.number())`) so call sites
  *   get autocomplete and type-checking. A `TSchema` IS JSON Schema, so it is
  *   stored verbatim and re-validated with `Value.Check` after the Yjs/JSON

--- a/apps/wiki/src/lib/workspace/wiki.test.ts
+++ b/apps/wiki/src/lib/workspace/wiki.test.ts
@@ -34,7 +34,7 @@ test('exports a typed page to markdown and answers a typed SQLite query', async 
 	const dir = await mkdtemp(join(tmpdir(), 'wiki-vault-'));
 	const wiki = createWiki();
 	try {
-		// 1 + 3. Define the youtube_video type at runtime (real column.* calls).
+		// 1 + 3. Define the youtube_video type at runtime (real field.* calls).
 		const defined = wiki.actions.types_define({
 			id: 'youtube_video',
 			name: 'YouTube Video',

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,16 +45,16 @@ The verbs are the architecture. If you remember nothing else, remember that Epic
 `defineTable` and `defineKv` are pure declarations. They do not create a `Y.Doc`, open IndexedDB, start a WebSocket, or touch the network.
 
 ```ts
+import { field } from '@epicenter/field';
 import {
-	column,
 	defineKv,
 	defineTable,
 } from '@epicenter/workspace';
 import Type from 'typebox';
 
 const files = defineTable({
-	id: column.string(),
-	name: column.string(),
+	id: field.string(),
+	name: field.string(),
 });
 
 const themeMode = defineKv(

--- a/docs/articles/cell-level-crdt-vs-row-level-lww.md
+++ b/docs/articles/cell-level-crdt-vs-row-level-lww.md
@@ -152,8 +152,8 @@ You don't have to choose one approach for everything.
 // `_v` is library-managed, so it never appears in column declarations or
 // in the rows you write.
 const posts = defineTable(
-  { id: column.string(), title: column.string() },
-  { id: column.string(), title: column.string(), authorId: column.string() },
+  { id: field.string(), title: field.string() },
+  { id: field.string(), title: field.string(), authorId: field.string() },
 ).migrate(({ value, version }) => {
   switch (version) {
     case 1: return { ...value, authorId: 'unknown' };

--- a/docs/articles/inline-single-use-definitions-in-tests.md
+++ b/docs/articles/inline-single-use-definitions-in-tests.md
@@ -9,12 +9,12 @@ AI coding assistants and many developers default to extracting every definition:
 ```typescript
 test('binds tables to a Y.Doc', () => {
   const posts = defineTable({
-    id: column.string(),
-    title: column.string(),
+    id: field.string(),
+    title: field.string(),
   });
 
   const theme = defineKv(
-    column.enum(['light', 'dark']),
+    field.select(['light', 'dark']),
     () => 'light' as const,
   );
 
@@ -44,13 +44,13 @@ test('binds tables to a Y.Doc', () => {
   const ydoc = new Y.Doc();
   const tables = attachTables(ydoc, {
     posts: defineTable({
-      id: column.string(),
-      title: column.string(),
+      id: field.string(),
+      title: field.string(),
     }),
   });
   const kv = attachKv(ydoc, {
     theme: defineKv(
-      column.enum(['light', 'dark']),
+      field.select(['light', 'dark']),
       () => 'light' as const,
     ),
   });

--- a/docs/articles/schema-granularity-matches-write-granularity.md
+++ b/docs/articles/schema-granularity-matches-write-granularity.md
@@ -69,21 +69,22 @@ If Alice edits `title` and Bob edits `views` at the same time, one of their chan
 Here's how it looks in practice:
 
 ```typescript
-import { column, defineTable } from '@epicenter/workspace';
+import { field } from '@epicenter/field';
+import { defineTable } from '@epicenter/workspace';
 import Type from 'typebox';
 
 const posts = defineTable(
-	{ id: column.string(), title: column.string() },
+	{ id: field.string(), title: field.string() },
 	{
-		id: column.string(),
-		title: column.string(),
-		views: column.number(),
+		id: field.string(),
+		title: field.string(),
+		views: field.number(),
 	},
 	{
-		id: column.string(),
-		title: column.string(),
-		views: column.number(),
-		tags: column.json(Type.Array(Type.String())),
+		id: field.string(),
+		title: field.string(),
+		views: field.number(),
+		tags: field.json(Type.Array(Type.String())),
 	},
 ).migrate(({ value, version }) => {
 	switch (version) {
@@ -101,13 +102,14 @@ Each version is a positional argument to `defineTable(...)`. The `.migrate()` fu
 The same principle applies to key-value storage, though KV values don't carry a stored version stamp. They're validate-or-default: if the stored value fails validation, the entry falls back to the factory default:
 
 ```typescript
-import { column, defineKv } from '@epicenter/workspace';
+import { field } from '@epicenter/field';
+import { defineKv } from '@epicenter/workspace';
 import Type from 'typebox';
 
 const theme = defineKv(
 	Type.Object({
 		mode: Type.Union([Type.Literal('light'), Type.Literal('dark'), Type.Literal('system')]),
-		accentColor: column.string(),
+		accentColor: field.string(),
 	}),
 	() => ({ mode: 'light' as const, accentColor: '#3b82f6' }),
 );

--- a/docs/articles/versioned-schemas-migrate-on-read.md
+++ b/docs/articles/versioned-schemas-migrate-on-read.md
@@ -54,26 +54,27 @@ migrate return value: the version is the argument position (1-indexed).
 Multi-version tables require `.migrate(({ value, version }) => ...)`:
 
 ```typescript
-import { column, defineTable } from '@epicenter/workspace';
+import { field } from '@epicenter/field';
+import { defineTable } from '@epicenter/workspace';
 
 const posts = defineTable(
 	// V1: original schema
 	{
-		id: column.string(),
-		title: column.string(),
+		id: field.string(),
+		title: field.string(),
 	},
 	// V2: added views counter
 	{
-		id: column.string(),
-		title: column.string(),
-		views: column.number(),
+		id: field.string(),
+		title: field.string(),
+		views: field.number(),
 	},
 	// V3: added tags
 	{
-		id: column.string(),
-		title: column.string(),
-		views: column.number(),
-		tags: column.json(Type.Array(Type.String())),
+		id: field.string(),
+		title: field.string(),
+		views: field.number(),
+		tags: field.json(Type.Array(Type.String())),
 	},
 ).migrate(({ value, version }) => {
 	// `value` is narrowed to the matching version's user-facing columns.
@@ -166,10 +167,11 @@ The trade-off is you must handle all versions yourself, but TypeScript helps ens
 KV stores don't use versioning or migration. They use validate-or-default semantics: if stored data fails validation, it falls back to the default value. The default is a factory (`() => value`) so every consumer gets a fresh instance:
 
 ```typescript
-import { column, defineKv } from '@epicenter/workspace';
+import { field } from '@epicenter/field';
+import { defineKv } from '@epicenter/workspace';
 
-const fontSize = defineKv(column.number(), () => 14);
-const mode = defineKv(column.enum(['light', 'dark', 'system']), () => 'light' as const);
+const fontSize = defineKv(field.number(), () => 14);
+const mode = defineKv(field.select(['light', 'dark', 'system']), () => 'light' as const);
 
 // Usage
 kv['fontSize'].set(16);

--- a/docs/articles/your-data-is-probably-a-table-not-a-file.md
+++ b/docs/articles/your-data-is-probably-a-table-not-a-file.md
@@ -10,24 +10,24 @@ Honeycrisp is an Apple Notes clone. Its data model is two tables and some KV set
 
 ```typescript
 const foldersTable = defineTable({
-  id: column.string<FolderId>(),
-  name: column.string(),
-  sortOrder: column.number(),
+  id: field.string<FolderId>(),
+  name: field.string(),
+  sortOrder: field.number(),
 });
 
 const notesTable = defineTable(
   {
-    id: column.string<NoteId>(),
-    folderId: column.string<FolderId>(),
-    title: column.string(),
-    preview: column.string(),
+    id: field.string<NoteId>(),
+    folderId: field.string<FolderId>(),
+    title: field.string(),
+    preview: field.string(),
   },
   {
-    id: column.string<NoteId>(),
-    folderId: column.string<FolderId>(),
-    title: column.string(),
-    preview: column.string(),
-    deletedAt: column.dateTime(),
+    id: field.string<NoteId>(),
+    folderId: field.string<FolderId>(),
+    title: field.string(),
+    preview: field.string(),
+    deletedAt: field.datetime(),
   },
 ).migrate(({ value, version }) => {
   switch (version) {

--- a/docs/guides/consuming-epicenter-api.md
+++ b/docs/guides/consuming-epicenter-api.md
@@ -28,6 +28,7 @@ This snippet shows a signed-in cloud workspace. The client builds the sync URL w
 The per-app browser opener is the single source of truth for "how this app mounts in a browser." `createWorkspace` builds the typed bundle in one call; every other `attach*` step is visible top-to-bottom against `workspace.ydoc`.
 
 ```typescript
+import { field } from '@epicenter/field';
 import {
 	attachLocalStorage,
 	createDeviceId,
@@ -35,7 +36,6 @@ import {
 	defineActions,
 	defineMutation,
 	defineWorkspace,
-	column,
 	defineTable,
 	openCollaboration,
 	roomWsUrl,
@@ -49,8 +49,8 @@ const MY_APP_ID = 'epicenter.my-app';
 
 const myAppTables = {
 	notes: defineTable({
-		id: column.string(),
-		title: column.string(),
+		id: field.string(),
+		title: field.string(),
 	}),
 };
 


### PR DESCRIPTION
Workspace table docs had drifted in two related places: migration guidance under-described nullable columns, and many examples still used the deleted `column.*` namespace. This PR makes the docs match the current runtime contract and field vocabulary.

## Nullable Columns

Adding `nullable(x)` to an existing table is still a shape change. The key must be present with either `x` or `null`; missing keys fail validation before migration, so pre-existing rows must come through an older table version and a `.migrate()` that explicitly fills the new column.

```ts
const notes = defineTable(
  { id: field.string(), title: field.string() },
  {
    id: field.string(),
    title: field.string(),
    archivedAt: nullable(field.string()),
  },
).migrate(({ value, version }) => {
  switch (version) {
    case 1:
      return { ...value, archivedAt: null };
    case 2:
      return value;
  }
});
```

The new guidance also calls out that migrate output is not re-validated against the latest schema. A migration that forgets a column can hand back `undefined` while the type says `x | null`, so migrations need to return the complete latest row shape.

## Field Vocabulary

The rest of the sweep updates skills, reference docs, evergreen articles, and wiki text from `column.*` to `field.*` plus standalone `nullable(...)`. This covers the common mappings (`column.enum` to `field.select`, `column.dateTime` to `field.datetime`, `column.json` to `field.json`) and fixes the few source comments and description strings that still said "column.* result".

## Kept Out Of Scope

`specs/` stays untouched because those are dated planning artifacts, including the field-vocabulary convergence spec that records the old vocabulary on purpose. The Temporal article also stays as-is because it narrates the older column DSL history; rewriting those examples would change the story rather than correct current guidance.

Docs and text only. No runtime code paths change.
