### PR TITLE
feat(zhongwen): delete a conversation's local doc and server room

### DIFF
--- a/apps/zhongwen/zhongwen.browser.ts
+++ b/apps/zhongwen/zhongwen.browser.ts
@@ -15,8 +15,10 @@
  */
 
 import type { SignedIn } from '@epicenter/svelte';
+import { ROOM_ROUTE } from '@epicenter/sync';
 import {
 	attachLocalStorage,
+	clearLocalStorageForDoc,
 	createDisposableCache,
 	type DeviceId,
 	defineWorkspace,
@@ -24,12 +26,35 @@ import {
 	roomWsUrl,
 	wipeLocalStorage,
 } from '@epicenter/workspace';
+import { defineErrors } from 'wellcrafted/error';
+import { createLogger } from 'wellcrafted/logger';
 import * as Y from 'yjs';
 import {
 	type ConversationId,
 	createZhongwen,
 	zhongwenConversationDocGuid,
 } from './zhongwen';
+
+const log = createLogger('zhongwen/browser');
+
+const ZhongwenCleanupError = defineErrors({
+	/**
+	 * A deleted conversation's child doc could not be fully cleaned up. The local
+	 * clear or the server room DELETE failed (e.g. offline). The conversation is
+	 * already gone from the table; this leaves orphaned storage to reclaim later.
+	 */
+	ConversationCleanupFailed: ({
+		cause,
+		conversationId,
+	}: {
+		cause: unknown;
+		conversationId: ConversationId;
+	}) => ({
+		message: `[zhongwen] failed to clean up deleted conversation ${conversationId}`,
+		cause,
+		conversationId,
+	}),
+});
 
 export function openZhongwenBrowser({
 	signedIn,
@@ -100,11 +125,63 @@ export function openZhongwenBrowser({
 		},
 	);
 
+	// Deleting a conversation is a pure row tombstone (chat-state); the durable
+	// child doc behind it lives in a separate local IDB database and a separate
+	// server room, neither of which the row delete touches. This observer turns
+	// the CRDT fact "a row disappeared" into the cleanup, on every device that
+	// learns of the deletion (the deleter included), so cleanup converges without
+	// a special deleter role. Reuses the deterministic child guid so the delete
+	// path can't drift from the create path.
+	const conversations = workspace.tables.conversations;
+	const inFlightCleanups = new Set<ConversationId>();
+
+	async function cleanupConversation(
+		conversationId: ConversationId,
+	): Promise<void> {
+		if (inFlightCleanups.has(conversationId)) return;
+		inFlightCleanups.add(conversationId);
+		const guid = zhongwenConversationDocGuid(conversationId);
+		try {
+			// Dispose before clear: wait for any open handle to unmount so a live
+			// persistence writer can't repopulate the database we are about to
+			// delete. The cache is keyed by conversation id; resolves immediately
+			// when nothing holds it.
+			await conversationDocs.whenReleased(conversationId);
+			await clearLocalStorageForDoc({
+				server: signedIn.server,
+				ownerId: signedIn.ownerId,
+				guid,
+			});
+			// Idempotent server drop + tombstone. Best-effort: a failure here
+			// (e.g. offline) leaves the room to reclaim later, never a hard error.
+			await signedIn.fetch(
+				ROOM_ROUTE.url(signedIn.baseURL, signedIn.ownerId, guid),
+				{ method: 'DELETE' },
+			);
+		} catch (cause) {
+			log.warn(
+				ZhongwenCleanupError.ConversationCleanupFailed({
+					cause,
+					conversationId,
+				}),
+			);
+		} finally {
+			inFlightCleanups.delete(conversationId);
+		}
+	}
+
+	const unobserveConversations = conversations.observe((changedIds) => {
+		for (const id of changedIds) {
+			if (!conversations.has(id)) void cleanupConversation(id);
+		}
+	});
+
 	let docsTornDown = false;
 
 	function teardownDocs() {
 		if (docsTornDown) return;
 		docsTornDown = true;
+		unobserveConversations();
 		conversationDocs[Symbol.dispose]();
 		workspace[Symbol.dispose]();
 	}

--- a/packages/server/src/ai/doc-generation.test.ts
+++ b/packages/server/src/ai/doc-generation.test.ts
@@ -18,8 +18,8 @@ import {
 } from '@epicenter/workspace/ai';
 import { EventType, type ModelMessage, type StreamChunk } from '@tanstack/ai';
 import * as Y from 'yjs';
-import { createRoomCore } from '../room/core.js';
 import type { RoomUpdateLog } from '../room/contracts.js';
+import { createRoomCore } from '../room/core.js';
 import { runDocGeneration } from './doc-generation.js';
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -32,6 +32,9 @@ function createMemoryUpdateLog(): RoomUpdateLog {
 		loadAll: () => entries,
 		append: (update) => {
 			entries.push(update);
+		},
+		clear: () => {
+			entries = [];
 		},
 		replaceAll: (compacted) => {
 			entries = [compacted];

--- a/packages/server/src/room/backends/cloudflare/durable-object.test.ts
+++ b/packages/server/src/room/backends/cloudflare/durable-object.test.ts
@@ -22,6 +22,7 @@
 
 import { describe, expect, mock, test } from 'bun:test';
 import {
+	encodeSyncRequest,
 	encodeSyncStep1,
 	encodeSyncUpdate,
 	SYNC_MESSAGE_TYPE,
@@ -121,6 +122,10 @@ type SqlRow = { id: number; data: ArrayBuffer };
 function makeSqlStorage() {
 	const updates: SqlRow[] = [];
 	let nextId = 1;
+	// Models the `room_tombstone` table as a single boolean: destruction writes
+	// one row, `isDestroyed()` counts it. Kept separate from `updates` so the
+	// two COUNT queries route by table name, not by accident.
+	let tombstoned = false;
 
 	function exec(
 		query: string,
@@ -129,6 +134,19 @@ function makeSqlStorage() {
 		const q = query.trim().toUpperCase();
 		if (q.startsWith('CREATE TABLE')) {
 			return { toArray: () => [], one: () => ({ count: 0 }) };
+		}
+		if (q.includes('ROOM_TOMBSTONE')) {
+			if (q.startsWith('SELECT COUNT')) {
+				return {
+					toArray: () => [],
+					one: () => ({ count: tombstoned ? 1 : 0 }),
+				};
+			}
+			if (q.startsWith('INSERT')) {
+				tombstoned = true;
+				return { toArray: () => [], one: () => ({ count: 0 }) };
+			}
+			throw new Error(`Unsupported SQL: ${query}`);
 		}
 		if (q.startsWith('SELECT DATA FROM UPDATES')) {
 			return {
@@ -171,6 +189,12 @@ function makeStorage() {
 	let alarm: number | null = null;
 	return {
 		sql: makeSqlStorage(),
+		// `transactionSync` lives on `ctx.storage` (DurableObjectStorage) in the
+		// real runtime, not on `ctx.storage.sql`. `update-log` replaceAll and
+		// `Room.destroy` both call it there.
+		transactionSync<T>(fn: () => T): T {
+			return fn();
+		},
 		async setAlarm(when: number) {
 			alarm = when;
 		},
@@ -820,5 +844,93 @@ describe('Room dispatch: malformed frames', () => {
 
 		expect(callerWs.closeCalls).toHaveLength(1);
 		expect(callerWs.closeCalls[0]?.code).toBe(4400);
+	});
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// DESTROY (tombstone)
+// ────────────────────────────────────────────────────────────────────────────
+
+/** HTTP sync body carrying a single `{ m: { k: 'v' } }` update. */
+function populateSyncBody(): Uint8Array {
+	const src = new Y.Doc();
+	src.getMap('m').set('k', 'v');
+	return encodeSyncRequest(
+		Y.encodeStateVector(new Y.Doc()),
+		Y.encodeStateAsUpdateV2(src),
+	);
+}
+
+/** Decode a room's current doc state into a fresh Y.Doc for assertions. */
+async function readRoomValue(room: RoomLike): Promise<unknown> {
+	const doc = new Y.Doc();
+	Y.applyUpdateV2(doc, (await room.getDoc()).data);
+	return doc.getMap('m').get('k');
+}
+
+describe('destroy', () => {
+	test('empties the doc and refuses resurrection from a racing sync', async () => {
+		const { room } = await makeRoom();
+		await room.sync(populateSyncBody());
+		expect(await readRoomValue(room)).toBe('v');
+
+		await room.destroy();
+
+		// getDoc exposes an empty snapshot, never the lingering in-memory doc.
+		expect(await readRoomValue(room)).toBeUndefined();
+
+		// A client that still held the doc and re-pushes it is discarded.
+		const res = await room.sync(populateSyncBody());
+		expect(res.error).toBeNull();
+		expect(res.data.diff).toBeNull();
+		expect(await readRoomValue(room)).toBeUndefined();
+	});
+
+	test('refuses new WebSocket upgrades with 410', async () => {
+		const { room } = await makeRoom();
+		await room.destroy();
+		const res = await room.fetch(upgradeRequest('dev-1'));
+		expect(res.status).toBe(410);
+	});
+
+	test('closes live sockets with the permanent room-gone code', async () => {
+		const { room } = await makeRoom();
+		const ws = await upgrade(room, 'dev-1');
+		await room.destroy();
+		expect(ws.closeCalls.some((c) => c.code === 4410)).toBe(true);
+	});
+
+	test('close + alarm after destroy do not resurrect via compaction', async () => {
+		const { room, ctx } = await makeRoom();
+		const ws = await upgrade(room, 'dev-1');
+		await room.sync(populateSyncBody());
+		await room.destroy();
+
+		// The runtime still delivers the close, then fires the pending alarm. A
+		// non-destroyed room would arm + run compaction, re-encoding the in-memory
+		// doc back into the emptied log. The destroyed room must do neither.
+		await room.webSocketClose(ws, 1000, 'bye', true);
+		await room.alarm();
+
+		expect(await readRoomValue(room)).toBeUndefined();
+		expect(await ctx.storage.getAlarm()).toBeNull();
+	});
+
+	test('a reconstructed room stays destroyed (tombstone persists)', async () => {
+		const { room, ctx } = await makeRoom();
+		await room.sync(populateSyncBody());
+		await room.destroy();
+
+		// Cold start: a fresh Room over the SAME persisted storage must read the
+		// tombstone synchronously in its constructor and refuse from the start.
+		const { Room } = await import('./durable-object.js');
+		const ctx2 = makeCtx();
+		ctx2.storage = ctx.storage;
+		const room2 = new Room(ctx2 as never, {} as never) as RoomLike;
+		await Promise.resolve();
+
+		const res = await room2.sync(populateSyncBody());
+		expect(res.data.diff).toBeNull();
+		expect(await readRoomValue(room2)).toBeUndefined();
 	});
 });

--- a/packages/server/src/room/backends/cloudflare/durable-object.ts
+++ b/packages/server/src/room/backends/cloudflare/durable-object.ts
@@ -33,8 +33,14 @@
 import { DurableObject } from 'cloudflare:workers';
 import { asUserId } from '@epicenter/auth';
 import { MAIN_SUBPROTOCOL, parseSubprotocols } from '@epicenter/sync';
+import { Ok } from 'wellcrafted/result';
+import * as Y from 'yjs';
 import type { Connection } from '../../../types.js';
 import { createRoomCore, type RoomCore } from '../../core.js';
+import {
+	createDurableObjectTombstone,
+	type DurableObjectTombstone,
+} from './tombstone.js';
 import { createDurableObjectUpdateLog } from './update-log.js';
 
 /** Delay before alarm-based compaction fires (30 seconds). */
@@ -76,6 +82,28 @@ const CONNECTION_SWEEP_INTERVAL_MS = 5 * 60_000;
  * instead of making the client give up.
  */
 const CONNECTION_LIFETIME_CLOSE_CODE = 4408;
+
+/**
+ * Close code sent to every live socket when a room is destroyed
+ * ({@link Room.destroy}).
+ *
+ * App-defined (4000-4999) and permanent: the client sync supervisor parks on
+ * this code (like the auth-failure 4401) instead of reconnecting, so a device
+ * that still had the doc open does not churn reconnects against the tombstoned
+ * room. The reason is JSON (`{ code }`) to match the supervisor's permanent-
+ * failure parser.
+ */
+const ROOM_GONE_CLOSE_CODE = 4410;
+
+/** JSON close reason paired with {@link ROOM_GONE_CLOSE_CODE}. */
+const ROOM_GONE_CLOSE_REASON = JSON.stringify({ code: 'room_deleted' });
+
+/**
+ * Encoded state of an empty Y.Doc. Returned by {@link Room.getDoc} for a
+ * destroyed room so a racing client hydrates nothing instead of the lingering
+ * in-memory transcript. Computed once at module load.
+ */
+const EMPTY_DOC_SNAPSHOT: Uint8Array = Y.encodeStateAsUpdateV2(new Y.Doc());
 
 /**
  * Yjs sync + dispatch room backed by a Cloudflare Durable Object.
@@ -123,6 +151,26 @@ export class Room extends DurableObject {
 	 */
 	private core!: RoomCore;
 
+	/**
+	 * This room's persisted update log. Held so {@link Room.destroy} can empty it
+	 * through the owner of the `updates` table rather than running raw SQL.
+	 */
+	private updateLog!: ReturnType<typeof createDurableObjectUpdateLog>;
+
+	/**
+	 * Tombstone for this room. Read synchronously in the constructor and marked
+	 * in {@link Room.destroy}. A marked room refuses every doc-touching path.
+	 */
+	private tombstone!: DurableObjectTombstone;
+
+	/**
+	 * Whether this room has been destroyed. Mirrors {@link tombstone} in memory
+	 * so every hot path gates on a field read, not a SQL query. Seeded from the
+	 * tombstone on cold start so a destroyed room stays destroyed across DO
+	 * eviction and reconstruction.
+	 */
+	private destroyed = false;
+
 	constructor(ctx: DurableObjectState, env: Cloudflare.Env) {
 		super(ctx, env);
 
@@ -131,8 +179,10 @@ export class Room extends DurableObject {
 		);
 
 		ctx.blockConcurrencyWhile(async () => {
-			const updateLog = createDurableObjectUpdateLog(ctx.storage);
-			this.core = createRoomCore({ updateLog });
+			this.updateLog = createDurableObjectUpdateLog(ctx.storage);
+			this.tombstone = createDurableObjectTombstone(ctx.storage);
+			this.destroyed = this.tombstone.isDestroyed();
+			this.core = createRoomCore({ updateLog: this.updateLog });
 
 			// Restore connections that survived hibernation. The hibernation
 			// WebSocket structurally satisfies RoomSocket (send/close/
@@ -175,6 +225,12 @@ export class Room extends DurableObject {
 	override async fetch(request: Request): Promise<Response> {
 		if (request.headers.get('Upgrade') !== 'websocket') {
 			return new Response('Method not allowed', { status: 405 });
+		}
+
+		// A destroyed room accepts no new connections: refuse the upgrade so the
+		// client cannot start syncing (and thus cannot re-push) the dead doc.
+		if (this.destroyed) {
+			return new Response('Room destroyed', { status: 410 });
 		}
 
 		const url = new URL(request.url);
@@ -245,6 +301,19 @@ export class Room extends DurableObject {
 		ws: WebSocket,
 		message: ArrayBuffer | string,
 	): Promise<void> {
+		// A destroyed room never applies an inbound update: reaching
+		// `core.handleMessage` -> `applyUpdateV2` -> `updateLog.append` would
+		// resurrect the just-deleted doc. `destroy()` already closed live
+		// sockets; this guards a frame that raced the close. Closing an
+		// already-closed socket throws, so swallow it.
+		if (this.destroyed) {
+			try {
+				ws.close(ROOM_GONE_CLOSE_CODE, ROOM_GONE_CLOSE_REASON);
+			} catch {
+				/* already closed by destroy() or the remote end */
+			}
+			return;
+		}
 		if (this.closeIfExpired(ws, Date.now())) return;
 		this.core.handleMessage(ws, message);
 	}
@@ -306,7 +375,11 @@ export class Room extends DurableObject {
 			/* already closed by the remote end */
 		}
 
-		if (this.core.connectionCount === 0) {
+		// A destroyed room must NOT schedule compaction. Compaction re-encodes the
+		// still-populated in-memory doc and writes it back via `replaceAll`, which
+		// would resurrect the transcript into SQLite after `destroy()` emptied it.
+		// This is the subtle resurrection path; the `alarm()` guard backs it up.
+		if (!this.destroyed && this.core.connectionCount === 0) {
 			void this.ctx.storage.setAlarm(Date.now() + COMPACTION_DELAY_MS);
 		}
 	}
@@ -335,6 +408,9 @@ export class Room extends DurableObject {
 	 * @see https://developers.cloudflare.com/durable-objects/api/alarms/
 	 */
 	override async alarm(): Promise<void> {
+		// A destroyed room neither sweeps nor compacts: compaction would
+		// `replaceAll` the in-memory doc back into the emptied update log.
+		if (this.destroyed) return;
 		const now = Date.now();
 		for (const ws of this.ctx.getWebSockets()) this.closeIfExpired(ws, now);
 		if (this.core.connectionCount > 0) {
@@ -352,6 +428,10 @@ export class Room extends DurableObject {
 	 * body without throwing.
 	 */
 	async sync(body: Uint8Array) {
+		// A destroyed room discards the client's update without applying it (no
+		// resurrection) and reports itself as empty. The client's local copy is
+		// torn down separately once it observes the parent-row tombstone.
+		if (this.destroyed) return Ok({ diff: null, storageBytes: 0 });
 		return this.core.sync(body);
 	}
 
@@ -359,6 +439,43 @@ export class Room extends DurableObject {
 	 * Snapshot bootstrap via RPC. Forwards to {@link RoomCore.getDoc}.
 	 */
 	async getDoc() {
+		// A destroyed room exposes an EMPTY snapshot, never the still-populated
+		// in-memory doc (it lingers until eviction). `destroy()` emptied the
+		// persisted log, so a cold-restarted room returns empty here too.
+		if (this.destroyed) {
+			return { data: EMPTY_DOC_SNAPSHOT, storageBytes: 0 };
+		}
 		return this.core.getDoc();
+	}
+
+	/**
+	 * Permanently destroy this room (RPC, called by the rooms DELETE route).
+	 *
+	 * Order matters and the durable mutation is atomic:
+	 * 1. Flip the in-memory gate so any concurrent RPC starts refusing at once.
+	 * 2. In one `transactionSync`, empty the update log and write the tombstone,
+	 *    so the room can never be observed half-deleted (data gone, mark missing)
+	 *    or half-alive (mark set, data lingering).
+	 * 3. Cancel any pending sweep/compaction alarm so no maintenance writer runs.
+	 * 4. Close every live socket with the permanent room-gone code so connected
+	 *    clients park instead of reconnecting into the 410 upgrade.
+	 *
+	 * Idempotent: a second call empties an already-empty log and re-marks an
+	 * already-marked tombstone.
+	 */
+	async destroy(): Promise<void> {
+		this.destroyed = true;
+		this.ctx.storage.transactionSync(() => {
+			this.updateLog.clear();
+			this.tombstone.mark();
+		});
+		void this.ctx.storage.deleteAlarm();
+		for (const ws of this.ctx.getWebSockets()) {
+			try {
+				ws.close(ROOM_GONE_CLOSE_CODE, ROOM_GONE_CLOSE_REASON);
+			} catch {
+				/* already closed by the remote end */
+			}
+		}
 	}
 }

--- a/packages/server/src/room/backends/cloudflare/registry.ts
+++ b/packages/server/src/room/backends/cloudflare/registry.ts
@@ -41,6 +41,7 @@ export function createDurableObjectRooms(
 				sync: (body) => stub.sync(body),
 				getDoc: () => stub.getDoc(),
 				handleUpgrade: (request) => stub.fetch(request),
+				destroy: () => stub.destroy(),
 			} satisfies ResolvedRoom;
 		},
 	} satisfies Rooms;

--- a/packages/server/src/room/backends/cloudflare/tombstone.ts
+++ b/packages/server/src/room/backends/cloudflare/tombstone.ts
@@ -1,0 +1,53 @@
+/**
+ * Per-room tombstone backed by a Cloudflare Durable Object's embedded SQLite.
+ *
+ * A Durable Object cannot be truly deleted: `deleteAll()` empties storage but
+ * the same name keeps resolving to a live, empty object on the next request.
+ * So "drop a room" structurally means *empty its update log and mark it
+ * destroyed*, then refuse every future operation. This module owns that mark.
+ *
+ * Kept in a SEPARATE table from `updates` so the update log's `replaceAll`
+ * (DELETE + INSERT) can never clobber the tombstone, and so the mark survives
+ * the `DELETE FROM updates` that `Room.destroy()` runs in the same transaction.
+ *
+ * Reads are synchronous (`storage.sql`) on purpose: the Durable Object reads
+ * `isDestroyed()` inside its constructor's await-free `blockConcurrencyWhile`
+ * callback, which must stay synchronous to keep `core` definite-assigned.
+ */
+
+/**
+ * Build a tombstone over a Durable Object's `storage` handle. Creates the
+ * `room_tombstone` table if missing (idempotent, safe on every cold start).
+ */
+export function createDurableObjectTombstone(storage: DurableObjectStorage) {
+	storage.sql.exec(`
+		CREATE TABLE IF NOT EXISTS room_tombstone (
+			id INTEGER PRIMARY KEY
+		)
+	`);
+
+	return {
+		/**
+		 * Whether this room has been destroyed. Synchronous so the constructor
+		 * can gate on it without awaiting.
+		 */
+		isDestroyed(): boolean {
+			const { count } = storage.sql
+				.exec('SELECT COUNT(*) as count FROM room_tombstone')
+				.one();
+			return (count as number) > 0;
+		},
+
+		/**
+		 * Mark this room destroyed. Idempotent: a second mark is a no-op. Intended
+		 * to run inside the same `transactionSync` that empties the update log.
+		 */
+		mark(): void {
+			storage.sql.exec('INSERT OR IGNORE INTO room_tombstone (id) VALUES (1)');
+		},
+	};
+}
+
+export type DurableObjectTombstone = ReturnType<
+	typeof createDurableObjectTombstone
+>;

--- a/packages/server/src/room/backends/cloudflare/update-log.ts
+++ b/packages/server/src/room/backends/cloudflare/update-log.ts
@@ -51,6 +51,16 @@ export function createDurableObjectUpdateLog(storage: DurableObjectStorage) {
 		},
 
 		/**
+		 * Empty the log without compacting. Transaction-free (like `append`) so a
+		 * caller that owns a wider transaction (room destruction, which must empty
+		 * the log and write the tombstone atomically) can compose it. The `updates`
+		 * table name lives here, not at the call site.
+		 */
+		clear(): void {
+			storage.sql.exec('DELETE FROM updates');
+		},
+
+		/**
 		 * Replace the entire log with one compacted blob. Wrapped in
 		 * `storage.transactionSync` so the DELETE + INSERT is one atomic
 		 * unit with respect to readers.

--- a/packages/server/src/room/contracts.ts
+++ b/packages/server/src/room/contracts.ts
@@ -56,6 +56,12 @@ export type RoomUpdateLog = {
 	loadAll(): Uint8Array[];
 	/** Append one Yjs update. Sync because the Yjs listener cannot await. */
 	append(update: Uint8Array): void;
+	/**
+	 * Empty the log without compacting. Transaction-free (like {@link append}) so
+	 * a caller owning a wider transaction (room destruction, which empties the log
+	 * and writes a tombstone atomically) can compose it.
+	 */
+	clear(): void;
 	/** Replace the entire log with one compacted blob. Atomic. */
 	replaceAll(compacted: Uint8Array): void;
 	/** Total bytes used by the log; surfaced as `storageBytes` to callers. */
@@ -136,6 +142,17 @@ export type ResolvedRoom = {
 	 * success, or an HTTP error response if the upgrade is malformed.
 	 */
 	handleUpgrade(request: Request): Promise<Response>;
+	/**
+	 * Permanently destroy this room: empty its persisted update log, write a
+	 * durable tombstone so every future `sync`/`getDoc`/upgrade is refused, and
+	 * close any live sockets. Idempotent.
+	 *
+	 * A backend cannot reclaim the room's name (a Cloudflare Durable Object name
+	 * keeps resolving to a live, empty object), so destruction is a logical
+	 * tombstone, not a deallocation. The tombstone is what defeats resurrection
+	 * from a peer that still holds the doc and re-pushes its state.
+	 */
+	destroy(): Promise<void>;
 };
 
 /**

--- a/packages/server/src/routes/rooms.ts
+++ b/packages/server/src/routes/rooms.ts
@@ -22,6 +22,7 @@
 import { RequestGuardError } from '@epicenter/constants/request-guard-errors';
 import type { OwnerId } from '@epicenter/identity';
 import { ROOM_ROUTE } from '@epicenter/sync';
+import { eq } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { Hono } from 'hono';
 import { describeRoute } from 'hono-openapi';
@@ -52,6 +53,20 @@ const RoomsTelemetryError = defineErrors({
 		doName: string;
 	}) => ({
 		message: 'durableObjectInstance telemetry upsert failed; row dropped',
+		cause,
+		ownerId,
+		doName,
+	}),
+	DoInstanceDeleteFailed: ({
+		cause,
+		ownerId,
+		doName,
+	}: {
+		cause: unknown;
+		ownerId: OwnerId;
+		doName: string;
+	}) => ({
+		message: 'durableObjectInstance telemetry delete failed; row orphaned',
 		cause,
 		ownerId,
 		doName,
@@ -112,6 +127,30 @@ async function upsertDoInstance(
 	} catch (cause) {
 		log.warn(
 			RoomsTelemetryError.DoInstanceUpsertFailed({
+				cause,
+				ownerId: params.ownerId,
+				doName: params.doName,
+			}),
+		);
+	}
+}
+
+/**
+ * Best-effort delete of a room's DO instance telemetry row after the room is
+ * destroyed. Like {@link upsertDoInstance}, errors are logged and dropped: a
+ * stale row over-reports storage but is not authority for anything.
+ */
+async function deleteDoInstance(
+	db: Db,
+	params: { ownerId: OwnerId; doName: string },
+): Promise<void> {
+	try {
+		await db
+			.delete(schema.durableObjectInstance)
+			.where(eq(schema.durableObjectInstance.doName, params.doName));
+	} catch (cause) {
+		log.warn(
+			RoomsTelemetryError.DoInstanceDeleteFailed({
 				cause,
 				ownerId: params.ownerId,
 				doName: params.doName,
@@ -213,6 +252,38 @@ const roomsApp = new Hono<Env>()
 	);
 
 /**
+ * Destructive room surface, mounted in personal mode only (see
+ * {@link mountRoomsApp}).
+ *
+ * `DELETE` permanently destroys a room: it empties the persisted doc and
+ * tombstones the Durable Object so every future sync/upgrade is refused. This
+ * is owner-wide and irreversible, so it is gated to personal mode where the
+ * owner partition is the user's own id (you can only destroy your own rooms).
+ * In shared mode every user shares one partition, so exposing it would let any
+ * member tombstone any shared room (including the root doc); that capability is
+ * withheld until room deletion is scoped to declared child docs.
+ */
+const roomsDeleteApp = new Hono<Env>().delete(
+	ROOM_ROUTE.pattern,
+	describeRoute({
+		description: 'Destroy a room and its persisted doc',
+		tags: ['rooms'],
+	}),
+	async (c) => {
+		const roomId = c.req.param('roomId');
+		const name = doName(c.var.ownerId, roomId);
+
+		await c.var.rooms.get(name).destroy();
+
+		c.var.afterResponse.push(
+			deleteDoInstance(c.var.db, { ownerId: c.var.ownerId, doName: name }),
+		);
+
+		return new Response(null, { status: 204 });
+	},
+);
+
+/**
  * Mount the rooms surface on a deployment's server app.
  *
  * Bundles the full request pipeline for the only WebSocket surface:
@@ -236,4 +307,9 @@ export function mountRoomsApp(
 		createRequireOwnership(opts.ownership),
 	);
 	app.route('/', roomsApp);
+	// Room destruction is owner-wide and irreversible; expose it only where the
+	// owner partition is a single user (personal mode). See {@link roomsDeleteApp}.
+	if (opts.ownership.kind === 'personal') {
+		app.route('/', roomsDeleteApp);
+	}
 }

--- a/packages/svelte-utils/src/session.svelte.ts
+++ b/packages/svelte-utils/src/session.svelte.ts
@@ -54,6 +54,13 @@ export type SignedIn = {
 	 * sub site rather than for the publisher's verb.
 	 */
 	onReconnectSignal: SyncAuthClient['onStateChange'];
+	/**
+	 * Auth-owned fetch: attaches the bearer and surfaces auth failures into the
+	 * client's `state`. Use for owner-scoped API calls (e.g. the rooms `DELETE`
+	 * that destroys a child doc's server room) instead of attaching credentials
+	 * by hand.
+	 */
+	fetch: SyncAuthClient['fetch'];
 };
 
 /**
@@ -114,6 +121,7 @@ export function createSession<T extends Disposable>({
 			},
 			openWebSocket: auth.openWebSocket,
 			onReconnectSignal: auth.onStateChange,
+			fetch: auth.fetch,
 		});
 	}
 

--- a/packages/workspace/src/cache/disposable-cache.test.ts
+++ b/packages/workspace/src/cache/disposable-cache.test.ts
@@ -316,3 +316,45 @@ describe('re-entrancy', () => {
 		expect(cache.has('a')).toBe(false);
 	});
 });
+
+// ════════════════════════════════════════════════════════════════════════════
+// whenReleased
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('whenReleased', () => {
+	test('resolves immediately when nothing holds the id', async () => {
+		const cache = makeYDocCache({ gcTime: 0 });
+		await expect(cache.whenReleased('absent')).resolves.toBeUndefined();
+	});
+
+	test('stays pending while held, resolves once the last handle disposes', async () => {
+		const cache = makeYDocCache({ gcTime: 0 });
+		const handle = cache.open('a');
+		const released = cache.whenReleased('a');
+		let settled = false;
+		void released.then(() => {
+			settled = true;
+		});
+
+		await Promise.resolve();
+		expect(settled).toBe(false); // still held
+		expect(handle.ydoc.isDestroyed).toBe(false);
+
+		handle[Symbol.dispose]();
+		await released;
+		expect(settled).toBe(true);
+		// The underlying dispose ran before the waiter resumed: the whole point of
+		// the "dispose before clear" ordering callers depend on.
+		expect(handle.ydoc.isDestroyed).toBe(true);
+	});
+
+	test('observing a release never triggers one', async () => {
+		const cache = makeYDocCache({ gcTime: 0 });
+		const handle = cache.open('a');
+		void cache.whenReleased('a');
+		await Promise.resolve();
+		expect(cache.has('a')).toBe(true);
+		expect(handle.ydoc.isDestroyed).toBe(false);
+		handle[Symbol.dispose]();
+	});
+});

--- a/packages/workspace/src/cache/disposable-cache.ts
+++ b/packages/workspace/src/cache/disposable-cache.ts
@@ -141,7 +141,8 @@
  *   the cache stays sync, readiness is a value-level concern.
  * - **No max size / LRU eviction.** Out of scope; add when needed.
  * - **No per-id force-close.** One way to release a handle: dispose it.
- *   Two ways means call sites that mismatch open/close.
+ *   Two ways means call sites that mismatch open/close. (`whenReleased(id)`
+ *   only *observes* a release; it never triggers one.)
  * - **No subscriptions / change events.** Just construct, share, dispose.
  *
  * @module
@@ -181,6 +182,8 @@ type CacheEntry<TValue extends Disposable> = {
 	openCount: number;
 	gcTimer: ReturnType<typeof setTimeout> | null;
 	disposed: boolean;
+	/** Resolvers for `whenReleased(id)` callers awaiting this entry's teardown. */
+	releaseWaiters: Array<() => void>;
 };
 
 /**
@@ -224,6 +227,12 @@ export function createDisposableCache<
 		} catch (cause) {
 			log.error(DisposableCacheError.ValueDisposeThrew({ cause }));
 		}
+		// Wake `whenReleased(id)` callers. `[Symbol.dispose]` ran synchronously
+		// above, so the underlying teardown (e.g. `ydoc.destroy()`) has been
+		// invoked before any waiter resumes.
+		const waiters = entry.releaseWaiters;
+		entry.releaseWaiters = [];
+		for (const resolve of waiters) resolve();
 	}
 
 	const cache = {
@@ -246,7 +255,13 @@ export function createDisposableCache<
 				// into the cache; next `open(sameId)` re-runs the closure (no
 				// poisoned entry). The caller sees the thrown error.
 				const value = build(id);
-				entry = { value, openCount: 0, gcTimer: null, disposed: false };
+				entry = {
+					value,
+					openCount: 0,
+					gcTimer: null,
+					disposed: false,
+					releaseWaiters: [],
+				};
 				entries.set(id, entry);
 			}
 
@@ -294,6 +309,25 @@ export function createDisposableCache<
 		/** Whether an instance is currently held (refcounted or in grace window). */
 		has(id: TId) {
 			return entries.has(id);
+		},
+
+		/**
+		 * Resolve once the entry for `id` is no longer held: immediately if it is
+		 * absent or already disposed, otherwise when its grace timer elapses and
+		 * the underlying value is torn down.
+		 *
+		 * Read-only observation, NOT a force-close: it does not trigger disposal,
+		 * it waits for the refcount to reach zero on its own. Callers that must act
+		 * only after a shared resource is fully released (e.g. deleting a Y.Doc's
+		 * local persistence after its handle unmounts) await this instead of
+		 * racing the teardown.
+		 */
+		whenReleased(id: TId): Promise<void> {
+			const entry = entries.get(id);
+			if (entry === undefined || entry.disposed) return Promise.resolve();
+			return new Promise<void>((resolve) => {
+				entry.releaseWaiters.push(resolve);
+			});
 		},
 
 		[Symbol.dispose]() {

--- a/packages/workspace/src/document/attach-local-storage.test.ts
+++ b/packages/workspace/src/document/attach-local-storage.test.ts
@@ -23,7 +23,10 @@ import { randomBytes } from '@noble/ciphers/utils.js';
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb';
 import * as Y from 'yjs';
 import { attachLocalStorage } from './attach-local-storage.js';
-import { wipeLocalStorage } from './wipe-local-storage.js';
+import {
+	clearLocalStorageForDoc,
+	wipeLocalStorage,
+} from './wipe-local-storage.js';
 
 Object.assign(globalThis, { indexedDB, IDBKeyRange });
 
@@ -371,5 +374,38 @@ describe('wipeLocalStorage', () => {
 		expect(remaining).not.toContain(`epicenter/${SERVER}/owners/user-1/doc-a`);
 		expect(remaining).toContain(`epicenter/${SERVER}/owners/user-2/doc-c`);
 		expect(remaining).toContain('unscoped-doc');
+	});
+});
+
+describe('clearLocalStorageForDoc', () => {
+	afterEach(async () => {
+		await Promise.all(
+			(await databaseNames()).map((name) => deleteDatabase(name)),
+		);
+	});
+
+	test('deletes exactly the one database for the guid', async () => {
+		await createDatabase(`epicenter/${SERVER}/owners/user-1/doc-a`);
+		await createDatabase(`epicenter/${SERVER}/owners/user-1/doc-b`);
+
+		await clearLocalStorageForDoc({
+			server: SERVER,
+			ownerId: asOwnerId('user-1'),
+			guid: 'doc-a',
+		});
+
+		const remaining = await databaseNames();
+		expect(remaining).not.toContain(`epicenter/${SERVER}/owners/user-1/doc-a`);
+		expect(remaining).toContain(`epicenter/${SERVER}/owners/user-1/doc-b`);
+	});
+
+	test('is idempotent: clearing an absent database is a no-op', async () => {
+		await expect(
+			clearLocalStorageForDoc({
+				server: SERVER,
+				ownerId: asOwnerId('user-1'),
+				guid: 'never-existed',
+			}),
+		).resolves.toBeUndefined();
 	});
 });

--- a/packages/workspace/src/document/internal/sync-supervisor.ts
+++ b/packages/workspace/src/document/internal/sync-supervisor.ts
@@ -39,10 +39,17 @@ export type SyncError = { type: 'connection' };
  * Reason a sync entered the terminal `failed` phase.
  *
  * `code` is `string` (not a closed enum): the server is the source of truth
- * for the vocabulary, so unknown codes pass through. Documented codes today:
- * 'invalid_token', 'token_expired', 'deauthorized', 'unknown'.
+ * for the vocabulary, so unknown codes pass through.
+ *
+ * - `auth`: credentials are permanently invalid (close 4401). Documented
+ *   codes: 'invalid_token', 'token_expired', 'deauthorized', 'unknown'.
+ * - `gone`: the room was destroyed server-side (close 4410). The doc no longer
+ *   exists; reconnecting would only hit a 410 upgrade. Documented code:
+ *   'room_deleted'.
  */
-export type SyncFailedReason = { type: 'auth'; code: string };
+export type SyncFailedReason =
+	| { type: 'auth'; code: string }
+	| { type: 'gone'; code: string };
 
 export type SyncStatus =
 	| { phase: 'offline' }
@@ -52,12 +59,17 @@ export type SyncStatus =
 
 /**
  * Thrown via `whenConnected` rejection when the server signals a permanent
- * auth failure (close code 4401). The `code` carries the server's canonical
- * reason string so callers can switch on it without magic strings.
+ * failure: an auth rejection (close 4401) or a destroyed room (close 4410). The
+ * `code` carries the server's canonical reason string so callers can switch on
+ * it without magic strings.
  */
 const SyncFailedError = defineErrors({
 	AuthRejected: ({ code }: { code: string }) => ({
 		message: `[sync] server rejected auth: ${code}`,
+		code,
+	}),
+	RoomGone: ({ code }: { code: string }) => ({
+		message: `[sync] room destroyed: ${code}`,
 		code,
 	}),
 });
@@ -132,32 +144,52 @@ const CONNECT_TIMEOUT_MS = 15_000;
  * transient close codes (1006 network blip, 1011 server error, etc.).
  */
 const PERMANENT_AUTH_CLOSE_CODE = 4401;
+/**
+ * App-defined WebSocket close code signaling the room was destroyed
+ * server-side. Permanent like 4401: the doc no longer exists, so reconnecting
+ * would only hit a 410 upgrade. Paired by the server with a `{ code }` JSON
+ * reason (see `ROOM_GONE_CLOSE_CODE` in the room Durable Object).
+ */
+const PERMANENT_ROOM_GONE_CLOSE_CODE = 4410;
 
 /**
- * Failsafe: returns null when `event` is not a permanent-failure signal,
- * `SyncFailedReason` otherwise. A buggy server that sends 4401 with malformed
- * JSON still produces a usable reason (`code: 'unknown'`); we never throw
- * from here.
+ * Extract the server's canonical reason `code` from a close event's JSON
+ * reason. A buggy server that sends malformed JSON still yields `'unknown'`;
+ * never throws.
  */
-function parsePermanentFailure(event: {
-	code: number;
-	reason: string;
-}): SyncFailedReason | null {
-	if (event.code !== PERMANENT_AUTH_CLOSE_CODE) return null;
+function parseReasonCode(reason: string): string {
 	try {
-		const parsed = JSON.parse(event.reason) as unknown;
+		const parsed = JSON.parse(reason) as unknown;
 		if (
 			parsed !== null &&
 			typeof parsed === 'object' &&
 			'code' in parsed &&
 			typeof parsed.code === 'string'
 		) {
-			return { type: 'auth', code: parsed.code };
+			return parsed.code;
 		}
 	} catch {
 		// fall through to 'unknown'
 	}
-	return { type: 'auth', code: 'unknown' };
+	return 'unknown';
+}
+
+/**
+ * Failsafe: returns null when `event` is not a permanent-failure signal,
+ * `SyncFailedReason` otherwise. Recognizes auth rejection (4401) and room
+ * destruction (4410); we never throw from here.
+ */
+function parsePermanentFailure(event: {
+	code: number;
+	reason: string;
+}): SyncFailedReason | null {
+	if (event.code === PERMANENT_AUTH_CLOSE_CODE) {
+		return { type: 'auth', code: parseReasonCode(event.reason) };
+	}
+	if (event.code === PERMANENT_ROOM_GONE_CLOSE_CODE) {
+		return { type: 'gone', code: parseReasonCode(event.reason) };
+	}
+	return null;
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -327,7 +359,10 @@ export function createSyncSupervisor(
 			if (failure) {
 				setStatus({ phase: 'failed', reason: failure });
 				connected.reject(
-					SyncFailedError.AuthRejected({ code: failure.code }).error,
+					(failure.type === 'gone'
+						? SyncFailedError.RoomGone({ code: failure.code })
+						: SyncFailedError.AuthRejected({ code: failure.code })
+					).error,
 				);
 				log.warn(
 					SyncSupervisorError.PermanentClose({

--- a/packages/workspace/src/document/wipe-local-storage.ts
+++ b/packages/workspace/src/document/wipe-local-storage.ts
@@ -22,7 +22,7 @@
 
 import type { OwnerId } from '@epicenter/identity';
 import { clearDocument } from 'y-indexeddb';
-import { getOwnedYjsPrefix } from './local-yjs-key.js';
+import { createOwnedYjsKey, getOwnedYjsPrefix } from './local-yjs-key.js';
 
 /**
  * Delete every encrypted IndexedDB database owned by `(server, ownerId)` on
@@ -50,4 +50,39 @@ export async function wipeLocalStorage({
 				typeof name === 'string' && name.startsWith(prefix),
 		);
 	await Promise.all(names.map((name) => clearDocument(name)));
+}
+
+/**
+ * Delete the encrypted IndexedDB database backing a single Y.Doc, addressed by
+ * its `(server, ownerId, guid)` tuple.
+ *
+ * The single-doc counterpart to {@link wipeLocalStorage}: where wipe drops every
+ * database under the owner prefix, this drops exactly one. It reuses
+ * {@link createOwnedYjsKey}, the same name builder `attachLocalStorage` uses to
+ * create the database, so the delete path can never drift from the create path.
+ *
+ * Idempotent: deleting a database that does not exist is a no-op. The caller
+ * must ensure the doc is no longer mounted (its `Y.Doc` destroyed and its
+ * storage attachment disposed) before clearing, otherwise a still-open
+ * persistence writer can recreate the database after deletion.
+ *
+ * @example
+ * ```ts
+ * await clearLocalStorageForDoc({
+ *   server: signedIn.server,
+ *   ownerId: signedIn.ownerId,
+ *   guid: childDocGuid,
+ * });
+ * ```
+ */
+export async function clearLocalStorageForDoc({
+	server,
+	ownerId,
+	guid,
+}: {
+	server: string;
+	ownerId: OwnerId;
+	guid: string;
+}): Promise<void> {
+	await clearDocument(createOwnedYjsKey(server, ownerId, guid));
 }

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -208,7 +208,10 @@ export {
 // same single URL form is used in both personal and shared modes. Both browser
 // apps and the daemon use this one builder.
 export { type RoomWsUrlOptions, roomWsUrl } from './document/transport.js';
-export { wipeLocalStorage } from './document/wipe-local-storage.js';
+export {
+	clearLocalStorageForDoc,
+	wipeLocalStorage,
+} from './document/wipe-local-storage.js';
 export {
 	type CreateWorkspaceOptions,
 	createWorkspace,


### PR DESCRIPTION
Stacked on #1930 (doc-as-wire). Base is `feat/zhongwen-chat-doc-as-wire`; retarget to `main` once that merges.

The problem this addresses is:

Deleting a Zhongwen conversation only tombstoned the metadata row. Each conversation's transcript is a **separate child Y.Doc**, so its local encrypted IndexedDB database and its server Durable Object room were orphaned **forever**: local storage leaked and the server kept the plaintext transcript indefinitely.

## Design: one tombstone, every layer reacts

```
deleteConversation(id):  conversations.delete(id)   ← CRDT row tombstone, the source of truth (unchanged)
                                 │  (everything below is idempotent, retryable cleanup)
                                 ▼
every device, on a row disappearing (deleter included, no special role):
    whenReleased(handle) → clearLocalStorageForDoc(guid) → DELETE /rooms/:guid
```

Tombstone-the-pointer-first then asynchronously GC the orphan-able resources: the standard soft-delete + GC shape. Cleanup is a pure reactive function of the row tombstone, so it converges across devices with no coordination.

## The server keystone

A Cloudflare Durable Object cannot be truly deleted (the name keeps resolving to a live, empty object), so **drop = empty + tombstone**:

```
destroy():  flag → transactionSync(updateLog.clear(); tombstone.mark()) → deleteAlarm → close sockets(4410)

gated when destroyed:  fetch→410 · webSocketMessage→drop · webSocketClose→no compaction
                       alarm→no compact · sync→discard(no apply) · getDoc→empty snapshot
```

The `webSocketClose`/`alarm` gates close a subtle resurrection path: a post-close compaction would otherwise re-encode the in-memory doc back into the emptied log. The tombstone lives in a separate `room_tombstone` table, read **synchronously** in the DO constructor, so it survives `DELETE FROM updates`, survives eviction, and keeps the no-`await` `blockConcurrencyWhile` invariant.

The `DELETE /api/owners/:ownerId/rooms/:roomId` route is **personal-mode only**: a shared-mode owner partition is a single shared id, so a generic room delete there could tombstone any shared room (including the root doc).

## Commits

1. `feat(workspace)` clearLocalStorageForDoc + cache.whenReleased (generic client primitives)
2. `feat(server)` room destroy + durable tombstone + DELETE route (the keystone)
3. `feat(workspace)` park sync on the room-gone close code (4410)
4. `feat(zhongwen)` reactive cleanup observer + SignedIn.fetch

## Grounding

Designed against DeepWiki (Cloudflare DO deletion semantics, Yjs/y-indexeddb), an independent plan agent, and a Codex adversarial review (which caught the compaction-resurrection path and the shared-mode blast radius). A post-implementation review then fixed a leaky-SQL ownership bug (destroy ran raw `DELETE FROM updates`; now it calls `updateLog.clear()`).

For verification:

- Typecheck: workspace, server, sync, svelte-utils, zhongwen — clean
- `packages/server` tests: 115 pass (5 new destroy tests: no-resurrection sync, close→alarm→compact leaves log empty, 410 upgrade, empty getDoc, reconstructed-room stays destroyed)
- `packages/workspace` tests: 488 pass (whenReleased + clearLocalStorageForDoc)
- Also fixed a latent test-fake bug: `transactionSync` was mocked on `storage.sql` instead of `ctx.storage`

## Known limitations (documented, deferred)

- **Offline sole-device delete** still leaks the server room (local clear succeeds, DELETE never retries). Multi-device/online are covered. Follow-up: a persisted per-guid retry queue.
- **North star**: making "this table field is a child doc" a declared workspace property, so child-doc cleanup is automatic for every app instead of hand-rolled per app.

Note: this branch is one `chore: apply formatting` commit behind the base; the merge is trivial.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783919985&installation_id=128463665&pr_number=1934&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1934&signature=3b27817e2f864b49e39d2c4ad4827a66e8eecc523257dac450f54d977173177a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->