### PR TITLE
fix(zhongwen): drop grok from the provider picker

### DIFF
--- a/apps/zhongwen/package.json
+++ b/apps/zhongwen/package.json
@@ -30,7 +30,6 @@
 		"@tanstack/ai-anthropic": "catalog:",
 		"@tanstack/ai-client": "^0.16.3",
 		"@tanstack/ai-gemini": "catalog:",
-		"@tanstack/ai-grok": "catalog:",
 		"@tanstack/ai-openai": "catalog:",
 		"@tanstack/ai-svelte": "^0.13.4",
 		"arktype": "catalog:",

--- a/apps/zhongwen/src/routes/(signed-in)/chat/providers.ts
+++ b/apps/zhongwen/src/routes/(signed-in)/chat/providers.ts
@@ -5,13 +5,14 @@
  */
 
 import { GeminiTextModels } from '@tanstack/ai-gemini';
-import { GROK_CHAT_MODELS } from '@tanstack/ai-grok';
 import { OPENAI_CHAT_MODELS } from '@tanstack/ai-openai';
 
+// Only providers the `/api/ai/chat/doc` route can actually serve belong here:
+// its `providerModel` validator accepts openai and gemini, so offering a third
+// provider in the picker would persist a row the server rejects with a 400.
 export const PROVIDER_MODELS = {
 	openai: OPENAI_CHAT_MODELS,
 	gemini: GeminiTextModels,
-	grok: GROK_CHAT_MODELS,
 } as const;
 
 export type Provider = keyof typeof PROVIDER_MODELS;

--- a/bun.lock
+++ b/bun.lock
@@ -533,7 +533,6 @@
         "@tanstack/ai-anthropic": "catalog:",
         "@tanstack/ai-client": "^0.16.3",
         "@tanstack/ai-gemini": "catalog:",
-        "@tanstack/ai-grok": "catalog:",
         "@tanstack/ai-openai": "catalog:",
         "@tanstack/ai-svelte": "^0.13.4",
         "arktype": "catalog:",


### PR DESCRIPTION
Selecting Grok in the model picker produced a chat that failed on every send. The picker offered three providers (`openai`, `gemini`, `grok`), but both AI chat routes validate only `openai | gemini`, so a Grok selection persisted a conversation the server rejected with a raw 400 the moment you hit send. The option could never work, and it predates the doc-as-wire rewrite: the SSE route on `main` rejects Grok the same way. So the `@tanstack/ai-grok` dependency and its picker entry were dead weight with no servable consumer.

The fix is deletion. Drop `grok` from `PROVIDER_MODELS` so the picker only offers providers the server can actually serve, and remove the now-unused `@tanstack/ai-grok` dependency (it stays in the lockfile for other workspaces that still use it). There is no fallback for a conversation already saved with `provider: 'grok'`, because such a row could only exist if someone had selected Grok while it was already failing on every send.

```ts
// providers.ts, before
export const PROVIDER_MODELS = {
	openai: OPENAI_CHAT_MODELS,
	gemini: GeminiTextModels,
	grok: GROK_CHAT_MODELS, // offered in the picker, rejected by the server
} as const;

// after
export const PROVIDER_MODELS = {
	openai: OPENAI_CHAT_MODELS,
	gemini: GeminiTextModels,
} as const;
```

Worth flagging for a follow-up: the picker's list (`PROVIDER_MODELS`) and the server's validator (`providerModel` in the AI route) are independent sources of truth for the same set, which is exactly how Grok drifted in. Realigning them by deletion fixes today's mismatch; a shared registry would prevent the next one, but that spans the shared AI route and the SSE clients and deserves its own pass rather than over-abstracting for two providers.