### PR TITLE
chore(api,docs): keep the wrangler fix and record the deletion refusal

### DIFF
--- a/apps/api/scripts/dev.ts
+++ b/apps/api/scripts/dev.ts
@@ -33,7 +33,7 @@ if (auth.exitCode !== 0 || !auth.stdout.toString().trim()) {
 }
 
 const wrangler =
-	await Bun.$`infisical run --silent --env=dev --path=/api -- wrangler dev --var ${`API_PUBLIC_ORIGIN:${localUrl(APPS.API)}`}`
+	await Bun.$`infisical run --silent --env=dev --path=/api -- bun x wrangler dev --var ${`API_PUBLIC_ORIGIN:${localUrl(APPS.API)}`}`
 		.cwd(apiRoot)
 		// Dev narrows the public auth origin to localhost with Wrangler's --var
 		// override, derived from the same APPS source as the dashboard proxy and

--- a/docs/articles/20260612T230000-the-server-is-a-collaborator-not-a-stream.md
+++ b/docs/articles/20260612T230000-the-server-is-a-collaborator-not-a-stream.md
@@ -1,0 +1,57 @@
+# The server is a collaborator on the doc, not a stream
+
+The benefit of using Yjs as the source of truth, instead of streaming AI tokens over TanStack AI, is that you survive full page refreshes. The server is a real-time collaborator on the document, the same as the rest of the app. It is not pushing tokens down a pipe to you; it is editing the same doc you are looking at. That is the whole trick, and it is really cool once you see it.
+
+Here is the contrast. With SSE, the assistant's reply lives in a connection. The server generates a token, writes it to the stream, you render it. Refresh the page and the connection dies, so the half-written reply dies with it unless you separately wrote it somewhere. Persistence, multi-device live view, and resume-after-refresh are each a feature you bolt on by hand.
+
+With doc-as-wire, the transcript is a Yjs doc, and tokens are just edits to it. The client appends the user's message:
+
+```typescript
+appendUserMessage(doc, { id, content, createdAt });
+```
+
+The server opens that same doc as a sync peer, appends an empty assistant message, and flushes deltas into it. Each flush is one Durable Object RPC that carries the diff:
+
+```typescript
+const replica = new Y.Doc({ gc: true });
+const writer = appendAssistantMessage(replica, { id, createdAt });
+// per ~75ms / 512-char flush:
+writer.appendText(delta);
+await room.sync(encodeSyncRequest(replicaStateVector, update));
+```
+
+The client never subscribes to a token stream. It observes the doc and re-renders when it changes:
+
+```typescript
+const messages: ChatDocMessage[] = readChatDocMessages(doc);
+observeChatDocMessages(doc, () => { messages = readChatDocMessages(doc); });
+```
+
+Now the refresh case falls out for free. When you reload, the doc re-opens, hydrates from local IndexedDB, and syncs the rest from the room. The partial assistant text is already there on first paint, and because the server is still a peer writing into that same doc, it keeps growing. You did not resume anything. There was nothing to resume; the doc was always the truth, and you just reattached to it.
+
+```
+client                                  server (one peer among many)
+append user message to doc  ----->      open same doc, append assistant msg
+  (sync carries it)                       room.sync(diff) per flush
+observe the doc  <-----                 finish key written once at the end
+  partial text renders
+  (refresh -> re-read doc -> still growing)
+```
+
+The shape of the message is plain data, decoupled from the live Y types, so both writers and the UI agree on one layout:
+
+```typescript
+type ChatDocMessage = {
+  id: string;
+  role: 'user' | 'assistant';
+  createdAt: number;
+  text: string;
+  finish?: { kind: 'completed' } | { kind: 'cancelled' } | { kind: 'failed'; code: string; message: string };
+};
+```
+
+A few things follow from this that surprised me. The POST that kicks off generation carries no message history, because the doc already has it; the body is just a guid and a generation id. Stop is not a control message, it is aborting the kickoff fetch, and the server finishes the turn as cancelled on its own via `waitUntil`. And liveness, the "is it still typing" state, is never stored. You derive it from how recently the doc changed. Persistence, multi-device, and refresh-resume stopped being features I had to build and became consequences of having one source of truth.
+
+It is not free. You give up the tidy request/response mental model, and the server has to be a real sync peer, which is more machinery than an SSE pipe. Retrying an interrupted turn appends a second assistant message and leaves the partial one visible, because that is what honestly happened to the doc. Deleting a conversation orphans its doc's local storage until there is a per-row cleanup primitive. Those are real costs.
+
+But you write the sync layer once, and then every AI surface you build on top of it resumes across refreshes, shows up live on every device, and persists, without you thinking about any of it. The server stops being something you stream from and becomes someone you collaborate with.

--- a/specs/zhongwen-conversation-deletion-refusal.md
+++ b/specs/zhongwen-conversation-deletion-refusal.md
@@ -1,0 +1,71 @@
+# Decision: refuse server/local deletion reclaim for zhongwen conversations
+
+Status: Refused (deferred). Date: 2026-06-12.
+Supersedes: closed PR #1934 (`feat(zhongwen): delete a conversation's local doc and server room`).
+
+## Context
+
+A zhongwen conversation is a row in the `conversations` table (the parent
+workspace doc, a CRDT). Each conversation's transcript is a separate child
+Y.Doc with two durable homes the row delete does not touch: a local encrypted
+IndexedDB database, and a server room (one Cloudflare Durable Object, embedded
+SQLite `updates` table). PR #1934 proposed reclaiming both on delete via a
+durable per-room tombstone (`room_tombstone` table), refuse-everything guards on
+every room method, a `room-gone` (4410) WebSocket close code, a sync-supervisor
+`gone` state, and an `EMPTY_DOC_SNAPSHOT`.
+
+## Decision
+
+Do not build server-side or local-side reclaim right now. Deletion stays exactly
+what it already is: `conversations.delete(id)`, a CRDT row tombstone that is the
+source of truth and removes the conversation everywhere it is visible, on every
+device, for free. Dormant child-doc storage is left to be reclaimed lazily, if
+ever.
+
+## Why (grounded)
+
+- Cost is decision-irrelevant. A SQLite-backed Durable Object that is idle and
+  evicted bills only stored bytes: a ~12 KB empty-DB floor plus a tens-of-KB
+  transcript, on the order of $0.0001 per conversation per month. The owner is
+  happy to pay storage; the only driver for the feature priced out near zero.
+- The tombstone premise was false and counterproductive. A Durable Object *can*
+  be truly deleted: `ctx.storage.deleteAll()` + `ctx.storage.deleteAlarm()`
+  empties it, and an empty-on-evict DO ceases to exist (Cloudflare docs).
+  Writing a `room_tombstone` row does the opposite of the goal: it keeps the DO
+  permanently non-empty, hence permanently billable, plus a row-read on every
+  cold boot.
+- The parent-doc CRDT tombstone left by each row delete is not a growth problem:
+  with `gc: true` (set in `createRoomCore`), deleted entries become tiny,
+  mergeable GC structs (`{id, length}`), so `encodeStateAsUpdateV2` growth is
+  bounded per delete.
+- `EMPTY_DOC_SNAPSHOT` constructed a `Y.Doc` at module scope, which the Workers
+  runtime forbids (random clientID/guid in global scope); it crashed the worker
+  on boot. That bug was a symptom: it only existed because `destroy()` left the
+  in-memory doc populated and then guarded every read path instead of clearing
+  it.
+- The maintenance surface (686 lines across 4 packages, a multi-device
+  convergence protocol, a platform-fighting tombstone) is not worth a cents-level
+  saving. Convergence was already guaranteed by the per-device cleanup observer,
+  not by the tombstone; the tombstone only closed a transient few-second
+  re-upload window for a straggler tab on the owner's own devices.
+
+## The cheap path, if revisited
+
+- Server reclaim: a ~3-line `Room.destroy()` (`deleteAll()` + `deleteAlarm()`,
+  true deletion, accept that re-requesting a deleted room yields a fresh empty
+  room) plus a personal-mode `DELETE` route. No tombstone, no guards, no close
+  code, no empty-doc snapshot.
+- Local reclaim: `clearLocalStorageForDoc` + a `whenReleased` dispose-before-
+  clear on the doc cache, behind a row-gone observer. Note it is IndexedDB-
+  specific and does not generalize to a native (Tauri) persistence backend, and
+  local storage is already fully wiped on sign-out (`wipeLocalStorage`).
+
+## Triggers to revisit
+
+1. Durable Object storage shows up as a real line item on the bill.
+2. We make an explicit "delete purges the data from the server" product promise.
+3. A heavy-deleter reports browser-storage pressure between sign-outs.
+4. Room deletion is exposed in shared mode (multi-user partition, untrusted
+   peers, the root doc at stake). There the permanent-refusal semantics the
+   tombstone provided may actually be earned; the cents-level personal-mode case
+   never earned them.


### PR DESCRIPTION
We closed #1934 (the zhongwen conversation-deletion PR) after a design review. To reclaim a deleted conversation's orphaned storage it built a permanent durable-tombstone subsystem (a per-room SQL table, refuse-everything guards on every room method, a `room-gone` close code, an `EMPTY_DOC_SNAPSHOT`) on the premise that a Durable Object cannot be truly deleted. That premise is false (`ctx.storage.deleteAll()` + `deleteAlarm()` truly deletes a DO, and an empty-on-evict DO ceases to exist), the tombstone is actively counterproductive (a tombstone row keeps the DO permanently non-empty and therefore permanently billable), and the storage it raced to reclaim prices out near $0.0001 per conversation per month. Three things were worth keeping off that abandoned branch; this lands them on main and leaves the 686-line subsystem behind.

**The wrangler change is a real dev boot-crash fix, not a nicety.** `infisical run` resolved `wrangler` from `PATH`, where a stale global install shadows the workspace pin. Older wrangler silently ignores the `secrets` field, so required secrets never bind and the worker crashes at boot reading `ENCRYPTION_SECRETS`. Routing through `bun x` resolves the workspace version regardless of `PATH` order:

```diff
-  infisical run ... -- wrangler dev --var ...
+  infisical run ... -- bun x wrangler dev --var ...
```

---

**The article captures the mental model that made the review tractable.** "The server is a collaborator on the doc, not a stream" explains why the transcript is a Yjs doc the server edits as a peer rather than tokens streamed over SSE. That framing is what made it obvious the conversation row is the only authority and the server room is just dumb storage, which is the whole basis for refusing the deletion machinery.

---

**The decision record is so we never re-derive this.** `specs/zhongwen-conversation-deletion-refusal.md` writes down the cost math, the false tombstone premise, the boot-crashing module-scope `Y.Doc`, the ~3-line cheap path if we ever do want server reclaim (`deleteAll()` + `deleteAlarm()` + a personal-mode `DELETE` route), and four triggers to revisit. The sharpest trigger: if room deletion is ever exposed in shared mode, where permanent-refusal semantics might actually be earned.

Three commits, 129 lines added, one 686-line subsystem that didn't make the cut.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783925222&installation_id=128463665&pr_number=1939&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1939&signature=c15a3524958feb421642c907ca9c4b318beade1d4448872e2e8ec73bd9d3700c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->