### PR TITLE
refactor: trim three over-built surfaces from the #1936 read-surface work

### DIFF
--- a/apps/fuji/src/lib/workspace/index.ts
+++ b/apps/fuji/src/lib/workspace/index.ts
@@ -329,8 +329,10 @@ export function createFuji(opts: { keyring: () => Keyring }) {
 						createdAt: now,
 						updatedAt: now,
 					}));
-					const { refused } = await tables.entries.bulkSet(rows);
-					return { written: rows.length - refused.length, refused };
+					// Fresh generateId() ids cannot collide with a stored row, so
+					// bulkSet never refuses on this path; report a clean count.
+					await tables.entries.bulkSet(rows);
+					return { count: rows.length };
 				},
 			}),
 		}),

--- a/apps/fuji/src/routes/(signed-in)/components/BulkAddModal.svelte
+++ b/apps/fuji/src/routes/(signed-in)/components/BulkAddModal.svelte
@@ -6,18 +6,12 @@
 	import { Textarea } from '@epicenter/ui/textarea';
 	import { TimezoneCombobox } from '@epicenter/ui/timezone-combobox';
 	import * as Tooltip from '@epicenter/ui/tooltip';
-	import { IanaTimeZone, type TableWriteError } from '@epicenter/workspace';
+	import { IanaTimeZone } from '@epicenter/workspace';
 	import ClipboardPasteIcon from '@lucide/svelte/icons/clipboard-paste';
 	import { requireFuji } from '$lib/session';
 
 	const LINE_REGEX = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)\s(.+)$/;
 	const fuji = requireFuji();
-
-	/** One-line reason per refusal, matching the Needs Attention page's wording. */
-	const REFUSAL_REASON = {
-		NewerWriterRefusal: 'written by a newer version of Fuji',
-		UnreadableRefusal: 'encrypted with a key this device does not have',
-	} satisfies Record<TableWriteError['name'], string>;
 
 	let isOpen = $state(false);
 	let rawText = $state('');
@@ -36,39 +30,24 @@
 	});
 
 	/**
-	 * Send the parsed lines to the workspace and report the outcome. bulkSet
-	 * refuses any row whose id already holds a newer or undecryptable entry; with
-	 * fresh ids that cannot happen on this path, but if it ever does, say how many
-	 * were held back and why instead of reporting a clean import. Clear and close
+	 * Send the parsed lines to the workspace and report how many were added.
+	 * Every row gets a fresh id, so bulkSet cannot collide with a stored entry
+	 * and cannot refuse; the result is always a clean count. Clear and close
 	 * only on success so a failure leaves the pasted text recoverable.
 	 */
 	async function importEntries() {
 		importing = true;
 		try {
-			const { written, refused } =
-				await fuji.collaboration.actions.entries_bulk_create({
-					dateZone: timezone,
-					entries: parsed.entries.map(({ iso, text }) => ({
-						title: text,
-						date: iso,
-					})),
-				});
+			const { count } = await fuji.collaboration.actions.entries_bulk_create({
+				dateZone: timezone,
+				entries: parsed.entries.map(({ iso, text }) => ({
+					title: text,
+					date: iso,
+				})),
+			});
 			rawText = '';
 			isOpen = false;
-
-			if (refused.length === 0) {
-				toast.success(`Added ${written} ${written === 1 ? 'entry' : 'entries'}`);
-				return;
-			}
-			const byReason = new Map<TableWriteError['name'], number>();
-			for (const { name } of refused) {
-				byReason.set(name, (byReason.get(name) ?? 0) + 1);
-			}
-			toast.warning(`Added ${written}, skipped ${refused.length}`, {
-				description: [...byReason]
-					.map(([name, n]) => `${n} ${REFUSAL_REASON[name]}`)
-					.join(', '),
-			});
+			toast.success(`Added ${count} ${count === 1 ? 'entry' : 'entries'}`);
 		} catch (error) {
 			toast.error("Couldn't add entries", {
 				description: error instanceof Error ? error.message : String(error),

--- a/apps/fuji/src/routes/(signed-in)/conformance/+page.svelte
+++ b/apps/fuji/src/routes/(signed-in)/conformance/+page.svelte
@@ -116,9 +116,9 @@
 						not match the current schema
 					</Alert.Title>
 					<Alert.Description>
-						The data is intact but kept out of your lists because it does not
-						match the current schema. It stays stored and untouched; discard
-						removes the entry permanently.
+						The data is intact but hidden from your lists. To bring these back,
+						ship a schema migration: Fuji owns the version stamp and the step
+						that upgrades old rows. Discard removes the entry permanently.
 					</Alert.Description>
 				</Alert.Root>
 

--- a/apps/fuji/src/routes/(signed-in)/conformance/+page.svelte
+++ b/apps/fuji/src/routes/(signed-in)/conformance/+page.svelte
@@ -3,21 +3,15 @@
 	import { Button } from '@epicenter/ui/button';
 	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import * as Empty from '@epicenter/ui/empty';
-	import { toastOnError } from '@epicenter/ui/sonner';
 	import * as Table from '@epicenter/ui/table';
-	import {
-		DateTimeString,
-		type IanaTimeZone,
-		type TableParseError,
-	} from '@epicenter/workspace';
+	import { type TableParseError } from '@epicenter/workspace';
 	import ArrowUpCircleIcon from '@lucide/svelte/icons/arrow-up-circle';
 	import CircleCheckIcon from '@lucide/svelte/icons/circle-check';
 	import LockIcon from '@lucide/svelte/icons/lock';
 	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
-	import WrenchIcon from '@lucide/svelte/icons/wrench';
 	import XIcon from '@lucide/svelte/icons/x';
 	import { requireFuji } from '$lib/session';
-	import { asEntryId, type Entry } from '$lib/workspace';
+	import { asEntryId } from '$lib/workspace';
 
 	const fuji = requireFuji();
 
@@ -28,40 +22,6 @@
 		MigrationFailed: 'Migration failed',
 		UnknownVersion: 'Unrecognized version stamp',
 	} satisfies Record<TableParseError['name'], string>;
-
-	/**
-	 * Rebuild a valid entry from a nonconforming row, keeping every field
-	 * that still fits the current schema and defaulting the rest. Every parse
-	 * error carries the raw stored value, so all three nonconforming causes
-	 * (failed validation, failed migration, corrupt version stamp) repair the
-	 * same way: coerce what fits, default the rest, and let set() restamp the
-	 * current version.
-	 */
-	function repairEntry(error: TableParseError): Entry {
-		const raw = error.row as Record<string, unknown>;
-		const now = DateTimeString.now();
-		const str = (v: unknown) => (typeof v === 'string' ? v : '');
-		const strings = (v: unknown) =>
-			Array.isArray(v)
-				? v.filter((x): x is string => typeof x === 'string')
-				: [];
-		return {
-			id: asEntryId(error.id),
-			title: str(raw.title),
-			subtitle: str(raw.subtitle),
-			type: strings(raw.type),
-			tags: strings(raw.tags),
-			pinned: raw.pinned === true,
-			rating: typeof raw.rating === 'number' ? raw.rating : 0,
-			deletedAt: DateTimeString.is(raw.deletedAt) ? raw.deletedAt : null,
-			date: DateTimeString.is(raw.date) ? raw.date : now,
-			dateZone: (typeof raw.dateZone === 'string'
-				? raw.dateZone
-				: 'UTC') as IanaTimeZone,
-			createdAt: DateTimeString.is(raw.createdAt) ? raw.createdAt : now,
-			updatedAt: now,
-		};
-	}
 
 	function discard(error: TableParseError) {
 		confirmationDialog.open({
@@ -156,8 +116,8 @@
 						not match the current schema
 					</Alert.Title>
 					<Alert.Description>
-						The data is intact but hidden from your lists. Repair keeps the
-						fields that still fit and fills in defaults for the rest; discard
+						The data is intact but kept out of your lists because it does not
+						match the current schema. It stays stored and untouched; discard
 						removes the entry permanently.
 					</Alert.Description>
 				</Alert.Root>
@@ -180,20 +140,7 @@
 									{error.message}
 								</Table.Cell>
 								<Table.Cell>
-									<div class="flex items-center justify-end gap-1">
-										<Button
-											variant="ghost"
-											size="icon-sm"
-											title="Repair entry"
-											onclick={() => {
-												toastOnError(
-													fuji.tables.entries.set(repairEntry(error)),
-													'Couldn\'t repair entry',
-												);
-											}}
-										>
-											<WrenchIcon class="size-4" />
-										</Button>
+									<div class="flex justify-end">
 										<Button
 											variant="ghost-destructive"
 											size="icon-sm"

--- a/packages/svelte-utils/src/from-table.svelte.test.ts
+++ b/packages/svelte-utils/src/from-table.svelte.test.ts
@@ -1,0 +1,227 @@
+import { expect, test } from 'bun:test';
+import type {
+	BaseRow,
+	ReadonlyTable,
+	TableReadError,
+} from '@epicenter/workspace';
+import {
+	TableNewerWriterError,
+	TableParseError,
+	TableUnreadableError,
+} from '@epicenter/workspace';
+import { Err, Ok } from 'wellcrafted/result';
+import { fromTable } from './from-table.svelte.js';
+
+// `bun test` runs `.svelte.ts` modules without the Svelte compiler, so the runes
+// the source uses are plain globals here. `$derived` is stubbed as identity,
+// which means the memoized bucket array getters (`nonconforming`, `newerWriter`,
+// `unreadable`) capture their value once at construction and never recompute.
+// Consequence: seed-time bucket contents are observable, but the bucket maps the
+// `observe()` callback mutates are NOT visible through the frozen getters.
+//
+// What stays fully testable is the live `rows` SvelteMap (a real Map returned by
+// reference) and dispose. The `observe()` switch's bucket *destination* per error
+// variant is guarded instead by its compile-time `error satisfies never`
+// exhaustiveness; what the tests below pin is the rows-side decision the switch
+// makes for every variant, plus seed classification and teardown.
+(globalThis as unknown as { $derived: <T>(v: T) => T }).$derived = (v) => v;
+(globalThis as unknown as { $state: <T>(v: T) => T }).$state = (v) => v;
+
+type Row = BaseRow & { name: string };
+
+type StoredEntry =
+	| { kind: 'row'; row: Row }
+	| { kind: 'error'; error: TableReadError };
+
+const row = (id: string, name = id): StoredEntry => ({
+	kind: 'row',
+	row: { id, _v: 1, name } as Row,
+});
+
+const nonconforming = (id: string): StoredEntry => ({
+	kind: 'error',
+	error: TableParseError.ValidationFailed({
+		id,
+		errors: [{ path: '/name', message: 'required' }],
+		row: {},
+	}).error,
+});
+
+const newerWriter = (id: string): StoredEntry => ({
+	kind: 'error',
+	error: TableNewerWriterError.NewerWriter({
+		id,
+		version: 9,
+		latestVersion: 1,
+		row: {},
+	}).error,
+});
+
+const unreadable = (id: string): StoredEntry => ({
+	kind: 'error',
+	error: TableUnreadableError.UnreadableRow({
+		id,
+		reason: 'keyVersion=3 not in keyring [1]',
+	}).error,
+});
+
+/**
+ * A `ReadonlyTable` standing on a plain Map. `fromTable` only ever calls
+ * `scan()`, `observe()`, and `get()`, so the rest throws to fail loud if the
+ * contract widens. `fire(ids)` plays the role of a CRDT/local write landing.
+ */
+function createMockTable() {
+	const store = new Map<string, StoredEntry>();
+	let observer: ((changedIds: ReadonlySet<string>) => void) | undefined;
+
+	const table = {
+		scan() {
+			const scan = {
+				rows: [] as Row[],
+				nonconforming: [] as TableParseError[],
+				newerWriter: [] as TableNewerWriterError[],
+				unreadable: [] as TableUnreadableError[],
+			};
+			for (const entry of store.values()) {
+				if (entry.kind === 'row') {
+					scan.rows.push(entry.row);
+				} else if (entry.error.name === 'NewerWriter') {
+					scan.newerWriter.push(entry.error);
+				} else if (entry.error.name === 'UnreadableRow') {
+					scan.unreadable.push(entry.error);
+				} else {
+					scan.nonconforming.push(entry.error);
+				}
+			}
+			return scan;
+		},
+		get(id: string) {
+			const entry = store.get(id);
+			if (!entry) return Ok(null);
+			return entry.kind === 'row' ? Ok(entry.row) : Err(entry.error);
+		},
+		observe(callback: (changedIds: ReadonlySet<string>) => void) {
+			observer = callback;
+			return () => {
+				observer = undefined;
+			};
+		},
+	} as unknown as ReadonlyTable<Row>;
+
+	return {
+		table,
+		store,
+		fire(...ids: string[]) {
+			if (!observer) throw new Error('no active observer');
+			observer(new Set(ids));
+		},
+		isObserved: () => observer !== undefined,
+	};
+}
+
+test('seed: scan routes conforming rows and each issue bucket', () => {
+	const { table, store } = createMockTable();
+	store.set('ok', row('ok'));
+	store.set('bad', nonconforming('bad'));
+	store.set('ahead', newerWriter('ahead'));
+	store.set('locked', unreadable('locked'));
+
+	const entries = fromTable(table);
+
+	expect(entries.size).toBe(1);
+	expect(entries.has('ok')).toBe(true);
+	expect(entries.has('bad')).toBe(false);
+	expect(entries.has('ahead')).toBe(false);
+	expect(entries.has('locked')).toBe(false);
+
+	expect(entries.nonconforming.map((e) => e.id)).toEqual(['bad']);
+	expect(entries.newerWriter.map((e) => e.id)).toEqual(['ahead']);
+	expect(entries.unreadable.map((e) => e.id)).toEqual(['locked']);
+
+	entries[Symbol.dispose]();
+});
+
+test('observe: a newly conforming id enters the row map', () => {
+	const { table, store, fire } = createMockTable();
+	const entries = fromTable(table);
+	expect(entries.size).toBe(0);
+
+	store.set('a', row('a', 'Ada'));
+	fire('a');
+
+	expect(entries.has('a')).toBe(true);
+	expect(entries.get('a')?.name).toBe('Ada');
+
+	entries[Symbol.dispose]();
+});
+
+test('observe: a deleted id leaves the row map', () => {
+	const { table, store, fire } = createMockTable();
+	store.set('a', row('a'));
+	const entries = fromTable(table);
+	expect(entries.has('a')).toBe(true);
+
+	store.delete('a');
+	fire('a');
+
+	expect(entries.has('a')).toBe(false);
+
+	entries[Symbol.dispose]();
+});
+
+test('observe: a conforming row that turns unreadable is dropped from the row map', () => {
+	const { table, store, fire } = createMockTable();
+	store.set('a', row('a'));
+	const entries = fromTable(table);
+	expect(entries.has('a')).toBe(true);
+
+	store.set('a', unreadable('a'));
+	fire('a');
+
+	expect(entries.has('a')).toBe(false);
+
+	entries[Symbol.dispose]();
+});
+
+test('observe: every error variant drops a previously conforming id from the row map', () => {
+	for (const toError of [nonconforming, newerWriter, unreadable]) {
+		const { table, store, fire } = createMockTable();
+		store.set('a', row('a'));
+		const entries = fromTable(table);
+		expect(entries.has('a')).toBe(true);
+
+		store.set('a', toError('a'));
+		fire('a');
+
+		expect(entries.has('a')).toBe(false);
+
+		entries[Symbol.dispose]();
+	}
+});
+
+test('observe: a previously failing id re-enters the row map once it conforms', () => {
+	const { table, store, fire } = createMockTable();
+	store.set('a', nonconforming('a'));
+	const entries = fromTable(table);
+	expect(entries.has('a')).toBe(false);
+
+	store.set('a', row('a', 'fixed'));
+	fire('a');
+
+	expect(entries.has('a')).toBe(true);
+	expect(entries.get('a')?.name).toBe('fixed');
+
+	entries[Symbol.dispose]();
+});
+
+test('dispose stops observation and is idempotent', () => {
+	const { table, fire, isObserved } = createMockTable();
+	const entries = fromTable(table);
+	expect(isObserved()).toBe(true);
+
+	entries[Symbol.dispose]();
+	expect(isObserved()).toBe(false);
+	expect(() => fire('a')).toThrow('no active observer');
+
+	expect(() => entries[Symbol.dispose]()).not.toThrow();
+});

--- a/packages/svelte-utils/src/from-table.svelte.ts
+++ b/packages/svelte-utils/src/from-table.svelte.ts
@@ -39,6 +39,13 @@ export type ReactiveTableMap<TRow extends BaseRow> = SvelteMap<string, TRow> &
  * O(n) re-scan: the classification rides the per-id delta the row map already
  * walks.
  *
+ * The buckets reclassify on table changes only, not on keyring changes: the
+ * binding observes the table, not the keys. When a missing key syncs in, the
+ * encrypted rows' stored bytes are unchanged, so no observe fires and
+ * `unreadable` stays stale until the next write to that row reclassifies it (or
+ * the view reloads). Adding a keyring dependency to live-update that rare case
+ * is not worth the coupling.
+ *
  * Read-only: mutations go through `table.set()`, `table.update()`, etc. The
  * observer picks up changes from both local writes and remote CRDT sync.
  *

--- a/packages/svelte-utils/src/from-table.svelte.ts
+++ b/packages/svelte-utils/src/from-table.svelte.ts
@@ -68,7 +68,7 @@ export type ReactiveTableMap<TRow extends BaseRow> = SvelteMap<string, TRow> &
 export function fromTable<TRow extends BaseRow>(
 	table: ReadonlyTable<TRow>,
 ): ReactiveTableMap<TRow> {
-	const map = new SvelteMap<string, TRow>();
+	const rows = new SvelteMap<string, TRow>();
 	const nonconforming = new SvelteMap<string, TableParseError>();
 	const newerWriter = new SvelteMap<string, TableNewerWriterError>();
 	const unreadable = new SvelteMap<string, TableUnreadableError>();
@@ -76,7 +76,7 @@ export function fromTable<TRow extends BaseRow>(
 	// Seed every surface from one classified scan: conforming rows into the map,
 	// the rest into their issue bucket. After this each id lives in exactly one.
 	const initial = table.scan();
-	for (const row of initial.rows) map.set(row.id, row);
+	for (const row of initial.rows) rows.set(row.id, row);
 	for (const e of initial.nonconforming) nonconforming.set(e.id, e);
 	for (const e of initial.newerWriter) newerWriter.set(e.id, e);
 	for (const e of initial.unreadable) unreadable.set(e.id, e);
@@ -92,14 +92,29 @@ export function fromTable<TRow extends BaseRow>(
 			unreadable.delete(id);
 			const { data: row, error } = table.get(id);
 			if (!error) {
-				if (row === null) map.delete(id);
-				else map.set(id, row);
+				if (row === null) rows.delete(id);
+				else rows.set(id, row);
 				continue;
 			}
-			map.delete(id);
-			if (error.name === 'NewerWriter') newerWriter.set(id, error);
-			else if (error.name === 'UnreadableRow') unreadable.set(id, error);
-			else nonconforming.set(id, error);
+			rows.delete(id);
+			// Route by variant the same way `scan()` does, so adding a new
+			// TableReadError variant fails the build here instead of silently
+			// falling through into `nonconforming`.
+			switch (error.name) {
+				case 'NewerWriter':
+					newerWriter.set(id, error);
+					break;
+				case 'UnreadableRow':
+					unreadable.set(id, error);
+					break;
+				case 'UnknownVersion':
+				case 'ValidationFailed':
+				case 'MigrationFailed':
+					nonconforming.set(id, error);
+					break;
+				default:
+					error satisfies never;
+			}
 		}
 	});
 
@@ -109,20 +124,17 @@ export function fromTable<TRow extends BaseRow>(
 	const newerWriterList = $derived([...newerWriter.values()]);
 	const unreadableList = $derived([...unreadable.values()]);
 
-	let disposed = false;
-	Object.defineProperties(map, {
+	Object.defineProperties(rows, {
 		nonconforming: { get: () => nonconformingList, enumerable: false },
 		newerWriter: { get: () => newerWriterList, enumerable: false },
 		unreadable: { get: () => unreadableList, enumerable: false },
 		[Symbol.dispose]: {
-			value() {
-				if (disposed) return;
-				disposed = true;
-				unobserve();
-			},
+			// `unobserve` is idempotent (it deletes a handler from a Set), so a
+			// double dispose is a harmless no-op; no guard needed.
+			value: unobserve,
 			enumerable: false,
 		},
 	});
 
-	return map as ReactiveTableMap<TRow>;
+	return rows as ReactiveTableMap<TRow>;
 }

--- a/packages/svelte-utils/src/from-table.svelte.ts
+++ b/packages/svelte-utils/src/from-table.svelte.ts
@@ -9,13 +9,12 @@ import { SvelteMap } from 'svelte/reactivity';
 
 /**
  * A reactive `SvelteMap` of a table's conforming rows, with the table's three
- * issue buckets attached as debounced properties.
+ * issue buckets attached as properties.
  *
- * The map itself is the hot surface: `get`, `has`, `size`, and iteration all
- * update granularly per changed row. The issue buckets (`nonconforming`,
- * `newerWriter`, `unreadable`) recompute on a debounce, because they change
- * rarely (a schema edit, a sync from a newer build, a key change) while rows
- * change on every keystroke.
+ * Every surface updates granularly from one `observe()` subscription. A changed
+ * id lands in the map when it parses and in exactly one issue bucket
+ * (`nonconforming`, `newerWriter`, `unreadable`) when it does not. No surface
+ * ever re-reads the whole table on change.
  */
 export type ReactiveTableMap<TRow extends BaseRow> = SvelteMap<string, TRow> &
 	Disposable & {
@@ -33,11 +32,12 @@ export type ReactiveTableMap<TRow extends BaseRow> = SvelteMap<string, TRow> &
  *
  * The returned value is a `SvelteMap<id, Row>` of the conforming rows that
  * stays in sync via granular per-row updates: only changed rows trigger
- * re-renders, not the entire collection. The same subscription also exposes the
- * three issue buckets (`nonconforming`, `newerWriter`, `unreadable`) as
- * debounced properties, so a view can surface what the rows hide without a
- * second subscription. Buckets are recomputed via a full `scan()` on a debounce
- * because they change rarely; rows stay granular because they change often.
+ * re-renders, not the entire collection. The same subscription classifies each
+ * changed id with `get(id)` and routes the ones that do not parse into the
+ * three issue buckets (`nonconforming`, `newerWriter`, `unreadable`), so a view
+ * can surface what the rows hide without a second subscription and without an
+ * O(n) re-scan: the classification rides the per-id delta the row map already
+ * walks.
  *
  * Read-only: mutations go through `table.set()`, `table.update()`, etc. The
  * observer picks up changes from both local writes and remote CRDT sync.
@@ -56,7 +56,7 @@ export type ReactiveTableMap<TRow extends BaseRow> = SvelteMap<string, TRow> &
  * // Iterate the conforming rows (reactive):
  * for (const [id, entry] of entries) { ... }
  *
- * // Issue buckets (reactive, debounced):
+ * // Issue buckets (reactive):
  * entries.nonconforming.length;
  * entries.newerWriter.length;
  * entries.unreadable.length;
@@ -67,52 +67,57 @@ export type ReactiveTableMap<TRow extends BaseRow> = SvelteMap<string, TRow> &
  */
 export function fromTable<TRow extends BaseRow>(
 	table: ReadonlyTable<TRow>,
-	{ debounceMs = 100 }: { debounceMs?: number } = {},
 ): ReactiveTableMap<TRow> {
 	const map = new SvelteMap<string, TRow>();
+	const nonconforming = new SvelteMap<string, TableParseError>();
+	const newerWriter = new SvelteMap<string, TableNewerWriterError>();
+	const unreadable = new SvelteMap<string, TableUnreadableError>();
 
-	// Seed both surfaces from one scan: the conforming rows into the map, the
-	// issue buckets into the debounced state.
+	// Seed every surface from one classified scan: conforming rows into the map,
+	// the rest into their issue bucket. After this each id lives in exactly one.
 	const initial = table.scan();
 	for (const row of initial.rows) map.set(row.id, row);
-
-	let nonconforming = $state.raw<TableParseError[]>(initial.nonconforming);
-	let newerWriter = $state.raw<TableNewerWriterError[]>(initial.newerWriter);
-	let unreadable = $state.raw<TableUnreadableError[]>(initial.unreadable);
-	let timer: ReturnType<typeof setTimeout> | undefined;
+	for (const e of initial.nonconforming) nonconforming.set(e.id, e);
+	for (const e of initial.newerWriter) newerWriter.set(e.id, e);
+	for (const e of initial.unreadable) unreadable.set(e.id, e);
 
 	const unobserve = table.observe((changedIds) => {
-		// Granular per-row updates: only touch changed rows. A row that goes
-		// unreadable, nonconforming, newer-stamped, or deleted leaves the map.
 		for (const id of changedIds) {
+			// A changed id belongs to exactly one surface. Clear it from the issue
+			// buckets, then place it by re-reading its classified state. `get(id)`
+			// returns the conforming row or the same error variant `scan()` would
+			// have bucketed it under, so the map and the buckets can never disagree.
+			nonconforming.delete(id);
+			newerWriter.delete(id);
+			unreadable.delete(id);
 			const { data: row, error } = table.get(id);
-			if (error || row === null) {
-				map.delete(id);
+			if (!error) {
+				if (row === null) map.delete(id);
+				else map.set(id, row);
 				continue;
 			}
-			map.set(id, row);
+			map.delete(id);
+			if (error.name === 'NewerWriter') newerWriter.set(id, error);
+			else if (error.name === 'UnreadableRow') unreadable.set(id, error);
+			else nonconforming.set(id, error);
 		}
-		// Debounced full re-scan for the issue buckets. They change rarely, so a
-		// debounced rebuild is the right cost trade against a per-change rescan.
-		clearTimeout(timer);
-		timer = setTimeout(() => {
-			const scan = table.scan();
-			nonconforming = scan.nonconforming;
-			newerWriter = scan.newerWriter;
-			unreadable = scan.unreadable;
-		}, debounceMs);
 	});
+
+	// Memoized array views: each recomputes only when its bucket map mutates,
+	// not on every property read, and hands out a stable reference in between.
+	const nonconformingList = $derived([...nonconforming.values()]);
+	const newerWriterList = $derived([...newerWriter.values()]);
+	const unreadableList = $derived([...unreadable.values()]);
 
 	let disposed = false;
 	Object.defineProperties(map, {
-		nonconforming: { get: () => nonconforming, enumerable: false },
-		newerWriter: { get: () => newerWriter, enumerable: false },
-		unreadable: { get: () => unreadable, enumerable: false },
+		nonconforming: { get: () => nonconformingList, enumerable: false },
+		newerWriter: { get: () => newerWriterList, enumerable: false },
+		unreadable: { get: () => unreadableList, enumerable: false },
 		[Symbol.dispose]: {
 			value() {
 				if (disposed) return;
 				disposed = true;
-				clearTimeout(timer);
 				unobserve();
 			},
 			enumerable: false,


### PR DESCRIPTION
Follow-up to #1936. That PR landed the one-classified-`scan()` read surface well: the four-bucket model, the write guard, and the `kv.ts` collapse all earn their keep and are consumed across every app. This trims three surfaces around it that were built for states that cannot occur, that re-read more than they need, or that duplicate a system the workspace already owns.

## Bulk add cannot be refused, so it no longer pretends it can

`entries_bulk_create` builds every row with a fresh `generateId()`, so a `bulkSet` over it can never collide with a stored row and never refuses. The modal still carried a per-reason refusal map, a `byReason` aggregation, and a "skipped N" warning toast for that path (its own comment already admitted the case was impossible). The action owns the fresh-id invariant, so it reports a clean count and the modal reports a simple success:

```ts
// action
await tables.entries.bulkSet(rows);
return { count: rows.length };

// modal
const { count } = await fuji.collaboration.actions.entries_bulk_create({ ... });
toast.success(`Added ${count} ${count === 1 ? 'entry' : 'entries'}`);
```

No user-visible behavior is lost: the removed toast branch could not fire.

## `fromTable` keeps its issue buckets without re-scanning the table

The observe loop already reads each changed id with `get(id)`, which returns either the conforming row or the same classified error `scan()` would have bucketed it under. It was discarding that error and instead scheduling a debounced full `table.scan()` (an O(n) re-parse) to rebuild `nonconforming` / `newerWriter` / `unreadable`. Every `fromTable` consumer paid that re-scan on each write burst, while only Fuji reads the buckets, and the `debounceMs` option had no callers.

The changed id is now routed into one of three `SvelteMap`s in the same loop and exposed as memoized `$derived` array views:

```ts
const { data: row, error } = table.get(id);
if (!error) { row === null ? map.delete(id) : map.set(id, row); continue; }
map.delete(id);
if (error.name === 'NewerWriter') newerWriter.set(id, error);
else if (error.name === 'UnreadableRow') unreadable.set(id, error);
else nonconforming.set(id, error);
```

The buckets now update instantly and granularly, matching the row map and the Yjs delta-observe pattern (incremental per-key application, not a full re-read). The timer, the full scan, and the `debounceMs` option are gone. The public `ReactiveTableMap` shape and every call site (`fromTable(x.tables.y)`) are unchanged.

## The conformance page refuses one-click repair

`repairEntry` was a second hand-written copy of the `Entry` schema: twelve fields of bespoke coercion over the raw stored value, plus two unsafe casts (`error.row as Record<string, unknown>` and a string `as IanaTimeZone`). It ran only when a user opened Needs Attention and clicked Repair on a nonconforming row, so it was rarely-exercised code that drifts silently the moment the schema gains a field, and it restamped the current version while defaulting whatever did not fit, which can blank data behind a success toast.

Schema evolution belongs to the migration system (the `_v` tuple and `migrate` functions), not a per-row UI button. The workspace already refuses a `repair()` for the same reason. Nonconforming rows stay listed as intact-but-hidden with a discard action; the copy now points at the schema instead of offering a coerce:

> The data is intact but kept out of your lists because it does not match the current schema. It stays stored and untouched; discard removes the entry permanently.

Removing the function also clears both unsafe casts and the now-dead `toastOnError`, `Wrench`, `DateTimeString`, `IanaTimeZone`, and `Entry` imports.
