### PR TITLE
fix(apps): serve app-root workspace modules in honeycrisp and opensidian dev

### DIFF
--- a/apps/honeycrisp/vite.config.ts
+++ b/apps/honeycrisp/vite.config.ts
@@ -1,4 +1,5 @@
 import { APPS } from '@epicenter/constants/apps';
+import { workspaceAppFsAllow } from '@epicenter/constants/vite-config';
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
@@ -11,5 +12,6 @@ export default defineConfig({
 	server: {
 		port: APPS.HONEYCRISP.port,
 		strictPort: true,
+		fs: { allow: workspaceAppFsAllow() },
 	},
 });

--- a/apps/opensidian/vite.config.ts
+++ b/apps/opensidian/vite.config.ts
@@ -1,4 +1,5 @@
 import { APPS } from '@epicenter/constants/apps';
+import { workspaceAppFsAllow } from '@epicenter/constants/vite-config';
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
@@ -26,6 +27,7 @@ export default defineConfig({
 	server: {
 		port: APPS.OPENSIDIAN.port,
 		strictPort: true,
+		fs: { allow: workspaceAppFsAllow() },
 		headers: {
 			// Required for SharedArrayBuffer (used by @libsql WASM worker)
 			'Cross-Origin-Opener-Policy': 'same-origin',

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -15,6 +15,7 @@
 		"./auth": "./src/auth.ts",
 		"./oauth": "./src/oauth.ts",
 		"./vite": "./src/vite.ts",
+		"./vite-config": "./src/vite-config.ts",
 		"./versions": "./src/versions.ts",
 		"./ai-chat-errors": "./src/ai-chat-errors.ts",
 		"./api-routes": "./src/api-routes.ts",

--- a/packages/constants/src/vite-config.ts
+++ b/packages/constants/src/vite-config.ts
@@ -1,0 +1,17 @@
+import { searchForWorkspaceRoot } from 'vite';
+
+/**
+ * `server.fs.allow` for a workspace app whose package contract (`<app>.ts`)
+ * and browser composition (`<app>.browser.ts`) live at the app root, outside
+ * `src/`, as the app's `.` / `./browser` package exports.
+ *
+ * SvelteKit's default fs.allow does not reach app-root files, so dev requests
+ * for them (e.g. `/<app>.browser.ts`) are denied with a 403 Restricted without
+ * this entry. Note: setting `allow` REPLACES the default, so it must also span
+ * sibling workspace package source served over `/@fs`; the workspace root
+ * covers both. Narrowing to just the app dir (`process.cwd()`) serves the
+ * app-root modules but re-breaks sibling packages, so use the workspace root.
+ */
+export function workspaceAppFsAllow(): string[] {
+	return [searchForWorkspaceRoot(process.cwd())];
+}


### PR DESCRIPTION
Honeycrisp and Opensidian keep their package contract (`<app>.ts`) and browser composition (`<app>.browser.ts`) at the app root, outside `src/`, as the package's `.` and `./browser` exports. But neither dev server widened `server.fs.allow` to reach those files, and SvelteKit's default denies app-root paths, so a signed-in route 403'd on `/<app>.browser.ts` (and `/<app>.ts`) the moment the client tried to load the workspace browser layer in local dev.

This adds a shared `workspaceAppFsAllow()` helper in `@epicenter/constants/vite-config` and applies it in both apps. The helper documents, once, the subtle part: setting `allow` REPLACES SvelteKit's default, so it must also span sibling workspace package source served over `/@fs`, which is why it uses the workspace root rather than just the app dir (narrowing to `process.cwd()` re-breaks the siblings).

Verified with a dev server before and after: `/<app>.browser.ts` and `/<app>.ts` go from 403 to 200, and sibling `packages/*` source still serves 200.

## Changelog

- Honeycrisp and Opensidian local dev servers now serve their app-root workspace modules, so signed-in routes load correctly in `bun dev`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783927814&installation_id=128463665&pr_number=1942&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1942&signature=4b1d010245a6cdf0465627c8132baa7add6f7d75232dec9bf0fbfe4940153325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->