### PR TITLE
feat(matter): sandbox-first dev workflow

### DIFF
--- a/apps/matter/.gitignore
+++ b/apps/matter/.gitignore
@@ -16,6 +16,9 @@ Thumbs.db
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
+# Disposable dev sandbox seeded by `dev:fixture` (a throwaway copy of the sample fixture)
+.dev-vault/
+
 # Matter's derived SQLite index (sits next to each vault's matter.json, rebuilt from files)
 *.sqlite
 *.sqlite-journal

--- a/apps/matter/README.md
+++ b/apps/matter/README.md
@@ -157,7 +157,29 @@ updates instantly, only set membership waits for the reconcile plus the re-query
 ## Developing
 
 ```sh
-bun run tauri dev      # desktop app (talks to Tauri directly, no platform seam)
+bun run tauri dev      # desktop app, empty (open a folder via the picker)
 cargo test             # in src-tauri: runs Rust tests AND regenerates FileDelta.ts
 bun run typecheck
 ```
+
+Matter writes your edits back to disk, so the dev loop runs against a **disposable
+sandbox**, never your real files. `dev:fixture` copies the sample fixture into a
+gitignored sandbox (`apps/matter/.dev-vault`) and launches the app, so every edit
+and the `matter.sqlite` mirror it drops land on throwaway files:
+
+```sh
+bun run dev:fixture          # copy the sample fresh, then open Matter
+bun run dev:fixture --keep   # reuse the existing sandbox (keep what you typed)
+```
+
+Open the printed sandbox path in the folder picker. The app persists open folders
+by path, so you only pick it once: the stable sandbox path keeps working across
+resets and reloads. By default the script re-copies on every launch, so you always
+start from known state. The sample (`examples/matter/sample-vault/drafts`) covers
+every conformance category (valid, invalid, unparseable, no-frontmatter), so one
+fixture is enough.
+
+A **real** folder opens the exact same way: pick it in the picker (it watches one
+flat folder with its own `matter.json`, edits write to those actual files, and it
+persists across reloads, so you only pick it once). The app needs no dev-only mode
+to tell the two apart, the sandbox is just a folder you opened.

--- a/apps/matter/package.json
+++ b/apps/matter/package.json
@@ -6,6 +6,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
+		"dev:fixture": "bun scripts/dev-fixture.ts",
 		"build": "vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/apps/matter/scripts/dev-fixture.ts
+++ b/apps/matter/scripts/dev-fixture.ts
@@ -1,0 +1,55 @@
+/**
+ * The dev loop: prepare a DISPOSABLE sandbox, then open Matter on it.
+ *
+ * Matter writes your edits back to disk, so opening the committed sample directly
+ * would dirty the git tree the moment you touch a cell. This copies the sample
+ * fixture into a gitignored sandbox (`apps/matter/.dev-vault`) and launches the
+ * app, so every edit, and the `matter.sqlite` mirror it drops next to
+ * `matter.json`, lands on throwaway files.
+ *
+ *   bun run dev:fixture          # copy the sample fresh, then open Matter
+ *   bun run dev:fixture --keep   # reuse the existing sandbox (keep what you typed)
+ *
+ * Open the printed sandbox path in Matter's folder picker. The app persists open
+ * folders by path, so you only pick it once: the stable sandbox path keeps working
+ * across resets and reloads. Real folders open the exact same way, so the app needs
+ * no dev-only code to know about the sandbox.
+ *
+ * Fresh-copies on every launch by default, so you always start from known state.
+ * The sample lives at `examples/matter/sample-vault/drafts` and covers every
+ * conformance category (valid, invalid, unparseable, no-frontmatter), so one
+ * fixture is enough.
+ */
+
+import { existsSync } from 'node:fs';
+import { cp, rm } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+const appRoot = resolve(import.meta.dir, '..');
+const repoRoot = resolve(appRoot, '../..');
+const source = join(repoRoot, 'examples/matter/sample-vault/drafts');
+const sandbox = join(appRoot, '.dev-vault');
+
+const keep = Bun.argv.includes('--keep');
+
+if (!existsSync(source)) {
+	console.error(`Sample fixture is missing: ${source}`);
+	process.exit(1);
+}
+
+if (keep && existsSync(sandbox)) {
+	console.log(`Reusing Matter sandbox (--keep): ${sandbox}`);
+} else {
+	await rm(sandbox, { recursive: true, force: true });
+	await cp(source, sandbox, { recursive: true });
+	console.log(`Seeded Matter sandbox from the sample: ${sandbox}`);
+}
+
+console.log(
+	`Open this folder in Matter's picker (you only pick it once): ${sandbox}`,
+);
+
+// Stream the dev server to this terminal and exit with its code (no throw on a
+// non-zero exit like Ctrl+C), matching the house dev-launcher in apps/api/scripts.
+const dev = await Bun.$`bun run tauri dev`.nothrow();
+process.exit(dev.exitCode);


### PR DESCRIPTION
Matter writes your edits back to disk, so the dev loop must never open files you care about by default. This makes the dev loop run against a disposable sandbox and keeps every folder, sandbox or real, opened the same explicit way: through the picker.

`dev:fixture` copies the committed sample into a gitignored `apps/matter/.dev-vault` and launches the app, so every edit, and the `matter.sqlite` mirror it drops, lands on throwaway files:

```sh
bun run dev:fixture          # copy the sample fresh, then open Matter
bun run dev:fixture --keep   # reuse the sandbox (keep what you typed)
```

It re-copies on each launch, so you always start from known state. The sample already covers every conformance category (valid, invalid, unparseable, no-frontmatter), so a single fixture is enough.

Open the printed sandbox path in the folder picker. The app already persists open folders by path, and the sandbox path is stable, so you pick it once and it survives every reset and reload. A real folder opens identically.

This deliberately adds no dev-only code to the app. An earlier spike injected the sandbox through a `VITE_MATTER_DEV_VAULT` env hook, which wove a dev id, seed/filter passes, a getter, and a redirect effect through `open-vaults` (the durable state module) just to skip that one first pick. Not worth it: production code stays unaware of dev, and the workflow lives entirely in `dev:fixture` plus config and docs.