### PR TITLE
chore(api): drop the dead grok provider label

### DIFF
--- a/apps/api/worker/billing/ai-model-pricing.ts
+++ b/apps/api/worker/billing/ai-model-pricing.ts
@@ -95,7 +95,7 @@ export const MODEL_CREDITS = {
  *  rather than guessed at, so a misclassification never quietly ships. */
 export function providerOf(
 	model: string,
-): 'OpenAI' | 'Google' | 'xAI' | 'Unknown' {
+): 'OpenAI' | 'Google' | 'Unknown' {
 	if (
 		model.startsWith('gpt') ||
 		model.startsWith('o1') ||
@@ -108,6 +108,5 @@ export function providerOf(
 		return 'OpenAI';
 	}
 	if (model.startsWith('gemini')) return 'Google';
-	if (model.startsWith('grok')) return 'xAI';
 	return 'Unknown';
 }

--- a/apps/api/worker/billing/ai-model-pricing.ts
+++ b/apps/api/worker/billing/ai-model-pricing.ts
@@ -93,9 +93,7 @@ export const MODEL_CREDITS = {
 /** Coarse provider classification used by the dashboard model-cost
  *  table. Models that do not match any prefix are labeled "Unknown"
  *  rather than guessed at, so a misclassification never quietly ships. */
-export function providerOf(
-	model: string,
-): 'OpenAI' | 'Google' | 'Unknown' {
+export function providerOf(model: string): 'OpenAI' | 'Google' | 'Unknown' {
 	if (
 		model.startsWith('gpt') ||
 		model.startsWith('o1') ||

--- a/apps/api/worker/billing/contracts.ts
+++ b/apps/api/worker/billing/contracts.ts
@@ -143,7 +143,7 @@ export type PortalSession = {
 export type ModelCostGuide = {
 	models: Array<{
 		model: string;
-		provider: 'OpenAI' | 'Google' | 'xAI' | 'Unknown';
+		provider: 'OpenAI' | 'Google' | 'Unknown';
 		credits: number;
 	}>;
 };


### PR DESCRIPTION
`providerOf()` labels a model's provider for the billing dashboard's cost table. Its `grok -> xAI` branch is dead: no grok model reaches billing now that the pickers dropped grok and the `/api/ai` validator rejects it, so the branch never fires and `'xAI'` is never returned.

Remove the branch and the now-unreachable `'xAI'` member from both the function's return type and the `ModelCostGuide` contract. No consumer matches on `'xAI'` (it appeared only in the type), and the narrowed return type stays assignable to the contract.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783928041&installation_id=128463665&pr_number=1944&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1944&signature=93d0d7c9e25d9b392e7b6db85d7a69bd06f5457961e8b14d84ed4f70668b418f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->