### PR TITLE
perf(whispering): force CPU execution provider for ONNX engines on macOS

### DIFF
--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -141,6 +141,18 @@ pub async fn run() {
     #[cfg(target_os = "windows")]
     transcribe_rs::accel::set_ort_accelerator(transcribe_rs::accel::OrtAccelerator::DirectMl);
 
+    // On macOS, force the CPU execution provider for the ONNX engines
+    // (Parakeet, Moonshine). The default `Auto` selects CoreML, but our models
+    // are int8-quantized and CoreML cannot run the int8 ops (ConvInteger,
+    // DynamicQuantizeLinear): it silently falls back to CPU for them anyway,
+    // then adds Metal context setup plus partition-boundary copies on top.
+    // Benchmarks on parakeet-tdt-0.6b-v3-int8 measured CPU at ~3.5 us/sample
+    // versus ~12 us/sample warm on CoreML (about 3x faster), and CPU also
+    // silences the macOS "Context leak detected" GPU log spam. Prefer an fp16
+    // model if you ever want genuine CoreML or Neural Engine acceleration.
+    #[cfg(target_os = "macos")]
+    transcribe_rs::accel::set_ort_accelerator(transcribe_rs::accel::OrtAccelerator::CpuOnly);
+
     let log_plugin = tauri_plugin_log::Builder::new()
         .level(log::LevelFilter::Info)
         .level_for("whispering::transcription", log::LevelFilter::Debug)

--- a/apps/whispering/src-tauri/src/transcription/model_manager.rs
+++ b/apps/whispering/src-tauri/src/transcription/model_manager.rs
@@ -282,6 +282,7 @@ impl ModelManager {
         let model_path = self
             .model_path_for(&config)
             .map_err(|message| TranscriptionError::ConfigError { message })?;
+        let inference_started = std::time::Instant::now();
         let transcript = match config.engine {
             EngineKind::Whispercpp => {
                 let mut params = WhisperInferenceParams::default();
@@ -326,9 +327,10 @@ impl ModelManager {
         };
 
         info!(
-            "[Transcription] {:?} transcription complete: characters={}",
+            "[Transcription] {:?} transcription complete: characters={} elapsed_ms={}",
             config.engine,
-            transcript.len()
+            transcript.len(),
+            inference_started.elapsed().as_millis(),
         );
         self.evict_if_immediate(config.unload_policy, generation);
         Ok(transcript)


### PR DESCRIPTION
On macOS, Whispering's ONNX engines (Parakeet, Moonshine) defaulted to `OrtAccelerator::Auto`, which selects the CoreML execution provider. That sounds like the fast path, but for the int8-quantized models we ship it is the slow one.

CoreML cannot execute the int8 operators that dominate these graphs (`ConvInteger`, `DynamicQuantizeLinear`). ONNX Runtime silently falls back to CPU for those nodes, so the heavy math runs on CPU either way. On top of that you pay for CoreML's Metal context setup and a memory copy at every CPU/CoreML partition boundary. Net result: "CoreML" does the same CPU work as pure CPU, plus overhead.

Forcing the CPU-only provider on macOS removes that overhead. Measured on `parakeet-tdt-0.6b-v3-int8`, normalized to microseconds per audio sample so clip length does not skew the comparison:

| Provider | warm throughput | relative |
| --- | --- | --- |
| CoreML (`Auto`, before) | ~12 us/sample | 1x |
| CPU (this PR) | ~3.5 us/sample | ~3x faster |

Cold CoreML runs, which also pay first-inference graph warmup, were closer to ~24 us/sample.

It also silences the macOS `Context leak detected, msgtracer returned -1` log lines. Those came from the CoreML Metal context, not from anything in Whispering or transcribe-rs, and never reached the app log file (they go straight to stderr), so this is a developer-console cleanup, not a user-facing log change.

This only forces CPU; it does not drop the `ort-coreml` feature, so an fp16 model could opt back into genuine CoreML or Neural Engine acceleration later. Windows keeps its explicit DirectML selection and Linux is unaffected.

A note for anyone downstream on transcribe-rs (hi, Handy): if you ship int8 Parakeet or Moonshine and leave the accelerator on `Auto`, you are very likely on this same slow CoreML path. Setting `OrtAccelerator::CpuOnly` on macOS is a one-line change that gave us roughly 3x. If you want the Neural Engine to actually earn its keep, ship an fp16 model rather than int8, since fp16 is the precision CoreML can run.

The transcription-complete log line now also reports `elapsed_ms`, so anyone can reproduce this comparison from their own logs (pair it with `ORT_LOG_SEVERITY_LEVEL=0` to confirm which provider ONNX Runtime selected).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783955327&installation_id=128463665&pr_number=1946&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1946&signature=ec44a0403efbfc0d25fbdd1d336d4c3c88c8754fa63ac21bc1bf6012d8a2c4a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->