### PR TITLE
feat(whispering)!: record timezone with recordings

### DIFF
--- a/apps/whispering/src/lib/operations/pipeline.ts
+++ b/apps/whispering/src/lib/operations/pipeline.ts
@@ -1,3 +1,5 @@
+import { InstantString } from '@epicenter/field';
+import { IanaTimeZone } from '@epicenter/workspace';
 import { extractErrorMessage } from 'wellcrafted/error';
 import { goto } from '$app/navigation';
 import {
@@ -42,7 +44,7 @@ export async function processRecordingPipeline({
 	durationMs,
 	deliverySource = 'recording',
 }: PipelineInput) {
-	const now = new Date().toISOString();
+	const now = InstantString.now();
 	const recordingId =
 		source.kind === 'artifact' ? source.artifact.id : source.recordingId;
 
@@ -50,6 +52,7 @@ export async function processRecordingPipeline({
 		id: recordingId,
 		title: '',
 		recordedAt: now,
+		recordedAtZone: IanaTimeZone.current(),
 		updatedAt: now,
 		transcript: '',
 		duration: durationMs,
@@ -69,7 +72,7 @@ export async function processRecordingPipeline({
 			recordings.update(recordingId, {
 				transcription: {
 					status: 'failed',
-					completedAt: new Date().toISOString(),
+					completedAt: InstantString.now(),
 					error: extractErrorMessage(saveError),
 				},
 			});

--- a/apps/whispering/src/lib/operations/transcribe.ts
+++ b/apps/whispering/src/lib/operations/transcribe.ts
@@ -1,3 +1,4 @@
+import { InstantString } from '@epicenter/field';
 import { stat } from '@tauri-apps/plugin-fs';
 import {
 	type AnyTaggedError,
@@ -200,7 +201,7 @@ export async function transcribeAndPersist(
 		recordings.update(recordingId, {
 			transcription: {
 				status: 'failed',
-				completedAt: new Date().toISOString(),
+				completedAt: InstantString.now(),
 				error: extractErrorMessage(error),
 			},
 		});
@@ -210,7 +211,7 @@ export async function transcribeAndPersist(
 		transcript: transcribedText,
 		transcription: {
 			status: 'completed',
-			completedAt: new Date().toISOString(),
+			completedAt: InstantString.now(),
 		},
 	});
 	return Ok(transcribedText);

--- a/apps/whispering/src/lib/operations/transform.ts
+++ b/apps/whispering/src/lib/operations/transform.ts
@@ -1,3 +1,4 @@
+import { InstantString } from '@epicenter/field';
 import { nanoid } from 'nanoid/non-secure';
 import {
 	defineErrors,
@@ -172,7 +173,7 @@ export async function runTransformation({
 		});
 	}
 
-	const now = new Date().toISOString();
+	const now = InstantString.now();
 	const runId = nanoid();
 
 	const transformationRun = {
@@ -196,7 +197,7 @@ export async function runTransformation({
 			stepId: step.id,
 			order: stepIndex,
 			input: currentInput,
-			startedAt: new Date().toISOString(),
+			startedAt: InstantString.now(),
 			result: null,
 		} satisfies TransformationStepRun;
 		transformationStepRuns.set(stepRun);
@@ -208,7 +209,7 @@ export async function runTransformation({
 
 		if (isErr(handleStepResult)) {
 			const stepError = extractErrorMessage(handleStepResult.error);
-			const failedNow = new Date().toISOString();
+			const failedNow = InstantString.now();
 			transformationStepRuns.set({
 				...stepRun,
 				result: {
@@ -234,7 +235,7 @@ export async function runTransformation({
 			...stepRun,
 			result: {
 				status: 'completed',
-				completedAt: new Date().toISOString(),
+				completedAt: InstantString.now(),
 				output: handleStepOutput,
 			},
 		});
@@ -246,7 +247,7 @@ export async function runTransformation({
 		...transformationRun,
 		result: {
 			status: 'completed',
-			completedAt: new Date().toISOString(),
+			completedAt: InstantString.now(),
 			output: currentInput,
 		},
 	} satisfies TransformationRun);

--- a/apps/whispering/src/lib/state/README.md
+++ b/apps/whispering/src/lib/state/README.md
@@ -33,6 +33,8 @@ settings.set('recording.mode', 'vad');
 Recording metadata backed by Yjs workspace table. SvelteMap provides per-key reactivity: updating one recording doesn't re-render the entire list. Audio blobs are not stored here because they are too large for CRDTs; use `$lib/rpc/audio` for playback URLs and `services.blobs.audio` for raw blob access.
 
 ```typescript
+import { InstantString } from '@epicenter/field';
+
 import { recordings } from '$lib/state/recordings.svelte';
 
 // Read recordings reactively
@@ -43,7 +45,7 @@ const sorted = recordings.sorted; // newest first
 recordings.set(recording);
 recordings.update(id, {
 	transcript,
-	transcription: { status: 'completed', completedAt: new Date().toISOString() },
+	transcription: { status: 'completed', completedAt: InstantString.now() },
 });
 recordings.delete(id);
 ```

--- a/apps/whispering/src/lib/state/transformations.svelte.ts
+++ b/apps/whispering/src/lib/state/transformations.svelte.ts
@@ -19,6 +19,7 @@
  * ```
  */
 
+import { InstantString } from '@epicenter/field';
 import { fromTable } from '@epicenter/svelte';
 import { nanoid } from 'nanoid/non-secure';
 import { whispering } from '#platform/whispering';
@@ -109,7 +110,7 @@ if (import.meta.hot) {
  * ```
  */
 export function generateDefaultTransformation(): Transformation {
-	const now = new Date().toISOString();
+	const now = InstantString.now();
 	return {
 		id: nanoid(),
 		title: '',
@@ -143,7 +144,7 @@ export function saveTransformationWithSteps(
 	whispering.ydoc.transact(() => {
 		transformations.set({
 			...transformation,
-			updatedAt: new Date().toISOString(),
+			updatedAt: InstantString.now(),
 		});
 		transformationSteps.deleteByTransformationId(transformation.id);
 		for (const [order, step] of steps.entries()) {

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -4,6 +4,7 @@ import {
 	defineKv,
 	defineTable,
 	defineWorkspace,
+	type IanaTimeZone,
 	type InferKvValue,
 	type InferTableRow,
 	nullable,
@@ -40,11 +41,11 @@ import {
 const TranscriptionOutcome = Type.Union([
 	Type.Object({
 		status: Type.Literal('completed'),
-		completedAt: Type.String(),
+		completedAt: field.instant(),
 	}),
 	Type.Object({
 		status: Type.Literal('failed'),
-		completedAt: Type.String(),
+		completedAt: field.instant(),
 		error: Type.String(),
 	}),
 ]);
@@ -59,8 +60,9 @@ const TranscriptionOutcome = Type.Union([
 const recordings = defineTable({
 	id: field.string(),
 	title: field.string(),
-	recordedAt: field.string(),
-	updatedAt: field.string(),
+	recordedAt: field.instant(),
+	recordedAtZone: field.string<IanaTimeZone>(),
+	updatedAt: field.instant(),
 	transcript: field.string(),
 	duration: nullable(field.number()),
 	transcription: nullable(field.json(TranscriptionOutcome)),
@@ -74,8 +76,8 @@ const transformations = defineTable({
 	id: field.string(),
 	title: field.string(),
 	description: field.string(),
-	createdAt: field.string(),
-	updatedAt: field.string(),
+	createdAt: field.instant(),
+	updatedAt: field.instant(),
 });
 
 /** Transformation row type inferred from the workspace table schema. */
@@ -139,13 +141,13 @@ export type TransformationStep = InferTableRow<typeof transformationSteps>;
  */
 const CompletedResult = Type.Object({
 	status: Type.Literal('completed'),
-	completedAt: Type.String(),
+	completedAt: field.instant(),
 	output: Type.String(),
 });
 
 const FailedResult = Type.Object({
 	status: Type.Literal('failed'),
-	completedAt: Type.String(),
+	completedAt: field.instant(),
 	error: Type.String(),
 });
 
@@ -163,7 +165,7 @@ const transformationRuns = defineTable({
 	transformationId: field.string(),
 	recordingId: nullable(field.string()),
 	input: field.string(),
-	startedAt: field.string(),
+	startedAt: field.instant(),
 	result: nullable(field.json(TransformationRunResult)),
 });
 
@@ -177,7 +179,7 @@ const transformationStepRuns = defineTable({
 	stepId: field.string(),
 	order: field.number(),
 	input: field.string(),
-	startedAt: field.string(),
+	startedAt: field.instant(),
 	result: nullable(field.json(TransformationRunResult)),
 });
 

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -44,7 +44,6 @@
 		getSortedRowModel,
 	} from '@tanstack/table-core';
 	import { type } from 'arktype';
-	import { format } from 'date-fns';
 	import { createRawSnippet } from 'svelte';
 	import TranscriptDialog from '$lib/components/copyable/TranscriptDialog.svelte';
 	import { PATHS } from '$lib/services/fs-paths';
@@ -60,18 +59,27 @@
 	import { RecordingRowActions } from './row-actions';
 
 	/**
-	 * Returns a cell renderer for a date/time column using date-fns format.
-	 *
-	 * @param formatString - date-fns format string
+	 * Returns a cell renderer for an instant, optionally using a row-owned
+	 * display timezone.
 	 */
-	function formattedCell(formatString: string) {
-		return ({ getValue }: { getValue: () => unknown }) => {
+	function formattedCell(getTimeZone?: (recording: Recording) => string) {
+		return ({
+			getValue,
+			row,
+		}: {
+			getValue: () => unknown;
+			row: { original: Recording };
+		}) => {
 			const value = getValue();
 			if (typeof value !== 'string' || !value) return '';
 			const date = new Date(value);
 			if (Number.isNaN(date.getTime())) return value;
 			try {
-				return format(date, formatString);
+				return new Intl.DateTimeFormat(undefined, {
+					dateStyle: 'medium',
+					timeStyle: 'short',
+					timeZone: getTimeZone?.(row.original),
+				}).format(date);
 			} catch {
 				return value;
 			}
@@ -81,7 +89,6 @@
 	const transcribeRecordings = createMutation(
 		() => rpc.transcription.transcribeRecordings.options,
 	);
-	const DATE_FORMAT = 'PP p'; // e.g., Aug 13, 2025, 10:00 AM
 
 	const columns = [
 		{
@@ -137,7 +144,7 @@
 					column,
 					headerText: 'Recorded',
 				}),
-			cell: formattedCell(DATE_FORMAT),
+			cell: formattedCell((recording) => recording.recordedAtZone),
 		},
 		{
 			accessorKey: 'updatedAt',
@@ -147,7 +154,7 @@
 					column,
 					headerText: 'Updated At',
 				}),
-			cell: formattedCell(DATE_FORMAT),
+			cell: formattedCell(),
 		},
 		{
 			accessorKey: 'transcript',

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -74,14 +74,24 @@
 			if (typeof value !== 'string' || !value) return '';
 			const date = new Date(value);
 			if (Number.isNaN(date.getTime())) return value;
+			const timeZone = getTimeZone?.(row.original);
+			const options: Intl.DateTimeFormatOptions = {
+				year: 'numeric',
+				month: 'short',
+				day: 'numeric',
+				hour: 'numeric',
+				minute: '2-digit',
+				timeZone,
+				...(timeZone ? { timeZoneName: 'short' } : {}),
+			};
 			try {
-				return new Intl.DateTimeFormat(undefined, {
-					dateStyle: 'medium',
-					timeStyle: 'short',
-					timeZone: getTimeZone?.(row.original),
-				}).format(date);
+				return new Intl.DateTimeFormat(undefined, options).format(date);
 			} catch {
-				return value;
+				return new Intl.DateTimeFormat(undefined, {
+					...options,
+					timeZone: undefined,
+					timeZoneName: undefined,
+				}).format(date);
 			}
 		};
 	}

--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/EditRecordingModal.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/EditRecordingModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { InstantString } from '@epicenter/field';
 	import { Button } from '@epicenter/ui/button';
 	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { Input } from '@epicenter/ui/input';
@@ -6,6 +7,7 @@
 	import * as Modal from '@epicenter/ui/modal';
 	import { Spinner } from '@epicenter/ui/spinner';
 	import { Textarea } from '@epicenter/ui/textarea';
+	import { TimezoneCombobox } from '@epicenter/ui/timezone-combobox';
 	import EditIcon from '@lucide/svelte/icons/pencil';
 	import { createQuery } from '@tanstack/svelte-query';
 	import { onDestroy } from 'svelte';
@@ -153,11 +155,29 @@
 					id="recordedAt"
 					value={workingCopy.recordedAt}
 					oninput={(e) => {
-						workingCopy = { ...workingCopy, recordedAt: e.currentTarget.value };
+						workingCopy = {
+							...workingCopy,
+							recordedAt: e.currentTarget.value as Recording['recordedAt'],
+						};
 						isWorkingCopyDirty = true;
 					}}
 					class="col-span-3"
 				/>
+			</div>
+			<div class="grid grid-cols-4 items-center gap-4">
+				<Label class="text-right">Recorded Timezone</Label>
+				<div class="col-span-3">
+					<TimezoneCombobox
+						bind:value={() => workingCopy.recordedAtZone,
+							(recordedAtZone) => {
+								workingCopy = {
+									...workingCopy,
+									recordedAtZone: recordedAtZone as Recording['recordedAtZone'],
+								};
+								isWorkingCopyDirty = true;
+							}}
+					/>
+				</div>
 			</div>
 			<div class="grid grid-cols-4 items-center gap-4">
 				<Label for="transcript" class="text-right">Transcript</Label>
@@ -201,13 +221,37 @@
 			</Button>
 			<Button
 				onclick={() => {
-				recordings.set($state.snapshot(workingCopy));
-				report.success({
-					title: 'Updated recording!',
-					description: 'Your recording has been updated successfully.',
-				});
-				isDialogOpen = false;
-			}}
+					const snapshot = $state.snapshot(workingCopy);
+					if (!InstantString.is(snapshot.recordedAt)) {
+						report.info({
+							title: 'Recorded At is not a valid instant',
+							description:
+								'Use a UTC ISO timestamp like 2026-06-13T16:20:00.000Z.',
+						});
+						return;
+					}
+
+					const { error } = recordings.update(recording.id, {
+						title: snapshot.title,
+						recordedAt: snapshot.recordedAt,
+						recordedAtZone: snapshot.recordedAtZone,
+						transcript: snapshot.transcript,
+					});
+
+					if (error) {
+						report.error({
+							title: 'Could not update recording',
+							cause: error,
+						});
+						return;
+					}
+
+					report.success({
+						title: 'Updated recording!',
+						description: 'Your recording has been updated successfully.',
+					});
+					isDialogOpen = false;
+				}}
 				disabled={!isWorkingCopyDirty}
 			>
 				Save


### PR DESCRIPTION
Whispering recordings now store the moment and the display zone separately. `recordedAt` remains a canonical UTC instant, and `recordedAtZone` carries the IANA timezone used to render that recording later.

Programmatic timestamp writers now use `InstantString.now()`, so transcription outcomes, transformation definitions, and transformation runs validate against `field.instant()` instead of arbitrary strings. The recordings table renders `recordedAt` in the row's stored zone and includes the zone abbreviation, while `updatedAt` stays viewer-local because it has no captured zone.

## Breaking

Recording rows must include `recordedAtZone`, and Whispering temporal fields now require canonical `field.instant()` values. This PR intentionally does not add a table migration; local rows from the previous shape that do not include the zone are invalid under the new clean-break schema.

```ts
// Before
{ recordedAt: "2026-06-13T16:20:00.000Z" }

// After
{
  recordedAt: "2026-06-13T16:20:00.000Z",
  recordedAtZone: "America/Los_Angeles",
}
```

## Changelog

- Add timezone-aware recording timestamps in Whispering
