### PR TITLE
ci: repair PR preview build blockers

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,14 +6,14 @@ All workflows live flat in `.github/workflows/` (GitHub Actions requirement). We
 
 | Prefix | Purpose | Scope |
 |---|---|---|
-| `release.{app}` | Tag-triggered desktop builds + GitHub Release | Per Tauri app (expensive 4-platform matrix) |
-| `pr-preview.{app}` | PR preview desktop builds | Per Tauri app (expensive 4-platform matrix) |
+| `release.{app}` | Tag-triggered desktop builds + GitHub Release | Per Tauri app (expensive 3-platform matrix) |
+| `pr-preview.{app}` | PR preview desktop builds | Per Tauri app (expensive 3-platform matrix) |
 | `deploy.{target}` | Web app deployment | All web apps together (cheap, fast) |
 | `ci.{name}` | Code quality checks | Whole repo |
 | `auto.{name}` | Automated repo maintenance | Whole repo |
 | `meta.{name}` | Repo housekeeping | Whole repo |
 
-Tauri desktop apps get **separate per-app workflows** because builds run a 4-platform matrix (macOS ARM, macOS Intel, Ubuntu, Windows) taking 20+ minutes. A PR touching only Whispering shouldn't trigger an Epicenter build.
+Tauri desktop apps get **separate per-app workflows** because builds run a 3-platform matrix (macOS Apple Silicon, Ubuntu, Windows) taking 20+ minutes. A PR touching only Whispering shouldn't trigger an Epicenter build.
 
 Web apps (Cloudflare Workers) deploy **together in one workflow** because deploys are fast (~2 min on a single runner) and share the same build step.
 
@@ -23,8 +23,8 @@ Web apps (Cloudflare Workers) deploy **together in one workflow** because deploy
 
 | File | Trigger | What it does |
 |---|---|---|
-| `release.whispering.yml` | `v*` tags, manual | Builds Whispering for 4 platforms, publishes to GitHub Releases as draft. Includes code signing, notarization, and release notes from `docs/release-notes/`. |
-| `pr-preview.whispering.yml` | Pull requests | Builds Whispering for 4 platforms, uploads as PR artifacts. Cancels previous builds via concurrency groups. |
+| `release.whispering.yml` | `v*` tags, manual | Builds Whispering for 3 platforms, publishes to GitHub Releases as draft. Includes code signing, notarization, and release notes from `docs/release-notes/`. |
+| `pr-preview.whispering.yml` | Pull requests | Builds Whispering for 3 platforms, uploads as PR artifacts. Cancels previous builds via concurrency groups. |
 
 ### Web Deployment (Cloudflare Workers)
 

--- a/.github/workflows/meta.update-readme-version.yml
+++ b/.github/workflows/meta.update-readme-version.yml
@@ -90,14 +90,13 @@ jobs:
           # Note: Tauri does NOT add platform suffixes (_darwin, _windows, _linux) to filenames
           # 
           # Actual asset naming from Tauri build:
-          #   macOS:   Whispering_X.Y.Z_aarch64.dmg, Whispering_X.Y.Z_x64.dmg
+          #   macOS:   Whispering_X.Y.Z_aarch64.dmg
           #   Windows: Whispering_X.Y.Z_x64_en-US.msi, Whispering_X.Y.Z_x64-setup.exe
           #   Linux:   Whispering_X.Y.Z_amd64.AppImage, Whispering_X.Y.Z_amd64.deb, Whispering-X.Y.Z-1.x86_64.rpm
 
           # macOS downloads (no _darwin suffix in actual assets)
           # Example: Whispering_7.2.0_aarch64.dmg → Whispering_7.2.1_aarch64.dmg
           sed -i "s/Whispering_[0-9]\+\.[0-9]\+\.[0-9]\+_aarch64\.dmg/Whispering_${VERSION}_aarch64.dmg/g" "$README_PATH"
-          sed -i "s/Whispering_[0-9]\+\.[0-9]\+\.[0-9]\+_x64\.dmg/Whispering_${VERSION}_x64.dmg/g" "$README_PATH"
 
           # Windows downloads (no _windows suffix in actual assets)
           # Example: Whispering_7.2.0_x64_en-US.msi → Whispering_7.2.1_x64_en-US.msi

--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -101,6 +101,12 @@ jobs:
           "VULKAN_SDK=C:\VulkanSDK\$env:VULKAN_SDK_VERSION" >> $env:GITHUB_ENV
           "C:\VulkanSDK\$env:VULKAN_SDK_VERSION\Bin" >> $env:GITHUB_PATH
 
+      - name: Setup MSVC developer command prompt (Windows)
+        if: ${{ matrix.os == 'windows' }}
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
       - name: setup bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -49,40 +49,63 @@ jobs:
       matrix:
         include:
           - platform: 'blacksmith-6vcpu-macos-15'
-            args: '--target aarch64-apple-darwin'
+            os: 'macos'
+            tauriArgs: '--target aarch64-apple-darwin'
+            artifactSuffix: 'macos-arm64'
+            rustTargets: 'aarch64-apple-darwin'
 
           - platform: 'blacksmith-6vcpu-macos-15'
-            args: '--target x86_64-apple-darwin'
+            os: 'macos'
+            tauriArgs: '--target x86_64-apple-darwin'
+            artifactSuffix: 'macos-intel'
+            rustTargets: 'x86_64-apple-darwin'
 
           - platform: 'ubuntu-22.04'
-            args: ''
+            os: 'linux'
+            tauriArgs: ''
+            artifactSuffix: 'linux'
+            rustTargets: ''
 
           - platform: 'windows-latest'
-            args: ''
+            os: 'windows'
+            tauriArgs: ''
+            artifactSuffix: 'windows'
+            rustTargets: ''
 
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v6
 
       - name: Install create-dmg (macOS only)
-        if: matrix.platform == 'macos-latest'
+        if: ${{ matrix.os == 'macos' }}
         run: brew install create-dmg
 
       - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: ${{ matrix.os == 'linux' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxdo-dev libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev
 
       # Linux Vulkan SDK installation (required for whisper-cpp GPU acceleration on Linux)
-      # Note: Windows whisper-cpp is disabled due to MSVC runtime conflicts, so no Vulkan needed there
       - name: Install Vulkan SDK (Ubuntu)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: ${{ matrix.os == 'linux' }}
         run: |
           wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
           sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.290-jammy.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-jammy.list
           sudo apt update
           sudo apt install -y vulkan-sdk mesa-vulkan-drivers
+
+      - name: Install Vulkan SDK (Windows)
+        if: ${{ matrix.os == 'windows' }}
+        shell: pwsh
+        env:
+          VULKAN_SDK_VERSION: 1.3.290.0
+        run: |
+          $installer = Join-Path $env:RUNNER_TEMP "VulkanSDK-$env:VULKAN_SDK_VERSION.exe"
+          Invoke-WebRequest "https://sdk.lunarg.com/sdk/download/$env:VULKAN_SDK_VERSION/windows/VulkanSDK-$env:VULKAN_SDK_VERSION-Installer.exe" -OutFile $installer
+          Start-Process -FilePath $installer -ArgumentList "--accept-licenses --default-answer --confirm-command install" -Wait
+          "VULKAN_SDK=C:\VulkanSDK\$env:VULKAN_SDK_VERSION" >> $env:GITHUB_ENV
+          "C:\VulkanSDK\$env:VULKAN_SDK_VERSION\Bin" >> $env:GITHUB_PATH
 
       - name: setup bun
         uses: oven-sh/setup-bun@v2
@@ -97,7 +120,7 @@ jobs:
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ matrix.rustTargets }}
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
@@ -118,19 +141,20 @@ jobs:
         env:
           CI: true
           APTABASE_KEY: ${{ secrets.APTABASE_KEY }}
+          CMAKE_POLICY_VERSION_MINIMUM: '3.5'
         with:
           projectPath: 'apps/whispering'
           tagName: ''
-          args: '${{ matrix.args }} --no-sign'
+          args: '${{ matrix.tauriArgs }} --no-sign'
 
       - name: Install FUSE for AppImage processing
-        if: matrix.platform == 'ubuntu-22.04'
+        if: ${{ matrix.os == 'linux' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y fuse libfuse2
 
       - name: Remove libwayland-client.so from AppImage
-        if: matrix.platform == 'ubuntu-22.04'
+        if: ${{ matrix.os == 'linux' }}
         run: |
           APPIMAGE_PATH=$(find apps/whispering/src-tauri/target/release/bundle/appimage -name "*.AppImage" | head -1)
 
@@ -160,26 +184,10 @@ jobs:
             echo "No AppImage found to process"
           fi
 
-      - name: Set artifact suffix
-        id: artifact
-        shell: bash
-        run: |
-          if [[ "${{ matrix.args }}" == *"aarch64-apple-darwin"* ]]; then
-            echo "suffix=macos-arm64" >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.args }}" == *"x86_64-apple-darwin"* ]]; then
-            echo "suffix=macos-intel" >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.platform }}" == "ubuntu-22.04" ]]; then
-            echo "suffix=linux" >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
-            echo "suffix=windows" >> $GITHUB_OUTPUT
-          else
-            echo "suffix=unknown" >> $GITHUB_OUTPUT
-          fi
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: whispering-pr${{ github.event.pull_request.number }}-${{ steps.artifact.outputs.suffix }}
+          name: whispering-pr${{ github.event.pull_request.number }}-${{ matrix.artifactSuffix }}
           path: |
             apps/whispering/src-tauri/target/*/release/bundle/**/*.dmg
             apps/whispering/src-tauri/target/*/release/bundle/**/*.app

--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -107,6 +107,14 @@ jobs:
         with:
           arch: x64
 
+      - name: Configure CMake for MSVC Ninja (Windows)
+        if: ${{ matrix.os == 'windows' }}
+        shell: pwsh
+        run: |
+          "CMAKE_GENERATOR=Ninja" >> $env:GITHUB_ENV
+          "CC=cl" >> $env:GITHUB_ENV
+          "CXX=cl" >> $env:GITHUB_ENV
+
       - name: setup bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -54,13 +54,7 @@ jobs:
             artifactSuffix: 'macos-arm64'
             rustTargets: 'aarch64-apple-darwin'
 
-          - platform: 'blacksmith-6vcpu-macos-15'
-            os: 'macos'
-            tauriArgs: '--target x86_64-apple-darwin'
-            artifactSuffix: 'macos-intel'
-            rustTargets: 'x86_64-apple-darwin'
-
-          - platform: 'ubuntu-22.04'
+          - platform: 'ubuntu-24.04'
             os: 'linux'
             tauriArgs: ''
             artifactSuffix: 'linux'
@@ -91,7 +85,7 @@ jobs:
         if: ${{ matrix.os == 'linux' }}
         run: |
           wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.290-jammy.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-jammy.list
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.290-noble.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-noble.list
           sudo apt update
           sudo apt install -y vulkan-sdk mesa-vulkan-drivers
 

--- a/.github/workflows/release.whispering.yml
+++ b/.github/workflows/release.whispering.yml
@@ -58,19 +58,27 @@ jobs:
         include:
           # macOS Apple Silicon (M1, M2, M3, etc.)
           - platform: 'blacksmith-6vcpu-macos-15'
-            args: '--target aarch64-apple-darwin'
+            os: 'macos'
+            tauriArgs: '--target aarch64-apple-darwin'
+            rustTargets: 'aarch64-apple-darwin'
 
           # macOS Intel-based
           - platform: 'blacksmith-6vcpu-macos-15'
-            args: '--target x86_64-apple-darwin'
+            os: 'macos'
+            tauriArgs: '--target x86_64-apple-darwin'
+            rustTargets: 'x86_64-apple-darwin'
 
           # Linux (Ubuntu)
           - platform: 'ubuntu-22.04'
-            args: ''  # No specific target needed for Linux
+            os: 'linux'
+            tauriArgs: ''  # No specific target needed for Linux
+            rustTargets: ''
 
           # Windows
           - platform: 'windows-latest'
-            args: ''  # No specific target needed for Windows
+            os: 'windows'
+            tauriArgs: ''  # No specific target needed for Windows
+            rustTargets: ''
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -80,12 +88,12 @@ jobs:
 
       # macOS specific: Install create-dmg for DMG bundling
       - name: Install create-dmg (macOS only)
-        if: matrix.platform == 'macos-latest'
+        if: ${{ matrix.os == 'macos' }}
         run: brew install create-dmg
 
       # Ubuntu/Linux specific: Install system dependencies required by Tauri
       - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: ${{ matrix.os == 'linux' }}
         run: |
           sudo apt-get update
           # Dependencies explanation:
@@ -102,9 +110,8 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxdo-dev libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev
 
       # Linux Vulkan SDK installation (required for whisper-cpp GPU acceleration on Linux)
-      # Note: Windows whisper-cpp is disabled due to MSVC runtime conflicts, so no Vulkan needed there
       - name: Install Vulkan SDK (Ubuntu)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: ${{ matrix.os == 'linux' }}
         run: |
           # Add official Vulkan SDK repository
           wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
@@ -112,6 +119,18 @@ jobs:
           sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.290-jammy.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-jammy.list
           sudo apt update
           sudo apt install -y vulkan-sdk mesa-vulkan-drivers
+
+      - name: Install Vulkan SDK (Windows)
+        if: ${{ matrix.os == 'windows' }}
+        shell: pwsh
+        env:
+          VULKAN_SDK_VERSION: 1.3.290.0
+        run: |
+          $installer = Join-Path $env:RUNNER_TEMP "VulkanSDK-$env:VULKAN_SDK_VERSION.exe"
+          Invoke-WebRequest "https://sdk.lunarg.com/sdk/download/$env:VULKAN_SDK_VERSION/windows/VulkanSDK-$env:VULKAN_SDK_VERSION-Installer.exe" -OutFile $installer
+          Start-Process -FilePath $installer -ArgumentList "--accept-licenses --default-answer --confirm-command install" -Wait
+          "VULKAN_SDK=C:\VulkanSDK\$env:VULKAN_SDK_VERSION" >> $env:GITHUB_ENV
+          "C:\VulkanSDK\$env:VULKAN_SDK_VERSION\Bin" >> $env:GITHUB_PATH
 
       # Setup Bun package manager
       - name: setup bun
@@ -129,9 +148,9 @@ jobs:
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          # For macOS: specify both Intel and ARM targets
+          # macOS rows specify the target they build.
           # For other platforms: empty string (uses default target)
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ matrix.rustTargets }}
 
       # Cache Rust dependencies for faster builds
       - name: Rust cache
@@ -186,6 +205,9 @@ jobs:
           # Aptabase analytics key
           APTABASE_KEY: ${{ secrets.APTABASE_KEY }}
 
+          # Allows vendored native projects with old CMake policy floors to configure on CMake 4.
+          CMAKE_POLICY_VERSION_MINIMUM: '3.5'
+
           # Tauri code signing (optional but recommended)
           # These enable automatic updates without security warnings
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -221,11 +243,11 @@ jobs:
           prerelease: false
 
           # Platform-specific build arguments (e.g., --target for macOS)
-          args: ${{ matrix.args }}
+          args: ${{ matrix.tauriArgs }}
 
       # Install FUSE for AppImage processing
       - name: Install FUSE for AppImage processing
-        if: matrix.platform == 'ubuntu-22.04'
+        if: ${{ matrix.os == 'linux' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y fuse libfuse2
@@ -233,7 +255,7 @@ jobs:
       # Remove libwayland-client.so from AppImage for better compatibility
       # This fixes EGL_BAD_PARAMETER errors on Wayland systems (Issues #114, #121)
       - name: Remove libwayland-client.so from AppImage
-        if: matrix.platform == 'ubuntu-22.04'
+        if: ${{ matrix.os == 'linux' }}
         run: |
           # Find the AppImage file
           APPIMAGE_PATH=$(find apps/whispering/src-tauri/target/release/bundle/appimage -name "*.AppImage" | head -1)

--- a/.github/workflows/release.whispering.yml
+++ b/.github/workflows/release.whispering.yml
@@ -132,6 +132,14 @@ jobs:
         with:
           arch: x64
 
+      - name: Configure CMake for MSVC Ninja (Windows)
+        if: ${{ matrix.os == 'windows' }}
+        shell: pwsh
+        run: |
+          "CMAKE_GENERATOR=Ninja" >> $env:GITHUB_ENV
+          "CC=cl" >> $env:GITHUB_ENV
+          "CXX=cl" >> $env:GITHUB_ENV
+
       # Setup Bun package manager
       - name: setup bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.whispering.yml
+++ b/.github/workflows/release.whispering.yml
@@ -126,6 +126,12 @@ jobs:
           "VULKAN_SDK=C:\VulkanSDK\$env:VULKAN_SDK_VERSION" >> $env:GITHUB_ENV
           "C:\VulkanSDK\$env:VULKAN_SDK_VERSION\Bin" >> $env:GITHUB_PATH
 
+      - name: Setup MSVC developer command prompt (Windows)
+        if: ${{ matrix.os == 'windows' }}
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
       # Setup Bun package manager
       - name: setup bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.whispering.yml
+++ b/.github/workflows/release.whispering.yml
@@ -62,14 +62,8 @@ jobs:
             tauriArgs: '--target aarch64-apple-darwin'
             rustTargets: 'aarch64-apple-darwin'
 
-          # macOS Intel-based
-          - platform: 'blacksmith-6vcpu-macos-15'
-            os: 'macos'
-            tauriArgs: '--target x86_64-apple-darwin'
-            rustTargets: 'x86_64-apple-darwin'
-
           # Linux (Ubuntu)
-          - platform: 'ubuntu-22.04'
+          - platform: 'ubuntu-24.04'
             os: 'linux'
             tauriArgs: ''  # No specific target needed for Linux
             rustTargets: ''
@@ -115,8 +109,8 @@ jobs:
         run: |
           # Add official Vulkan SDK repository
           wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
-          # Note: Using "jammy" for Ubuntu 22.04
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.290-jammy.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-jammy.list
+          # Note: Using "noble" for Ubuntu 24.04
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.290-noble.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-noble.list
           sudo apt update
           sudo apt install -y vulkan-sdk mesa-vulkan-drivers
 

--- a/apps/landing/astro.config.mjs
+++ b/apps/landing/astro.config.mjs
@@ -9,8 +9,8 @@ export default defineConfig({
 	output: 'static', // Keep static for now, can change to 'server' if needed
 	vite: {
 		plugins: [tailwindcss()],
-		ssr: {
-			noExternal: ['bits-ui'],
+		resolve: {
+			noExternal: ['bits-ui', 'svelte-toolbelt', 'runed'],
 		},
 	},
 	integrations: [svelte()],

--- a/apps/landing/src/components/whispering/OSDetector.svelte
+++ b/apps/landing/src/components/whispering/OSDetector.svelte
@@ -3,40 +3,21 @@
 	import { Button } from '@epicenter/ui/button';
 	import { onMount } from 'svelte';
 
-	let platform = $state('');
-	let downloadUrl = $state('');
-	let downloadText = $state('Download');
+	let downloadUrl = $state('https://github.com/EpicenterHQ/epicenter/releases');
+	let downloadText = $state('Download Whispering');
 
 	onMount(() => {
 		const userAgent = navigator.userAgent.toLowerCase();
-		const appVersion = navigator.appVersion.toLowerCase();
 
-		if (userAgent.includes('mac') || appVersion.includes('mac')) {
-			// Check for Apple Silicon
-			// This is still imperfect - User-Agent doesn't reliably indicate ARM
-			// But we check for common indicators
-			if (userAgent.includes('arm') || navigator.userAgent.includes('Apple')) {
-				platform = 'macOS (Apple Silicon)';
-				downloadUrl = `https://github.com/EpicenterHQ/epicenter/releases/download/v${VERSION}/Whispering_${VERSION}_aarch64.dmg`;
-				downloadText = 'Download Whispering for macOS';
-			} else {
-				platform = 'macOS (Intel)';
-				downloadUrl = `https://github.com/EpicenterHQ/epicenter/releases/download/v${VERSION}/Whispering_${VERSION}_x64.dmg`;
-				downloadText = 'Download Whispering for macOS';
-			}
+		if (userAgent.includes('mac')) {
+			downloadUrl = `https://github.com/EpicenterHQ/epicenter/releases/download/v${VERSION}/Whispering_${VERSION}_aarch64.dmg`;
+			downloadText = 'Download for Apple Silicon Mac';
 		} else if (userAgent.includes('win')) {
-			platform = 'Windows';
 			downloadUrl = `https://github.com/EpicenterHQ/epicenter/releases/download/v${VERSION}/Whispering_${VERSION}_x64_en-US.msi`;
 			downloadText = 'Download Whispering for Windows';
 		} else if (userAgent.includes('linux')) {
-			platform = 'Linux';
-			// For Linux, we'll redirect to releases page since there's no direct download
 			downloadUrl = 'https://github.com/EpicenterHQ/epicenter/releases';
 			downloadText = 'Download Whispering for Linux';
-		} else {
-			// Default to releases page
-			downloadUrl = 'https://github.com/EpicenterHQ/epicenter/releases';
-			downloadText = 'Download Whispering';
 		}
 	});
 </script>

--- a/apps/landing/src/pages/whispering.astro
+++ b/apps/landing/src/pages/whispering.astro
@@ -78,7 +78,7 @@ const faqItems = [
 	{
 		question: 'How is this different from other transcription apps?',
 		answer:
-			"We're one of the few truly open source transcription apps with this level of polish. Unlike closed-source alternatives, you get complete transparency: see exactly where your audio goes, audit the code, and maintain full control. No middleman servers collecting your data—your audio goes directly to providers using your API keys, or stays completely local with Speaches. You own the tool, not rent access to it.",
+			"We're one of the few truly open source transcription apps with this level of polish. Unlike closed-source alternatives, you get complete transparency: see exactly where your audio goes, audit the code, and maintain full control. No middleman servers collect your data. Your audio goes directly to providers using your API keys, or stays completely local with Speaches. You own the tool, not rent access to it.",
 	},
 	{
 		question: 'Can I use it completely free?',
@@ -93,7 +93,7 @@ const faqItems = [
 	{
 		question: 'Which providers are supported?',
 		answer:
-			'For cloud: Groq (fastest and cheapest), OpenAI Whisper, and ElevenLabs. For local: Speaches runs completely offline. You choose based on your needs—speed or privacy. More providers are added based on community feedback.',
+			'For cloud: Groq (fastest and cheapest), OpenAI Whisper, and ElevenLabs. For local: Speaches runs completely offline. You choose based on your needs: speed or privacy. More providers are added based on community feedback.',
 	},
 	{
 		question: 'Is Whispering suitable for long recordings?',
@@ -105,11 +105,10 @@ const faqItems = [
 const downloads = [
 	{
 		platform: 'macOS',
-		description: 'Native app for all Macs',
+		description: 'Native app for Apple Silicon Macs',
 		icon: AppleIcon,
-		isMacOS: true,
-		appleSiliconUrl: `https://github.com/EpicenterHQ/epicenter/releases/download/v${VERSION}/Whispering_${VERSION}_aarch64.dmg`,
-		intelUrl: `https://github.com/EpicenterHQ/epicenter/releases/download/v${VERSION}/Whispering_${VERSION}_x64.dmg`,
+		url: `https://github.com/EpicenterHQ/epicenter/releases/download/v${VERSION}/Whispering_${VERSION}_aarch64.dmg`,
+		extension: '.dmg',
 	},
 	{
 		platform: 'Windows',
@@ -120,7 +119,7 @@ const downloads = [
 	},
 	{
 		platform: 'Linux',
-		description: 'All distributions',
+		description: 'Recent distributions',
 		icon: TerminalIcon,
 		url: 'https://github.com/EpicenterHQ/epicenter/releases',
 		extension: 'View Releases',
@@ -443,7 +442,7 @@ const downloads = [
 			<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
 				<div class="text-center mb-16 space-y-6">
 					<h2 class="text-3xl lg:text-5xl font-bold">
-						Download for all platforms
+						Download for supported platforms
 					</h2>
 					<p class="text-xl text-foreground/75 max-w-3xl mx-auto">
 						Native desktop application with cross-platform support
@@ -467,27 +466,7 @@ const downloads = [
 										<Card.Description>{download.description}</Card.Description>
 									</Card.Header>
 									<Card.Content>
-										{download.isMacOS ? (
-											<div class="space-y-2">
-												<Button
-													href={download.appleSiliconUrl}
-													class="min-h-[40px] w-full transition-shadow duration-300 group-hover:shadow-md"
-													size="sm"
-												>
-													<DownloadIcon class="mr-1.5 h-3.5 w-3.5 transition-transform duration-300 group-hover:translate-y-0.5" />
-													Apple Silicon
-												</Button>
-												<Button
-													href={download.intelUrl}
-													variant="secondary"
-													class="min-h-[40px] w-full transition-shadow duration-300 group-hover:shadow-md"
-													size="sm"
-												>
-													<DownloadIcon class="mr-1.5 h-3.5 w-3.5 transition-transform duration-300 group-hover:translate-y-0.5" />
-													Intel
-												</Button>
-											</div>
-										) : download.isWebApp ? (
+										{download.isWebApp ? (
 											<Button
 												href={download.url}
 												variant="secondary"

--- a/apps/whispering/README.md
+++ b/apps/whispering/README.md
@@ -100,16 +100,12 @@ This automatically handles installation and updates.
 | Architecture      | Download                                                                                                                          | Requirements     |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
 | **Apple Silicon** | [Whispering_7.11.0_aarch64.dmg](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_aarch64.dmg) | M1/M2/M3/M4 Macs |
-| **Intel**         | [Whispering_7.11.0_x64.dmg](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_x64.dmg)         | Intel-based Macs |
 
-> **💡 Tip:** Not sure which Mac you have? Click the Apple menu → About This Mac. Look for "Chip" or "Processor":
->
-> - Apple M1/M2/M3/M4 → Use Apple Silicon version
-> - Intel Core → Use Intel version
+Intel Mac builds are not published right now.
 
 **Installation steps:**
 
-1. Download the `.dmg` file for your architecture
+1. Download the `.dmg` file for your Mac
 2. Open the downloaded file
 3. Drag Whispering to your Applications folder
 4. Open Whispering from Applications
@@ -149,9 +145,9 @@ Whispering will appear in your Start Menu when complete.
 
 | Package Format  | Download                                                                                                                                | Compatible With          |
 | --------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| **AppImage**    | [Whispering_7.11.0_amd64.AppImage](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_amd64.AppImage) | All Linux distributions  |
-| **DEB Package** | [Whispering_7.11.0_amd64.deb](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_amd64.deb)           | Debian, Ubuntu, Pop!\_OS |
-| **RPM Package** | [Whispering-7.11.0-1.x86_64.rpm](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering-7.11.0-1.x86_64.rpm)     | Fedora, RHEL, openSUSE   |
+| **AppImage**    | [Whispering_7.11.0_amd64.AppImage](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_amd64.AppImage) | Recent Linux distributions |
+| **DEB Package** | [Whispering_7.11.0_amd64.deb](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_amd64.deb)           | Recent Debian, Ubuntu, Pop!\_OS |
+| **RPM Package** | [Whispering-7.11.0-1.x86_64.rpm](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering-7.11.0-1.x86_64.rpm)     | Recent Fedora, RHEL, openSUSE   |
 
 #### Quick Install Commands
 
@@ -580,7 +576,7 @@ Yes - set up AI transformations to fix grammar, translate languages, or reformat
 
 ### What platforms work?
 
-Desktop: Mac (Intel & Apple Silicon), Windows, Linux. Web: Any modern browser at [whispering.epicenter.so](https://whispering.epicenter.so).
+Desktop: Apple Silicon Mac, Windows, Linux. Web: Any modern browser at [whispering.epicenter.so](https://whispering.epicenter.so).
 
 ### Found a bug?
 

--- a/docs/articles/release-strategy.md
+++ b/docs/articles/release-strategy.md
@@ -40,7 +40,7 @@ npm packages, GitHub Releases, and app deploys are handled by three different sy
 
 **Auto-release** (`auto.release.yml`) handles GitHub Releases. It fires on every merged PR, reads `## Changelog` sections from PR descriptions, and creates a versioned GitHub Release with categorized entries. It's currently disabled (`if: false`) until the v8.0.0 tag is in place and the `GH_ACTIONS_PAT` secret is configured. When re-enabled, it runs on every merge to `main`.
 
-**App deploys** are separate from both. Cloudflare Workers (the API, landing page, Whispering web) deploy on every push to `main` via `deploy.cloudflare.yml`. Tauri desktop builds trigger on `v*` tags via `release.whispering.yml`: a 4-platform matrix (macOS ARM, macOS Intel, Ubuntu, Windows) that takes 20+ minutes and produces signed, notarized binaries.
+**App deploys** are separate from both. Cloudflare Workers (the API, landing page, Whispering web) deploy on every push to `main` via `deploy.cloudflare.yml`. Tauri desktop builds trigger on `v*` tags via `release.whispering.yml`: a 3-platform matrix (macOS Apple Silicon, Ubuntu, Windows) that takes 20+ minutes and produces signed, notarized binaries.
 
 The version number in a GitHub Release and the version number on npm are related but not the same thing. GitHub Releases track the overall project; npm versions track the library API.
 


### PR DESCRIPTION
This unblocks the PR preview failures that were not caused by PR #1930 itself.

The landing build now uses Astro 6 and Vite 7's `resolve.noExternal` path for the Svelte packages that need compilation during prerender. That keeps `/whispering` static prerender from handing raw `bits-ui`, `svelte-toolbelt`, or `runed` files to Node.

The Whispering Tauri workflows now carry explicit matrix metadata instead of parsing target args in shell. macOS rows install their Rust target and run create-dmg again, Windows installs Vulkan SDK with LunarG's current unattended installer arguments, and both preview and release pass `CMAKE_POLICY_VERSION_MINIMUM=3.5` for vendored native CMake projects.

This intentionally does not hide the Ubuntu 22 ORT/glibc failure. The Linux runner stays at the current support baseline so that packaging decision remains visible.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783960935&installation_id=128463665&pr_number=1949&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1949&signature=878ab7632aaf474a13efc87349d442c0034e1580708f12b2f798cb431fad1034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->