### PR TITLE
docs(skills): add worktree-hygiene and pr-collapse-review skills

### DIFF
--- a/.agents/skills/pr-collapse-review/SKILL.md
+++ b/.agents/skills/pr-collapse-review/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: pr-collapse-review
+description: Run an isolated collapse-oriented review of a pull request, branch, or recent merged change. Use when the user asks to review a PR for simplification, collapse recent PRs, check whether a change can delete more indirection, run the PR in a new worktree, or apply grounded cleanup fixes after a PR review. Composes with collapse-pass, git, post-implementation-review, and claude-code-consult when another model is requested.
+metadata:
+  author: epicenter
+  version: '1.0'
+---
+
+# PR Collapse Review
+
+Use this skill for PR-shaped collapse work: start from a pull request, branch,
+or recent merged change, isolate it in a worktree by default, then use
+`collapse-pass` to find and fix grounded simplifications.
+
+This skill owns the PR mechanics. `collapse-pass` owns the simplification
+posture and finding ritual.
+
+## Compose With
+
+- `collapse-pass`: required for the inlining posture, anti-cosmetic gate, smell catalog, and final report shape.
+- `git`: branch, worktree, staging, commit, and message conventions.
+- `post-implementation-review`: required before final handoff after edits.
+- `claude-code-consult`: optional when the user asks to consult Claude or another model.
+
+## Required Inputs
+
+Get one of these from the user or local context:
+
+- PR URL or PR number.
+- Branch name and base branch.
+- Recent merged PR count or commit range.
+
+If the base branch is unknown, infer it from the PR metadata, upstream tracking
+branch, or `origin/main` in that order.
+
+## Default Worktree
+
+Use a separate worktree unless the user explicitly asks to work in the current
+checkout.
+
+For a GitHub PR number:
+
+```bash
+git fetch origin
+git fetch origin pull/<number>/head:codex/pr-<number>-collapse-review
+git worktree add ../epicenter-pr-<number>-collapse codex/pr-<number>-collapse-review
+```
+
+For a named branch:
+
+```bash
+git fetch origin <branch>:codex/<branch>-collapse-review
+git worktree add ../epicenter-<branch-slug>-collapse codex/<branch>-collapse-review
+```
+
+Use a filesystem-safe `<branch-slug>` for the directory, replacing slashes with
+hyphens. Use a unique branch or directory suffix if either name already exists.
+Do not use a destructive git command to reset the user's active checkout.
+
+For recent merged PR sweeps, use one worktree and one branch for the sweep:
+
+```bash
+git worktree add ../epicenter-recent-pr-collapse -b codex/recent-pr-collapse origin/main
+```
+
+## Workflow
+
+1. Load `collapse-pass` before reviewing code. Read its required references before any edit.
+2. Create or enter the review worktree. Confirm branch, base, and target.
+3. Compute the changed files against base with `git diff --name-only <base>...HEAD`.
+4. Read changed files first, then direct callers, tests, owned docs, and upstream docs only when external behavior affects correctness.
+5. Before analysis, list every file read as an ASCII tree.
+6. Report grounded findings before editing:
+
+   ```txt
+   Finding N: <smell>
+   Inline check: <what mental inlining showed>
+   Fix: <proposed change>
+   What stays the same: <visible behavior, durable strings, blob layout>
+   ```
+
+7. Apply only findings that clear the evidence bar. Defer product, compatibility, or broad ownership questions with evidence.
+8. After edits, re-read every touched file and run `post-implementation-review`.
+9. Run targeted tests and typechecks for impacted packages. Use `bun`, never npm, yarn, pnpm, or npx.
+10. End with files read, findings fixed, findings deferred, verification, and any rejected collapse candidates.
+
+## Keep Going
+
+Continue until every grounded finding in the PR scope is fixed, rejected, or
+explicitly deferred with evidence. Stop early only when tests or typechecks
+cannot be restored in one follow-up, the remaining findings require product
+input, the user gave a budget, or three consecutive scoped files produce no
+findings.
+
+## Claude Consult
+
+Use `claude-code-consult` only when the user requests another model or when
+diversity of judgment clearly matters. Codex remains the harness: Claude may
+advise, scout, or edit only in an isolated worker worktree, and Codex verifies
+anything that lands.
+
+For PR collapse work, prefer two small consults over one broad consult:
+
+1. A pre-edit design or risk pass over the reported findings.
+2. A post-edit review pass over the final diff.
+
+## Guardrails
+
+- Do not silently fix structural concerns. Report them first.
+- Do not broaden from touched files into unrelated cleanup without evidence.
+- Do not change durable strings, schemas, or public contracts unless the user explicitly requested greenfield cleanup and the finding names why compatibility no longer earns its cost.
+- Do not stage, commit, push, or open a PR unless the user asks.
+- Do not leave the worktree dirty without reporting its path and state.
+
+## References
+
+Read [references/eval-notes.md](references/eval-notes.md) when tuning this
+skill's description, deciding whether it still earns its own skill, or adding a
+script after repeated runs.

--- a/.agents/skills/pr-collapse-review/references/eval-notes.md
+++ b/.agents/skills/pr-collapse-review/references/eval-notes.md
@@ -1,0 +1,55 @@
+# PR Collapse Review Eval Notes
+
+Use this file when tuning trigger behavior, checking whether this skill still
+earns its own place, or deciding whether to add a script.
+
+## Classification
+
+This is a process skill with light tool workflow mechanics.
+
+It should stay separate from `collapse-pass` because PR checkout, worktree
+isolation, changed-file scoping, and recent-PR sweeps are different triggers
+from package-wide collapse passes.
+
+## Source Material
+
+- PR 1930 collapse review transcript from June 13, 2026.
+- `collapse-pass` skill and references.
+- `skill-creator` guidance on repeatable project expertise, progressive disclosure, description tuning, and validation.
+- Agent Skills docs on real source material, compact skill bodies, trigger evals, and scripts.
+
+## Should Trigger
+
+- "Run a collapse review on https://github.com/EpicenterHQ/epicenter/pull/1930 in a fresh worktree."
+- "Can you check the last three merged PRs and find any asymmetric collapses?"
+- "Review this branch like PR 1930: inline helpers, report findings first, then fix the clear wins."
+- "Open a new worktree and grill this PR for dead wrappers and stale boundaries."
+
+## Should Not Trigger
+
+- "Run a collapse pass on packages/workspace." Use `collapse-pass`.
+- "Review my staged diff for bugs." Use normal code review or `post-implementation-review`.
+- "Create a PR title and body." Use `pull-request`.
+- "Teach me how git worktrees work." Answer directly or use a teaching skill.
+
+## Assertions
+
+A good run should:
+
+- Use a separate worktree by default unless the user opts out.
+- Compute scope from the PR, branch, or commit range.
+- Print files read as an ASCII tree before analysis.
+- Report findings before editing.
+- Fix only grounded findings and explicitly defer the rest.
+- Re-read touched files after edits.
+- Run targeted `bun` tests or typechecks for impacted packages.
+- End with worktree path, verification, fixed findings, deferred findings, and rejected collapse candidates.
+
+## No Script Yet
+
+Do not add a helper script until at least three real runs show the agent
+repeatedly gets worktree setup, PR checkout, or changed-file scoping wrong.
+
+If a script becomes necessary, it should be non-interactive, dry-run capable,
+use structured stdout, diagnostics on stderr, and accept explicit flags for PR,
+base, target branch, and worktree path.

--- a/.agents/skills/worktree-hygiene/SKILL.md
+++ b/.agents/skills/worktree-hygiene/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: worktree-hygiene
+description: Reap merged git worktrees and branches safely across the warp, codex, opencode, and conductor harnesses. Use when worktrees pile up, after a branch merges, when cleaning up `git worktree list`, removing an orphaned or detached worktree, or deciding whether a worktree is safe to delete. Not for creating branches or authoring commits (use the git skill).
+metadata:
+  author: epicenter
+  version: '1.0'
+---
+
+# Worktree Hygiene
+
+> **Related Skills**: [git](../git/SKILL.md) for branch creation, staging, and commit messages. [standalone-commits](../standalone-commits/SKILL.md) for reviewable units. [pull-request](../pull-request/SKILL.md) for merge strategy.
+
+Four harnesses (warp, codex, opencode, conductor) mint worktrees here and nothing reaps them, so they accumulate. The cure is to reap on close: when a branch lands, remove its worktree and delete the branch in the same motion. This skill is the safe procedure for doing that, one-off or as a periodic sweep.
+
+## The reap signal (and the trap)
+
+"Branch merged" is **not** sufficient to reap. A merged branch routinely carries live uncommitted edits in its working tree; removing it with `--force` destroys that work. The real signal is:
+
+```txt
+reap = (branch fully contained in origin/main)  AND  (working tree clean OR only throwaway dirt)
+```
+
+Use `git merge-base --is-ancestor <branch> origin/main` for containment: if true, every commit on the branch is in `origin/main`, which is airtight even when the branch sits on a stacked base. `git cherry origin/main <branch>` shows unmerged commits (`+` lines).
+
+## Audit procedure
+
+Fetch first if `origin/main` is stale, then classify every worktree:
+
+```bash
+cd <main-checkout>; base=origin/main
+git worktree list --porcelain | awk '/^branch /{print $2}' | sed 's#refs/heads/##' | while read b; do
+  [ -z "$b" ] && continue
+  ahead=$(git cherry "$base" "$b" 2>/dev/null | grep -c '^+')
+  if git merge-base --is-ancestor "$b" "$base" 2>/dev/null; then st="MERGED"; else st="$ahead unmerged"; fi
+  printf "%-50s %s\n" "$b" "$st"
+done
+```
+
+For each MERGED worktree, check its working tree with `git -C <path> status --porcelain` (no output = clean). Inspect dirty file lists before deciding: lockfile-only churn is throwaway; modified source or unique untracked files are real work. Detached-HEAD worktrees have no branch line; test their tip with `git merge-base --is-ancestor <sha> origin/main`.
+
+## Decide per worktree
+
+```txt
+merged + clean                 -> reap: git worktree remove <path>; git branch -d/-D <branch>
+merged + throwaway dirt only   -> reap: git worktree remove --force <path>; git branch -d/-D <branch>
+detached + merged + clean      -> reap: git worktree remove <path>   (no branch to delete)
+merged + REAL uncommitted work -> preserve. Branch or commit the work first; do not reap.
+detached + REAL uncommitted    -> anchor before anything: git -C <path> switch -c holding/<name>
+unmerged commits               -> leave alone (active work)
+```
+
+## Reaping is destructive: gate it
+
+`git worktree remove` and `git branch -d` are destructive (AGENTS.md: destructive actions need approval). For a sweep, present an approve-list of exact commands grouped by tier before running any of them. Never reap on a self-reported "it's merged"; run the audit yourself.
+
+- `git branch -d` refuses unless the branch is merged into the current HEAD. If local `main` lags `origin/main`, it will refuse a branch that is merged only on the remote; `-D` is then justified by the `merge-base --is-ancestor origin/main` proof.
+- `git worktree remove` can fail with `Directory not empty` when ignored files (node_modules, `.DS_Store`) remain. It still de-registers the worktree. Finish with `git worktree prune` then `rm -rf <path>`.
+- The harnesses spawn and mutate worktrees continuously, even mid-sweep. Re-run the audit at the end; treat reaping as ongoing discipline, not a one-time event.
+
+## Repo-specific worktree gotchas
+
+- **`git stash` is shared across all worktrees here.** A bare `git stash`/`stash pop` can grab another worktree's entry. Prefer explicit branches; avoid stash.
+- **Animal-named warp branches are stacked on unmerged bases**, cut from whatever was checked out rather than clean `origin/main`. Before opening a PR from one, run `git diff --stat origin/main...HEAD` and confirm scope; unrelated work rides along otherwise.
+- **Verify HEAD before committing in a worktree** (`git rev-parse --abbrev-ref HEAD`). A handoff may claim a "fresh worktree on branch X" that does not exist; these stay checked out on the base branch itself.
+
+## Invariant: one owner per worktree
+
+Each worktree and branch has a single owner (the harness/agent that created it). Do not reap or commit into a worktree you do not own without confirming it is abandoned; a clean-looking tree may belong to a live session.
+
+## Final checks
+
+1. Re-run the audit; confirm reaped paths are gone with `git worktree list`.
+2. `git worktree prune` to clear stale registrations.
+3. Confirm any anchored `holding/*` branches still hold their edits.
+</content>
+</invoke>

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ tsconfig.tsbuildinfo
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+*.log
+
+# Agent / benchmark scratch (machine-local, never commit)
+bench-oneshot.ts
 
 # ENV files
 .env


### PR DESCRIPTION
Lands three commits that were sitting unpushed on a local `main`: two new agent skills and a small `.gitignore` chore.

## worktree-hygiene
A skill for safely reaping worktrees across harnesses. The motivating failure: a worktree branch gets deleted out from under an active session, stranding (or losing) commits that live only as a local ref. The skill covers verifying a worktree's commits are merged or pinned before removal, and recovering dangling commits when one disappears.

## pr-collapse-review
A skill for the collapse-and-simplify review pass on a PR: trimming over-built surfaces, finding indirection that does not earn its boundary, and deciding what to delete. Includes `references/eval-notes.md`.

## chore: ignore stray logs and bench scratch
Four lines added to `.gitignore` for stray logs and benchmark scratch output.

Each commit is self-contained and reviewable on its own.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783960948&installation_id=128463665&pr_number=1950&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1950&signature=dd7fb10fa7996746a4972e32e57c7043291e3bf8c114a89880a18300942a04d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->