### PR TITLE
fix(whispering): tolerate missing local model folder

### DIFF
--- a/.agents/skills/pr-collapse-review/SKILL.md
+++ b/.agents/skills/pr-collapse-review/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: pr-collapse-review
+description: Run an isolated collapse-oriented review of a pull request, branch, or recent merged change. Use when the user asks to review a PR for simplification, collapse recent PRs, check whether a change can delete more indirection, run the PR in a new worktree, or apply grounded cleanup fixes after a PR review. Composes with collapse-pass, git, post-implementation-review, and claude-code-consult when another model is requested.
+metadata:
+  author: epicenter
+  version: '1.0'
+---
+
+# PR Collapse Review
+
+Use this skill for PR-shaped collapse work: start from a pull request, branch,
+or recent merged change, isolate it in a worktree by default, then use
+`collapse-pass` to find and fix grounded simplifications.
+
+This skill owns the PR mechanics. `collapse-pass` owns the simplification
+posture and finding ritual.
+
+## Compose With
+
+- `collapse-pass`: required for the inlining posture, anti-cosmetic gate, smell catalog, and final report shape.
+- `git`: branch, worktree, staging, commit, and message conventions.
+- `post-implementation-review`: required before final handoff after edits.
+- `claude-code-consult`: optional when the user asks to consult Claude or another model.
+
+## Required Inputs
+
+Get one of these from the user or local context:
+
+- PR URL or PR number.
+- Branch name and base branch.
+- Recent merged PR count or commit range.
+
+If the base branch is unknown, infer it from the PR metadata, upstream tracking
+branch, or `origin/main` in that order.
+
+## Default Worktree
+
+Use a separate worktree unless the user explicitly asks to work in the current
+checkout.
+
+For a GitHub PR number:
+
+```bash
+git fetch origin
+git fetch origin pull/<number>/head:codex/pr-<number>-collapse-review
+git worktree add ../epicenter-pr-<number>-collapse codex/pr-<number>-collapse-review
+```
+
+For a named branch:
+
+```bash
+git fetch origin <branch>:codex/<branch>-collapse-review
+git worktree add ../epicenter-<branch-slug>-collapse codex/<branch>-collapse-review
+```
+
+Use a filesystem-safe `<branch-slug>` for the directory, replacing slashes with
+hyphens. Use a unique branch or directory suffix if either name already exists.
+Do not use a destructive git command to reset the user's active checkout.
+
+For recent merged PR sweeps, use one worktree and one branch for the sweep:
+
+```bash
+git worktree add ../epicenter-recent-pr-collapse -b codex/recent-pr-collapse origin/main
+```
+
+## Workflow
+
+1. Load `collapse-pass` before reviewing code. Read its required references before any edit.
+2. Create or enter the review worktree. Confirm branch, base, and target.
+3. Compute the changed files against base with `git diff --name-only <base>...HEAD`.
+4. Read changed files first, then direct callers, tests, owned docs, and upstream docs only when external behavior affects correctness.
+5. Before analysis, list every file read as an ASCII tree.
+6. Report grounded findings before editing:
+
+   ```txt
+   Finding N: <smell>
+   Inline check: <what mental inlining showed>
+   Fix: <proposed change>
+   What stays the same: <visible behavior, durable strings, blob layout>
+   ```
+
+7. Apply only findings that clear the evidence bar. Defer product, compatibility, or broad ownership questions with evidence.
+8. After edits, re-read every touched file and run `post-implementation-review`.
+9. Run targeted tests and typechecks for impacted packages. Use `bun`, never npm, yarn, pnpm, or npx.
+10. End with files read, findings fixed, findings deferred, verification, and any rejected collapse candidates.
+
+## Keep Going
+
+Continue until every grounded finding in the PR scope is fixed, rejected, or
+explicitly deferred with evidence. Stop early only when tests or typechecks
+cannot be restored in one follow-up, the remaining findings require product
+input, the user gave a budget, or three consecutive scoped files produce no
+findings.
+
+## Claude Consult
+
+Use `claude-code-consult` only when the user requests another model or when
+diversity of judgment clearly matters. Codex remains the harness: Claude may
+advise, scout, or edit only in an isolated worker worktree, and Codex verifies
+anything that lands.
+
+For PR collapse work, prefer two small consults over one broad consult:
+
+1. A pre-edit design or risk pass over the reported findings.
+2. A post-edit review pass over the final diff.
+
+## Guardrails
+
+- Do not silently fix structural concerns. Report them first.
+- Do not broaden from touched files into unrelated cleanup without evidence.
+- Do not change durable strings, schemas, or public contracts unless the user explicitly requested greenfield cleanup and the finding names why compatibility no longer earns its cost.
+- Do not stage, commit, push, or open a PR unless the user asks.
+- Do not leave the worktree dirty without reporting its path and state.
+
+## References
+
+Read [references/eval-notes.md](references/eval-notes.md) when tuning this
+skill's description, deciding whether it still earns its own skill, or adding a
+script after repeated runs.

--- a/.agents/skills/pr-collapse-review/references/eval-notes.md
+++ b/.agents/skills/pr-collapse-review/references/eval-notes.md
@@ -1,0 +1,55 @@
+# PR Collapse Review Eval Notes
+
+Use this file when tuning trigger behavior, checking whether this skill still
+earns its own place, or deciding whether to add a script.
+
+## Classification
+
+This is a process skill with light tool workflow mechanics.
+
+It should stay separate from `collapse-pass` because PR checkout, worktree
+isolation, changed-file scoping, and recent-PR sweeps are different triggers
+from package-wide collapse passes.
+
+## Source Material
+
+- PR 1930 collapse review transcript from June 13, 2026.
+- `collapse-pass` skill and references.
+- `skill-creator` guidance on repeatable project expertise, progressive disclosure, description tuning, and validation.
+- Agent Skills docs on real source material, compact skill bodies, trigger evals, and scripts.
+
+## Should Trigger
+
+- "Run a collapse review on https://github.com/EpicenterHQ/epicenter/pull/1930 in a fresh worktree."
+- "Can you check the last three merged PRs and find any asymmetric collapses?"
+- "Review this branch like PR 1930: inline helpers, report findings first, then fix the clear wins."
+- "Open a new worktree and grill this PR for dead wrappers and stale boundaries."
+
+## Should Not Trigger
+
+- "Run a collapse pass on packages/workspace." Use `collapse-pass`.
+- "Review my staged diff for bugs." Use normal code review or `post-implementation-review`.
+- "Create a PR title and body." Use `pull-request`.
+- "Teach me how git worktrees work." Answer directly or use a teaching skill.
+
+## Assertions
+
+A good run should:
+
+- Use a separate worktree by default unless the user opts out.
+- Compute scope from the PR, branch, or commit range.
+- Print files read as an ASCII tree before analysis.
+- Report findings before editing.
+- Fix only grounded findings and explicitly defer the rest.
+- Re-read touched files after edits.
+- Run targeted `bun` tests or typechecks for impacted packages.
+- End with worktree path, verification, fixed findings, deferred findings, and rejected collapse candidates.
+
+## No Script Yet
+
+Do not add a helper script until at least three real runs show the agent
+repeatedly gets worktree setup, PR checkout, or changed-file scoping wrong.
+
+If a script becomes necessary, it should be non-interactive, dry-run capable,
+use structured stdout, diagnostics on stderr, and accept explicit flags for PR,
+base, target branch, and worktree path.

--- a/.agents/skills/testing/references/setup-pattern.md
+++ b/.agents/skills/testing/references/setup-pattern.md
@@ -12,19 +12,19 @@ Every test file that needs shared infrastructure MUST have a `setup()` function.
 
 1. `setup()` ALWAYS returns a destructured object, even for single values
 2. Tests ALWAYS destructure the return: `const { thing } = setup()`
-3. `setup()` is a plain function, not a hook — each test calls it independently
-4. No mutable `let` variables at describe scope — setup returns fresh state per test
+3. `setup()` is a plain function, not a hook; each test calls it independently
+4. No mutable `let` variables at describe scope. Setup returns fresh state per test
 
 ### Why Always an Object (Even for One Value)
 
 - **Extensibility**: Adding a second value later doesn't require changing any existing callsites
 - **Self-documenting**: `const { files } = setup()` tells you what you're getting by name
-- **Consistency**: Every test file follows the same pattern — no guessing
+- **Consistency**: Every test file follows the same pattern. No guessing
 
 ### Single Value
 
 ```typescript
-// Good — always an object, even for one thing
+// Good: always an object, even for one thing
 function setup() {
 	const workspace = createWorkspace({
 		id: 'test',
@@ -42,7 +42,7 @@ test('creates a file', () => {
 ```
 
 ```typescript
-// Bad — returns value directly
+// Bad: returns value directly
 function setup() {
 	const workspace = createWorkspace({
 		id: 'test',
@@ -116,7 +116,7 @@ function setupWithBinding(
 Use `beforeEach`/`afterEach` ONLY for cleanup that must run even if a test fails (server shutdown, spy restoration). Never use them for data setup.
 
 ```typescript
-// Bad — mutable state, hidden setup
+// Bad: mutable state, hidden setup
 let files: TableHelper;
 beforeEach(() => {
 	const workspace = createWorkspace({
@@ -127,7 +127,7 @@ beforeEach(() => {
 	files = workspace.tables.files;
 });
 
-// Good — setup function, immutable per-test
+// Good: setup function, immutable per-test
 function setup() {
 	const workspace = createWorkspace({
 		id: 'test',
@@ -166,13 +166,13 @@ These are stateless definitions, safe to share. Stateful objects (Y.Doc, workspa
 Every property in the setup return should be used by at least one test. If no test uses `ydoc`, don't return it:
 
 ```typescript
-// Bad — ydoc is never destructured by any test
+// Bad: ydoc is never destructured by any test
 function setup() {
 	const ydoc = new Y.Doc();
 	return { ydoc, tl: createTimeline(ydoc) };
 }
 
-// Good — only return what tests actually use
+// Good: only return what tests actually use
 function setup() {
 	return { tl: createTimeline(new Y.Doc()) };
 }

--- a/.agents/skills/typescript/references/runtime-schema-patterns.md
+++ b/.agents/skills/typescript/references/runtime-schema-patterns.md
@@ -94,13 +94,13 @@ For IDs that flow through an **arktype** schema at a runtime boundary (auth user
 import { type } from 'arktype';
 import type { Brand } from 'wellcrafted/brand';
 
-// 1. VALIDATOR — declared first; brand lives inside `.as<>()`.
+// 1. VALIDATOR: declared first; brand lives inside `.as<>()`.
 export const UserId = type('string').as<string & Brand<'UserId'>>();
 
-// 2. TYPE — derived from the validator. One source of truth.
+// 2. TYPE: derived from the validator. One source of truth.
 export type UserId = typeof UserId.infer;
 
-// 3. AS HELPER — shorthand for `value as UserId` at trusted call sites.
+// 3. AS HELPER: shorthand for `value as UserId` at trusted call sites.
 export const asUserId = (value: string): UserId => value as UserId;
 ```
 
@@ -115,11 +115,11 @@ Declaring the validator first and deriving the type via `typeof UserId.infer` ma
 At trusted call sites that receive a `string` from another typed source (Better Auth user id, URL params, Hono context vars), use the `as*` helper:
 
 ```typescript
-// Good — uses the shorthand helper
+// Good: uses the shorthand helper
 const userId = asUserId(c.var.user.id);
 const ownerId = asOwnerId(c.req.param('ownerId')!);
 
-// Bad — scattered raw casts
+// Bad: scattered raw casts
 const userId = c.var.user.id as UserId;
 ```
 
@@ -141,7 +141,7 @@ For genuinely untyped boundaries (parsing `unknown` JSON, network input) use the
 Because the validator shares the type name, arktype schemas read with no `Schema` suffix anywhere:
 
 ```typescript
-// Good — one PascalCase name covers both namespaces
+// Good: one PascalCase name covers both namespaces
 export const PersistedAuth = type({
 	'+': 'delete',
 	grant: OAuthTokenGrant,
@@ -151,7 +151,7 @@ export const PersistedAuth = type({
 	mode: OwnershipMode,
 });
 
-// Bad — artificial `Schema` alias next to the type import
+// Bad: artificial `Schema` alias next to the type import
 import { UserIdSchema, type UserId } from './ids.js';
 ```
 
@@ -162,7 +162,7 @@ Reach for an alias only when two imported values genuinely collide in the same n
 An older pattern declared a PascalCase function that doubled as the brand constructor:
 
 ```typescript
-// Old pattern — DO NOT use for new code
+// Old pattern: DO NOT use for new code
 export type UserId = string & Brand<'UserId'>;
 export const UserId = (value: string): UserId => value as UserId;
 export const UserIdSchema = type('string').as<UserId>();

--- a/.agents/skills/workspace-api/references/primitive-api.md
+++ b/.agents/skills/workspace-api/references/primitive-api.md
@@ -62,7 +62,13 @@ The builder is a plain function. For a cached, refcounted fan-out surface (share
 For the app's top-level workspace doc, never call `new Y.Doc` directly. Use `createWorkspace`:
 
 ```typescript
-import { createWorkspace, defineActions, defineWorkspace } from '@epicenter/workspace';
+import { field } from '@epicenter/field';
+import {
+  createWorkspace,
+  defineActions,
+  defineKv,
+  defineWorkspace,
+} from '@epicenter/workspace';
 import { foldersTable, notesTable } from './definition';
 
 // Encrypted app: pass a `keyring` accessor.

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ tsconfig.tsbuildinfo
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+*.log
+
+# Agent / benchmark scratch (machine-local, never commit)
+bench-oneshot.ts
 
 # ENV files
 .env

--- a/apps/landing/astro.config.mjs
+++ b/apps/landing/astro.config.mjs
@@ -9,8 +9,8 @@ export default defineConfig({
 	output: 'static', // Keep static for now, can change to 'server' if needed
 	vite: {
 		plugins: [tailwindcss()],
-		ssr: {
-			noExternal: ['bits-ui'],
+		resolve: {
+			noExternal: ['bits-ui', 'runed', 'svelte-toolbelt'],
 		},
 	},
 	integrations: [svelte()],

--- a/apps/landing/src/content/blog/second-brain-infrastructure.md
+++ b/apps/landing/src/content/blog/second-brain-infrastructure.md
@@ -39,17 +39,20 @@ That's the `epicenter` CLI. Karpathy's monthly health check becomes a script you
 Schemas are typed and enforced at runtime, not just documented:
 
 ```typescript
-const workspace = defineWorkspace({
+import { field } from "@epicenter/field";
+import { createWorkspace, defineTable } from "@epicenter/workspace";
+
+const notes = defineTable({
+  id: field.string(),
+  title: field.string(),
+  content: field.string(),
+  tags: field.tags(),
+  folder: field.select(["raw", "wiki", "outputs"]),
+});
+
+const workspace = createWorkspace({
   id: "second-brain",
-  tables: {
-    notes: {
-      id: id(),
-      title: text(),
-      content: text(),
-      tags: text(),
-      folder: select({ options: ["raw", "wiki", "outputs"] }),
-    },
-  },
+  tables: { notes },
   kv: {},
 });
 ```

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -111,12 +111,13 @@ const ecosystem = [
 	},
 ];
 
-const quickstartCodeHtml = `<span class="text-violet-400">import</span> { column, createWorkspace, defineTable } <span class="text-violet-400">from</span> <span class="text-emerald-400">'@epicenter/workspace'</span>
+const quickstartCodeHtml = `<span class="text-violet-400">import</span> { field } <span class="text-violet-400">from</span> <span class="text-emerald-400">'@epicenter/field'</span>
+<span class="text-violet-400">import</span> { createWorkspace, defineTable } <span class="text-violet-400">from</span> <span class="text-emerald-400">'@epicenter/workspace'</span>
 
 <span class="text-violet-400">const</span> posts = <span class="text-amber-300">defineTable</span>({
-  id: column.<span class="text-amber-300">string</span>(),
-  title: column.<span class="text-amber-300">string</span>(),
-  published: column.<span class="text-amber-300">boolean</span>(),
+  id: field.<span class="text-amber-300">string</span>(),
+  title: field.<span class="text-amber-300">string</span>(),
+  published: field.<span class="text-amber-300">boolean</span>(),
 })
 
 <span class="text-violet-400">const</span> workspace = <span class="text-amber-300">createWorkspace</span>({
@@ -129,7 +130,7 @@ workspace.tables.posts.<span class="text-amber-300">set</span>({ id: <span class
 ---
 
 <BaseLayout
-	title="Epicenter — Local-First, Open-Source Apps"
+	title="Epicenter: Local-First, Open-Source Apps"
 	description="One folder of plain text and SQLite. Every tool shares this memory. Open source, local-first, self-hostable."
 >
 	<main class="bg-background">
@@ -317,7 +318,7 @@ workspace.tables.posts.<span class="text-amber-300">set</span>({ id: <span class
 						</div>
 						<pre
 							class="p-6 overflow-x-auto"
-						><code class="text-sm font-mono text-zinc-100"><span class="text-zinc-500">$</span> bun add @epicenter/workspace</code></pre>
+						><code class="text-sm font-mono text-zinc-100"><span class="text-zinc-500">$</span> bun add @epicenter/workspace @epicenter/field</code></pre>
 					</div>
 
 					<div
@@ -570,7 +571,7 @@ workspace.tables.posts.<span class="text-amber-300">set</span>({ id: <span class
 						</h3>
 						<p class="text-muted-foreground leading-relaxed">
 							Obsidian is a Markdown editor with sync. Epicenter is a
-							local-first storage substrate—multiple apps share the same
+							local-first storage substrate: multiple apps share the same
 							CRDT-backed data folder. Your notes, transcripts, and chat
 							histories all live together and sync conflict-free.
 						</p>
@@ -583,7 +584,7 @@ workspace.tables.posts.<span class="text-amber-300">set</span>({ id: <span class
 						<p class="text-muted-foreground leading-relaxed">
 							Encryption is opt-in per workspace. When enabled, Epicenter uses
 							XChaCha20-Poly1305 for data and HKDF-SHA256 for key derivation.
-							The sync server is a relay—it never sees your content.
+							The sync server is a relay; it never sees your content.
 						</p>
 					</div>
 
@@ -594,7 +595,7 @@ workspace.tables.posts.<span class="text-amber-300">set</span>({ id: <span class
 						<p class="text-muted-foreground leading-relaxed">
 							Yes. The sync server is open source and runs on Cloudflare Workers
 							or any WebSocket-compatible host. You can also run entirely
-							offline—sync is optional.
+							offline; sync is optional.
 						</p>
 					</div>
 
@@ -605,7 +606,7 @@ workspace.tables.posts.<span class="text-amber-300">set</span>({ id: <span class
 						<p class="text-muted-foreground leading-relaxed">
 							Your data is plain text and SQLite files on your disk. Open them
 							with any text editor, query them with any SQLite tool. No export
-							needed—the files are the product.
+							needed; the files are the product.
 						</p>
 					</div>
 				</div>

--- a/apps/whispering/src-tauri/src/transcription/mod.rs
+++ b/apps/whispering/src-tauri/src/transcription/mod.rs
@@ -15,7 +15,7 @@ use tauri::{AppHandle, State};
 /// invokes this once at startup and on every subsequent change to
 /// settings, model selection, language, prompt, or unload policy.
 ///
-/// Drift in `(engine, modelPath)` triggers a background preload so the
+/// Drift in `(engine, model_name)` triggers a background preload so the
 /// next `transcribe_recording` call does not pay cold-start latency.
 /// Other field changes take effect on the next transcription with no
 /// reload.

--- a/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
@@ -12,10 +12,13 @@
 	let {
 		model,
 		recommended = false,
+		onDiskChange,
 	}: {
 		model: LocalModelConfig;
 		/** Show the Recommended badge; the selector decides when it guides a choice. */
 		recommended?: boolean;
+		/** Re-scan the parent selector after this card changes the models folder. */
+		onDiskChange?: () => void | Promise<void>;
 	} = $props();
 
 	// Shared per-model handle: the selector hero reads the same one, so a
@@ -24,6 +27,21 @@
 
 	// Aliased so the template narrows the union per branch.
 	const modelState = $derived(download.state);
+
+	async function downloadModel() {
+		await download.download();
+		await onDiskChange?.();
+	}
+
+	async function deleteModel() {
+		await download.delete();
+		await onDiskChange?.();
+	}
+
+	async function activateModel() {
+		download.activate();
+		await onDiskChange?.();
+	}
 </script>
 
 <div
@@ -55,10 +73,10 @@
 				<span class="text-sm font-medium">{modelState.progress}%</span>
 			</div>
 		{:else if modelState.type === 'ready'}
-			<Button size="sm" variant="outline" onclick={() => download.activate()}>
+			<Button size="sm" variant="outline" onclick={activateModel}>
 				Activate
 			</Button>
-			<Button size="sm" variant="ghost" onclick={() => download.delete()}>
+			<Button size="sm" variant="ghost" onclick={deleteModel}>
 				<X class="size-4" />
 			</Button>
 		{:else if modelState.type === 'active'}
@@ -66,11 +84,11 @@
 				<CheckIcon class="size-4 mr-1" />
 				Activated
 			</Button>
-			<Button size="sm" variant="ghost" onclick={() => download.delete()}>
+			<Button size="sm" variant="ghost" onclick={deleteModel}>
 				<X class="size-4" />
 			</Button>
 		{:else}
-			<Button size="sm" variant="outline" onclick={() => download.download()}>
+			<Button size="sm" variant="outline" onclick={downloadModel}>
 				<Download class="size-4" />
 				Download
 			</Button>

--- a/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
@@ -130,6 +130,16 @@
 		}
 	}
 
+	async function downloadRecommendedModel() {
+		await recommendedDownload.download();
+		await refreshEntries();
+	}
+
+	async function activateRecommendedModel() {
+		recommendedDownload.activate();
+		await refreshEntries();
+	}
+
 	// Rescan on mount, when the engine changes, and whenever the active model
 	// changes (e.g. a catalog download just landed in the folder).
 	$effect(() => {
@@ -227,11 +237,11 @@
 							</span>
 						</div>
 					{:else if recommendedState.type === 'ready'}
-						<Button onclick={() => recommendedDownload.activate()}>
+						<Button onclick={activateRecommendedModel}>
 							Activate {recommended.name}
 						</Button>
 					{:else}
-						<Button onclick={() => recommendedDownload.download()}>
+						<Button onclick={downloadRecommendedModel}>
 							<Download class="size-4" />
 							Download {recommended.name} ({recommended.size})
 						</Button>
@@ -266,6 +276,7 @@
 					<LocalModelDownloadCard
 						{model}
 						recommended={models.length > 1 && model.id === recommended.id}
+						onDiskChange={refreshEntries}
 					/>
 				{/each}
 

--- a/apps/whispering/src/lib/services/transcription/local-model-folder.ts
+++ b/apps/whispering/src/lib/services/transcription/local-model-folder.ts
@@ -32,7 +32,10 @@ import {
 	type InferErrors,
 } from 'wellcrafted/error';
 import { Err, Ok, type Result, tryAsync } from 'wellcrafted/result';
-import type { LocalModelConfig } from '$lib/constants/local-models';
+import {
+	type LocalModelConfig,
+	modelEntryName,
+} from '$lib/constants/local-models';
 import { PATHS } from '$lib/services/fs-paths';
 import { isModelFileSizeValid } from '$lib/services/transcription/model-file';
 
@@ -261,6 +264,13 @@ export function createModelStorage(model: LocalModelConfig) {
 		}
 	}
 
+	async function hasListedSymlinkEntry(): Promise<boolean> {
+		const entries = await listModelEntries(model.engine);
+		return entries.some(
+			(entry) => entry.name === modelEntryName(model) && entry.isSymlink,
+		);
+	}
+
 	return {
 		/**
 		 * The canonical install path: a file for Whisper, a directory for
@@ -278,17 +288,32 @@ export function createModelStorage(model: LocalModelConfig) {
 			const { data: installedPath } = await tryAsync({
 				try: async (): Promise<string | null> => {
 					const path = await getPath();
-					if (!(await exists(path))) return null;
+					const { data: pathExists } = await tryAsync({
+						try: () => exists(path),
+						catch: () => Ok(false),
+					});
+					if (!pathExists) return (await hasListedSymlinkEntry()) ? path : null;
+
 					switch (model.engine) {
 						case 'whispercpp': {
-							const stats = await stat(path);
-							return isModelFileSizeValid(stats.size, model.sizeBytes)
-								? path
-								: null;
+							const { data: stats } = await tryAsync({
+								try: () => stat(path),
+								catch: () => Ok(null),
+							});
+							if (!stats) {
+								return (await hasListedSymlinkEntry()) ? path : null;
+							}
+							return isModelFileSizeValid(stats.size, model.sizeBytes) ? path : null;
 						}
 						case 'parakeet':
 						case 'moonshine': {
-							const dirStats = await stat(path);
+							const { data: dirStats } = await tryAsync({
+								try: () => stat(path),
+								catch: () => Ok(null),
+							});
+							if (!dirStats) {
+								return (await hasListedSymlinkEntry()) ? path : null;
+							}
 							if (!dirStats.isDirectory) return null;
 							for (const file of model.files) {
 								const filePath = await join(path, file.filename);

--- a/apps/whispering/src/lib/services/transcription/local-model-folder.ts
+++ b/apps/whispering/src/lib/services/transcription/local-model-folder.ts
@@ -147,6 +147,7 @@ export async function deleteModelEntry({
 	const { data: found, error: readError } = await tryAsync({
 		try: async () => {
 			const modelsDir = await PATHS.MODELS[engine]();
+			if (!(await exists(modelsDir))) return null;
 			const entry = (await readDir(modelsDir)).find((e) => e.name === name);
 			if (!entry) return null;
 			return { entry, path: await join(modelsDir, name) };

--- a/apps/whispering/src/lib/services/transcription/local-model-folder.ts
+++ b/apps/whispering/src/lib/services/transcription/local-model-folder.ts
@@ -303,7 +303,9 @@ export function createModelStorage(model: LocalModelConfig) {
 							if (!stats) {
 								return (await hasListedSymlinkEntry()) ? path : null;
 							}
-							return isModelFileSizeValid(stats.size, model.sizeBytes) ? path : null;
+							return isModelFileSizeValid(stats.size, model.sizeBytes)
+								? path
+								: null;
 						}
 						case 'parakeet':
 						case 'moonshine': {

--- a/apps/whispering/src/lib/state/device-config.svelte.ts
+++ b/apps/whispering/src/lib/state/device-config.svelte.ts
@@ -119,10 +119,47 @@ const DEVICE_DEFINITIONS = {
 type DeviceConfigDefs = typeof DEVICE_DEFINITIONS;
 export type DeviceConfigKey = keyof DeviceConfigDefs & string;
 
+// ── Legacy migration ─────────────────────────────────────────────────────────
+
+const DEVICE_CONFIG_PREFIX = 'whispering.device.';
+
+const LEGACY_LOCAL_MODEL_SELECTIONS = [
+	{
+		from: 'transcription.whispercpp.modelPath',
+		to: 'transcription.whispercpp.model',
+	},
+	{
+		from: 'transcription.parakeet.modelPath',
+		to: 'transcription.parakeet.model',
+	},
+	{
+		from: 'transcription.moonshine.modelPath',
+		to: 'transcription.moonshine.model',
+	},
+] as const satisfies readonly {
+	from: string;
+	to: DeviceConfigKey;
+}[];
+
+function modelEntryNameFromLegacyPath(path: string) {
+	return path.replace(/\\/g, '/').replace(/\/+$/, '').split('/').at(-1) ?? '';
+}
+
+function readLegacyString(key: string) {
+	const raw = window.localStorage.getItem(`${DEVICE_CONFIG_PREFIX}${key}`);
+	if (raw === null) return null;
+	try {
+		const value = JSON.parse(raw) as unknown;
+		return typeof value === 'string' ? value : null;
+	} catch {
+		return null;
+	}
+}
+
 // ── Singleton ────────────────────────────────────────────────────────────────
 
 export const deviceConfig = createPersistedMap({
-	prefix: 'whispering.device.',
+	prefix: DEVICE_CONFIG_PREFIX,
 	definitions: DEVICE_DEFINITIONS,
 	onError: (key) => {
 		log.info(`Invalid device config for "${key}", using default`);
@@ -137,3 +174,11 @@ export const deviceConfig = createPersistedMap({
 		});
 	},
 });
+
+for (const migration of LEGACY_LOCAL_MODEL_SELECTIONS) {
+	if (deviceConfig.get(migration.to)) continue;
+	const legacyPath = readLegacyString(migration.from);
+	if (!legacyPath) continue;
+	const entryName = modelEntryNameFromLegacyPath(legacyPath);
+	if (entryName) deviceConfig.set(migration.to, entryName);
+}

--- a/apps/whispering/src/lib/tauri/bindings.gen.ts
+++ b/apps/whispering/src/lib/tauri/bindings.gen.ts
@@ -124,7 +124,7 @@ export const commands = {
 	 *  invokes this once at startup and on every subsequent change to
 	 *  settings, model selection, language, prompt, or unload policy.
 	 *
-	 *  Drift in `(engine, modelPath)` triggers a background preload so the
+	 *  Drift in `(engine, model_name)` triggers a background preload so the
 	 *  next `transcribe_recording` call does not pay cold-start latency.
 	 *  Other field changes take effect on the next transcription with no
 	 *  reload.

--- a/docs/articles/20260429T180000-temporal-is-a-value-type-not-a-storage-format.md
+++ b/docs/articles/20260429T180000-temporal-is-a-value-type-not-a-storage-format.md
@@ -1,6 +1,6 @@
 # Temporal Is a Value Type, Not a Storage Format
 
-Temporal is the right answer for date math. It's the wrong answer for what sits in your SQLite column. Epicenter stores `DateTimeString` (a branded text format) and only constructs a `Temporal.ZonedDateTime` when something actually needs to compute with it. Two layers, two jobs.
+Temporal is the right answer for date math. It's the wrong answer for what sits in your SQLite column. Epicenter stores `DateTimeString` as a branded RFC 3339 string, with a separate zone field when the originating IANA zone matters. It only constructs a `Temporal.ZonedDateTime` when something actually needs to compute with it. Two layers, two jobs.
 
 ## The two questions are not the same
 
@@ -49,66 +49,68 @@ SQLite sorts TEXT lexicographically. The canonical `Temporal.ZonedDateTime` stri
 
 The leading bytes are *local time*. Two rows from different zones sort by local wall clock, not by the actual instant. `ORDER BY createdAt` is silently wrong.
 
-`DateTimeString` puts the UTC instant first:
+`DateTimeString` stores the instant in RFC 3339 form:
 
 ```
-2024-01-01T20:00:00.000Z|America/New_York
-└──── UTC instant ─────┘└──── IANA ─────┘
+2024-01-01T20:00:00.000Z
+└──── UTC instant ─────┘
 ```
 
-UTC instant is the prefix, so lex order equals chronological order, for free, across every zone.
+When zone semantics matter, store the IANA zone in a sidecar field such as `createdAtZone`. UTC instant remains the sortable prefix, so lex order equals chronological order, for free, across every zone.
 
 ### 2. Per-row `fromDriver` overhead
 
 If your column type is "Temporal," every row read invokes a `fromDriver` hook to parse text into a `Temporal.ZonedDateTime`. On a 10k-row query that's 10k synchronous parses, possibly through a polyfill, before you've done any work. The cost lands on every read whether or not you needed date math.
 
-`DateTimeString` is a branded plain string. The driver hands you the bytes; you parse to Temporal *only* at the call site that needs `.add({ months: 1 })`. The "last responsible moment" pattern.
+`DateTimeString` is a branded plain string. The driver hands you the bytes; you build a Temporal value *only* at the call site that needs `.add({ months: 1 })`. The "last responsible moment" pattern.
 
 ```ts
 // Read path: zero conversion
 const rows = tables.notes.getAll()         // each createdAt is a DateTimeString
 
 // Math path: convert exactly once, where the math happens
-const due = DateTimeString.parse(row.createdAt).add({ days: 7 })
+const due = Temporal.Instant
+  .from(row.createdAt)
+  .toZonedDateTimeISO(row.createdAtZone)
+  .add({ days: 7 })
 ```
 
 ### 3. Wire and portability friction
 
-`DateTimeString` is already a JSON string. It serializes for free, parses for free in any language with `split('|')`, and survives logs, BI tools, and other services without a Temporal polyfill.
+`DateTimeString` is already a JSON string. It serializes for free, parses with stock date-time tooling, and survives logs, BI tools, and other services without a Temporal polyfill.
 
 The bracketed-IANA suffix that Temporal uses (`...[America/New_York]`) is a Temporal-era extension. Lots of parsers reject it. You either ship a polyfill everywhere or you stringify on every wire boundary.
 
 ## The split: text in storage, Temporal in hand
 
 ```
-┌──────────────┐   read    ┌────────────────┐   parse    ┌──────────────────────┐
-│   SQLite     │ ────────▶ │ DateTimeString │ ─────────▶ │ Temporal.ZonedDateTime│
-│ TEXT column  │           │ (branded str)  │            │  (only when needed)   │
-└──────────────┘           └────────────────┘            └──────────────────────┘
-        ▲                          │                              │
-        │                          │ stringify back when storing  │
-        └──────────────────────────┴──────────────────────────────┘
+┌──────────────┐   read    ┌──────────────────────┐   construct ┌──────────────────────┐
+│   SQLite     │ ────────▶ │ DateTimeString + zone│ ──────────▶ │ Temporal.ZonedDateTime│
+│ TEXT columns │           │ (branded strings)    │             │  (only when needed)   │
+└──────────────┘           └──────────────────────┘             └──────────────────────┘
+        ▲                              │                                  │
+        │                              │ stringify back when storing      │
+        └──────────────────────────────┴──────────────────────────────────┘
 ```
 
 In code:
 
 ```ts
 // Storage: DateTimeString round-trips with zero conversion
-type DateTimeString = `${DateIsoString}|${TimezoneId}` & Brand<'DateTimeString'>
+type DateTimeString = string & Brand<'DateTimeString'>
+type TimezoneId = string & Brand<'TimezoneId'>
 
-// Companion object: parse lazily
+// Companion object: validate and create storage values
 const DateTimeString = {
-  parse(s: DateTimeString): Temporal.ZonedDateTime,
-  stringify(zdt: Temporal.ZonedDateTime): DateTimeString,
-  now(tz?: string): DateTimeString,
+  now(): DateTimeString,
   is(v: unknown): v is DateTimeString,
 }
 
-// Schema: column.zonedDateTime() stores DateTimeString as TEXT
+// Schema: field.datetime() stores the instant; the zone rides beside it
 const notes = defineTable({
-  _v: column.literal(1),
-  id: column.id<'NoteId'>(),
-  createdAt: column.zonedDateTime(),   // DateTimeString in storage
+  id: field.string(),
+  createdAt: field.datetime(),         // DateTimeString
+  createdAtZone: field.string(),       // TimezoneId
 })
 
 // Read: no conversion
@@ -116,12 +118,15 @@ const note = tables.notes.get(id)
 note.createdAt                         // DateTimeString, branded
 
 // Math: convert at the point of use
-const dueAt = DateTimeString.parse(note.createdAt).add({ days: 7 })
+const dueAt = Temporal.Instant
+  .from(note.createdAt)
+  .toZonedDateTimeISO(note.createdAtZone)
+  .add({ days: 7 })
 
 // Write back: stringify back to storage shape
 tables.notes.update(id, {
-  remindAt: DateTimeString.stringify(dueAt),
-  _v: 1 as const,
+  remindAt: dueAt.toInstant().toString() as DateTimeString,
+  remindAtZone: dueAt.timeZoneId as TimezoneId,
 })
 ```
 
@@ -131,7 +136,7 @@ The storage format never changes. The math format never touches storage. Each la
 
 `Temporal.Instant` would actually sort fine: its serialization is `2024-01-01T20:00:00Z`, which is lex-sortable. The problem is it has no zone. "Created at 9am in Tokyo" loses the Tokyo. DST transitions, "remind me at 9am wherever you are next week," and locale rendering all need the origination zone preserved.
 
-`DateTimeString` keeps both: UTC instant for sortability and wire compactness, IANA name for zone semantics. `Instant` keeps neither side of that.
+`DateTimeString` keeps the instant sortable and compact. The sidecar zone keeps the IANA semantics. `Instant` by itself only keeps the first half.
 
 `PlainDateTime` is for wall-clock values with no zone (birthdays, "9am alarm"). Use it when there is genuinely no zone, not as a `createdAt`.
 
@@ -142,13 +147,13 @@ This is a specific instance of a more general pattern: **the type you compute wi
 - Encryption: store ciphertext bytes, decrypt to a plaintext value object only when you need to read.
 - Markdown: store the source string, parse to an AST only when rendering.
 - Money: store integer cents, construct a `Money` object at the boundary that does math.
-- Dates: store `DateTimeString`, construct `Temporal.ZonedDateTime` at the boundary that does math.
+- Dates: store `DateTimeString` plus a zone when needed, construct `Temporal.ZonedDateTime` at the boundary that does math.
 
 The mistake is letting the value-type API leak into your storage layer because it has nice methods. Nice methods are for working with values, not for sitting in a column. Keep the storage representation cheap, sortable, and JSON-native; pay the construction cost only where the methods actually get called.
 
 ## References
 
-- `packages/workspace/src/shared/datetime-string.ts` (`DateTimeString` type and companion functions)
+- `packages/field/src/datetime-string.ts` (`DateTimeString` type and companion functions)
 - `docs/articles/datetime-string-intermediate-representation.md` (the original migration from `DateWithTimezone`)
 - `docs/articles/iso-8601-is-lossy-without-a-timezone.md` (why ISO alone isn't enough)
-- `packages/workspace/specs/20260429T000000-column-dsl-and-define-table.md` (column DSL spec; note the spec since dropped `column.zonedDateTime()` for `column.string<T>()` plus `DateTimeString.schema()`)
+- `packages/workspace/specs/20260429T000000-column-dsl-and-define-table.md` (historical column DSL spec; current schemas use `field.datetime()`)

--- a/docs/articles/crdt-schema-evolution-without-migrations.md
+++ b/docs/articles/crdt-schema-evolution-without-migrations.md
@@ -42,14 +42,10 @@ Notice what's _not_ there: no error when the row doesn't match the schema. The r
 KV stores (settings, preferences) use a flat Y.Map with string keys:
 
 ```typescript
-const settings = createKv(ydoc, {
-  theme: kv({
-    field: select({ options: ['light', 'dark'], default: 'light' }),
-  }),
-  fontSize: kv({
-    field: integer({ default: 14 }),
-  }),
-});
+const settings = {
+  theme: defineKv(field.select(['light', 'dark']), () => 'light' as const),
+  fontSize: defineKv(field.integer(), () => 14),
+};
 ```
 
 The schema exists in your code, not in the data. The Y.Map just stores whatever you write to it.
@@ -57,18 +53,12 @@ The schema exists in your code, not in the data. The Y.Map just stores whatever 
 **Add a new setting?**
 
 ```typescript
-const settings = createKv(ydoc, {
-  theme: kv({
-    field: select({ options: ['light', 'dark'], default: 'light' }),
-  }),
-  fontSize: kv({
-    field: integer({ default: 14 }),
-  }),
-  // New field - just add it
-  language: kv({
-    field: select({ options: ['en', 'es', 'fr'], default: 'en' }),
-  }),
-});
+const settings = {
+  theme: defineKv(field.select(['light', 'dark']), () => 'light' as const),
+  fontSize: defineKv(field.integer(), () => 14),
+  // New field: just add it
+  language: defineKv(field.select(['en', 'es', 'fr']), () => 'en' as const),
+};
 
 // Old clients: ignore language (they don't know about it)
 // New clients: read language, get default 'en' if never set
@@ -80,12 +70,10 @@ No migration needed. Old clients just don't read that key. New clients get the d
 
 ```typescript
 // Just remove it from the code
-const settings = createKv(ydoc, {
-  theme: kv({
-    field: select({ options: ['light', 'dark'], default: 'light' }),
-  }),
+const settings = {
+  theme: defineKv(field.select(['light', 'dark']), () => 'light' as const),
   // fontSize: removed from code
-});
+};
 
 // The data stays in Y.Map forever
 // But nobody reads it anymore
@@ -99,15 +87,10 @@ Tables work similarly, but with a twist: each field has its own validator and de
 
 ```typescript
 const tables = {
-  posts: table({
-    fields: {
-      id: id(),
-      title: text(),
-      status: select({
-        options: ['draft', 'published'],
-        default: 'draft'
-      }),
-    },
+  posts: defineTable({
+    id: field.string(),
+    title: field.string(),
+    status: field.select(['draft', 'published'], { default: 'draft' }),
   }),
 };
 ```
@@ -116,17 +99,12 @@ const tables = {
 
 ```typescript
 const tables = {
-  posts: table({
-    fields: {
-      id: id(),
-      title: text(),
-      status: select({
-        options: ['draft', 'published'],
-        default: 'draft'
-      }),
-      // New field
-      priority: integer({ default: 0 }),
-    },
+  posts: defineTable({
+    id: field.string(),
+    title: field.string(),
+    status: field.select(['draft', 'published'], { default: 'draft' }),
+    // New field
+    priority: field.integer({ default: 0 }),
   }),
 };
 ```

--- a/docs/articles/schema-evolution-without-migrations.md
+++ b/docs/articles/schema-evolution-without-migrations.md
@@ -48,10 +48,14 @@ if (result.status === 'valid') {
 
 ```typescript
 // Before
-const postFields = { id: id(), title: text() };
+const postFields = { id: field.string(), title: field.string() };
 
 // After: existing posts get status: 'draft' automatically
-const postFields = { id: id(), title: text(), status: select({ options: ['draft', 'published'], default: 'draft' }) };
+const postFields = {
+  id: field.string(),
+  title: field.string(),
+  status: field.select(['draft', 'published'], { default: 'draft' }),
+};
 ```
 
 **Removing a field**: Remove it from the schema. The data stays in the Y.Doc, but your code stops reading it. No data loss, no migration, the field is just ignored.

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -59,23 +59,23 @@ swap `attachIndexedDb` + `attachBroadcastChannel` for the owner-scoped
 `attachLocalStorage` composite; see [Plaintext vs encrypted](#plaintext-vs-encrypted).
 
 ```bash
-bun add @epicenter/workspace
+bun add @epicenter/workspace @epicenter/field
 ```
 
 ```typescript
+import { field } from '@epicenter/field';
 import {
 	attachBroadcastChannel,
 	attachIndexedDb,
-	column,
 	createWorkspace,
 	defineTable,
 } from '@epicenter/workspace';
 
 const posts = defineTable({
-	id: column.string(),
-	title: column.string(),
-	body: column.string(),
-	published: column.boolean(),
+	id: field.string(),
+	title: field.string(),
+	body: field.string(),
+	published: field.boolean(),
 });
 
 export function openBlog() {
@@ -531,21 +531,23 @@ is library-managed: never declare it as a column, never pass it to `set` or
 version on write, routes by it on read, and strips it before handing the row
 back.
 
-Columns are TypeBox-native. Use the `column.*` factory helpers (`column.string`,
-`column.number`, `column.boolean`, `column.dateTime`, `column.enum`,
-`column.nullable`, `column.json`, ...) for the SQLite-flat default set, or pass
-raw `Type.*` schemas if you need a shape the helpers don't cover. The library
-enforces 1:1 SQLite-column mapping at the type level either way.
+Columns are TypeBox-native. Use the `field.*` builders from
+`@epicenter/field` (`field.string`, `field.number`, `field.boolean`,
+`field.datetime`, `field.select`, `field.json`, ...) plus the standalone
+`nullable(...)` wrapper from `@epicenter/workspace` for intentional emptiness,
+or pass raw `Type.*` schemas if you need a shape the helpers don't cover. The
+library enforces 1:1 SQLite-column mapping at the type level either way.
 
 ### Single-version tables
 
 ```typescript
-import { column, defineTable } from '@epicenter/workspace';
+import { field } from '@epicenter/field';
+import { defineTable } from '@epicenter/workspace';
 
 const users = defineTable({
-	id: column.string(),
-	email: column.string(),
-	name: column.string(),
+	id: field.string(),
+	email: field.string(),
+	name: field.string(),
 });
 
 void users;
@@ -556,17 +558,18 @@ Use the single-schema form when the table has only one version today.
 ### Versioned tables
 
 ```typescript
-import { column, defineTable } from '@epicenter/workspace';
+import { field } from '@epicenter/field';
+import { defineTable } from '@epicenter/workspace';
 
 const posts = defineTable(
 	{
-		id: column.string(),
-		title: column.string(),
+		id: field.string(),
+		title: field.string(),
 	},
 	{
-		id: column.string(),
-		title: column.string(),
-		slug: column.string(),
+		id: field.string(),
+		title: field.string(),
+		slug: field.string(),
 	},
 ).migrate(({ value, version }) => {
 	switch (version) {
@@ -591,14 +594,15 @@ in storage until you rewrite them.
 ### KV entries
 
 ```typescript
-import { column, defineKv } from '@epicenter/workspace';
+import { field } from '@epicenter/field';
+import { defineKv } from '@epicenter/workspace';
 
 const themeMode = defineKv(
-	column.enum(['light', 'dark', 'system']),
+	field.select(['light', 'dark', 'system']),
 	() => 'light' as const,
 );
-const sidebarWidth = defineKv(column.number(), () => 280);
-const sidebarCollapsed = defineKv(column.boolean(), () => false);
+const sidebarWidth = defineKv(field.number(), () => 280);
+const sidebarCollapsed = defineKv(field.boolean(), () => false);
 
 void themeMode;
 void sidebarWidth;
@@ -643,11 +647,11 @@ the cache owns live content Y.Docs. App-local helpers own browser cleanup.
 Node one-shot code can open the content document directly for one operation.
 
 ```typescript
+import { field } from '@epicenter/field';
 import * as Y from 'yjs';
 import {
 	attachIndexedDb,
 	attachPlainText,
-	column,
 	createDisposableCache,
 	createWorkspace,
 	defineTable,
@@ -657,9 +661,9 @@ import {
 import { clearDocument } from 'y-indexeddb';
 
 const files = defineTable({
-	id: column.string(),
-	name: column.string(),
-	updatedAt: column.number(),
+	id: field.string(),
+	name: field.string(),
+	updatedAt: field.number(),
 });
 
 function openFilesWorkspace() {
@@ -895,16 +899,16 @@ For authenticated apps, call `await wipeLocalStorage({ server, ownerId })` after
 `attachBunSqliteMaterializer` and `attachMarkdownExport` are not persistence: they project workspace rows into queryable SQLite tables or `.md` files. They are read surfaces, not write surfaces. Projection actions such as `sqlite_rebuild`, `sqlite_search`, and `markdown_rebuild` maintain or query the projection; app data mutations stay in app-defined actions. See the materializer subsections below.
 
 ```typescript
+import { field } from '@epicenter/field';
 import {
-	column,
 	createWorkspace,
 	defineTable,
 } from '@epicenter/workspace';
 import { attachYjsLog } from '@epicenter/workspace/node';
 
 const notes = defineTable({
-	id: column.string(),
-	title: column.string(),
+	id: field.string(),
+	title: field.string(),
 });
 
 function openNotes() {
@@ -928,10 +932,10 @@ void openNotes;
 One primitive wraps the WebSocket transport: `openCollaboration`. The workspace document passes a real `actions` registry; content documents that only need bytes-on-the-wire pass `actions: {}`. Compose it with `attachBroadcastChannel(ydoc)` for unauthenticated local-only documents. Authenticated browser workspaces use `attachLocalStorage(ydoc, { server, ownerId, keyring })`, which pairs encrypted IDB with an owner-scoped BroadcastChannel in one call.
 
 ```typescript
+import { field } from '@epicenter/field';
 import {
 	attachBroadcastChannel,
 	attachIndexedDb,
-	column,
 	createDeviceId,
 	createWorkspace,
 	defineTable,
@@ -942,8 +946,8 @@ import type { AuthClient } from '@epicenter/auth';
 import type { OwnerId } from '@epicenter/identity';
 
 const tabs = defineTable({
-	id: column.string(),
-	url: column.string(),
+	id: field.string(),
+	url: field.string(),
 });
 
 function openTabs({
@@ -991,8 +995,8 @@ Markdown comes from one seam, `attachMarkdownExport` (in `@epicenter/workspace/d
 The projection is read-only on purpose. The materialized `.md` is never read back into Yjs, so it carries no round-trip obligation and can shape the output however a human-readable export or a published site wants. App data mutates through validated actions (`epicenter run <mount>.<action>`, `connectDaemonActions`, or TanStack AI tools created by `actionsToAiTools`), never by editing the materialized files. If an app needs Markdown as the authoring format, that parser/editor belongs in an app action or UI surface that writes Yjs. This export is not that path. The SQLite materializer is the read-only sibling for a relational projection.
 
 ```typescript
+import { field } from '@epicenter/field';
 import {
-	column,
 	createWorkspace,
 	defineTable,
 } from '@epicenter/workspace';
@@ -1000,9 +1004,9 @@ import { attachYjsLog } from '@epicenter/workspace/node';
 import { attachMarkdownExport } from '@epicenter/workspace/document/materializer/markdown';
 
 const notes = defineTable({
-	id: column.string(),
-	title: column.string(),
-	body: column.string(),
+	id: field.string(),
+	title: field.string(),
+	body: field.string(),
 });
 
 function openNotes() {
@@ -1032,18 +1036,18 @@ The SQLite materializer is exported from `@epicenter/workspace/document/material
 Treat the mirror as a read-only SQL projection. Scripts open it with `openSqliteReader`, which sets `PRAGMA query_only = ON`; app writes go through the daemon action path (`connectDaemonActions` or `epicenter run`) so the live Y.Doc stays authoritative and the mirror catches up from the same source as every other projection.
 
 ```typescript
+import { field } from '@epicenter/field';
 import {
-	column,
 	createWorkspace,
 	defineTable,
 } from '@epicenter/workspace';
 import { attachBunSqliteMaterializer } from '@epicenter/workspace/document/materializer/sqlite';
 
 const posts = defineTable({
-	id: column.string(),
-	title: column.string(),
-	body: column.string(),
-	published: column.boolean(),
+	id: field.string(),
+	title: field.string(),
+	body: field.string(),
+	published: field.boolean(),
 });
 
 function openBlog() {
@@ -1139,9 +1143,9 @@ They have four important properties:
 Use `defineQuery(...)` for reads.
 
 ```typescript
+import { field } from '@epicenter/field';
 import Type from 'typebox';
 import {
-	column,
 	createWorkspace,
 	defineActions,
 	defineQuery,
@@ -1150,9 +1154,9 @@ import {
 } from '@epicenter/workspace';
 
 const posts = defineTable({
-	id: column.string(),
-	title: column.string(),
-	published: column.boolean(),
+	id: field.string(),
+	title: field.string(),
+	published: field.boolean(),
 });
 
 function openPosts() {
@@ -1193,9 +1197,9 @@ void actionType;
 Use `defineMutation(...)` for writes or side effects.
 
 ```typescript
+import { field } from '@epicenter/field';
 import Type from 'typebox';
 import {
-	column,
 	createWorkspace,
 	defineActions,
 	defineMutation,
@@ -1205,9 +1209,9 @@ import {
 } from '@epicenter/workspace';
 
 const posts = defineTable({
-	id: column.string(),
-	title: column.string(),
-	published: column.boolean(),
+	id: field.string(),
+	title: field.string(),
+	published: field.boolean(),
 });
 
 function openPosts() {

--- a/packages/workspace/src/document/README.md
+++ b/packages/workspace/src/document/README.md
@@ -39,12 +39,13 @@ Three prefixes, each with a consistent meaning:
 See `.agents/skills/attach-primitive/SKILL.md` for the full contract (shape, invariants, barrier naming).
 
 ```typescript
-import { column, createWorkspace, defineTable } from '@epicenter/workspace';
+import { field } from '@epicenter/field';
+import { createWorkspace, defineTable } from '@epicenter/workspace';
 
 // Pure schema. `_v` is library-managed: never declare it as a column.
 const postsTable = defineTable({
-  id: column.string(),
-  title: column.string(),
+  id: field.string(),
+  title: field.string(),
 });
 
 // Vanilla factory: createWorkspace owns Y.Doc creation; the factory composes


### PR DESCRIPTION
The collapse review caught a few small but real follow-ups. The public workspace examples still taught older field APIs in a few places, even though current code authors schemas through `@epicenter/field`. This updates the README-style examples and related articles so copied code uses `field.*`, `defineTable`, and `defineKv` in their current shape. The Temporal article also now matches the current `DateTimeString` contract: instant string first, sidecar zone when IANA semantics matter.

Whispering had local-model folder edge cases around upgrades and user-managed files. Deleting a model entry now tolerates the entire models folder already being gone. Old device-local `modelPath` selections are migrated to entry names on startup, catalog-name symlinks can still be activated from the UI, and the selector refreshes after catalog downloads or deletes even when the selected entry name does not change.

CI also caught an Astro 6 prerender issue on the Whispering landing page: Svelte package exports from Bits UI and its helper packages need to be bundled during prerender. The landing config now no-externalizes that Svelte dependency chain.

## Changelog
- Fix local model deletion when the models folder was already removed outside Whispering.
- Migrate old local model path selections to the current entry-name setting.
- Keep catalog-name local model symlinks activatable from settings.
- Fix landing preview prerendering for Svelte UI dependencies.