### PR TITLE
feat(workspace)!: make daemon runtimes action-first

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,7 +8,7 @@ Each verb is a one-line shell shortcut for one workspace primitive:
                  +------------+---------------------------------------------+
                  | Verb       | Workspace primitive                         |
                  +------------+---------------------------------------------+
-   Enumerate     | list       | Object.entries(collaboration.actions)       |
+   Enumerate     | list       | Object.entries(runtime.actions)             |
    Invoke        | run        | local daemon invoke                         |
    Dispatch      | run --peer | relay dispatch to a live peer               |
    Presence      | peers      | collaboration.devices.list()                |
@@ -108,17 +108,14 @@ export default [
   defineMount({
     name: "notes",
     async open({
-      keyring,
-      openWebSocket,
       projectDir,
       mount,
-      ownerId,
-      deviceId,
-      yDocClientId,
     }) {
       // Open the long-lived local runtime.
       // `mount` is the canonical mount name carried on the Mount object.
-      // Return { collaboration, [Symbol.asyncDispose] }.
+      // Return { actions, [Symbol.asyncDispose] }.
+      // Add `collaboration` only when this mount participates in Yjs sync,
+      // presence, and peer dispatch.
     },
   }),
 ];

--- a/packages/cli/src/commands/up.test.ts
+++ b/packages/cli/src/commands/up.test.ts
@@ -34,6 +34,7 @@ import { MachineAuthStorageError } from '@epicenter/auth/node';
 import { asOwnerId } from '@epicenter/identity';
 import {
 	claimDaemonLease,
+	daemonClient,
 	metadataPathFor,
 	pingDaemon,
 	socketPathFor,
@@ -151,6 +152,7 @@ function writeRuntimeMount({
 			name: 'demo',
 			async open() {
 				return {
+					actions,
 					collaboration,
 					async [Symbol.asyncDispose]() {
 						${onDisposeMarker ? `writeFileSync(${JSON.stringify(onDisposeMarker)}, 'disposed');` : ''}
@@ -192,6 +194,53 @@ describe('runUp: happy path', () => {
 		}
 		expect(existsSync(metadataPathFor(workDir))).toBe(false);
 		expect(existsSync(socketPathFor(workDir))).toBe(false);
+	});
+
+	test('serves a local-only mount without collaboration', async () => {
+		writeDemoMount(`
+			const sync = () => ({ imported: 2 });
+			sync.type = 'query';
+			sync.description = 'Sync local mirror';
+			const actions = {
+				sync,
+			};
+
+			export default {
+				name: 'mirror',
+				async open() {
+					return {
+						actions,
+						async [Symbol.asyncDispose]() {},
+					};
+				},
+			};
+		`);
+		writeDemoConfig();
+
+		const handle = expectOk(
+			await runUp({
+				projectDir: workDir,
+				quiet: true,
+				createAuthClient: stubAuthFactory,
+			}),
+		);
+		try {
+			const client = daemonClient(socketPathFor(workDir));
+			const manifest = expectOk(await client.list());
+			expect(Object.keys(manifest)).toEqual(['mirror.sync']);
+			expect(manifest['mirror.sync']?.description).toBe('Sync local mirror');
+			expect(expectOk(await client.peers())).toEqual([]);
+			expect(
+				expectOk(
+					await client.run({
+						actionPath: 'mirror.sync',
+						input: null,
+					}),
+				),
+			).toEqual({ imported: 2 });
+		} finally {
+			await handle.teardown();
+		}
 	});
 });
 
@@ -330,6 +379,7 @@ describe('runUp: failure cleanup', () => {
 					name: 'good',
 					async open() {
 						return {
+							actions: {},
 							collaboration,
 							async [Symbol.asyncDispose]() {
 								writeFileSync(${JSON.stringify(disposeMarker)}, 'disposed');

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -246,7 +246,9 @@ function ensureProjectGitignore(projectDir: string): void {
 }
 
 function printPeersSnapshot(entry: StartedMount): void {
-	const devices = entry.runtime.collaboration.devices.list();
+	const collaboration = entry.runtime.collaboration;
+	if (!collaboration) return;
+	const devices = collaboration.devices.list();
 	if (devices.length === 0) {
 		process.stderr.write(`${entry.mount}: no peers connected\n`);
 		return;
@@ -257,14 +259,12 @@ function printPeersSnapshot(entry: StartedMount): void {
 }
 
 function subscribePeers(entry: StartedMount, quiet: boolean): void {
+	const collaboration = entry.runtime.collaboration;
+	if (!collaboration) return;
 	const snapshot = () =>
-		new Set(
-			entry.runtime.collaboration.devices
-				.list()
-				.map((device) => device.deviceId),
-		);
+		new Set(collaboration.devices.list().map((device) => device.deviceId));
 	let prev = snapshot();
-	entry.runtime.collaboration.devices.subscribe(() => {
+	collaboration.devices.subscribe(() => {
 		const next = snapshot();
 		for (const deviceId of next) {
 			if (!prev.has(deviceId)) {
@@ -285,7 +285,9 @@ function subscribePeers(entry: StartedMount, quiet: boolean): void {
 }
 
 function subscribeSyncStatus(entry: StartedMount): void {
-	entry.runtime.collaboration.onStatusChange((status) => {
+	const collaboration = entry.runtime.collaboration;
+	if (!collaboration) return;
+	collaboration.onStatusChange((status) => {
 		if (status.phase === 'connecting') {
 			logSyncStatus(`${entry.mount}: connecting (retry ${status.retries})`);
 		} else if (status.phase === 'connected') {

--- a/packages/cli/test/fixtures/inline-actions/workspaces/demo/daemon.ts
+++ b/packages/cli/test/fixtures/inline-actions/workspaces/demo/daemon.ts
@@ -1,8 +1,7 @@
 /**
  * Minimal fixture: one mount with inline `defineQuery` / `defineMutation`
  * nodes grouped under `actions:`. No sqlite or encryption, no real WebSocket:
- * a hand-stubbed `collaboration` matches the daemon's structural contract so
- * mount startup accepts it.
+ * a hand-stubbed `collaboration` covers the peer-only fields.
  *
  * CLI paths are `demo.counter_{get,increment,set}`.
  */
@@ -61,6 +60,7 @@ const collaboration = {
 
 export const demoRuntime = {
 	workspaceId: ydoc.guid,
+	actions,
 	collaboration,
 	async [Symbol.asyncDispose]() {
 		ydoc.destroy();

--- a/packages/workspace/src/daemon/action-handler.test.ts
+++ b/packages/workspace/src/daemon/action-handler.test.ts
@@ -31,26 +31,29 @@ function fakeEntry({
 	actions = {
 		tabs_list: defineQuery({ handler: () => [] }),
 	},
+	collaboration = true,
 	syncStatus = { phase: 'connected' },
 	dispatch = (async () => ({ data: null, error: null })) as FakeDispatch,
 }: {
 	mount?: string;
 	actions?: ActionRegistry;
+	collaboration?: boolean;
 	syncStatus?: SyncStatus;
 	dispatch?: FakeDispatch;
 } = {}): DaemonServedMount {
+	const runtime: DaemonServedMount['runtime'] = { actions };
+	if (collaboration) {
+		runtime.collaboration = {
+			status: syncStatus,
+			devices: {
+				list: () => [],
+			},
+			dispatch,
+		};
+	}
 	return {
 		mount,
-		runtime: {
-			collaboration: {
-				actions,
-				status: syncStatus,
-				devices: {
-					list: () => [],
-				},
-				dispatch,
-			},
-		},
+		runtime,
 	};
 }
 
@@ -166,6 +169,21 @@ describe('executeRun peer target', () => {
 		expectOk(result);
 		expect(invokedAction).toBe('peer_only_action');
 	});
+
+	test('rejects peer dispatch for a local-only mount', async () => {
+		const result = await executeRun([fakeEntry({ collaboration: false })], {
+			actionPath: 'demo.tabs_list',
+			input: undefined,
+			peer: { to: 'mac', waitMs: 25 },
+		});
+
+		const error = expectErr(result);
+		expect(error.name).toBe('UsageError');
+		if (error.name !== 'UsageError') {
+			throw new Error(`expected UsageError, got ${error.name}`);
+		}
+		expect(error.message).toContain('does not expose collaboration');
+	});
 });
 
 describe('executeRun mount-prefixed routing', () => {
@@ -249,5 +267,24 @@ describe('executeRun mount-prefixed routing', () => {
 		// A bad input is the caller's mistake (exit 1), not a handler crash (exit 2).
 		expect(error.name).toBe('UsageError');
 		expect(error.message).toContain('maxDeletes');
+	});
+
+	test('local action execution does not require collaboration', async () => {
+		const entry = fakeEntry({
+			collaboration: false,
+			mount: 'mirror',
+			actions: {
+				sync: defineMutation({
+					handler: () => ({ imported: 3 }),
+				}),
+			},
+		});
+
+		const result = await executeRun([entry], {
+			actionPath: 'mirror.sync',
+			input: {},
+		});
+
+		expect(expectOk(result)).toEqual({ imported: 3 });
 	});
 });

--- a/packages/workspace/src/daemon/action-handler.ts
+++ b/packages/workspace/src/daemon/action-handler.ts
@@ -54,7 +54,13 @@ export async function executeRun(
 	if (peer === undefined) {
 		return runLocal(mountRuntime, actionPath, localPath, actionInput);
 	}
-	return runOnPeer(mountRuntime, localPath, actionInput, peer);
+	const collaboration = mountRuntime.runtime.collaboration;
+	if (!collaboration) {
+		return RunError.UsageError({
+			message: `Mount "${mount}" does not expose collaboration, so "${actionPath}" cannot run on peer "${peer.to}".`,
+		});
+	}
+	return runOnPeer(collaboration, localPath, actionInput, peer);
 }
 
 /** Local run: this daemon's registry is the authority for action existence. */
@@ -64,7 +70,7 @@ async function runLocal(
 	localPath: string,
 	actionInput: unknown,
 ): Promise<Result<unknown, RunError>> {
-	const action = mountRuntime.runtime.collaboration.actions[localPath];
+	const action = mountRuntime.runtime.actions[localPath];
 	if (!action) {
 		const descendants = daemonActionSuggestionLines(mountRuntime, localPath);
 		if (descendants.length > 0) {
@@ -94,7 +100,7 @@ async function runLocal(
 
 /** Peer run: the recipient decides action existence, the relay reachability. */
 async function runOnPeer(
-	mountRuntime: DaemonServedMount,
+	collaboration: NonNullable<DaemonServedMount['runtime']['collaboration']>,
 	localPath: string,
 	actionInput: unknown,
 	{ to, waitMs }: NonNullable<RunRequest['peer']>,
@@ -106,9 +112,7 @@ async function runOnPeer(
 		});
 	}
 
-	const { runtime } = mountRuntime;
-
-	const result = await runtime.collaboration.dispatch({
+	const result = await collaboration.dispatch({
 		to,
 		action: localPath,
 		input: actionInput,
@@ -116,7 +120,7 @@ async function runOnPeer(
 	});
 
 	if (result.error !== null) {
-		const syncStatus = toPeerSyncStatus(runtime.collaboration.status);
+		const syncStatus = toPeerSyncStatus(collaboration.status);
 		switch (result.error.name) {
 			case 'RecipientOffline':
 				return RunError.PeerNotFound({
@@ -166,7 +170,7 @@ function daemonActionSuggestionLines(
 	mountRuntime: DaemonServedMount,
 	prefix: string,
 ): string[] {
-	return Object.entries(mountRuntime.runtime.collaboration.actions)
+	return Object.entries(mountRuntime.runtime.actions)
 		.filter(([path]) => !prefix || path.startsWith(prefix))
 		.map(
 			([path, action]) =>

--- a/packages/workspace/src/daemon/app.ts
+++ b/packages/workspace/src/daemon/app.ts
@@ -5,7 +5,7 @@
  *
  * Each route is a one-line shell shortcut for one daemon runtime primitive:
  *
- *   /peers  ->  collaboration.devices.list()                       all mounts
+ *   /peers  ->  collaboration.devices.list()              collaborative mounts
  *   /list   ->  flat manifest of `${mount}.${action_key}` -> meta  all mounts
  *   /run    ->  invokeAction(...) locally, or collab.dispatch(...)
  *               on a peer when `peer` is present                   mount-routed
@@ -83,7 +83,9 @@ export function buildDaemonApp(mounts: readonly DaemonServedMount[]) {
 		.post('/peers', (c) => {
 			const rows: PeerSnapshot[] = [];
 			for (const entry of mounts) {
-				for (const device of entry.runtime.collaboration.devices.list()) {
+				const collaboration = entry.runtime.collaboration;
+				if (!collaboration) continue;
+				for (const device of collaboration.devices.list()) {
 					rows.push({
 						mount: entry.mount,
 						deviceId: device.deviceId,
@@ -95,9 +97,7 @@ export function buildDaemonApp(mounts: readonly DaemonServedMount[]) {
 		.post('/list', (c) => {
 			const manifest: ActionManifest = {};
 			for (const entry of mounts) {
-				for (const [path, action] of Object.entries(
-					entry.runtime.collaboration.actions,
-				)) {
+				for (const [path, action] of Object.entries(entry.runtime.actions)) {
 					manifest[joinDaemonActionPath(entry.mount, path)] =
 						toActionMeta(action);
 				}

--- a/packages/workspace/src/daemon/attach-project-infrastructure.ts
+++ b/packages/workspace/src/daemon/attach-project-infrastructure.ts
@@ -18,10 +18,10 @@
  * browser-only actions pass `{}` to refuse them on the daemon side, while
  * workspaces with daemon-safe actions pass `workspace.actions`.
  *
- * Returns the parts the host reads (`collaboration`) plus the side-effectful
- * `yjsLog` handle and an `[Symbol.asyncDispose]` that encodes the destroy
- * order. Callers usually spread the result into their `DaemonRuntime` and
- * compose materializers around the same ydoc.
+ * Returns the daemon-served `actions`, the optional-peer `collaboration`, the
+ * side-effectful `yjsLog` handle, and an `[Symbol.asyncDispose]` that encodes
+ * the destroy order. Callers usually spread the result into their
+ * `DaemonRuntime` and compose materializers around the same ydoc.
  */
 
 import type { OwnerId } from '@epicenter/identity';
@@ -89,6 +89,8 @@ export function attachProjectInfrastructure<TActions extends ActionRegistry>(
 	});
 
 	return {
+		/** Local action registry served by this daemon runtime. */
+		actions,
 		/** Durable Y.Doc update log handle. */
 		yjsLog,
 		/** Cloud sync, presence, and dispatch handle for this mount. */

--- a/packages/workspace/src/daemon/define-mount.ts
+++ b/packages/workspace/src/daemon/define-mount.ts
@@ -7,8 +7,8 @@
  * `MountContext` so handlers can use it for logging.
  *
  * The host calls `open(ctx)` once on `epicenter daemon up`. The returned
- * runtime shape matches `DaemonRuntime` so the socket app does not branch on
- * mount origin.
+ * runtime always exposes local `actions`, and may expose `collaboration` when
+ * the mount participates in Yjs sync, presence, and peer dispatch.
  */
 
 import type { Keyring } from '@epicenter/encryption';

--- a/packages/workspace/src/daemon/list-mount.test.ts
+++ b/packages/workspace/src/daemon/list-mount.test.ts
@@ -9,7 +9,12 @@
 import { describe, expect, test } from 'bun:test';
 import type { Result } from 'wellcrafted/result';
 import { expectOk } from 'wellcrafted/testing';
-import { type ActionManifest, defineQuery } from '../shared/actions.js';
+import type { PresenceDevice } from '../document/presence-protocol.js';
+import {
+	type ActionManifest,
+	type ActionRegistry,
+	defineQuery,
+} from '../shared/actions.js';
 import { joinDaemonActionPath, parseDaemonActionPath } from './action-path.js';
 import { buildDaemonApp } from './app.js';
 import type { DaemonServedMount } from './types.js';
@@ -17,22 +22,27 @@ import type { DaemonServedMount } from './types.js';
 function makeMount({
 	mount,
 	actions,
+	collaboration = true,
+	devices = [],
 }: {
 	mount: string;
-	actions: DaemonServedMount['runtime']['collaboration']['actions'];
+	actions: ActionRegistry;
+	collaboration?: boolean;
+	devices?: PresenceDevice[];
 }): DaemonServedMount {
+	const runtime: DaemonServedMount['runtime'] = { actions };
+	if (collaboration) {
+		runtime.collaboration = {
+			devices: {
+				list: () => devices,
+			},
+			status: { phase: 'connected' },
+			dispatch: async () => ({ data: null, error: null }) as never,
+		};
+	}
 	return {
 		mount,
-		runtime: {
-			collaboration: {
-				actions,
-				devices: {
-					list: () => [],
-				},
-				status: { phase: 'connected' },
-				dispatch: async () => ({ data: null, error: null }) as never,
-			},
-		},
+		runtime,
 	};
 }
 
@@ -79,7 +89,7 @@ describe('/list route', () => {
 		expect(manifest['demo.counter_get']?.description).toBe('Read the counter');
 	});
 
-	test('returns an empty manifest when the collaboration has no actions', async () => {
+	test('returns an empty manifest when the mount has no actions', async () => {
 		const res = await buildDaemonApp([
 			makeMount({ mount: 'demo', actions: {} }),
 		]).request('/list', { method: 'POST' });
@@ -90,7 +100,28 @@ describe('/list route', () => {
 		expect(manifest).toEqual({});
 	});
 
-	test('prefixes actions from every mount', async () => {
+	test('returns actions from a mount without collaboration', async () => {
+		const res = await buildDaemonApp([
+			makeMount({
+				mount: 'mirror',
+				collaboration: false,
+				actions: {
+					sync: defineQuery({
+						description: 'Sync local mirror',
+						handler: () => null,
+					}),
+				},
+			}),
+		]).request('/list', { method: 'POST' });
+
+		const manifest = expectOk(
+			(await res.json()) as Result<ActionManifest, never>,
+		);
+		expect(Object.keys(manifest)).toEqual(['mirror.sync']);
+		expect(manifest['mirror.sync']?.description).toBe('Sync local mirror');
+	});
+
+	test('prefixes actions from collaborative and local-only mounts', async () => {
 		const res = await buildDaemonApp([
 			makeMount({
 				mount: 'notes',
@@ -100,6 +131,7 @@ describe('/list route', () => {
 			}),
 			makeMount({
 				mount: 'tasks',
+				collaboration: false,
 				actions: {
 					tasks_list: defineQuery({ handler: () => [] }),
 				},
@@ -113,5 +145,32 @@ describe('/list route', () => {
 			'notes.notes_add',
 			'tasks.tasks_list',
 		]);
+	});
+});
+
+describe('/peers route', () => {
+	test('skips mounts without collaboration', async () => {
+		const res = await buildDaemonApp([
+			makeMount({
+				mount: 'mirror',
+				collaboration: false,
+				actions: {
+					sync: defineQuery({ handler: () => null }),
+				},
+			}),
+			makeMount({
+				mount: 'notes',
+				actions: {},
+				devices: [{ deviceId: 'laptop', connectedAt: 1, actions: {} }],
+			}),
+		]).request('/peers', { method: 'POST' });
+
+		const peers = expectOk(
+			(await res.json()) as Result<
+				Array<{ mount: string; deviceId: string }>,
+				never
+			>,
+		);
+		expect(peers).toEqual([{ mount: 'notes', deviceId: 'laptop' }]);
 	});
 });

--- a/packages/workspace/src/daemon/server.test.ts
+++ b/packages/workspace/src/daemon/server.test.ts
@@ -28,21 +28,26 @@ let workDir: string;
 
 function makeRuntime({
 	actions = {},
+	collaboration = true,
 	dispatch = async () => ({ data: null, error: null }) as never,
 }: {
 	actions?: ActionRegistry;
-	dispatch?: DaemonServedMount['runtime']['collaboration']['dispatch'];
+	collaboration?: boolean;
+	dispatch?: NonNullable<
+		DaemonServedMount['runtime']['collaboration']
+	>['dispatch'];
 } = {}): DaemonServedMount['runtime'] {
-	return {
-		collaboration: {
-			actions,
+	const runtime: DaemonServedMount['runtime'] = { actions };
+	if (collaboration) {
+		runtime.collaboration = {
 			devices: {
 				list: () => [],
 			},
 			status: { phase: 'connected' },
 			dispatch,
-		},
-	};
+		};
+	}
+	return runtime;
 }
 
 function claimTestLease(): DaemonLease {
@@ -177,6 +182,34 @@ describe('startDaemonServer', () => {
 		}
 	});
 
+	test('run executes a local-only mount action over the socket', async () => {
+		const lease = claimTestLease();
+		const runtime = makeRuntime({
+			collaboration: false,
+			actions: {
+				sync: defineQuery({ handler: () => ({ imported: 1 }) }),
+			},
+		});
+		const serverResult = await startDaemonServer({
+			lease,
+			mounts: [{ mount: 'mirror', runtime }],
+		});
+
+		try {
+			const server = expectOk(serverResult);
+			const data = expectOk(
+				await daemonClient(server.socketPath).run({
+					actionPath: 'mirror.sync',
+					input: null,
+				}),
+			);
+			expect(data).toEqual({ imported: 1 });
+		} finally {
+			if (serverResult.error === null) await serverResult.data.close();
+			lease.release();
+		}
+	});
+
 	test('run with to forwards mount-local action keys over the socket', async () => {
 		const lease = claimTestLease();
 		let invokedAction = '';
@@ -225,6 +258,31 @@ describe('startDaemonServer', () => {
 					actionPath: 'demo.peer_only_action',
 					input: null,
 					peer: { to: 'mac', waitMs: -1 },
+				}),
+			);
+			expect(error.name).toBe('UsageError');
+		} finally {
+			if (serverResult.error === null) await serverResult.data.close();
+			lease.release();
+		}
+	});
+
+	test('run with to rejects local-only mounts as a usage error', async () => {
+		const lease = claimTestLease();
+		const serverResult = await startDaemonServer({
+			lease,
+			mounts: [
+				{ mount: 'mirror', runtime: makeRuntime({ collaboration: false }) },
+			],
+		});
+
+		try {
+			const server = expectOk(serverResult);
+			const error = expectErr(
+				await daemonClient(server.socketPath).run({
+					actionPath: 'mirror.sync',
+					input: null,
+					peer: { to: 'mac', waitMs: 25 },
 				}),
 			);
 			expect(error.name).toBe('UsageError');

--- a/packages/workspace/src/daemon/types.ts
+++ b/packages/workspace/src/daemon/types.ts
@@ -2,8 +2,9 @@
  * Daemon-side runtime types.
  *
  * `DaemonRuntime` is the contract every opened mount returns: async dispose
- * plus the hosted `Collaboration<TActions>` that owns identity, actions, sync,
- * and the live-device surface.
+ * plus the local action registry the daemon serves. Collaborative mounts may
+ * also expose a hosted `Collaboration<TActions>` for identity, sync, peer
+ * presence, and peer dispatch.
  *
  * `DaemonServedMount` is the narrowed mount-handler contract for the socket
  * app. `StartedMount` is the lifecycle-owning mount shape opened from a
@@ -19,13 +20,10 @@ import type { ActionRegistry } from '../shared/actions.js';
 import type { MaybePromise } from '../shared/types.js';
 
 /**
- * Collaboration fields the daemon socket app reads while serving `/peers`,
- * `/list`, and `/run`.
+ * Collaboration fields the daemon socket app reads while serving `/peers` and
+ * peer `/run`.
  */
-type DaemonServedCollaboration<
-	TActions extends ActionRegistry = ActionRegistry,
-> = {
-	actions: TActions;
+type DaemonServedCollaboration = {
 	devices: {
 		list(): PresenceDevice[];
 	};
@@ -44,7 +42,8 @@ export type DaemonServedMount<
 > = {
 	mount: string;
 	runtime: {
-		collaboration: DaemonServedCollaboration<TActions>;
+		actions: TActions;
+		collaboration?: DaemonServedCollaboration;
 	};
 };
 
@@ -56,10 +55,18 @@ export type DaemonRuntime<TActions extends ActionRegistry = ActionRegistry> = {
 	[Symbol.asyncDispose](): MaybePromise<void>;
 
 	/**
-	 * The hosted collaboration. Identity, action registry, sync status, and
-	 * the live-device surface for cross-mount dispatch all live here.
+	 * The action registry this daemon serves locally. When `collaboration` is
+	 * present, this must be the same registry handed to `openCollaboration`, so
+	 * local runs, peer manifests, and inbound peer dispatch stay in lockstep.
 	 */
-	readonly collaboration: Collaboration<TActions>;
+	readonly actions: TActions;
+
+	/**
+	 * Optional hosted collaboration. Identity, sync status, live-device
+	 * presence, and peer dispatch live here when the mount participates in a
+	 * collaborative Yjs workspace.
+	 */
+	readonly collaboration?: Collaboration<TActions>;
 };
 
 /** One configured mount runtime hosted by the daemon. */

--- a/packages/workspace/src/document/open-collaboration.ts
+++ b/packages/workspace/src/document/open-collaboration.ts
@@ -108,9 +108,11 @@ export type OpenCollaborationConfig<TActions extends ActionRegistry> = {
 	connectDeadlineMs?: number;
 	log?: Logger;
 	/**
-	 * Local action registry. Pass `{}` for content docs and consume-only
-	 * participants. When the registry is empty, inbound `dispatch_inbound`
-	 * frames always reply with `ActionNotFound`.
+	 * Injected local action registry. Collaboration publishes this registry to
+	 * peers and uses it for inbound dispatch, but the caller remains the
+	 * registry owner. Pass `{}` for content docs and consume-only participants.
+	 * When the registry is empty, inbound `dispatch_inbound` frames always reply
+	 * with `ActionNotFound`.
 	 */
 	actions: TActions;
 };

--- a/packages/workspace/src/workspace-apps/open-project.test.ts
+++ b/packages/workspace/src/workspace-apps/open-project.test.ts
@@ -55,7 +55,7 @@ function stubAuthClient(): WorkspaceAuthClient {
 }
 
 /** A mount literal whose runtime disposes cleanly, written into a config. */
-const RUNTIME = '{ collaboration: {}, async [Symbol.asyncDispose]() {} }';
+const RUNTIME = '{ actions: {}, async [Symbol.asyncDispose]() {} }';
 
 describe('openProject', () => {
 	test('returns a structured not-found error instead of throwing', async () => {
@@ -101,7 +101,7 @@ describe('openProject', () => {
 				{
 					name: 'good',
 					open: () => ({
-						collaboration: {},
+						actions: {},
 						async [Symbol.asyncDispose]() { writeFileSync(marker, 'disposed'); },
 					}),
 				},

--- a/specs/20260613T100235-action-first-daemon-runtime.md
+++ b/specs/20260613T100235-action-first-daemon-runtime.md
@@ -1,0 +1,221 @@
+# Action-first daemon runtime
+
+**Date**: 2026-06-13
+**Status**: Implemented
+**Owner**: Epicenter maintainers
+
+## One Sentence
+
+Daemon-served runtimes expose `actions` as the required local capability, and
+expose `collaboration` only when the mount participates in Yjs sync, peer
+presence, and peer dispatch.
+
+## Product Shape
+
+Epicenter should be able to serve local-only integrations, such as a Gmail or
+QuickBooks mirror, without pretending that every mount owns a collaborative Yjs
+workspace. The daemon can still be the long-lived process that runs actions,
+keeps projections fresh, and talks over the local socket. Collaboration becomes
+one optional capability on that process, not the thing that makes a runtime
+servable.
+
+This gives source mirrors a clean first home:
+
+```ts
+return defineMount({
+  name: 'gmail',
+  open: async () => ({
+    actions,
+    [Symbol.asyncDispose]: async () => {
+      await closeMirror();
+    },
+  }),
+});
+```
+
+Those mounts can support:
+
+```sh
+epicenter list
+epicenter run gmail.sync '{}'
+epicenter run quickbooks.pull_transactions '{}'
+```
+
+They do not support:
+
+```sh
+epicenter peers
+epicenter run gmail.sync '{}' --peer laptop
+```
+
+The second class requires collaboration because it is about remote peers, device
+presence, and inbound dispatch over the shared workspace transport.
+
+## Terminology Decision
+
+Keep the field name `collaboration`.
+
+It is still the right term for the optional capability because the existing
+object represents more than storage. It owns device presence, sync status, peer
+addressing, and peer dispatch. Renaming it to `sync`, `peer`, or `workspace`
+would each hide part of what the object does.
+
+The mistake is not the word. The mistake is threading collaboration through
+surfaces that only need local actions. The target rule is:
+
+| Capability | Required | Used by | Meaning |
+| --- | --- | --- | --- |
+| `runtime.actions` | Yes | `list`, local `run`, daemon route suggestions | The actions this mount serves on this machine. |
+| `runtime.collaboration` | No | `peers`, `run --peer`, sync status logging | Optional Yjs-backed peer and sync capability. |
+
+Do not make a second daemon kind. The daemon is still one local process with a
+set of mounted runtimes. Each runtime advertises capabilities by shape:
+
+```ts
+type DaemonRuntime<TActions extends ActionRegistry = ActionRegistry> = {
+  readonly actions: TActions;
+  readonly collaboration?: DaemonServedCollaboration;
+  [Symbol.asyncDispose](): MaybePromise<void>;
+};
+```
+
+`DaemonServedCollaboration` should no longer be the action registry owner. It
+may continue to expose `actions` on the public browser/workspace object if that
+is useful for app code, but daemon code should not read actions through
+`runtime.collaboration.actions`.
+
+For the daemon socket app, the served narrowing should make that rule
+structural:
+
+```ts
+type DaemonServedCollaboration = {
+  devices: {
+    list(): PresenceDevice[];
+  };
+  status: SyncStatus;
+  dispatch(req: DispatchRequest): Promise<Result<unknown, DispatchError>>;
+};
+
+type DaemonServedMount<TActions extends ActionRegistry = ActionRegistry> = {
+  mount: string;
+  runtime: {
+    actions: TActions;
+    collaboration?: DaemonServedCollaboration;
+  };
+};
+```
+
+## Before
+
+The current daemon contract makes Yjs collaboration mandatory:
+
+```ts
+type DaemonRuntime<TActions extends ActionRegistry = ActionRegistry> = {
+  readonly collaboration: Collaboration<TActions>;
+  [Symbol.asyncDispose](): MaybePromise<void>;
+};
+```
+
+That means a local-only mirror has to either create fake collaboration or avoid
+the daemon route entirely. Both options blur the source-of-truth story.
+
+## After
+
+The daemon can serve actions with or without collaboration:
+
+```txt
+workspace-backed mount
+  actions
+  collaboration
+    devices
+    status
+    dispatch
+
+local-only mirror
+  actions
+  no collaboration
+```
+
+Route behavior becomes simple:
+
+| Route | Local-only mount | Collaborative mount |
+| --- | --- | --- |
+| `/list` | List actions | List actions |
+| `/run` local | Run local action | Run local action |
+| `/run` with peer | Usage error | Dispatch to peer |
+| `/peers` | Skip mount | List peer devices |
+| daemon status logs | No sync row | Sync row |
+
+## Implementation Plan
+
+- [x] Update daemon runtime types so `actions` is required and
+  `collaboration` is optional.
+- [x] Drop `actions` from the daemon-served collaboration narrowing so daemon
+  code has exactly one action registry source.
+- [x] Move daemon list, run, and suggestion paths to `runtime.actions`.
+- [x] Guard peer dispatch so `run --peer` on a local-only mount returns a
+  usage error instead of dereferencing optional collaboration.
+- [x] Make `/peers` skip mounts that do not expose collaboration.
+- [x] Make `epicenter daemon up` peer and sync logging skip local-only mounts.
+- [x] Keep `attachProjectInfrastructure` returning the same action registry it
+  receives, so workspace-backed mounts can spread the infrastructure result and
+  satisfy the new runtime contract.
+- [x] Update daemon and CLI tests for mixed collaborative plus local-only
+  mounts.
+- [x] Update project loading fixtures that synthesize runtime code.
+- [x] Run focused workspace and CLI verification.
+- [x] Consult Claude Code again after the implementation and run a
+  post-implementation review.
+
+## Test Plan
+
+Add or adjust tests for:
+
+- `list` includes actions from a mount without collaboration.
+- Local `run` can execute an action from a mount without collaboration.
+- `run --peer` against a mount without collaboration returns a usage error.
+- `/peers` excludes local-only mounts while preserving collaborative peer rows.
+- daemon up logging/subscription helpers tolerate mixed runtimes.
+- generated project-loading fixtures include top-level `actions`.
+
+Type-level coverage is useful if it is cheap:
+
+- A daemon-served mount with `actions` and no `collaboration` should compile
+  and work through `/list` plus local `/run`.
+- A daemon-served mount with `collaboration` and no `actions` should fail in
+  the daemon contract if there is a cheap local type-test home.
+
+## Explicit Non-goal
+
+This spec does not remove `daemon up` auth-client construction. Today `runUp`
+constructs machine auth before opening mounts. That is acceptable for this
+runtime-contract pass because the change is about what an opened mount can
+serve. A later local-only project pass should decide whether a project with no
+collaborative mounts can start without persisted sync auth.
+
+## Deferred Work
+
+This spec does not build Gmail, QuickBooks, Every, Arc, or Rho integrations.
+It only creates the runtime slot they need.
+
+It also does not add a dedicated `epicenter mirror` command. `epicenter run`
+remains the action entry point. Future integrations can decide whether they want
+actions named `sync`, `pull`, `import`, or `materialize`, but that is namespace
+design inside each mount, not a new daemon command family.
+
+## Source Mirror Direction
+
+For local-only source mirrors, prefer this storage split:
+
+- SQLite for durable cursor state, raw provider IDs, normalized projection
+  tables, dedupe keys, and audit metadata.
+- Files or plain text exports only when they are useful review artifacts.
+- Plain text accounting files, such as Ledger, Beancount, or hledger journals,
+  as generated review surfaces for finances, not the only raw source cache.
+- No Yjs layer unless the data is genuinely collaborative and user-authored
+  inside an Epicenter workspace.
+
+That keeps the source of truth honest. QuickBooks, Gmail, or a bank provider
+remains the upstream system. Epicenter stores enough local state to review,
+query, diff, and ask agents questions, while avoiding bidirectional sync until a
+specific product workflow earns it.


### PR DESCRIPTION
Daemon mounts used to be servable only when they returned a collaboration handle, because the daemon read actions through `runtime.collaboration.actions`. That made local-only source mirrors awkward: a Gmail, QuickBooks, or other read-only mirror would have to fabricate collaboration just to expose local actions.

This changes the daemon runtime contract so local actions are the required capability and collaboration is optional peer/sync machinery:

```ts
type DaemonRuntime<TActions extends ActionRegistry = ActionRegistry> = {
  readonly actions: TActions;
  readonly collaboration?: Collaboration<TActions>;
  [Symbol.asyncDispose](): MaybePromise<void>;
};
```

`epicenter list` and local `epicenter run` now read `runtime.actions`. Peer-only surfaces such as `epicenter peers`, sync logging, and `epicenter run --peer` only use `runtime.collaboration` when the mount exposes it. A local-only mount can now serve actions without joining Yjs sync, while collaborative mounts continue to wire the same registry into `openCollaboration` for manifests and inbound peer dispatch.

The included spec records the terminology decision: keep `collaboration` for the optional Yjs-backed peer capability, but stop threading it through daemon surfaces that only need actions.

BREAKING CHANGE: `DaemonRuntime` now requires top-level `actions`, and `collaboration` is optional. Mounts that returned only `collaboration` must return an action registry at `runtime.actions`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783967500&installation_id=128463665&pr_number=1955&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1955&signature=e0545024a572b6ac0f838ccd2410dbcd8c614fd5bd0b91c3bec6bf835eaa5530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->