### PR TITLE
refactor(whispering): drop unread timestamp columns from workspace schema

### DIFF
--- a/apps/whispering/src/lib/operations/pipeline.ts
+++ b/apps/whispering/src/lib/operations/pipeline.ts
@@ -53,7 +53,6 @@ export async function processRecordingPipeline({
 		title: '',
 		recordedAt: now,
 		recordedAtZone: IanaTimeZone.current(),
-		updatedAt: now,
 		transcript: '',
 		duration: durationMs,
 		transcription: null,

--- a/apps/whispering/src/lib/state/transformations.svelte.ts
+++ b/apps/whispering/src/lib/state/transformations.svelte.ts
@@ -2,8 +2,8 @@
  * Reactive transformation state backed by Yjs workspace tables.
  *
  * Replaces TanStack Query + BlobStore for transformation CRUD. The workspace
- * model stores transformations as metadata rows (title, description, timestamps)
- * without embedded steps. Steps live in a separate `transformationSteps` table.
+ * model stores transformations as metadata rows (title, description) without
+ * embedded steps. Steps live in a separate `transformationSteps` table.
  *
  * @example
  * ```typescript
@@ -19,7 +19,6 @@
  * ```
  */
 
-import { InstantString } from '@epicenter/field';
 import { fromTable } from '@epicenter/svelte';
 import { nanoid } from 'nanoid/non-secure';
 import { whispering } from '#platform/whispering';
@@ -110,13 +109,10 @@ if (import.meta.hot) {
  * ```
  */
 export function generateDefaultTransformation(): Transformation {
-	const now = InstantString.now();
 	return {
 		id: nanoid(),
 		title: '',
 		description: '',
-		createdAt: now,
-		updatedAt: now,
 	};
 }
 
@@ -124,7 +120,6 @@ export function generateDefaultTransformation(): Transformation {
  * Atomically save a transformation and its steps in a single workspace batch.
  *
  * Works for both create and update:
- * - Sets `updatedAt` to now (harmless on create since it was already "now").
  * - Deletes existing steps first (no-op on create since none exist yet),
  *   then re-inserts with correct ordering.
  *
@@ -142,10 +137,7 @@ export function saveTransformationWithSteps(
 	steps: TransformationStep[],
 ) {
 	whispering.ydoc.transact(() => {
-		transformations.set({
-			...transformation,
-			updatedAt: InstantString.now(),
-		});
+		transformations.set(transformation);
 		transformationSteps.deleteByTransformationId(transformation.id);
 		for (const [order, step] of steps.entries()) {
 			transformationSteps.set({

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -63,7 +63,6 @@ const recordings = defineTable({
 	title: field.string(),
 	recordedAt: field.instant(),
 	recordedAtZone: field.string<IanaTimeZone>(),
-	updatedAt: field.instant(),
 	transcript: field.string(),
 	duration: nullable(field.number()),
 	transcription: nullable(field.json(TranscriptionOutcome)),
@@ -77,8 +76,6 @@ const transformations = defineTable({
 	id: field.string(),
 	title: field.string(),
 	description: field.string(),
-	createdAt: field.instant(),
-	updatedAt: field.instant(),
 });
 
 /** Transformation row type inferred from the workspace table schema. */

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -157,16 +157,6 @@
 			cell: formattedCell((recording) => recording.recordedAtZone),
 		},
 		{
-			accessorKey: 'updatedAt',
-			meta: { label: 'Updated At' },
-			header: ({ column }) =>
-				renderComponent(SortableTableHeader, {
-					column,
-					headerText: 'Updated At',
-				}),
-			cell: formattedCell(),
-		},
-		{
 			accessorKey: 'transcript',
 			meta: { label: 'Transcript' },
 			header: ({ column }) =>
@@ -257,7 +247,6 @@
 		schema: type('Record<string, boolean>'),
 		defaultValue: {
 			id: false,
-			updatedAt: false,
 		},
 	});
 	let rowSelection = createPersistedState({


### PR DESCRIPTION
Removes three timestamp columns from the synced Whispering workspace schema that nothing reads.

This change does the following:

- `recordings.updatedAt` (table column + write site + the hidden "Updated At" table column and its visibility default)
- `transformations.createdAt`
- `transformations.updatedAt` (schema, `generateDefaultTransformation`, and the `saveTransformationWithSteps` write)

The reason for this shape is:

These were inherited SQL/ORM convention. No read path in the app sorts or displays by mutation time:

- `recordings.updatedAt` was written once at creation, set equal to `recordedAt`, and never bumped again. None of the later writers touch it (`transcribeAndPersist` writes `transcript`/`transcription`; `EditRecordingModal` writes `title`/`recordedAt`/`recordedAtZone`/`transcript`; the pipeline fail path writes `transcription`). The hidden "Updated At" column only ever duplicated "Recorded".
- `transformations.createdAt` had no reader anywhere. `transformations.updatedAt` was correctly bumped on save but never read; the transformation list sorts alphabetically by `title`.

On a synced schema every column is bytes replicated to other devices and the cloud relay (and row values are the encrypted payload), so an unread column is dead weight that still costs sync and encryption surface.

The unchanged parts are intentional:

The date keys that earn their place are untouched:

- `recordings.recordedAt` + `recordedAtZone` (the zone renders the instant in the wall-clock zone it was recorded in)
- `transformationRuns` / `transformationStepRuns` `startedAt` + `result.completedAt` (a real span: gives duration and liveness)
- the `recordings.transcription` terminal outcome

`recordings.duration` and `recordings.transcription.completedAt` are also currently unread, but were kept deliberately: `duration` is an intrinsic, correctly computed audio attribute that is simply not surfaced yet, and `completedAt` is terminal-outcome provenance riding free inside one JSON cell, parallel to the runs' displayed `completedAt`.

## Migration safety

The workspace tables are a single schema version built with `Type.Object(...)` and no `additionalProperties` constraint, so `Value.Check` tolerates extra keys. Legacy synced rows that still carry `updatedAt` / `createdAt` validate as ignored extras and keep reading normally; new rows simply omit them. No data migration required.

The scope is intentionally bounded:

The legacy Dexie `.stores()` index strings in `blob-store/web/dexie-database.ts` still name `createdAt` / `updatedAt`. That is a separate IndexedDB layer (now only audio blobs), and changing those declarations requires a Dexie version bump plus an IndexedDB upgrade, so it is left as a follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783975401&installation_id=128463665&pr_number=1958&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1958&signature=e81a6a62a0da427caaedba030ac1eaa6914ce99ee7793cca14f2ec1333cfe460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->