### PR TITLE
refactor(whispering): collapse terminal-outcome unions into one helper

### DIFF
--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -9,7 +9,7 @@ import {
 	type InferTableRow,
 	nullable,
 } from '@epicenter/workspace';
-import { Type } from 'typebox';
+import { Type, type TProperties } from 'typebox';
 
 // ── Constant imports ─────────────────────────────────────────────────────────
 
@@ -28,28 +28,40 @@ import {
  * `table.set()`, there's no field-level merging. Schemas validate rows on read.
  */
 /**
- * Terminal outcome of transcribing a recording. Only finished states are
- * stored. A recording that is currently transcribing has no `transcription`
- * (the column is null); liveness comes from the in-flight transcription
- * mutation, never from durable state. A stored 'TRANSCRIBING' status would
+ * A terminal job outcome: `completed` or `failed`. Both variants carry the
+ * finish instant; `failed` adds the error message; `completed` carries whatever
+ * job-specific payload the caller declares through `completedExtra`.
+ *
+ * Only terminal states are ever stored. A job still in flight has no outcome
+ * (the storing column is null); liveness comes from the in-flight mutation,
+ * never from durable state. A stored 'running'/'transcribing' status would
  * wedge on crash: the process that died can no longer write the terminal
  * state. See
  * docs/articles/20260612T190745-liveness-belongs-to-the-process-not-the-row.md.
- *
- * The transcript text lives in its own `transcript` column, so a completed
- * outcome only records when it finished.
  */
-const TranscriptionOutcome = Type.Union([
-	Type.Object({
-		status: Type.Literal('completed'),
-		completedAt: field.instant(),
-	}),
-	Type.Object({
-		status: Type.Literal('failed'),
-		completedAt: field.instant(),
-		error: Type.String(),
-	}),
-]);
+function terminalOutcome<CompletedExtra extends TProperties>(
+	completedExtra: CompletedExtra,
+) {
+	return Type.Union([
+		Type.Object({
+			status: Type.Literal('completed'),
+			completedAt: field.instant(),
+			...completedExtra,
+		}),
+		Type.Object({
+			status: Type.Literal('failed'),
+			completedAt: field.instant(),
+			error: Type.String(),
+		}),
+	]);
+}
+
+/**
+ * Terminal outcome of transcribing a recording. The transcript text lives in
+ * its own `transcript` column, so the `completed` variant only records when it
+ * finished.
+ */
+const TranscriptionOutcome = terminalOutcome({});
 
 /**
  * Audio recordings captured by the user. One row per recording session.
@@ -128,32 +140,12 @@ const transformationSteps = defineTable({
 export type TransformationStep = InferTableRow<typeof transformationSteps>;
 
 /**
- * Per-variant result shapes for a finished transformation run or step run.
- *
- * Only terminal outcomes are stored. A run that is currently executing has no
- * `result` (the column is null); liveness is derived from `startedAt` recency,
- * never written. A stored `running` status would wedge on crash: the process
- * that died can no longer write the terminal state, so the row would claim
- * `running` forever. See
- * docs/articles/20260612T190745-liveness-belongs-to-the-process-not-the-row.md.
- *
- * Storage is one nullable JSON-encoded TEXT column (`result`); nothing in the
- * read path filters or sorts on these fields. Run and step run share it.
+ * Terminal outcome of a transformation run or step run, carrying the produced
+ * `output` on success. Stored as one nullable JSON-encoded TEXT column
+ * (`result`); nothing in the read path filters or sorts on these fields. Run
+ * and step run share it.
  */
-const CompletedResult = Type.Object({
-	status: Type.Literal('completed'),
-	completedAt: field.instant(),
-	output: Type.String(),
-});
-
-const FailedResult = Type.Object({
-	status: Type.Literal('failed'),
-	completedAt: field.instant(),
-	error: Type.String(),
-});
-
-/** A terminal outcome. Absence (null) means the run never reached one. */
-const TransformationRunResult = Type.Union([CompletedResult, FailedResult]);
+const TransformationRunResult = terminalOutcome({ output: Type.String() });
 
 /**
  * Execution records for transformation pipelines. One run per invocation.

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -9,7 +9,7 @@ import {
 	type InferTableRow,
 	nullable,
 } from '@epicenter/workspace';
-import { Type, type TProperties } from 'typebox';
+import { type TProperties, Type } from 'typebox';
 
 // ── Constant imports ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Collapses three near-identical "completed or failed" terminal-outcome unions in the Whispering workspace schema into one shared helper.

This change does the following:

The schema had two bespoke union definitions encoding the same shape:

- `TranscriptionOutcome` (on `recordings.transcription`): `completed{status, completedAt}` | `failed{status, completedAt, error}`
- `TransformationRunResult` (shared by `transformationRuns` and `transformationStepRuns`, built from `CompletedResult` + `FailedResult`): `completed{status, completedAt, output}` | `failed{status, completedAt, error}`

They differ only in whether the `completed` variant carries an `output` string. One owner now expresses both:

```ts
function terminalOutcome<CompletedExtra extends TProperties>(completedExtra: CompletedExtra) {
  return Type.Union([
    Type.Object({ status: Type.Literal('completed'), completedAt: field.instant(), ...completedExtra }),
    Type.Object({ status: Type.Literal('failed'),    completedAt: field.instant(), error: Type.String() }),
  ]);
}

const TranscriptionOutcome    = terminalOutcome({});
const TransformationRunResult = terminalOutcome({ output: Type.String() });
```

The `CompletedResult` / `FailedResult` intermediates are removed.

The reason for this shape is:

One owner for "what a finished job looks like." The completed/failed/timestamp/error shape was written out three times; the only real variation is the success payload, which is now the single parameter.

## No behavior or migration change

The generic produces the identical JSON shape (stored in a nullable JSON-encoded TEXT column), and `Static<>` inference is preserved: the `output` field still narrows on the `completed` variant, verified by the existing consumers (`run.result.output`, the transform write sites) typechecking clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783976754&installation_id=128463665&pr_number=1959&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1959&signature=605c0cf462de0f6be92240946d672941de444bcdbaf7222fd40edf931f4a7419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->