### PR TITLE
refactor(workspace)!: rename project root API

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -1,6 +1,6 @@
 # Apps
 
-Each app under `apps/` owns its hosted UI plus, when needed, one reusable project mount.
+Each app under `apps/` owns its hosted UI plus, when needed, one reusable daemon mount.
 
 The current center is:
 
@@ -24,7 +24,7 @@ defineWorkspace()
 
 ```
 apps/<app>/
-├── project.ts       optional `<app>()` project mount factory
+├── project.ts       optional `<app>()` daemon mount factory
 ├── workspace.ts     shared schema, branded IDs, create<App>, actions
 ├── src/             SvelteKit app
 └── package.json     "exports": { ".": "./workspace.ts", "./project": "./project.ts" }
@@ -43,11 +43,11 @@ boundary is the same: shared model in the workspace file, runtime wiring in
 
 Browser and desktop code compose runtime-only attachments around the same `create<App>(...)` model. Scripts usually skip Yjs entirely: they read materialized files or SQLite and call daemon actions through `connectDaemonActions`.
 
-## Adding a Project Mount
+## Adding a Daemon Mount
 
 1. Add `apps/<app>/workspace.ts` or `apps/<app>/src/lib/workspace.ts`, following the package's existing layout.
 2. Point `package.json` `exports["."]` at the workspace contract file.
 3. Add `create<App>()` and return `defineWorkspace({ ...workspace, actions, ...sharedChildDocs })`.
 4. Add `apps/<app>/project.ts` exporting `<app>(opts?)`, a factory that returns `defineMount({ name, open })`.
 5. Point `package.json` `exports["./project"]` at `./project.ts`.
-6. Run `epicenter daemon up -C <project>` and confirm the mount appears in `epicenter list`.
+6. Run `epicenter daemon up -C <epicenter-root>` and confirm the mount appears in `epicenter list`.

--- a/apps/fuji/README.md
+++ b/apps/fuji/README.md
@@ -14,7 +14,7 @@ SvelteKit app (static adapter, SSR disabled) with three panels: a sidebar for fi
 
 ### Data model
 
-Workspace ID: `FUJI_ID` (`epicenter-fuji`). Rich-text content and entry metadata are separate CRDTs. The entries table stays lean: metadata rows live in the root Y.Doc, and each entry's body lives in its own child Y.Doc addressed by `entryContentDocGuid(id)`. The browser opens bodies through a `createDisposableCache` keyed on the entry id; the project daemon opens a throwaway body doc per row when deriving markdown. Loading a list of 500 entries doesn't mean loading 500 rich-text trees; the editor and the list never contend for the same document.
+Workspace ID: `FUJI_ID` (`epicenter-fuji`). Rich-text content and entry metadata are separate CRDTs. The entries table stays lean: metadata rows live in the root Y.Doc, and each entry's body lives in its own child Y.Doc addressed by `entryContentDocGuid(id)`. The browser opens bodies through a `createDisposableCache` keyed on the entry id; the daemon-side Fuji mount opens a throwaway body doc per row when deriving markdown. Loading a list of 500 entries doesn't mean loading 500 rich-text trees; the editor and the list never contend for the same document.
 
 - `entries` table: `id` (EntryId), `title`, `subtitle`, `type` (string[]), `tags` (string[]), `pinned`, `deletedAt`, `date`, `dateZone`, `createdAt`, `updatedAt`, and `rating`.
 - `entryBodies`: browser child-doc cache. `entryContentDocGuid(id)` defines the Y.Doc identity; `openFujiBrowser()` attaches rich text, storage, sync, and the `updatedAt` bump.
@@ -32,7 +32,7 @@ createFuji()
 
 openFujiBrowser()
 fuji()
-  runtime-specific wiring (browser opener, project mount factory)
+  runtime-specific wiring (browser opener, daemon mount factory)
 
 defineWorkspace()
   preserves the inferred bundle shape after composition
@@ -147,9 +147,9 @@ import { fuji } from "@epicenter/fuji/project";
 export default [fuji()];
 ```
 
-`fuji()` returns a `Mount` whose `name` is `fuji`; `Mount.name` is the CLI prefix. `epicenter.config.ts` default-exports a mount list, so a one-mount project still wraps it in an array. Disk paths follow the mount layout: the read-only markdown projection lands at `<epicenterRoot>/fuji/` (visible, a direct child of the Epicenter root keyed by the mount name) and the guid-keyed SQLite mirror under `.epicenter/sqlite/<id>.db` (hidden). The materialized `.md` is read-only; mutate entries through actions (`epicenter run fuji.<action>`), never by editing the files.
+`fuji()` returns a `Mount` whose `name` is `fuji`; `Mount.name` is the CLI prefix. `epicenter.config.ts` default-exports a mount list, so a one-mount Epicenter root still wraps it in an array. Disk paths follow the mount layout: the read-only markdown projection lands at `<epicenterRoot>/fuji/` (visible, a direct child of the Epicenter root keyed by the mount name) and the guid-keyed SQLite mirror under `.epicenter/sqlite/<id>.db` (hidden). The materialized `.md` is read-only; mutate entries through actions (`epicenter run fuji.<action>`), never by editing the files.
 
-`epicenter daemon up -C <project>` starts every mount declared in `epicenter.config.ts` inside one daemon process. It creates `.epicenter/` for generated project data when it is missing, but sockets and daemon logs live in platform user paths instead of inside the project.
+`epicenter daemon up -C <epicenter-root>` starts every mount declared in `epicenter.config.ts` inside one daemon process. It creates `.epicenter/` for generated machine state when it is missing, but sockets and daemon logs live in platform user paths instead of inside the root.
 
 ---
 

--- a/examples/fuji/entries/welcome.md
+++ b/examples/fuji/entries/welcome.md
@@ -1,7 +1,7 @@
 ---
 id: 01HM0000000000000000000000
 title: Welcome to Fuji
-subtitle: A canonical Epicenter project layout
+subtitle: A canonical Epicenter root layout
 type: []
 tags: ["welcome"]
 pinned: true
@@ -24,9 +24,9 @@ SQLite projections update.
 
 ## Layout
 
-The project's data layout is documented in `specs/20260522T220000-workspace-project-layout.md`:
+This fixture is a committed markdown projection for a Fuji mount:
 
-- `epicenter.config.ts` is the project marker and default-exports the mount list.
+- `epicenter.config.ts` is the Epicenter root marker and default-exports the mount list.
 - `entries/` (this directory) holds the markdown projection.
 - `.epicenter/` is the runtime cache (gitignored).
 

--- a/examples/notes-cross-peer/README.md
+++ b/examples/notes-cross-peer/README.md
@@ -2,9 +2,9 @@
 
 Two-peer minimal repro for the `system.describe` cross-peer fetch.
 
-Both project configs default-export a one-item `Mount[]` containing the `notes` mount from `workspaces/notes/daemon.ts`. `Mount.name` is the canonical CLI prefix. The two mount modules construct the same workspace (`epicenter-notes-repro`) with distinct peer ids, so each appears in the other's awareness.
+Both Epicenter configs default-export a one-item `Mount[]` containing the `notes` mount from `workspaces/notes/daemon.ts`. `Mount.name` is the canonical CLI prefix. The two mount modules construct the same workspace (`epicenter-notes-repro`) with distinct peer ids, so each appears in the other's awareness.
 
-This example runs one daemon process per project directory. In a normal project, one daemon can host many mounts (default-export `Mount[]`). This repro keeps peer-a and peer-b in separate project directories so they behave like two different machines.
+This example runs one daemon process per Epicenter root. In a normal root, one daemon can host many mounts (default-export `Mount[]`). This repro keeps peer-a and peer-b in separate Epicenter folders so they behave like two different machines.
 
 Exercises `createRemoteClient({ awareness, rpc }).describe(peerId)` end-to-end against the deployed API.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # @epicenter/cli
 
-> Introspect and invoke `defineQuery` / `defineMutation` actions exposed by configured project mounts, locally or on a currently online peer.
+> Introspect and invoke `defineQuery` / `defineMutation` actions exposed by configured mounts, locally or on a currently online peer.
 
 Each verb is a one-line shell shortcut for one workspace primitive:
 
@@ -36,7 +36,7 @@ The same env var and scripts apply to every command that talks to the API, inclu
 
 ## Commands
 
-`epicenter daemon up` opens every mount listed in the project's `epicenter.config.ts`. `list`, `run`, and `peers` dispatch to that local daemon over its Unix socket.
+`epicenter daemon up` opens every mount listed in the Epicenter root's `epicenter.config.ts`. `list`, `run`, and `peers` dispatch to that local daemon over its Unix socket.
 
 ```bash
 epicenter auth login
@@ -72,7 +72,7 @@ epicenter peers -C ~/workspace
 
 Error text goes to stderr; machine-readable output (`--format json|jsonl`, tables, and `run` results) goes to stdout.
 
-## Project Mounts
+## Epicenter Roots And Mounts
 
 `epicenter.config.ts` marks the Epicenter root and owns mount discovery. The default export is a `Mount[]`. App packages ship mount factories that return `Mount` values; each `Mount.name` owns the CLI prefix. The folder that holds `epicenter.config.ts` is your Epicenter folder: Epicenter owns its direct children, so each mount's visible markdown projection is a direct child folder named after the mount.
 
@@ -84,7 +84,7 @@ export default [fuji()];
 
 The returned `Mount.name` is `fuji`, so the CLI addresses actions as `fuji.<action_key>` regardless of the Epicenter folder name.
 
-For projects that host more than one mount, add more entries to the array:
+For Epicenter roots that host more than one mount, add more entries to the array:
 
 ```ts
 import { fuji } from "@epicenter/fuji/project";
@@ -131,7 +131,7 @@ export default [
 ];
 ```
 
-`Mount.name` is the CLI prefix. Two mounts in one project must have distinct names; duplicates fail before any mount opens.
+`Mount.name` is the CLI prefix. Two mounts in one Epicenter root must have distinct names; duplicates fail before any mount opens.
 
 `.epicenter/` holds the Epicenter root's generated machine state such as SQLite materializers, Yjs update logs, markdown materializers, and its generated `.gitignore`. It is not a registry. Runtime files live outside the Epicenter root: sockets and daemon metadata use the OS runtime directory, while daemon logs use the platform log directory from `env-paths`.
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,11 +10,10 @@ import { runCommand } from './commands/run.js';
  * Create the Epicenter CLI instance.
  *
  * Introspect and invoke `defineQuery` / `defineMutation` actions exposed by
- * configured project mounts, either locally or on a peer that's online right
- * now.
+ * configured mounts, either locally or on a peer that's online right now.
  *
  *   - `auth`:  manage the local machine auth session (pre-workspace)
- *   - `init`:  scaffold epicenter.config.ts (explicit project creation)
+ *   - `init`:  scaffold epicenter.config.ts (explicit root creation)
  *   - `daemon`: operate daemon lifecycle commands
  *   - `list`:  runnable actions grouped by mount (local schema is authoritative)
  *   - `run`:   invoke one by mount-prefixed action path; `--peer` dispatches over RPC

--- a/packages/cli/src/commands/down.ts
+++ b/packages/cli/src/commands/down.ts
@@ -21,7 +21,7 @@ import {
 	unlinkMetadata,
 } from '@epicenter/workspace/node';
 import { cmd } from '../util/cmd.js';
-import { projectOption } from '../util/common-options.js';
+import { epicenterRootOption } from '../util/common-options.js';
 import { isProcessAlive } from '../util/process-alive.js';
 
 const SHUTDOWN_TIMEOUT_MS = 1000;
@@ -72,7 +72,7 @@ export const downCommand = cmd({
 	command: 'down',
 	describe: 'Stop a running `epicenter daemon up` daemon.',
 	builder: {
-		C: projectOption,
+		C: epicenterRootOption,
 		all: {
 			type: 'boolean',
 			default: false,

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -6,7 +6,7 @@
 import { afterEach, beforeEach, expect, test } from 'bun:test';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { DEFAULT_PROJECT_CONFIG_SOURCE } from '@epicenter/workspace/node';
+import { DEFAULT_EPICENTER_CONFIG_SOURCE } from '@epicenter/workspace/node';
 import { createCLI } from '../cli.js';
 
 let workDir: string;
@@ -23,7 +23,7 @@ test('init scaffolds the default config', async () => {
 	await createCLI().run(['init', workDir]);
 
 	expect(readFileSync(join(workDir, 'epicenter.config.ts'), 'utf8')).toBe(
-		DEFAULT_PROJECT_CONFIG_SOURCE,
+		DEFAULT_EPICENTER_CONFIG_SOURCE,
 	);
 });
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -33,7 +33,9 @@ export const initCommand = cmd({
 	handler: (argv) => {
 		const epicenterConfigPath = join(argv.dir, 'epicenter.config.ts');
 		if (existsSync(epicenterConfigPath)) {
-			process.stderr.write(`${epicenterConfigPath} already exists; left as is\n`);
+			process.stderr.write(
+				`${epicenterConfigPath} already exists; left as is\n`,
+			);
 			return;
 		}
 		writeFileSync(epicenterConfigPath, DEFAULT_EPICENTER_CONFIG_SOURCE, {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -16,7 +16,7 @@
 
 import { existsSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { DEFAULT_PROJECT_CONFIG_SOURCE } from '@epicenter/workspace/node';
+import { DEFAULT_EPICENTER_CONFIG_SOURCE } from '@epicenter/workspace/node';
 import { cmd } from '../util/cmd.js';
 
 export const initCommand = cmd({
@@ -31,14 +31,14 @@ export const initCommand = cmd({
 			coerce: (dir: string) => resolve(dir),
 		}),
 	handler: (argv) => {
-		const projectConfigPath = join(argv.dir, 'epicenter.config.ts');
-		if (existsSync(projectConfigPath)) {
-			process.stderr.write(`${projectConfigPath} already exists; left as is\n`);
+		const epicenterConfigPath = join(argv.dir, 'epicenter.config.ts');
+		if (existsSync(epicenterConfigPath)) {
+			process.stderr.write(`${epicenterConfigPath} already exists; left as is\n`);
 			return;
 		}
-		writeFileSync(projectConfigPath, DEFAULT_PROJECT_CONFIG_SOURCE, {
+		writeFileSync(epicenterConfigPath, DEFAULT_EPICENTER_CONFIG_SOURCE, {
 			mode: 0o600,
 		});
-		process.stdout.write(`created ${projectConfigPath}\n`);
+		process.stdout.write(`created ${epicenterConfigPath}\n`);
 	},
 });

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -1,5 +1,5 @@
 /**
- * `epicenter list [mount.action_key]`: render actions exposed by this project.
+ * `epicenter list [mount.action_key]`: render actions exposed by this root.
  *
  * The daemon returns mount-prefixed action paths for every opened
  * mount. The CLI only filters and renders that manifest.
@@ -7,7 +7,7 @@
  * Per-peer schema introspection is a script concern. The CLI lists the local
  * daemon's mount-prefixed action surface only.
  *
- * `epicenter list` requires a running daemon for the discovered project.
+ * `epicenter list` requires a running daemon for the discovered Epicenter root.
  * Without `daemon up`, the handler errors with a hint pointing at
  * `epicenter daemon up`.
  */
@@ -18,7 +18,7 @@ import Type, { type TSchema } from 'typebox';
 import type { Result } from 'wellcrafted/result';
 
 import { cmd } from '../util/cmd.js';
-import { projectOption } from '../util/common-options.js';
+import { epicenterRootOption } from '../util/common-options.js';
 import {
 	fail,
 	formatOptions,
@@ -35,7 +35,7 @@ export const listCommand = cmd({
 				type: 'string',
 				describe: 'Optional mount-prefixed path to narrow the view',
 			})
-			.option('C', projectOption)
+			.option('C', epicenterRootOption)
 			.options(formatOptions),
 	handler: async (argv) => {
 		const path = argv.path ?? '';

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -5,7 +5,7 @@
  * live daemon's log, run `tail -F` against the printed path: the OS already
  * does follow-through-rotation correctly, so the CLI does not reimplement it.
  *
- * Uses the discovered project by default. `-C <dir>` changes the discovery
+ * Uses the discovered Epicenter root by default. `-C <dir>` changes the discovery
  * start point.
  *
  * See spec: `20260426T235000-cli-up-long-lived-peer.md` § "Logging".
@@ -14,7 +14,7 @@
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { logPathFor } from '@epicenter/workspace/node';
 import { cmd } from '../util/cmd.js';
-import { projectOption } from '../util/common-options.js';
+import { epicenterRootOption } from '../util/common-options.js';
 
 const DEFAULT_TAIL_LINES = 50;
 
@@ -41,7 +41,7 @@ export const logsCommand = cmd({
 	command: 'logs',
 	describe: 'Print recent log lines for a running daemon.',
 	builder: {
-		C: projectOption,
+		C: epicenterRootOption,
 	},
 	handler: (argv) => {
 		const logPath = logPathFor(argv.C);

--- a/packages/cli/src/commands/peers.ts
+++ b/packages/cli/src/commands/peers.ts
@@ -5,7 +5,7 @@
  * The relay carries only `deviceId` on the wire; product-level
  * display names live in app-owned state and are out of scope here.
  *
- * `epicenter peers` requires a running daemon for the discovered project.
+ * `epicenter peers` requires a running daemon for the discovered Epicenter root.
  * Without `daemon up`, the handler errors with a hint pointing at
  * `epicenter daemon up`.
  *
@@ -15,7 +15,7 @@
 
 import { getDaemon, type PeerSnapshot } from '@epicenter/workspace/node';
 import { cmd } from '../util/cmd.js';
-import { projectOption } from '../util/common-options.js';
+import { epicenterRootOption } from '../util/common-options.js';
 import {
 	fail,
 	formatOptions,
@@ -27,7 +27,7 @@ export const peersCommand = cmd({
 	command: 'peers',
 	describe: 'List connected peers (presence)',
 	builder: {
-		C: projectOption,
+		C: epicenterRootOption,
 		...formatOptions,
 	},
 	handler: async (argv) => {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -9,7 +9,7 @@
  * shapes are one `/run` request (the optional `peer` object selects the
  * target and carries the wait budget).
  *
- * `epicenter run` requires a running daemon for the discovered project.
+ * `epicenter run` requires a running daemon for the discovered Epicenter root.
  * Without `daemon up`, the handler errors with a hint pointing at
  * `epicenter daemon up`.
  *
@@ -32,7 +32,7 @@ import { extractErrorMessage } from 'wellcrafted/error';
 import type { Result } from 'wellcrafted/result';
 
 import { cmd } from '../util/cmd.js';
-import { projectOption } from '../util/common-options.js';
+import { epicenterRootOption } from '../util/common-options.js';
 import {
 	fail,
 	formatOptions,
@@ -56,7 +56,7 @@ export const runCommand = cmd({
 				type: 'string',
 				describe: 'Inline JSON or @file.json',
 			})
-			.option('C', projectOption)
+			.option('C', epicenterRootOption)
 			.option('peer', {
 				type: 'string',
 				description: 'Dispatch to a remote peer by peer id',

--- a/packages/cli/src/commands/up.test.ts
+++ b/packages/cli/src/commands/up.test.ts
@@ -1,9 +1,9 @@
 /**
  * Unit-level tests for `epicenter daemon up`.
  *
- * These tests run `runUp` in-process against tiny project-mount fixtures.
+ * These tests run `runUp` in-process against tiny root-and-mount fixtures.
  * They never spawn a child or call `process.exit`; each test owns a temp
- * project and temp runtime root.
+ * Epicenter root and temp runtime root.
  *
  * Auth is injected: every test passes a `createAuthClient` factory to
  * `runUp`. Happy paths return `STUB_AUTH`; the AuthFailed test returns a
@@ -226,7 +226,7 @@ describe('runUp: failure cleanup', () => {
 			}),
 		);
 
-		expect(error.name).toBe('ProjectConfigNotFound');
+		expect(error.name).toBe('EpicenterConfigNotFound');
 		expect(existsSync(join(workDir, 'epicenter.config.ts'))).toBe(false);
 		expect(existsSync(join(workDir, '.epicenter'))).toBe(false);
 
@@ -234,7 +234,7 @@ describe('runUp: failure cleanup', () => {
 		lease.release();
 	});
 
-	test('does not overwrite an existing config when provisioning project data', async () => {
+	test('does not overwrite an existing config when provisioning root data', async () => {
 		const original = ['export default [];', '', '// keep me', ''].join('\n');
 		writeFileSync(join(workDir, 'epicenter.config.ts'), original);
 		const gitignore = 'custom-rule\n';
@@ -336,7 +336,7 @@ describe('runUp: failure cleanup', () => {
 				createAuthClient: stubAuthFactory,
 			}),
 		);
-		expect(error.name).toBe('ProjectConfigImportFailed');
+		expect(error.name).toBe('EpicenterConfigImportFailed');
 
 		const lease = expectOk(claimDaemonLease(workDir));
 		lease.release();

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -23,8 +23,8 @@ import type { StartedMount } from '@epicenter/workspace/daemon';
 import {
 	claimDaemonLease,
 	type DaemonMetadata,
-	openEpicenterRoot,
 	type EpicenterConfigError,
+	openEpicenterRoot,
 	StartupError,
 	startDaemonServer,
 	unlinkMetadata,

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -1,14 +1,14 @@
 /**
- * `epicenter daemon up`: start the long-lived foreground daemon for one project.
+ * `epicenter daemon up`: start the long-lived foreground daemon for one Epicenter root.
  *
  * Loads every mount declared in `epicenter.config.ts`, opens each one in
- * parallel, and exposes a Unix-socket IPC channel for that project. `peers`,
+ * parallel, and exposes a Unix-socket IPC channel for that root. `peers`,
  * `list`, and `run` dispatch to this daemon over IPC; without `daemon up`
  * they error with a hint pointing back here.
  *
- * One daemon per project; that daemon serves every configured mount.
+ * One daemon per Epicenter root; that daemon serves every configured mount.
  * Resource isolation between mounts is expressed by splitting them into
- * different projects, not by a flag.
+ * different roots, not by a flag.
  *
  * Foreground by design; backgrounding is the user's job.
  */
@@ -23,8 +23,8 @@ import type { StartedMount } from '@epicenter/workspace/daemon';
 import {
 	claimDaemonLease,
 	type DaemonMetadata,
-	openProject,
-	type ProjectConfigError,
+	openEpicenterRoot,
+	type EpicenterConfigError,
 	StartupError,
 	startDaemonServer,
 	unlinkMetadata,
@@ -34,7 +34,7 @@ import {
 import { Ok, type Result, trySync } from 'wellcrafted/result';
 import packageJson from '../../package.json' with { type: 'json' };
 import { cmd } from '../util/cmd.js';
-import { projectOption } from '../util/common-options.js';
+import { epicenterRootOption } from '../util/common-options.js';
 
 const CLI_VERSION = packageJson.version;
 
@@ -75,7 +75,7 @@ type UpOptions = {
  * startup, exercise the IPC handler in-process, and call `teardown()` to
  * release resources without spawning a child.
  *
- * - `mounts` is every started mount runtime the project declares; the daemon
+ * - `mounts` is every started mount runtime the root declares; the daemon
  *   serves them all and routes IPC requests by mount name.
  * - `metadata` is what was written to disk.
  * - `teardown()` closes the server, asyncDisposes the runtimes, releases the
@@ -88,22 +88,23 @@ type UpHandle = {
 };
 
 /**
- * Daemon body. Opens every configured mount (the project must already have an
+ * Daemon body. Opens every configured mount (the root must already have an
  * `epicenter.config.ts`; see `epicenter init`), binds the IPC socket, and
  * returns a handle. The yargs `handler` calls this,
  * prints the operator-facing banner, installs SIGINT/SIGTERM, and parks the
  * process; tests call it directly and assert on the returned handle.
  *
  * A SQLite daemon lease serializes startup before any mount opens. After that,
- * `openProject` imports `epicenter.config.ts`, claims the Epicenter folder,
- * opens every configured mount, and `startDaemonServer` binds the socket.
+ * `openEpicenterRoot` imports `epicenter.config.ts`, claims the Epicenter
+ * folder, opens every configured mount, and `startDaemonServer` binds the
+ * socket.
  */
 export async function runUp(
 	options: UpOptions,
 ): Promise<
 	Result<
 		UpHandle,
-		| ProjectConfigError
+		| EpicenterConfigError
 		| WorkspaceAppError
 		| StartupError
 		| MachineAuthStorageError
@@ -137,7 +138,7 @@ export async function runUp(
 	const auth = authResult.data;
 	stack.defer(() => auth[Symbol.dispose]());
 
-	const startResult = await openProject({ epicenterRoot, auth });
+	const startResult = await openEpicenterRoot({ epicenterRoot, auth });
 	if (startResult.error) return startResult;
 	const mounts = startResult.data;
 	stack.defer(async () => {
@@ -177,7 +178,7 @@ export const upCommand = cmd({
 	describe:
 		'Open every mount in epicenter.config.ts and serve them on the daemon socket (foreground).',
 	builder: {
-		C: projectOption,
+		C: epicenterRootOption,
 		quiet: {
 			type: 'boolean',
 			default: false,

--- a/packages/cli/src/util/common-options.test.ts
+++ b/packages/cli/src/util/common-options.test.ts
@@ -26,7 +26,9 @@ function tempEpicenterRoot() {
 describe('epicenterRootOption', () => {
 	test('discovers the nearest Epicenter root from a start directory', () => {
 		const { root, nested } = tempEpicenterRoot();
-		const argv = yargs().option('C', epicenterRootOption).parseSync(['-C', nested]);
+		const argv = yargs()
+			.option('C', epicenterRootOption)
+			.parseSync(['-C', nested]);
 
 		expect(argv.C).toBe(root as typeof argv.C);
 	});

--- a/packages/cli/src/util/common-options.test.ts
+++ b/packages/cli/src/util/common-options.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import yargs from 'yargs';
 
-import { projectOption } from './common-options.js';
+import { epicenterRootOption } from './common-options.js';
 
 const roots: string[] = [];
 
@@ -14,8 +14,8 @@ afterEach(() => {
 	}
 });
 
-function tempProject() {
-	const root = mkdtempSync(join(tmpdir(), 'ep-cli-project-'));
+function tempEpicenterRoot() {
+	const root = mkdtempSync(join(tmpdir(), 'ep-cli-root-'));
 	roots.push(root);
 	writeFileSync(join(root, 'epicenter.config.ts'), 'export default {};\n');
 	const nested = join(root, 'nested', 'child');
@@ -23,22 +23,22 @@ function tempProject() {
 	return { root, nested };
 }
 
-describe('projectOption', () => {
-	test('discovers the nearest Epicenter project from a start directory', () => {
-		const { root, nested } = tempProject();
-		const argv = yargs().option('C', projectOption).parseSync(['-C', nested]);
+describe('epicenterRootOption', () => {
+	test('discovers the nearest Epicenter root from a start directory', () => {
+		const { root, nested } = tempEpicenterRoot();
+		const argv = yargs().option('C', epicenterRootOption).parseSync(['-C', nested]);
 
 		expect(argv.C).toBe(root as typeof argv.C);
 	});
 
 	test('fails when discovery misses', () => {
-		const root = mkdtempSync(join(tmpdir(), 'ep-cli-no-project-'));
+		const root = mkdtempSync(join(tmpdir(), 'ep-cli-no-root-'));
 		roots.push(root);
 
 		expect(() =>
 			yargs()
 				.exitProcess(false)
-				.option('C', projectOption)
+				.option('C', epicenterRootOption)
 				.parseSync(['-C', root]),
 		).toThrow('No epicenter.config.ts found');
 	});

--- a/packages/cli/src/util/common-options.ts
+++ b/packages/cli/src/util/common-options.ts
@@ -9,7 +9,7 @@
 import { findEpicenterRoot } from '@epicenter/workspace/node';
 import type { Options } from 'yargs';
 
-export const projectOption = {
+export const epicenterRootOption = {
 	type: 'string',
 	description:
 		'Epicenter root (or any directory under it; discovery walks up to the nearest `epicenter.config.ts`).',

--- a/packages/workspace/src/client/connect-daemon-actions.ts
+++ b/packages/workspace/src/client/connect-daemon-actions.ts
@@ -30,7 +30,7 @@ import { getDaemon } from '../daemon/client.js';
 import type { ActionRegistry } from '../shared/actions.js';
 import type { EpicenterRoot } from '../shared/types.js';
 import { buildDaemonActions, type DaemonActions } from './daemon-actions.js';
-import { findEpicenterRoot } from './find-project-root.js';
+import { findEpicenterRoot } from './find-epicenter-root.js';
 
 /**
  * Connect to a workspace's public actions hosted by a running daemon.
@@ -42,7 +42,7 @@ import { findEpicenterRoot } from './find-project-root.js';
  * `epicenterRoot` defaults to walking up from `process.cwd()` for an
  * `epicenter.config.ts` file.
  *
- * Throws via `findEpicenterRoot` when no project config is found, or
+ * Throws via `findEpicenterRoot` when no Epicenter config is found, or
  * `DaemonError.Required` when no daemon is listening on the resolved socket.
  * Start one with `epicenter daemon up`. There is no auto-spawn: explicit
  * lifecycle is the contract.

--- a/packages/workspace/src/client/find-epicenter-root.test.ts
+++ b/packages/workspace/src/client/find-epicenter-root.test.ts
@@ -4,38 +4,38 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import type { EpicenterRoot } from '../shared/types.js';
-import { findEpicenterRoot } from './find-project-root.js';
+import { findEpicenterRoot } from './find-epicenter-root.js';
 
 let root: string;
 
 beforeEach(() => {
-	root = mkdtempSync(join(tmpdir(), 'find-project-root-'));
+	root = mkdtempSync(join(tmpdir(), 'find-epicenter-root-'));
 });
 
 afterEach(() => {
 	rmSync(root, { recursive: true, force: true });
 });
 
-function writeProjectConfig(dir: string = root): void {
+function writeEpicenterConfig(dir: string = root): void {
 	writeFileSync(join(dir, 'epicenter.config.ts'), 'export default {};\n');
 }
 
 describe('findEpicenterRoot', () => {
-	test('finds a project by epicenter.config.ts', () => {
-		writeProjectConfig();
+	test('finds an Epicenter root by epicenter.config.ts', () => {
+		writeEpicenterConfig();
 
 		expect(findEpicenterRoot(root)).toBe(root as EpicenterRoot);
 	});
 
 	test('walks up from a nested subdirectory', () => {
-		writeProjectConfig();
+		writeEpicenterConfig();
 		const nested = join(root, 'a', 'b', 'c');
 		mkdirSync(nested, { recursive: true });
 
 		expect(findEpicenterRoot(nested)).toBe(root as EpicenterRoot);
 	});
 
-	test('ignores workspaces and .epicenter as project markers', () => {
+	test('ignores workspaces and .epicenter as root markers', () => {
 		mkdirSync(join(root, 'workspaces'));
 		mkdirSync(join(root, '.epicenter'));
 

--- a/packages/workspace/src/client/find-epicenter-root.ts
+++ b/packages/workspace/src/client/find-epicenter-root.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
-import { PROJECT_CONFIG_FILENAME } from '../config/project-config-source.js';
+import { EPICENTER_CONFIG_FILENAME } from '../config/epicenter-config-source.js';
 import type { EpicenterRoot } from '../shared/types.js';
 
 export function findEpicenterRoot(
@@ -8,16 +8,16 @@ export function findEpicenterRoot(
 ): EpicenterRoot {
 	let current = resolve(start);
 	while (true) {
-		if (existsSync(join(current, PROJECT_CONFIG_FILENAME))) {
+		if (existsSync(join(current, EPICENTER_CONFIG_FILENAME))) {
 			return current as EpicenterRoot;
 		}
 
 		const parent = dirname(current);
 		if (parent === current) {
 			throw new Error(
-				`No ${PROJECT_CONFIG_FILENAME} found walking up from ${start}. ` +
+				`No ${EPICENTER_CONFIG_FILENAME} found walking up from ${start}. ` +
 					`Discovery is upward-only and never scans down, so run from inside your ` +
-					`Epicenter folder (the folder that holds ${PROJECT_CONFIG_FILENAME}), ` +
+					`Epicenter folder (the folder that holds ${EPICENTER_CONFIG_FILENAME}), ` +
 					`pass \`-C <epicenter-root>\`, or run \`epicenter init\` to create one.`,
 			);
 		}

--- a/packages/workspace/src/config/epicenter-config-source.ts
+++ b/packages/workspace/src/config/epicenter-config-source.ts
@@ -1,6 +1,6 @@
-export const PROJECT_CONFIG_FILENAME = 'epicenter.config.ts';
+export const EPICENTER_CONFIG_FILENAME = 'epicenter.config.ts';
 
-export const DEFAULT_PROJECT_CONFIG_SOURCE = `// Default-export a Mount[] value. Example:
+export const DEFAULT_EPICENTER_CONFIG_SOURCE = `// Default-export a Mount[] value. Example:
 //
 //   import { fuji } from '@epicenter/fuji/project';
 //   import { honeycrisp } from '@epicenter/honeycrisp/project';

--- a/packages/workspace/src/config/load-epicenter-config.test.ts
+++ b/packages/workspace/src/config/load-epicenter-config.test.ts
@@ -1,12 +1,12 @@
 /**
- * Project config loading tests.
+ * Epicenter config loading tests.
  *
  * Verifies that `epicenter.config.ts` is discovered, imported, and runtime
  * validated before daemon startup consumes the mount list.
  *
- * Invariant under test: `loadProjectConfig` is total. Every failure mode
+ * Invariant under test: `loadEpicenterConfig` is total. Every failure mode
  * (missing file, import/syntax error, wrong-shaped export) comes back as a
- * specific `ProjectConfigError` variant in the error channel; it never throws.
+ * specific `EpicenterConfigError` variant in the error channel; it never throws.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
@@ -14,12 +14,12 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { loadProjectConfig } from './load-project-config.js';
+import { loadEpicenterConfig } from './load-epicenter-config.js';
 
 let epicenterRoot: string;
 
 beforeEach(() => {
-	epicenterRoot = mkdtempSync(join(tmpdir(), 'load-project-config-'));
+	epicenterRoot = mkdtempSync(join(tmpdir(), 'load-epicenter-config-'));
 });
 
 afterEach(() => {
@@ -30,14 +30,14 @@ function writeConfig(source: string): void {
 	writeFileSync(join(epicenterRoot, 'epicenter.config.ts'), source);
 }
 
-describe('loadProjectConfig', () => {
+describe('loadEpicenterConfig', () => {
 	test('returns a typed not-found error when the config is missing', async () => {
-		const { data, error } = await loadProjectConfig(epicenterRoot);
+		const { data, error } = await loadEpicenterConfig(epicenterRoot);
 		expect(data).toBeNull();
-		if (error === null) throw new Error('Expected ProjectConfigNotFound');
+		if (error === null) throw new Error('Expected EpicenterConfigNotFound');
 		expect(error).toMatchObject({
-			name: 'ProjectConfigNotFound',
-			projectConfigPath: join(epicenterRoot, 'epicenter.config.ts'),
+			name: 'EpicenterConfigNotFound',
+			epicenterConfigPath: join(epicenterRoot, 'epicenter.config.ts'),
 		});
 	});
 
@@ -46,7 +46,7 @@ describe('loadProjectConfig', () => {
 			"export default [{ name: 'a', open() {} }, { name: 'b', open() {} }];\n",
 		);
 
-		const { data, error } = await loadProjectConfig(epicenterRoot);
+		const { data, error } = await loadEpicenterConfig(epicenterRoot);
 		if (error !== null) throw new Error(error.message);
 		expect(data.map((mount) => mount.name)).toEqual(['a', 'b']);
 	});
@@ -54,7 +54,7 @@ describe('loadProjectConfig', () => {
 	test('passes through an empty Mount[] default export', async () => {
 		writeConfig('export default [];\n');
 
-		const { data, error } = await loadProjectConfig(epicenterRoot);
+		const { data, error } = await loadEpicenterConfig(epicenterRoot);
 		if (error !== null) throw new Error(error.message);
 		expect(data).toEqual([]);
 	});
@@ -62,19 +62,19 @@ describe('loadProjectConfig', () => {
 	test('rejects a non-array default export', async () => {
 		writeConfig('export default { notAMount: true };\n');
 
-		const { error } = await loadProjectConfig(epicenterRoot);
+		const { error } = await loadEpicenterConfig(epicenterRoot);
 		expect(error).toMatchObject({
-			name: 'ProjectConfigInvalid',
-			projectConfigPath: join(epicenterRoot, 'epicenter.config.ts'),
+			name: 'EpicenterConfigInvalid',
+			epicenterConfigPath: join(epicenterRoot, 'epicenter.config.ts'),
 		});
 	});
 
 	test('rejects a bare Mount that is not wrapped in an array', async () => {
 		writeConfig("export default { name: 'demo', open() {} };\n");
 
-		const { error } = await loadProjectConfig(epicenterRoot);
+		const { error } = await loadEpicenterConfig(epicenterRoot);
 		expect(error).toMatchObject({
-			name: 'ProjectConfigInvalid',
+			name: 'EpicenterConfigInvalid',
 			detail:
 				'the default export is a single Mount; wrap it in an array, for example `export default [fuji()]`',
 		});
@@ -83,24 +83,24 @@ describe('loadProjectConfig', () => {
 	test('rejects a Mount[] containing a non-Mount value', async () => {
 		writeConfig("export default [{ name: 'demo', open() {} }, { open: 1 }];\n");
 
-		const { error } = await loadProjectConfig(epicenterRoot);
-		expect(error?.name).toBe('ProjectConfigInvalid');
+		const { error } = await loadEpicenterConfig(epicenterRoot);
+		expect(error?.name).toBe('EpicenterConfigInvalid');
 	});
 
 	test('rejects a config with no default export', async () => {
 		writeConfig('export const config = {};\n');
 
-		const { error } = await loadProjectConfig(epicenterRoot);
-		expect(error?.name).toBe('ProjectConfigInvalid');
+		const { error } = await loadEpicenterConfig(epicenterRoot);
+		expect(error?.name).toBe('EpicenterConfigInvalid');
 	});
 
 	test('reports a structured import error for bad syntax', async () => {
 		writeConfig('export default {;\n');
 
-		const { error } = await loadProjectConfig(epicenterRoot);
+		const { error } = await loadEpicenterConfig(epicenterRoot);
 		expect(error).toMatchObject({
-			name: 'ProjectConfigImportFailed',
-			projectConfigPath: join(epicenterRoot, 'epicenter.config.ts'),
+			name: 'EpicenterConfigImportFailed',
+			epicenterConfigPath: join(epicenterRoot, 'epicenter.config.ts'),
 		});
 	});
 });

--- a/packages/workspace/src/config/load-epicenter-config.ts
+++ b/packages/workspace/src/config/load-epicenter-config.ts
@@ -1,5 +1,5 @@
 /**
- * Load a project's `epicenter.config.ts` and return its mount list.
+ * Load an Epicenter root's `epicenter.config.ts` and return its mount list.
  *
  * The config default-exports a `Mount[]`. One app is a list of one:
  *
@@ -14,7 +14,7 @@
  * a clear, structured error pointed at the file instead of a cryptic
  * `TypeError` deep in startup.
  *
- * Every failure is a `ProjectConfigError` variant; this function never throws.
+ * Every failure is an `EpicenterConfigError` variant; this function never throws.
  */
 
 import { existsSync } from 'node:fs';
@@ -30,61 +30,61 @@ import { Err, Ok, type Result, tryAsync } from 'wellcrafted/result';
 
 import type { Mount } from '../daemon/define-mount.js';
 import type { EpicenterRoot } from '../shared/types.js';
-import { PROJECT_CONFIG_FILENAME } from './project-config-source.js';
+import { EPICENTER_CONFIG_FILENAME } from './epicenter-config-source.js';
 
-export const ProjectConfigError = defineErrors({
-	ProjectConfigNotFound: ({
-		projectConfigPath,
+export const EpicenterConfigError = defineErrors({
+	EpicenterConfigNotFound: ({
+		epicenterConfigPath,
 	}: {
-		projectConfigPath: string;
+		epicenterConfigPath: string;
 	}) => ({
-		message: `Project config not found at ${projectConfigPath}`,
-		projectConfigPath,
+		message: `Epicenter config not found at ${epicenterConfigPath}`,
+		epicenterConfigPath,
 	}),
-	ProjectConfigImportFailed: ({
-		projectConfigPath,
+	EpicenterConfigImportFailed: ({
+		epicenterConfigPath,
 		cause,
 	}: {
-		projectConfigPath: string;
+		epicenterConfigPath: string;
 		cause: unknown;
 	}) => ({
-		message: `Failed to load project config at ${projectConfigPath}: ${extractErrorMessage(cause)}`,
-		projectConfigPath,
+		message: `Failed to load Epicenter config at ${epicenterConfigPath}: ${extractErrorMessage(cause)}`,
+		epicenterConfigPath,
 		cause,
 	}),
-	ProjectConfigInvalid: ({
-		projectConfigPath,
+	EpicenterConfigInvalid: ({
+		epicenterConfigPath,
 		detail,
 	}: {
-		projectConfigPath: string;
+		epicenterConfigPath: string;
 		detail: string;
 	}) => ({
-		message: `Invalid project config at ${projectConfigPath}: ${detail}.`,
-		projectConfigPath,
+		message: `Invalid Epicenter config at ${epicenterConfigPath}: ${detail}.`,
+		epicenterConfigPath,
 		detail,
 	}),
 });
-export type ProjectConfigError = InferErrors<typeof ProjectConfigError>;
+export type EpicenterConfigError = InferErrors<typeof EpicenterConfigError>;
 
-export async function loadProjectConfig(
+export async function loadEpicenterConfig(
 	epicenterRoot: EpicenterRoot | string,
-): Promise<Result<Mount[], ProjectConfigError>> {
-	const projectConfigPath = join(
+): Promise<Result<Mount[], EpicenterConfigError>> {
+	const epicenterConfigPath = join(
 		resolve(epicenterRoot),
-		PROJECT_CONFIG_FILENAME,
+		EPICENTER_CONFIG_FILENAME,
 	);
-	if (!existsSync(projectConfigPath)) {
-		return ProjectConfigError.ProjectConfigNotFound({ projectConfigPath });
+	if (!existsSync(epicenterConfigPath)) {
+		return EpicenterConfigError.EpicenterConfigNotFound({ epicenterConfigPath });
 	}
 
 	const { data: module, error: importError } = await tryAsync({
 		try: () =>
-			import(pathToFileURL(projectConfigPath).href) as Promise<{
+			import(pathToFileURL(epicenterConfigPath).href) as Promise<{
 				default?: unknown;
 			}>,
 		catch: (cause) =>
-			ProjectConfigError.ProjectConfigImportFailed({
-				projectConfigPath,
+			EpicenterConfigError.EpicenterConfigImportFailed({
+				epicenterConfigPath,
 				cause,
 			}),
 	});
@@ -93,14 +93,14 @@ export async function loadProjectConfig(
 	const value = module.default;
 	if (Array.isArray(value) && value.every(isMount)) return Ok(value);
 	if (isMount(value)) {
-		return ProjectConfigError.ProjectConfigInvalid({
-			projectConfigPath,
+		return EpicenterConfigError.EpicenterConfigInvalid({
+			epicenterConfigPath,
 			detail:
 				'the default export is a single Mount; wrap it in an array, for example `export default [fuji()]`',
 		});
 	}
-	return ProjectConfigError.ProjectConfigInvalid({
-		projectConfigPath,
+	return EpicenterConfigError.EpicenterConfigInvalid({
+		epicenterConfigPath,
 		detail:
 			'the default export must be a Mount[] (each entry needs a string `name` and an `open` function)',
 	});

--- a/packages/workspace/src/config/load-epicenter-config.ts
+++ b/packages/workspace/src/config/load-epicenter-config.ts
@@ -74,7 +74,9 @@ export async function loadEpicenterConfig(
 		EPICENTER_CONFIG_FILENAME,
 	);
 	if (!existsSync(epicenterConfigPath)) {
-		return EpicenterConfigError.EpicenterConfigNotFound({ epicenterConfigPath });
+		return EpicenterConfigError.EpicenterConfigNotFound({
+			epicenterConfigPath,
+		});
 	}
 
 	const { data: module, error: importError } = await tryAsync({

--- a/packages/workspace/src/daemon/define-mount.ts
+++ b/packages/workspace/src/daemon/define-mount.ts
@@ -1,5 +1,5 @@
 /**
- * `defineMount`: typed entry contract for an app mount inside a project daemon.
+ * `defineMount`: typed entry contract for an app mount inside the daemon.
  *
  * `epicenter.config.ts` default-exports a `Mount[]`. Each mount carries its own
  * canonical `name`, which
@@ -71,7 +71,7 @@ export type MountContext = {
  * One app mount: a name plus an `open(ctx)` that returns a `DaemonRuntime`.
  *
  * Factories like `fuji()` return a `Mount`. The canonical mount name lives on
- * the value itself (`Mount.name`), so renaming a project folder never changes
+ * the value itself (`Mount.name`), so renaming an Epicenter folder never changes
  * the action namespace.
  */
 export type Mount<TRuntime extends DaemonRuntime = DaemonRuntime> = {

--- a/packages/workspace/src/daemon/lease.test.ts
+++ b/packages/workspace/src/daemon/lease.test.ts
@@ -2,7 +2,7 @@
  * Daemon Lease Tests
  *
  * Verifies that the SQLite-backed daemon lease is the single ownership
- * primitive for project daemon startup.
+ * primitive for daemon startup.
  *
  * Key behaviors:
  * - first claimant owns the lease while its transaction stays open

--- a/packages/workspace/src/daemon/metadata.ts
+++ b/packages/workspace/src/daemon/metadata.ts
@@ -27,11 +27,11 @@ const log = createLogger('workspace/daemon/metadata');
  * On-disk shape of `<dirHash>.meta.json`.
  *
  * `dir` is stored as the absolute, fs-resolved path so different cwd-relative
- * project discovery starts resolving to the same project match.
+ * Epicenter-root discovery starts resolving to the same root match.
  */
 export type DaemonMetadata = {
 	pid: number;
-	/** Absolute, fs-resolved project directory path. */
+	/** Absolute, fs-resolved Epicenter root path. */
 	dir: string;
 	/** ISO 8601 timestamp. */
 	startedAt: string;

--- a/packages/workspace/src/daemon/runtime-files.ts
+++ b/packages/workspace/src/daemon/runtime-files.ts
@@ -12,7 +12,7 @@ export function unlinkSocketFile(socketPath: string): void {
 	bestEffortSync(() => unlinkSync(socketPath));
 }
 
-/** Sweep runtime-dir files that identify a daemon for one project. */
+/** Sweep runtime-dir files that identify a daemon for one Epicenter root. */
 export function sweepDaemonRuntimeFiles(epicenterRoot: string): void {
 	unlinkSocketFile(socketPathFor(epicenterRoot));
 	unlinkMetadata(epicenterRoot);

--- a/packages/workspace/src/daemon/server.ts
+++ b/packages/workspace/src/daemon/server.ts
@@ -23,7 +23,7 @@ import type { DaemonServedMount } from './types.js';
 import { bindUnixSocket } from './unix-socket.js';
 
 export type DaemonServerOptions = {
-	/** Already-claimed project daemon lease. */
+	/** Already-claimed daemon lease. */
 	lease: DaemonLease;
 	/** Mounts served by the unix-socket app. */
 	mounts: readonly DaemonServedMount[];

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -122,16 +122,16 @@ export {
 } from './document/device-id.js';
 
 // ════════════════════════════════════════════════════════════════════════════
-// PROJECT CONFIG (browser-safe surface)
+// EPICENTER CONFIG (browser-safe surface)
 // ════════════════════════════════════════════════════════════════════════════
 
 // Node-only helpers that resolve real paths (`findEpicenterRoot`,
-// `openProject`, etc.) import `node:fs`, `node:path`, or `node:os`
+// `openEpicenterRoot`, etc.) import `node:fs`, `node:path`, or `node:os`
 // at module top level. They are exported from `@epicenter/workspace/node`;
 // keeping them out of this root barrel stops browser bundles (fuji,
 // whispering, etc.) from traversing `node:*` modules. Daemon runtime and
 // log paths live in `@epicenter/workspace/daemon/paths.ts`.
-export { DEFAULT_PROJECT_CONFIG_SOURCE } from './config/project-config-source.js';
+export { DEFAULT_EPICENTER_CONFIG_SOURCE } from './config/epicenter-config-source.js';
 export { defineMount } from './daemon/define-mount.js';
 export type { EpicenterRoot } from './shared/types';
 

--- a/packages/workspace/src/node.ts
+++ b/packages/workspace/src/node.ts
@@ -8,9 +8,9 @@
 export { connectDaemonActions } from './client/connect-daemon-actions.js';
 export type { DaemonActions } from './client/daemon-actions.js';
 export { buildDaemonActions } from './client/daemon-actions.js';
-export { findEpicenterRoot } from './client/find-project-root.js';
-export { ProjectConfigError } from './config/load-project-config.js';
-export { DEFAULT_PROJECT_CONFIG_SOURCE } from './config/project-config-source.js';
+export { findEpicenterRoot } from './client/find-epicenter-root.js';
+export { EpicenterConfigError } from './config/load-epicenter-config.js';
+export { DEFAULT_EPICENTER_CONFIG_SOURCE } from './config/epicenter-config-source.js';
 export {
 	type PeerSyncStatus,
 	RunError,
@@ -87,6 +87,6 @@ export { hashYDocClientId } from './shared/client-id.js';
 export type { WorkspaceAuthClient } from './workspace-apps/auth-client.js';
 export { WorkspaceAppError } from './workspace-apps/errors.js';
 export {
-	type OpenProjectOptions,
-	openProject,
-} from './workspace-apps/open-project.js';
+	type OpenEpicenterRootOptions,
+	openEpicenterRoot,
+} from './workspace-apps/open-epicenter-root.js';

--- a/packages/workspace/src/node.ts
+++ b/packages/workspace/src/node.ts
@@ -9,8 +9,8 @@ export { connectDaemonActions } from './client/connect-daemon-actions.js';
 export type { DaemonActions } from './client/daemon-actions.js';
 export { buildDaemonActions } from './client/daemon-actions.js';
 export { findEpicenterRoot } from './client/find-epicenter-root.js';
-export { EpicenterConfigError } from './config/load-epicenter-config.js';
 export { DEFAULT_EPICENTER_CONFIG_SOURCE } from './config/epicenter-config-source.js';
+export { EpicenterConfigError } from './config/load-epicenter-config.js';
 export {
 	type PeerSyncStatus,
 	RunError,

--- a/packages/workspace/src/shared/test-utils.ts
+++ b/packages/workspace/src/shared/test-utils.ts
@@ -16,7 +16,7 @@ import type { EpicenterRoot } from './types.js';
 
 /**
  * Create a fresh tmp directory and return it as `EpicenterRoot`. The cast
- * is honest in spirit (tests set up the project marker they need) and
+ * is honest in spirit (tests set up the config marker they need) and
  * contained to this helper.
  *
  * @example

--- a/packages/workspace/src/workspace-apps/auth-client.ts
+++ b/packages/workspace/src/workspace-apps/auth-client.ts
@@ -4,7 +4,7 @@ import type { AuthedFetch } from '../shared/types.js';
 /**
  * Workspace's structural view of an auth client. Any object whose shape
  * matches (notably `@epicenter/auth`'s `AuthClient`) can be passed to
- * `openProject`.
+ * `openEpicenterRoot`.
  *
  * Workspace reads four surfaces: the discriminated `state` (to gate startup
  * on signed-in and to derive the lazy keyring reader), `openWebSocket` (for

--- a/packages/workspace/src/workspace-apps/open-epicenter-root.test.ts
+++ b/packages/workspace/src/workspace-apps/open-epicenter-root.test.ts
@@ -60,7 +60,10 @@ const RUNTIME = '{ collaboration: {}, async [Symbol.asyncDispose]() {} }';
 
 describe('openEpicenterRoot', () => {
 	test('returns a structured not-found error instead of throwing', async () => {
-		const result = await openEpicenterRoot({ epicenterRoot, auth: stubAuthClient() });
+		const result = await openEpicenterRoot({
+			epicenterRoot,
+			auth: stubAuthClient(),
+		});
 		const error = expectErr(result);
 		expect(error).toMatchObject({
 			name: 'EpicenterConfigNotFound',
@@ -76,7 +79,10 @@ describe('openEpicenterRoot', () => {
 			];\n`,
 		);
 
-		const result = await openEpicenterRoot({ epicenterRoot, auth: stubAuthClient() });
+		const result = await openEpicenterRoot({
+			epicenterRoot,
+			auth: stubAuthClient(),
+		});
 		const mounts = expectOk(result);
 		expect(
 			mounts
@@ -95,7 +101,10 @@ describe('openEpicenterRoot', () => {
 	test('opens nothing for an empty config', async () => {
 		writeConfig('export default [];\n');
 
-		const result = await openEpicenterRoot({ epicenterRoot, auth: stubAuthClient() });
+		const result = await openEpicenterRoot({
+			epicenterRoot,
+			auth: stubAuthClient(),
+		});
 		expect(expectOk(result)).toEqual([]);
 	});
 
@@ -116,7 +125,10 @@ describe('openEpicenterRoot', () => {
 			];\n`,
 		);
 
-		const result = await openEpicenterRoot({ epicenterRoot, auth: stubAuthClient() });
+		const result = await openEpicenterRoot({
+			epicenterRoot,
+			auth: stubAuthClient(),
+		});
 		const error = expectErr(result);
 		expect(error).toMatchObject({ name: 'MountOpenFailed', mount: 'bad' });
 		expect(await Bun.file(join(epicenterRoot, 'good.disposed')).exists()).toBe(
@@ -139,7 +151,10 @@ describe('openEpicenterRoot', () => {
 			];\n`,
 		);
 
-		const result = await openEpicenterRoot({ epicenterRoot, auth: stubAuthClient() });
+		const result = await openEpicenterRoot({
+			epicenterRoot,
+			auth: stubAuthClient(),
+		});
 		expect(expectErr(result)).toMatchObject({
 			name: 'MountRejected',
 			mount: '__proto__',

--- a/packages/workspace/src/workspace-apps/open-epicenter-root.test.ts
+++ b/packages/workspace/src/workspace-apps/open-epicenter-root.test.ts
@@ -1,10 +1,10 @@
 /**
- * Tests for `openProject`, the single daemon entry point.
+ * Tests for `openEpicenterRoot`, the single daemon entry point.
  *
- * `openProject` imports `epicenter.config.ts`, claims the Epicenter folder, and
- * opens every mount it declares, so these tests drive it through real config
- * files on disk:
- * - a missing config returns a structured `ProjectConfigNotFound` Result
+ * `openEpicenterRoot` imports `epicenter.config.ts`, claims the Epicenter
+ * folder, and opens every mount it declares, so these tests drive it through
+ * real config files on disk:
+ * - a missing config returns a structured `EpicenterConfigNotFound` Result
  *   (not a throw), so the host surfaces it like any other startup error
  * - a valid config opens every declared mount in parallel
  * - an empty config opens nothing
@@ -14,7 +14,7 @@
  * - a signed-out auth refuses before any mount opens
  *
  * Config-shape validation (single -> array, malformed export, syntax errors)
- * is pinned separately in `config/load-project-config.test.ts`.
+ * is pinned separately in `config/load-epicenter-config.test.ts`.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
@@ -26,12 +26,12 @@ import { asOwnerId } from '@epicenter/identity';
 import { expectErr, expectOk } from 'wellcrafted/testing';
 
 import type { WorkspaceAuthClient } from './auth-client.js';
-import { openProject } from './open-project.js';
+import { openEpicenterRoot } from './open-epicenter-root.js';
 
 let epicenterRoot: string;
 
 beforeEach(() => {
-	epicenterRoot = mkdtempSync(join(tmpdir(), 'open-project-'));
+	epicenterRoot = mkdtempSync(join(tmpdir(), 'open-epicenter-root-'));
 });
 
 afterEach(() => {
@@ -58,13 +58,13 @@ function stubAuthClient(): WorkspaceAuthClient {
 /** A mount literal whose runtime disposes cleanly, written into a config. */
 const RUNTIME = '{ collaboration: {}, async [Symbol.asyncDispose]() {} }';
 
-describe('openProject', () => {
+describe('openEpicenterRoot', () => {
 	test('returns a structured not-found error instead of throwing', async () => {
-		const result = await openProject({ epicenterRoot, auth: stubAuthClient() });
+		const result = await openEpicenterRoot({ epicenterRoot, auth: stubAuthClient() });
 		const error = expectErr(result);
 		expect(error).toMatchObject({
-			name: 'ProjectConfigNotFound',
-			projectConfigPath: join(epicenterRoot, 'epicenter.config.ts'),
+			name: 'EpicenterConfigNotFound',
+			epicenterConfigPath: join(epicenterRoot, 'epicenter.config.ts'),
 		});
 	});
 
@@ -76,7 +76,7 @@ describe('openProject', () => {
 			];\n`,
 		);
 
-		const result = await openProject({ epicenterRoot, auth: stubAuthClient() });
+		const result = await openEpicenterRoot({ epicenterRoot, auth: stubAuthClient() });
 		const mounts = expectOk(result);
 		expect(
 			mounts
@@ -95,7 +95,7 @@ describe('openProject', () => {
 	test('opens nothing for an empty config', async () => {
 		writeConfig('export default [];\n');
 
-		const result = await openProject({ epicenterRoot, auth: stubAuthClient() });
+		const result = await openEpicenterRoot({ epicenterRoot, auth: stubAuthClient() });
 		expect(expectOk(result)).toEqual([]);
 	});
 
@@ -116,7 +116,7 @@ describe('openProject', () => {
 			];\n`,
 		);
 
-		const result = await openProject({ epicenterRoot, auth: stubAuthClient() });
+		const result = await openEpicenterRoot({ epicenterRoot, auth: stubAuthClient() });
 		const error = expectErr(result);
 		expect(error).toMatchObject({ name: 'MountOpenFailed', mount: 'bad' });
 		expect(await Bun.file(join(epicenterRoot, 'good.disposed')).exists()).toBe(
@@ -139,7 +139,7 @@ describe('openProject', () => {
 			];\n`,
 		);
 
-		const result = await openProject({ epicenterRoot, auth: stubAuthClient() });
+		const result = await openEpicenterRoot({ epicenterRoot, auth: stubAuthClient() });
 		expect(expectErr(result)).toMatchObject({
 			name: 'MountRejected',
 			mount: '__proto__',
@@ -156,7 +156,7 @@ describe('openProject', () => {
 			`export default [{ name: 'alpha', open() { throw new Error('must not open'); } }];\n`,
 		);
 
-		const result = await openProject({
+		const result = await openEpicenterRoot({
 			epicenterRoot,
 			auth: { state: { status: 'signed-out' } } as WorkspaceAuthClient,
 		});
@@ -184,7 +184,10 @@ describe('openProject', () => {
 			];\n`,
 		);
 
-		const result = await openProject({ epicenterRoot, auth: stubAuthClient() });
+		const result = await openEpicenterRoot({
+			epicenterRoot,
+			auth: stubAuthClient(),
+		});
 		expect(expectErr(result)).toMatchObject({
 			name: 'MountFolderNotEmpty',
 			mount: 'fuji',
@@ -216,7 +219,10 @@ describe('openProject', () => {
 			];\n`,
 		);
 
-		const result = await openProject({ epicenterRoot, auth: stubAuthClient() });
+		const result = await openEpicenterRoot({
+			epicenterRoot,
+			auth: stubAuthClient(),
+		});
 		expect(expectErr(result)).toMatchObject({
 			name: 'EpicenterFolderClaimFailed',
 			epicenterRoot,
@@ -238,7 +244,10 @@ describe('openProject', () => {
 			`export default [{ name: 'fuji', open: () => (${RUNTIME}) }];\n`,
 		);
 
-		const result = await openProject({ epicenterRoot, auth: stubAuthClient() });
+		const result = await openEpicenterRoot({
+			epicenterRoot,
+			auth: stubAuthClient(),
+		});
 		expect(expectOk(result)).toHaveLength(1);
 	});
 
@@ -248,7 +257,10 @@ describe('openProject', () => {
 			`export default [{ name: 'fuji', open: () => (${RUNTIME}) }];\n`,
 		);
 
-		const result = await openProject({ epicenterRoot, auth: stubAuthClient() });
+		const result = await openEpicenterRoot({
+			epicenterRoot,
+			auth: stubAuthClient(),
+		});
 		expect(expectOk(result)).toHaveLength(1);
 	});
 
@@ -261,7 +273,10 @@ describe('openProject', () => {
 			`export default [{ name: 'fuji', open: () => (${RUNTIME}) }];\n`,
 		);
 
-		const result = await openProject({ epicenterRoot, auth: stubAuthClient() });
+		const result = await openEpicenterRoot({
+			epicenterRoot,
+			auth: stubAuthClient(),
+		});
 		expect(expectOk(result)).toHaveLength(1);
 	});
 });

--- a/packages/workspace/src/workspace-apps/open-epicenter-root.ts
+++ b/packages/workspace/src/workspace-apps/open-epicenter-root.ts
@@ -34,8 +34,8 @@ import type { OwnerId } from '@epicenter/identity';
 import { Err, Ok, type Result, trySync } from 'wellcrafted/result';
 
 import {
-	loadEpicenterConfig,
 	type EpicenterConfigError,
+	loadEpicenterConfig,
 } from '../config/load-epicenter-config.js';
 import type { Mount, MountContext } from '../daemon/define-mount.js';
 import { validateMountNames } from '../daemon/mount-validation.js';

--- a/packages/workspace/src/workspace-apps/open-epicenter-root.ts
+++ b/packages/workspace/src/workspace-apps/open-epicenter-root.ts
@@ -1,11 +1,11 @@
 /**
- * Open a project: the single daemon entry point from `epicenter.config.ts` to
- * live mount runtimes.
+ * Open an Epicenter root: the single daemon entry point from
+ * `epicenter.config.ts` to live mount runtimes.
  *
- * `openProject()` is what `epicenter daemon up` calls. It owns the whole
+ * `openEpicenterRoot()` is what `epicenter daemon up` calls. It owns the whole
  * startup path:
  *
- *   1. `loadProjectConfig(epicenterRoot)` imports `epicenter.config.ts` and
+ *   1. `loadEpicenterConfig(epicenterRoot)` imports `epicenter.config.ts` and
  *      validates that its default export is a `Mount[]`.
  *   2. Refuse to start when machine auth is signed out, then validate the
  *      configured mount names.
@@ -34,9 +34,9 @@ import type { OwnerId } from '@epicenter/identity';
 import { Err, Ok, type Result, trySync } from 'wellcrafted/result';
 
 import {
-	loadProjectConfig,
-	type ProjectConfigError,
-} from '../config/load-project-config.js';
+	loadEpicenterConfig,
+	type EpicenterConfigError,
+} from '../config/load-epicenter-config.js';
 import type { Mount, MountContext } from '../daemon/define-mount.js';
 import { validateMountNames } from '../daemon/mount-validation.js';
 import type { StartedMount } from '../daemon/types.js';
@@ -47,27 +47,28 @@ import type { EpicenterRoot } from '../shared/types.js';
 import type { WorkspaceAuthClient } from './auth-client.js';
 import { WorkspaceAppError } from './errors.js';
 
-export type OpenProjectOptions = {
+export type OpenEpicenterRootOptions = {
 	epicenterRoot: EpicenterRoot | string;
 	auth: WorkspaceAuthClient;
 };
 
 /**
- * Bring a project's daemon online: import its config, then open every mount it
- * declares. Returns the started mounts or the first config/startup error.
+ * Bring an Epicenter root's daemon online: import its config, then open every
+ * mount it declares. Returns the started mounts or the first config/startup
+ * error.
  *
  * Opens run in parallel because each mount owns its own resources. If any open
  * fails, every successfully opened runtime is disposed before returning the
  * first failure.
  */
-export async function openProject(
-	options: OpenProjectOptions,
-): Promise<Result<StartedMount[], ProjectConfigError | WorkspaceAppError>> {
+export async function openEpicenterRoot(
+	options: OpenEpicenterRootOptions,
+): Promise<Result<StartedMount[], EpicenterConfigError | WorkspaceAppError>> {
 	const { auth } = options;
 	const epicenterRoot = resolve(options.epicenterRoot) as EpicenterRoot;
 
 	const { data: mounts, error: configError } =
-		await loadProjectConfig(epicenterRoot);
+		await loadEpicenterConfig(epicenterRoot);
 	if (configError !== null) return Err(configError);
 
 	if (auth.state.status === 'signed-out') {
@@ -197,9 +198,9 @@ function claimEpicenterFolder(epicenterRoot: EpicenterRoot): void {
 		}
 	}
 
-	const projectDataDir = join(epicenterRoot, '.epicenter');
-	mkdirSync(projectDataDir, { recursive: true, mode: 0o700 });
-	const cacheGitignorePath = join(projectDataDir, '.gitignore');
+	const epicenterDataDir = join(epicenterRoot, '.epicenter');
+	mkdirSync(epicenterDataDir, { recursive: true, mode: 0o700 });
+	const cacheGitignorePath = join(epicenterDataDir, '.gitignore');
 	if (!existsSync(cacheGitignorePath)) {
 		writeFileSync(cacheGitignorePath, '*\n', { mode: 0o600 });
 	}

--- a/specs/20260527T235147-mount-level-git-autosave.md
+++ b/specs/20260527T235147-mount-level-git-autosave.md
@@ -8,7 +8,7 @@
 
 ## One Sentence
 
-Git autosave lives inside `attachMarkdownMaterializer` as an optional `git` option, so the materializer that owns the disk writes also owns committing them, and every layer above (mount, daemon, project config) loses a concept.
+Git autosave lives inside `attachMarkdownMaterializer` as an optional `git` option, so the materializer that owns the disk writes also owns committing them, and every layer above (mount, daemon, Epicenter config) loses a concept.
 
 ## How To Read This Spec
 
@@ -52,7 +52,7 @@ delete ProjectGitConfig
 delete MountOutput
 delete DaemonRuntime.outputs
 delete outputs: [markdown] in every mount
-delete the third loadProjectConfig shape
+delete the third loadEpicenterConfig shape
 delete the runUp autosave branch
 delete daemon/autosave/ entirely
 delete a separate attachGitAutosave file
@@ -64,7 +64,7 @@ Accepted costs:
 
 ```txt
 cost: git child processes spawn from inside the materializer file (Bun.$)
-cost: per-materializer commits instead of one project-wide commit
+cost: per-materializer commits instead of one root-wide commit
 cost: per-mount git config duplication when users want shared settings
 cost: best-effort shutdown (SIGTERM may drop last batch if git is slow)
 benefit: one option on one existing attach call replaces an entire feature stack
@@ -118,7 +118,7 @@ The worktree currently adds a project-level autosave path:
 epicenter.config.ts
   -> default export Project | Mount | Mount[]
 
-loadProjectConfig()
+loadEpicenterConfig()
   -> Project { mounts, git? }
 
 runUp()
@@ -131,15 +131,15 @@ mount runtime
 startAutosaveService()
   -> subscribe to every runtime.output.onWrite()
   -> stage all observed paths
-  -> commit at the project root
+  -> commit at the Epicenter root
 ```
 
 Files in the current experiment:
 
 ```txt
 packages/workspace/src/config/define-project.ts
-packages/workspace/src/config/load-project-config.ts
-packages/workspace/src/config/project-config-source.ts
+packages/workspace/src/config/load-epicenter-config.ts
+packages/workspace/src/config/epicenter-config-source.ts
 packages/workspace/src/daemon/types.ts
 packages/workspace/src/daemon/autosave/autosave-service.ts
 packages/workspace/src/daemon/autosave/autosave-service.test.ts
@@ -153,7 +153,7 @@ This proves the implementation works, but the ownership is wrong twice over: the
 
 ## Target Shape
 
-Project config returns a mount list.
+Epicenter config returns a mount list.
 
 ```ts
 import { fuji } from "@epicenter/fuji/project";
@@ -161,7 +161,7 @@ import { fuji } from "@epicenter/fuji/project";
 export default [fuji()];
 ```
 
-Multi-mount projects return an array.
+Multi-mount Epicenter roots return an array.
 
 ```ts
 import { fuji } from "@epicenter/fuji/project";
@@ -196,19 +196,19 @@ export function fuji(opts: FujiMountOptions = {}) {
 
       const sqlite = attachBunSqliteMaterializer(workspace, {
         filePath:
-          opts.sqliteFile ?? sqlitePath(ctx.projectDir, workspace.ydoc.guid),
+          opts.sqliteFile ?? sqlitePath(ctx.epicenterRoot, workspace.ydoc.guid),
       });
 
       const markdown = attachMarkdownMaterializer(workspace, {
         dir:
-          opts.markdownDir ?? markdownPath(ctx.projectDir, workspace.ydoc.guid),
+          opts.markdownDir ?? markdownPath(ctx.epicenterRoot, workspace.ydoc.guid),
         perTable: { entries: { filename: slugFilename("title") } },
         git: opts.git,
       });
 
       const infrastructure = attachProjectInfrastructure(workspace.ydoc, {
         mount: ctx.mount,
-        projectDir: ctx.projectDir,
+        epicenterRoot: ctx.epicenterRoot,
         ownerId: ctx.ownerId,
         openWebSocket: ctx.openWebSocket,
         onReconnectSignal: ctx.onReconnectSignal,
@@ -229,7 +229,7 @@ export function fuji(opts: FujiMountOptions = {}) {
 The daemon host stays boring:
 
 ```txt
-loadProjectConfig(projectDir)
+loadEpicenterConfig(epicenterRoot)
   -> Mount[]
 
 runUp()
@@ -243,7 +243,7 @@ No daemon-level git branch. No output registry. No project wrapper. No separate 
 
 ### Config Loader
 
-`loadProjectConfig(projectDir)` accepts exactly one default export shape:
+`loadEpicenterConfig(epicenterRoot)` accepts exactly one default export shape:
 
 ```ts
 export default [fuji(), honeycrisp()];
@@ -252,7 +252,7 @@ export default [fuji(), honeycrisp()];
 It returns:
 
 ```ts
-Promise<Result<Mount[], ProjectConfigError>>;
+Promise<Result<Mount[], EpicenterConfigError>>;
 ```
 
 The default generated config returns an empty array. It does not import `defineProject`.
@@ -372,7 +372,7 @@ type Project, ProjectGitConfig, MountOutput                      delete
 DaemonRuntime.outputs                                            delete
 MaterializerWriteEvent, WriteListener (exported types)           delete
 attachMarkdownMaterializer(...).onWrite                          delete (becomes internal emit only)
-DEFAULT_PROJECT_CONFIG_SOURCE: `defineProject` reference          replace with `export default []`
+DEFAULT_EPICENTER_CONFIG_SOURCE: `defineProject` reference        replace with `export default []`
 runUp autosave branch                                            delete
 startAutosaveService, AutosaveService, attach-git-autosave.ts    do not create
 @epicenter/workspace/git subpath                                 do not create
@@ -435,11 +435,11 @@ Path-limited commit (`-- ${paths}`) is the canonical safe form (see "Staged-isol
 
 ## Implementation Plan
 
-- [x] **1. Restore project config to mount-only shapes.**
+- [x] **1. Restore Epicenter config to mount-only shapes.**
   - Delete `packages/workspace/src/config/define-project.ts`.
-  - Keep `loadProjectConfig` accepting `Mount[]` only.
-  - Revert `DEFAULT_PROJECT_CONFIG_SOURCE` to `export default []` with a comment showing `[fuji()]` as the example.
-  - Update `load-project-config.test.ts` to drop the `Project` shape.
+  - Keep `loadEpicenterConfig` accepting `Mount[]` only.
+  - Revert `DEFAULT_EPICENTER_CONFIG_SOURCE` to `export default []` with a comment showing `[fuji()]` as the example.
+  - Update `load-epicenter-config.test.ts` to drop the `Project` shape.
 
 - [x] **2. Remove daemon output plumbing.**
   - Delete `type MountOutput` from `packages/workspace/src/daemon/types.ts`.
@@ -653,7 +653,7 @@ Net deletion across the stack:
   - separate attach-git-autosave.ts
   - public MaterializerWriteEvent / WriteListener / onWrite
   - runUp autosave branch
-  - third loadProjectConfig shape
+  - third loadEpicenterConfig shape
 ```
 
 ### `git: true` instead of `git: {}`
@@ -702,7 +702,7 @@ Then add `whenAutosaved: Promise<void>` and have the daemon await it during tear
 
 ## Edge Cases
 
-Two materializers in one project (e.g. fuji + honeycrisp both with `git: {}`):
+Two materializers in one Epicenter root (e.g. fuji + honeycrisp both with `git: {}`):
 
 ```txt
 Each has its own dirty Set, its own timers, its own stageAndCommit.
@@ -787,7 +787,7 @@ Targeted tests:
 
 ```txt
 bun test packages/workspace/src/document/materializer/markdown/
-bun test packages/workspace/src/config/load-project-config.test.ts
+bun test packages/workspace/src/config/load-epicenter-config.test.ts
 ```
 
 Type and package checks:
@@ -827,7 +827,7 @@ Tests dropped from the previous draft:
 
 ```txt
 project-level multi-mount one-commit coalescing (no longer the behavior)
-path-escapes-projectDir guard (no longer applicable)
+path-escapes-epicenterRoot guard (no longer applicable)
 mid-rebase/merge/cherry-pick skip (no longer a behavior)
 hasStagedChanges precheck (replaced by commit-time stderr match)
 ```
@@ -916,7 +916,7 @@ The public markdown materializer surface is now `{ whenFlushed, push, pull, rebu
 ### Verification
 
 ```txt
-PASS  bun test packages/workspace/src/document/materializer/markdown/ packages/workspace/src/config/load-project-config.test.ts
+PASS  bun test packages/workspace/src/document/materializer/markdown/ packages/workspace/src/config/load-epicenter-config.test.ts
 PASS  bun test packages/cli/src/commands/up.test.ts  (rerun outside sandbox because Unix socket listen returned EPERM)
 PASS  bun test packages/workspace/src/document/open-collaboration.test.ts
 PASS  bun x tsc --noEmit -p packages/workspace/tsconfig.json

--- a/specs/20260528T121508-config-force-mount-array.md
+++ b/specs/20260528T121508-config-force-mount-array.md
@@ -11,21 +11,22 @@ is wrapping 6 in-repo single-mount configs in brackets.
 
 ### Why (one sentence)
 
-A project declares the **set** of apps its daemon serves; the daemon spine already
-speaks `Mount[]` end to end (`openProject` consumes `Mount[]` and never branches on
-shape, and the generated scaffold already ships `export default []`), so the single
-form is sugar that `loadProjectConfig` normalizes away one line after reading it.
+An Epicenter root declares the **set** of apps its daemon serves; the daemon spine
+already speaks `Mount[]` end to end (`openEpicenterRoot` consumes `Mount[]` and
+never branches on shape, and the generated scaffold already ships
+`export default []`), so the single form is sugar that `loadEpicenterConfig`
+normalizes away one line after reading it.
 
 ### Invariant this owns
 
 > The config default export **is** a `Mount[]`. Anything else, including a bare
 > valid `Mount` that is not wrapped in an array, is a structured
-> `ProjectConfigError.ProjectConfigInvalid` pointed at the file. `loadProjectConfig`
-> never throws.
+> `EpicenterConfigError.EpicenterConfigInvalid` pointed at the file.
+> `loadEpicenterConfig` never throws.
 
 ## Edits
 
-### 1. Core normalization: `packages/workspace/src/config/load-project-config.ts`
+### 1. Core normalization: `packages/workspace/src/config/load-epicenter-config.ts`
 
 **1a. Collapse the body** (current lines 95-108). Replace:
 
@@ -33,15 +34,15 @@ form is sugar that `loadProjectConfig` normalizes away one line after reading it
 	const value = module.default;
 	if (Array.isArray(value)) {
 		if (value.every(isMount)) return Ok(value);
-		return ProjectConfigError.ProjectConfigInvalid({
-			projectConfigPath,
+		return EpicenterConfigError.EpicenterConfigInvalid({
+			epicenterConfigPath,
 			detail:
 				'an array entry is not a Mount (each needs a string `name` and an `open` function)',
 		});
 	}
 	if (isMount(value)) return Ok([value]);
-	return ProjectConfigError.ProjectConfigInvalid({
-		projectConfigPath,
+	return EpicenterConfigError.EpicenterConfigInvalid({
+		epicenterConfigPath,
 		detail: 'the default export must be a Mount or a Mount[]',
 	});
 ```
@@ -51,8 +52,8 @@ with:
 ```ts
 	const value = module.default;
 	if (Array.isArray(value) && value.every(isMount)) return Ok(value);
-	return ProjectConfigError.ProjectConfigInvalid({
-		projectConfigPath,
+	return EpicenterConfigError.EpicenterConfigInvalid({
+		epicenterConfigPath,
 		detail:
 			'the default export must be a Mount[] (each entry needs a string `name` and an `open` function)',
 	});
@@ -89,7 +90,7 @@ with:
 Leave the `isMount`-is-real-input-validation paragraph and the "never throws"
 sentence intact.
 
-### 2. Tests: `packages/workspace/src/config/load-project-config.test.ts`
+### 2. Tests: `packages/workspace/src/config/load-epicenter-config.test.ts`
 
 - **Delete** the test `'normalizes a single Mount default export into a Mount[]'`
   (current lines 44-52). The behavior it pins no longer exists.
@@ -105,8 +106,8 @@ sentence intact.
 	test('rejects a bare Mount that is not wrapped in an array', async () => {
 		writeConfig("export default { name: 'demo', open() {} };\n");
 
-		const { error } = await loadProjectConfig(projectDir);
-		expect(error?.name).toBe('ProjectConfigInvalid');
+		const { error } = await loadEpicenterConfig(epicenterRoot);
+		expect(error?.name).toBe('EpicenterConfigInvalid');
 	});
 ```
 
@@ -118,11 +119,11 @@ no-default-export, and bad-syntax tests as-is.
 - `packages/workspace/src/daemon/define-mount.ts` (lines 4-5):
   `` `epicenter.config.ts` default-exports a `Mount` (single mount) or a `Mount[]`
   (multi-mount). `` -> `` `epicenter.config.ts` default-exports a `Mount[]`. ``
-- `packages/workspace/src/config/project-config-source.ts` (line 3):
+- `packages/workspace/src/config/epicenter-config-source.ts` (line 3):
   `// Default-export a Mount or Mount[] value. Example:` ->
   `// Default-export a Mount[] value. Example:`
   (The shipped `export default []` body is already correct.)
-- `packages/workspace/src/workspace-apps/open-project.ts` (line 9):
+- `packages/workspace/src/workspace-apps/open-epicenter-root.ts` (line 9):
   `validates that its default export is a `Mount` / `Mount[]`.` ->
   `validates that its default export is a `Mount[]`.`
 
@@ -158,10 +159,10 @@ Each is a one-line change (plus one doc line in fuji):
 
 ## Verification
 
-1. `bun test packages/workspace/src/config/load-project-config.test.ts` passes.
+1. `bun test packages/workspace/src/config/load-epicenter-config.test.ts` passes.
 2. `bun run --filter @epicenter/workspace typecheck` (or repo typecheck) is clean.
 3. `rg -n -i 'Mount or Mount\[\]|Mount` / `Mount\[\]|single Mount'` across source +
    `packages/cli/README.md` returns nothing in live code/docs (matches only the
    historical specs noted above, which stay).
 4. Sanity: `export default fuji()` (bare) in a config now fails with
-   `ProjectConfigInvalid`; `export default [fuji()]` succeeds.
+   `EpicenterConfigInvalid`; `export default [fuji()]` succeeds.

--- a/specs/20260610T193000-cli-daemon-collapse-waves.md
+++ b/specs/20260610T193000-cli-daemon-collapse-waves.md
@@ -14,14 +14,14 @@ dispatch, materializer projections).
 ## Experiment record
 
 Throwaway benchmark (`bench-oneshot.ts` at the repo root, untracked) drove
-the full one-shot path against a temp project mounting the real fuji app
+the full one-shot path against a temp Epicenter root mounting the real fuji app
 with stub signed-in auth and no relay: bun spawn, library import,
-`openProject`, invoke `entries_get_all_valid`, dispose.
+`openEpicenterRoot`, invoke `entries_get_all_valid`, dispose.
 
-| Scenario                          | openProject | total wall |
-| --------------------------------- | ----------- | ---------- |
-| Empty project                     | 41-53 ms    | 0.17-0.25 s |
-| 300 entries (2.8 MB Yjs log)      | 65-69 ms    | ~0.21 s    |
+| Scenario                          | openEpicenterRoot | total wall  |
+| --------------------------------- | ----------------- | ----------- |
+| Empty root                        | 41-53 ms          | 0.17-0.25 s |
+| 300 entries (2.8 MB Yjs log)      | 65-69 ms          | ~0.21 s     |
 
 Latency gate for daemonless `run` was "under ~1 s"; it passes by roughly 5x.
 `attachYjsLog` hydration is synchronous, dispose is clean, and the sync
@@ -39,9 +39,9 @@ zero body reads attempted across three subsequent opens.
 - Replaced the recursive tree renderer in `epicenter list` with mount-grouped
   flat output; action paths are exactly `mount.action_key`, so the tree was
   always two levels deep.
-- Moved project scaffolding out of `daemon up` into a new `epicenter init`.
+- Moved Epicenter-root scaffolding out of `daemon up` into a new `epicenter init`.
   `daemon up` no longer writes `epicenter.config.ts` or litters `.epicenter`
-  into non-project directories; on a missing config it fails with a hint
+  into non-Epicenter-root directories; on a missing config it fails with a hint
   pointing at `init`. Per-dir provisioning collapsed entirely: the attach
   primitives create their own data dirs on demand (verified by the benchmark,
   which never provisioned and still got `sqlite/` and `yjs/`), and
@@ -97,8 +97,8 @@ The fix, in three layers:
 ## Wave 3: daemonless `run` (deferred)
 
 Candidate:
-  `epicenter run`/`list` work without a running daemon: if the project
-  socket answers, route through it; otherwise open the project in-process
+  `epicenter run`/`list` work without a running daemon: if the root
+  socket answers, route through it; otherwise open the root in-process
   offline, run, dispose. The daemon remains for live-peer duties; `--peer`
   honestly requires it.
 

--- a/specs/20260612T000201-epicenter-namespace-root-layout.md
+++ b/specs/20260612T000201-epicenter-namespace-root-layout.md
@@ -327,7 +327,7 @@ epicenter list -C vault/apps
 epicenter run -C vault/apps fuji.entries_update '{}'
 ```
 
-Running inside `vault/apps/fuji` still works because `findProjectRoot()` walks up to `vault/apps/epicenter.config.ts`.
+Running inside `vault/apps/fuji` still works because `findEpicenterRoot()` walks up to `vault/apps/epicenter.config.ts`.
 
 ## Implementation Plan
 
@@ -363,8 +363,8 @@ Running inside `vault/apps/fuji` still works because `findProjectRoot()` walks u
 
 ### Phase 5: CLI and provisioning
 
-- [ ] **5.1** Change command descriptions from "Project root" to "Epicenter namespace root."
-- [ ] **5.2** Keep `findProjectRoot()` upward-only for command execution.
+- [x] **5.1** Change command descriptions from "Project root" to "Epicenter root."
+- [x] **5.2** Keep `findEpicenterRoot()` upward-only for command execution.
 - [ ] **5.3** Change `daemon up` provisioning so a missing config is not accidentally created at a normal repo root. Prefer an explicit init flow or require `-C <namespace-dir>`.
 - [ ] **5.4** Add docs showing `epicenter daemon up -C apps` from a repo root.
 - [ ] **5.5** Add or update tests for provisioning, discovery, and error messages.
@@ -384,7 +384,7 @@ Running inside `vault/apps/fuji` still works because `findProjectRoot()` walks u
 - [ ] **7.2** Update `packages/cli/README.md`.
 - [ ] **7.3** Update `packages/workspace/README.md`.
 - [ ] **7.4** Mark older path specs as superseded where they teach repo-root config or `projectDir/apps/<mount>`.
-- [ ] **7.5** Search for `appsMarkdownPath`, `Project root`, `project root`, and `projectDir/apps`.
+- [ ] **7.5** Search for `appsMarkdownPath`, stale root/config API names, and `projectDir/apps`.
 
 ## Gitignore Model
 
@@ -408,8 +408,9 @@ If the namespace needs a tracked `AGENTS.md` or README:
 ```
 
 Do not ignore the namespace without unignoring the config. The config is the
-tracked boundary marker. `openProject()` claims the namespace after config,
-auth, mount-name, and populated-folder validation, but before any mount opens.
+tracked boundary marker. `openEpicenterRoot()` claims the namespace after
+config, auth, mount-name, and populated-folder validation, but before any mount
+opens.
 Fresh claims write the root ignore before creating `.epicenter/`, so
 `.epicenter/` remains the "already claimed" marker.
 
@@ -419,7 +420,7 @@ Fresh claims write the root ignore before creating `.epicenter/`, so
 
 1. User has `repo/apps/epicenter.config.ts`.
 2. User runs `epicenter list` from `repo/`.
-3. `findProjectRoot()` does not scan down.
+3. `findEpicenterRoot()` does not scan down.
 4. Command should fail with a clear message: run from `repo/apps`, pass `-C apps`, or initialize a namespace.
 
 This is deliberate for v1. A scan-down fallback can be added later only if ambiguity rules are clear.
@@ -444,7 +445,7 @@ Recommendation: first implementation should refuse this on bootstrap if `.epicen
 
 1. User creates `repo/apps/epicenter.config.ts` with multiple mounts.
 2. The populated-folder guard passes.
-3. `openProject()` writes `repo/apps/.gitignore`, then creates `repo/apps/.epicenter/`.
+3. `openEpicenterRoot()` writes `repo/apps/.gitignore`, then creates `repo/apps/.epicenter/`.
 4. One mount later fails while opening.
 
 Recommendation: keep the namespace claim. The folder has already passed the
@@ -501,7 +502,7 @@ Rejected for v1. A repo may contain several namespace roots. Upward-only discove
 
 ### Store `.epicenter/` inside each mount folder
 
-Rejected. `.epicenter/` is namespace state, not projection content. Putting it inside each mount makes every mount look like a separate project root and blurs the boundary.
+Rejected. `.epicenter/` is namespace state, not projection content. Putting it inside each mount makes every mount look like a separate Epicenter root and blurs the boundary.
 
 ### Round-trip editing of the projection (markdown as source)
 
@@ -545,9 +546,9 @@ The single write path is the app or the CLI. If editor ergonomics matter later, 
 
 - `packages/workspace/src/document/workspace-paths.ts` - current `appsMarkdownPath`, `markdownPath`, `sqlitePath`, and `yjsPath` helpers.
 - `packages/workspace/src/document/materializer/markdown/export.ts` - current markdown exporter, path joins, and rebuild sweep.
-- `packages/workspace/src/client/find-project-root.ts` - upward-only config discovery.
+- `packages/workspace/src/client/find-epicenter-root.ts` - upward-only config discovery.
 - `packages/cli/src/commands/up.ts` - current provisioning writes `epicenter.config.ts` and `.epicenter/`.
-- `packages/cli/src/util/common-options.ts` - CLI `-C` language currently says project root.
+- `packages/cli/src/util/common-options.ts` - CLI `-C` language for Epicenter-root discovery.
 - `apps/fuji/src/lib/workspace/project.ts` - first-party mount factory using `appsMarkdownPath`.
 - `apps/honeycrisp/project.ts` - first-party mount factory using `appsMarkdownPath`.
 - `apps/tab-manager/project.ts` - first-party mount factory using `appsMarkdownPath`.

--- a/specs/20260612T000201-epicenter-namespace-root-layout.md
+++ b/specs/20260612T000201-epicenter-namespace-root-layout.md
@@ -263,7 +263,7 @@ repo root and siblings of namespaceRoot
 | Per-file manifest | 2 coherence | Reject | A manifest solves union folders. This design makes mount folders exclusive generated output. |
 | `apps/` name | 3 taste | Use as docs default for vault-style projects | It preserves the current visible path when config moves from `repo/` to `repo/apps/`. Revisit if `apps/` conflicts with source package directories. |
 | Project discovery from repo root | 3 taste | Keep upward-only discovery for commands, document `-C apps` | Scan-down adds ambiguity when a repo has multiple namespace roots. Revisit if the `-C` requirement becomes a daily paper cut. |
-| `projectDir` name in code | 3 taste | Keep for first implementation wave, redefine in docs | A full rename to `namespaceDir` is cleaner but wide. Revisit if the term keeps causing wrong config placement. |
+| Code boundary name | 2 coherence | Use `EpicenterRoot` / `epicenterRoot` in public code | The value is the folder marked by `epicenter.config.ts`. The branded name avoids repo-root and workspace-root confusion while staying less abstract than `namespaceDir`. |
 
 ## Call Sites: Before and After
 
@@ -283,7 +283,7 @@ const mdDir = mountMarkdownPath(projectDir, mount);
 // projectDir/<mount>
 ```
 
-Recommendation: add `mountMarkdownPath(projectDir, mountName)` and migrate first-party app factories to it. Keep `appsMarkdownPath` only as a temporary compatibility alias if removing it would force unrelated playground churn.
+Recommendation: use `mountMarkdownPath(epicenterRoot, mountName)` and migrate first-party app factories to it. Delete `appsMarkdownPath` instead of keeping a compatibility alias, so visible projections have one path shape.
 
 ### Vault layout
 
@@ -333,16 +333,16 @@ Running inside `vault/apps/fuji` still works because `findEpicenterRoot()` walks
 
 ### Phase 1: Name the namespace boundary
 
-- [ ] **1.1** Update docs and JSDoc so `projectDir` means "Epicenter namespace root," not "repo root."
-- [ ] **1.2** Add `mountMarkdownPath(projectDir, mountName)` returning `join(projectDir, mountName)`.
-- [ ] **1.3** Add tests for `mountMarkdownPath` and reserved mount names.
-- [ ] **1.4** Decide whether `appsMarkdownPath` is deleted immediately or kept as a deprecated alias for one release.
+- [x] **1.1** Update live docs and JSDoc so the boundary is the Epicenter root, not the repo root.
+- [x] **1.2** Add `mountMarkdownPath(epicenterRoot, mountName)` returning `join(epicenterRoot, mountName)`.
+- [x] **1.3** Add tests for `mountMarkdownPath` and reserved mount names.
+- [x] **1.4** Delete `appsMarkdownPath` instead of keeping a deprecated alias.
 
 ### Phase 2: Move first-party vault mounts to direct children
 
-- [ ] **2.1** Change Fuji, Honeycrisp, and Tab Manager project factories to materialize markdown with `mountMarkdownPath(projectDir, mount)`.
-- [ ] **2.2** Keep yjs and sqlite under `projectDir/.epicenter/` using existing guid-keyed helpers.
-- [ ] **2.3** Update comments in first-party mount factories that still describe `appsMarkdownPath`.
+- [x] **2.1** Change Fuji, Honeycrisp, and Tab Manager project factories to materialize markdown with `mountMarkdownPath(epicenterRoot, mount)`.
+- [x] **2.2** Keep yjs and sqlite under `epicenterRoot/.epicenter/` using existing guid-keyed helpers.
+- [x] **2.3** Update comments in first-party mount factories that still describe `appsMarkdownPath`.
 - [ ] **2.4** Run focused tests for workspace paths and each changed app package.
 
 ### Phase 3: Make markdown export confinement true
@@ -365,9 +365,9 @@ Running inside `vault/apps/fuji` still works because `findEpicenterRoot()` walks
 
 - [x] **5.1** Change command descriptions from "Project root" to "Epicenter root."
 - [x] **5.2** Keep `findEpicenterRoot()` upward-only for command execution.
-- [ ] **5.3** Change `daemon up` provisioning so a missing config is not accidentally created at a normal repo root. Prefer an explicit init flow or require `-C <namespace-dir>`.
-- [ ] **5.4** Add docs showing `epicenter daemon up -C apps` from a repo root.
-- [ ] **5.5** Add or update tests for provisioning, discovery, and error messages.
+- [x] **5.3** Change `daemon up` provisioning so a missing config is not accidentally created at a normal repo root. `epicenter init` owns creation.
+- [x] **5.4** Add docs showing `epicenter daemon up -C apps` from a repo root.
+- [x] **5.5** Add or update tests for provisioning, discovery, and error messages.
 
 ### Phase 6: Vault migration
 
@@ -517,8 +517,8 @@ The single write path is the app or the CLI. If editor ergonomics matter later, 
 1. **Should the default namespace folder be `apps/` or `epicenter/` in new docs?**
    - Recommendation: use `apps/` for vault-style projects because it preserves the current visible paths. Mention `epicenter/` as the escape hatch when `apps/` is already source-code territory.
 
-2. **Should `projectDir` be renamed to `namespaceDir` in public APIs?**
-   - Recommendation: defer the rename. First make the semantics true, then decide whether the name still misleads.
+2. **Should the code boundary be named `projectDir`, `namespaceDir`, or `epicenterRoot`?**
+   - Decision: use `epicenterRoot` / `EpicenterRoot` for live public APIs. "Epicenter root" is the canonical code term, "Epicenter folder" is the first-mention friendly prose, and "namespace root" remains architecture language.
 
 3. **Should `daemon up` create a namespace folder automatically?**
    - Recommendation: avoid implicit repo-root creation. Prefer an explicit init flow that writes `apps/epicenter.config.ts` or accepts the target namespace path.
@@ -532,33 +532,34 @@ The single write path is the app or the CLI. If editor ergonomics matter later, 
 
 ## Success Criteria
 
-- [ ] `projectDir` is documented as the Epicenter namespace root.
-- [ ] First-party visible markdown projections live at `projectDir/<mountName>`.
+- [x] `epicenterRoot` is documented as the Epicenter root.
+- [x] First-party visible markdown projections live at `epicenterRoot/<mountName>`.
 - [ ] The default vault layout keeps visible paths as `vault/apps/<mountName>` by moving the config to `vault/apps/epicenter.config.ts`.
-- [ ] `.epicenter/` lives next to `epicenter.config.ts`.
-- [ ] No per-mount sentinel or per-file manifest is introduced for the namespace-root model.
+- [x] `.epicenter/` lives next to `epicenter.config.ts`.
+- [x] No per-mount sentinel or per-file manifest is introduced for the namespace-root model.
 - [ ] `attachMarkdownExport` rejects table dirs and filenames that escape the export root.
 - [ ] `markdown_rebuild` cannot delete outside a declared mount projection.
-- [ ] CLI docs tell users to run from the namespace root or pass `-C <namespace-root>`.
-- [ ] Tests cover path helpers, discovery behavior, path confinement, and rebuild safety.
+- [x] CLI docs tell users to run from the Epicenter root or pass `-C <epicenter-root>`.
+- [x] Tests cover path helpers and discovery behavior.
+- [ ] Tests cover path confinement and rebuild safety.
 
 ## References
 
-- `packages/workspace/src/document/workspace-paths.ts` - current `appsMarkdownPath`, `markdownPath`, `sqlitePath`, and `yjsPath` helpers.
+- `packages/workspace/src/document/workspace-paths.ts` - current `mountMarkdownPath`, `markdownPath`, `sqlitePath`, and `yjsPath` helpers.
 - `packages/workspace/src/document/materializer/markdown/export.ts` - current markdown exporter, path joins, and rebuild sweep.
 - `packages/workspace/src/client/find-epicenter-root.ts` - upward-only config discovery.
 - `packages/cli/src/commands/up.ts` - current provisioning writes `epicenter.config.ts` and `.epicenter/`.
 - `packages/cli/src/util/common-options.ts` - CLI `-C` language for Epicenter-root discovery.
-- `apps/fuji/src/lib/workspace/project.ts` - first-party mount factory using `appsMarkdownPath`.
-- `apps/honeycrisp/project.ts` - first-party mount factory using `appsMarkdownPath`.
-- `apps/tab-manager/project.ts` - first-party mount factory using `appsMarkdownPath`.
+- `apps/fuji/src/lib/workspace/project.ts` - first-party mount factory using `mountMarkdownPath`.
+- `apps/honeycrisp/project.ts` - first-party mount factory using `mountMarkdownPath`.
+- `apps/tab-manager/project.ts` - first-party mount factory using `mountMarkdownPath`.
 - `specs/20260602T200000-vault-read-only-projection-agent-mutation.md` - previous visible `apps/` projection model.
 - `specs/20260522T220000-workspace-project-layout.md` - older project-root layout model.
 
 ## Decisions Log
 
-- Keep the code term `projectDir` for the first wave: this avoids a broad public rename while the layout changes.
-  Revisit when: docs still need to repeatedly explain that `projectDir` is not the repo root.
+- Use the code term `epicenterRoot` for the live public boundary: this avoids the old repo-root reading of `projectDir` and the abstract feel of `namespaceDir`.
+  Revisit when: the product stops using "Epicenter root" as the canonical code/API term.
 
 - Keep upward-only discovery for command execution: it is predictable and avoids choosing between several child namespace roots.
   Revisit when: users routinely run commands from repo roots that contain exactly one Epicenter namespace.


### PR DESCRIPTION
Follow-up to #1940 and #1947: the namespace-root layout now treats the folder holding `epicenter.config.ts` as the Epicenter root, but the live helper names still taught "project" at the public boundary. This removes that mixed vocabulary so daemon startup reads as one thing: find an Epicenter root, load its Epicenter config, open that Epicenter root.

```ts
// before
import { findEpicenterRoot, openProject } from "@epicenter/workspace/node";

const epicenterRoot = findEpicenterRoot();
const result = await openProject({ epicenterRoot, auth });
```

```ts
// after
import { findEpicenterRoot, openEpicenterRoot } from "@epicenter/workspace/node";

const epicenterRoot = findEpicenterRoot();
const result = await openEpicenterRoot({ epicenterRoot, auth });
```

The startup invariant from #1947 stays in the workspace package. `openEpicenterRoot` validates config, auth, mount names, and bootstrap ownership, claims the Epicenter folder, then opens mounts. `runUp` stays as daemon lifecycle glue: lease, auth, workspace startup, socket, metadata, teardown.

## Breaking

The old public names are removed instead of aliased:

```ts
// before
ProjectConfigError
DEFAULT_PROJECT_CONFIG_SOURCE
OpenProjectOptions
openProject

// after
EpicenterConfigError
DEFAULT_EPICENTER_CONFIG_SOURCE
OpenEpicenterRootOptions
openEpicenterRoot
```

Deep imports that reached into the old file names also need to move from `find-project-root`, `project-config-source`, `load-project-config`, and `open-project` to their `epicenter-*` equivalents. `findEpicenterRoot` remains the public export name; this PR makes its file path match the concept. `loadEpicenterConfig` remains an internal config-loader boundary consumed by `openEpicenterRoot`.

CLI and docs now use `Epicenter root` for the folder that holds `epicenter.config.ts`. The `apps/<app>/project.ts` mount-factory convention is left alone because that is a package export convention, not the root/config API this PR is cleaning up.

## Relationship To Recent PRs

This branch is based on current `origin/main` after #1947, including the Epicenter-folder gitignore and bootstrap hardening. Open PR #1957 overlaps with the same workspace startup/config files while changing config cardinality and moving the mount modules; if #1957 lands first, this rename should be replayed onto that new `mount/` tree.
