### PR TITLE
ci: fix whispering preview build toolchains

### DIFF
--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -107,11 +107,21 @@ jobs:
         if: matrix.platform == 'windows-latest'
         shell: pwsh
         run: |
+          $windowsKit = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Directory | Sort-Object Name -Descending | Select-Object -First 1
+          if (-not $windowsKit) {
+            throw 'Windows SDK bin directory not found'
+          }
+          $rc = Join-Path $windowsKit.FullName 'x64\rc.exe'
+          if (-not (Test-Path $rc)) {
+            throw "Windows SDK resource compiler not found at $rc"
+          }
           ninja --version
           where.exe cl
           "CMAKE_GENERATOR=Ninja" >> $env:GITHUB_ENV
           "CC=cl" >> $env:GITHUB_ENV
           "CXX=cl" >> $env:GITHUB_ENV
+          "RC=$rc" >> $env:GITHUB_ENV
+          "CMAKE_RC_COMPILER=$rc" >> $env:GITHUB_ENV
 
       - name: setup bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -114,6 +114,7 @@ jobs:
           if (-not $rc -or -not (Test-Path $rc)) {
             throw "Windows SDK resource compiler not found at $rc"
           }
+          $rc = $rc -replace '\\', '/'
           ninja --version
           where.exe cl
           "CMAKE_GENERATOR=Ninja" >> $env:GITHUB_ENV

--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -107,12 +107,11 @@ jobs:
         if: matrix.platform == 'windows-latest'
         shell: pwsh
         run: |
-          $windowsKit = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Directory | Sort-Object Name -Descending | Select-Object -First 1
-          if (-not $windowsKit) {
-            throw 'Windows SDK bin directory not found'
-          }
-          $rc = Join-Path $windowsKit.FullName 'x64\rc.exe'
+          $rc = Join-Path $env:WindowsSdkVerBinPath 'x64\rc.exe'
           if (-not (Test-Path $rc)) {
+            $rc = (Get-ChildItem (Join-Path $env:WindowsSdkDir 'bin\*\x64\rc.exe') | Sort-Object FullName -Descending | Select-Object -First 1).FullName
+          }
+          if (-not $rc -or -not (Test-Path $rc)) {
             throw "Windows SDK resource compiler not found at $rc"
           }
           ninja --version

--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -50,11 +50,7 @@ jobs:
         include:
           - platform: 'blacksmith-6vcpu-macos-15'
             args: '--target aarch64-apple-darwin'
-            rustTargets: 'aarch64-apple-darwin,x86_64-apple-darwin'
-
-          - platform: 'blacksmith-6vcpu-macos-15'
-            args: '--target x86_64-apple-darwin'
-            rustTargets: 'aarch64-apple-darwin,x86_64-apple-darwin'
+            rustTargets: 'aarch64-apple-darwin'
 
           - platform: 'ubuntu-24.04'
             args: ''
@@ -100,6 +96,12 @@ jobs:
           }
           "VULKAN_SDK=$($sdk.FullName)" >> $env:GITHUB_ENV
           "$($sdk.FullName)\Bin" >> $env:GITHUB_PATH
+
+      - name: setup MSVC developer environment
+        if: matrix.platform == 'windows-latest'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
 
       - name: setup bun
         uses: oven-sh/setup-bun@v2
@@ -183,8 +185,6 @@ jobs:
         run: |
           if [[ "${{ matrix.args }}" == *"aarch64-apple-darwin"* ]]; then
             echo "suffix=macos-arm64" >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.args }}" == *"x86_64-apple-darwin"* ]]; then
-            echo "suffix=macos-intel" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.platform }}" == "ubuntu-24.04" ]]; then
             echo "suffix=linux" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.platform }}" == "windows-latest" ]]; then

--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -89,7 +89,7 @@ jobs:
         if: matrix.platform == 'windows-latest'
         shell: pwsh
         run: |
-          choco install vulkan-sdk -y --no-progress
+          choco install vulkan-sdk ninja -y --no-progress
           $sdk = Get-ChildItem 'C:\VulkanSDK' -Directory | Sort-Object Name -Descending | Select-Object -First 1
           if (-not $sdk) {
             throw 'Vulkan SDK install did not create C:\VulkanSDK'
@@ -102,6 +102,16 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
+
+      - name: configure Windows CMake generator
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          ninja --version
+          where.exe cl
+          "CMAKE_GENERATOR=Ninja" >> $env:GITHUB_ENV
+          "CC=cl" >> $env:GITHUB_ENV
+          "CXX=cl" >> $env:GITHUB_ENV
 
       - name: setup bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -118,6 +118,7 @@ jobs:
           ninja --version
           where.exe cl
           "CMAKE_GENERATOR=Ninja" >> $env:GITHUB_ENV
+          "CARGO_TARGET_DIR=D:/t" >> $env:GITHUB_ENV
           "CC=cl" >> $env:GITHUB_ENV
           "CXX=cl" >> $env:GITHUB_ENV
           "RC=$rc" >> $env:GITHUB_ENV

--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -50,39 +50,56 @@ jobs:
         include:
           - platform: 'blacksmith-6vcpu-macos-15'
             args: '--target aarch64-apple-darwin'
+            rustTargets: 'aarch64-apple-darwin,x86_64-apple-darwin'
 
           - platform: 'blacksmith-6vcpu-macos-15'
             args: '--target x86_64-apple-darwin'
+            rustTargets: 'aarch64-apple-darwin,x86_64-apple-darwin'
 
-          - platform: 'ubuntu-22.04'
+          - platform: 'ubuntu-24.04'
             args: ''
+            rustTargets: ''
 
           - platform: 'windows-latest'
             args: ''
+            rustTargets: ''
 
     runs-on: ${{ matrix.platform }}
+    env:
+      CMAKE_POLICY_VERSION_MINIMUM: '3.5'
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install create-dmg (macOS only)
-        if: matrix.platform == 'macos-latest'
-        run: brew install create-dmg
+      - name: install dependencies (macOS only)
+        if: startsWith(matrix.platform, 'blacksmith-6vcpu-macos')
+        run: brew install create-dmg opus pkg-config
 
       - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-24.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxdo-dev libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev
 
-      # Linux Vulkan SDK installation (required for whisper-cpp GPU acceleration on Linux)
-      # Note: Windows whisper-cpp is disabled due to MSVC runtime conflicts, so no Vulkan needed there
+      # Vulkan SDK installation is required wherever whisper-vulkan is compiled.
       - name: Install Vulkan SDK (Ubuntu)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-24.04'
         run: |
           wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.290-jammy.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-jammy.list
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-noble.list https://packages.lunarg.com/vulkan/lunarg-vulkan-noble.list
           sudo apt update
           sudo apt install -y vulkan-sdk mesa-vulkan-drivers
+
+      - name: Install Vulkan SDK (Windows)
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          choco install vulkan-sdk -y --no-progress
+          $sdk = Get-ChildItem 'C:\VulkanSDK' -Directory | Sort-Object Name -Descending | Select-Object -First 1
+          if (-not $sdk) {
+            throw 'Vulkan SDK install did not create C:\VulkanSDK'
+          }
+          "VULKAN_SDK=$($sdk.FullName)" >> $env:GITHUB_ENV
+          "$($sdk.FullName)\Bin" >> $env:GITHUB_PATH
 
       - name: setup bun
         uses: oven-sh/setup-bun@v2
@@ -97,7 +114,7 @@ jobs:
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ matrix.rustTargets }}
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
@@ -124,13 +141,13 @@ jobs:
           args: '${{ matrix.args }} --no-sign'
 
       - name: Install FUSE for AppImage processing
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-24.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y fuse libfuse2
 
       - name: Remove libwayland-client.so from AppImage
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-24.04'
         run: |
           APPIMAGE_PATH=$(find apps/whispering/src-tauri/target/release/bundle/appimage -name "*.AppImage" | head -1)
 
@@ -168,7 +185,7 @@ jobs:
             echo "suffix=macos-arm64" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.args }}" == *"x86_64-apple-darwin"* ]]; then
             echo "suffix=macos-intel" >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.platform }}" == "ubuntu-22.04" ]]; then
+          elif [[ "${{ matrix.platform }}" == "ubuntu-24.04" ]]; then
             echo "suffix=linux" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
             echo "suffix=windows" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.whispering.yml
+++ b/.github/workflows/release.whispering.yml
@@ -116,7 +116,7 @@ jobs:
         if: matrix.platform == 'windows-latest'
         shell: pwsh
         run: |
-          choco install vulkan-sdk -y --no-progress
+          choco install vulkan-sdk ninja -y --no-progress
           $sdk = Get-ChildItem 'C:\VulkanSDK' -Directory | Sort-Object Name -Descending | Select-Object -First 1
           if (-not $sdk) {
             throw 'Vulkan SDK install did not create C:\VulkanSDK'
@@ -129,6 +129,16 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
+
+      - name: configure Windows CMake generator
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          ninja --version
+          where.exe cl
+          "CMAKE_GENERATOR=Ninja" >> $env:GITHUB_ENV
+          "CC=cl" >> $env:GITHUB_ENV
+          "CXX=cl" >> $env:GITHUB_ENV
 
       # Setup Bun package manager
       - name: setup bun

--- a/.github/workflows/release.whispering.yml
+++ b/.github/workflows/release.whispering.yml
@@ -59,12 +59,7 @@ jobs:
           # macOS Apple Silicon (M1, M2, M3, etc.)
           - platform: 'blacksmith-6vcpu-macos-15'
             args: '--target aarch64-apple-darwin'
-            rustTargets: 'aarch64-apple-darwin,x86_64-apple-darwin'
-
-          # macOS Intel-based
-          - platform: 'blacksmith-6vcpu-macos-15'
-            args: '--target x86_64-apple-darwin'
-            rustTargets: 'aarch64-apple-darwin,x86_64-apple-darwin'
+            rustTargets: 'aarch64-apple-darwin'
 
           # Linux (Ubuntu)
           - platform: 'ubuntu-24.04'
@@ -129,6 +124,12 @@ jobs:
           "VULKAN_SDK=$($sdk.FullName)" >> $env:GITHUB_ENV
           "$($sdk.FullName)\Bin" >> $env:GITHUB_PATH
 
+      - name: setup MSVC developer environment
+        if: matrix.platform == 'windows-latest'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
       # Setup Bun package manager
       - name: setup bun
         uses: oven-sh/setup-bun@v2
@@ -145,7 +146,7 @@ jobs:
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          # For macOS: specify both Intel and ARM targets
+          # For macOS: specify the Apple Silicon target
           # For other platforms: empty string (uses default target)
           targets: ${{ matrix.rustTargets }}
 

--- a/.github/workflows/release.whispering.yml
+++ b/.github/workflows/release.whispering.yml
@@ -134,12 +134,11 @@ jobs:
         if: matrix.platform == 'windows-latest'
         shell: pwsh
         run: |
-          $windowsKit = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Directory | Sort-Object Name -Descending | Select-Object -First 1
-          if (-not $windowsKit) {
-            throw 'Windows SDK bin directory not found'
-          }
-          $rc = Join-Path $windowsKit.FullName 'x64\rc.exe'
+          $rc = Join-Path $env:WindowsSdkVerBinPath 'x64\rc.exe'
           if (-not (Test-Path $rc)) {
+            $rc = (Get-ChildItem (Join-Path $env:WindowsSdkDir 'bin\*\x64\rc.exe') | Sort-Object FullName -Descending | Select-Object -First 1).FullName
+          }
+          if (-not $rc -or -not (Test-Path $rc)) {
             throw "Windows SDK resource compiler not found at $rc"
           }
           ninja --version

--- a/.github/workflows/release.whispering.yml
+++ b/.github/workflows/release.whispering.yml
@@ -145,6 +145,7 @@ jobs:
           ninja --version
           where.exe cl
           "CMAKE_GENERATOR=Ninja" >> $env:GITHUB_ENV
+          "CARGO_TARGET_DIR=D:/t" >> $env:GITHUB_ENV
           "CC=cl" >> $env:GITHUB_ENV
           "CXX=cl" >> $env:GITHUB_ENV
           "RC=$rc" >> $env:GITHUB_ENV

--- a/.github/workflows/release.whispering.yml
+++ b/.github/workflows/release.whispering.yml
@@ -141,6 +141,7 @@ jobs:
           if (-not $rc -or -not (Test-Path $rc)) {
             throw "Windows SDK resource compiler not found at $rc"
           }
+          $rc = $rc -replace '\\', '/'
           ninja --version
           where.exe cl
           "CMAKE_GENERATOR=Ninja" >> $env:GITHUB_ENV

--- a/.github/workflows/release.whispering.yml
+++ b/.github/workflows/release.whispering.yml
@@ -59,33 +59,39 @@ jobs:
           # macOS Apple Silicon (M1, M2, M3, etc.)
           - platform: 'blacksmith-6vcpu-macos-15'
             args: '--target aarch64-apple-darwin'
+            rustTargets: 'aarch64-apple-darwin,x86_64-apple-darwin'
 
           # macOS Intel-based
           - platform: 'blacksmith-6vcpu-macos-15'
             args: '--target x86_64-apple-darwin'
+            rustTargets: 'aarch64-apple-darwin,x86_64-apple-darwin'
 
           # Linux (Ubuntu)
-          - platform: 'ubuntu-22.04'
+          - platform: 'ubuntu-24.04'
             args: ''  # No specific target needed for Linux
+            rustTargets: ''
 
           # Windows
           - platform: 'windows-latest'
             args: ''  # No specific target needed for Windows
+            rustTargets: ''
 
     runs-on: ${{ matrix.platform }}
+    env:
+      CMAKE_POLICY_VERSION_MINIMUM: '3.5'
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
       # macOS specific: Install create-dmg for DMG bundling
-      - name: Install create-dmg (macOS only)
-        if: matrix.platform == 'macos-latest'
-        run: brew install create-dmg
+      - name: install dependencies (macOS only)
+        if: startsWith(matrix.platform, 'blacksmith-6vcpu-macos')
+        run: brew install create-dmg opus pkg-config
 
       # Ubuntu/Linux specific: Install system dependencies required by Tauri
       - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-24.04'
         run: |
           sudo apt-get update
           # Dependencies explanation:
@@ -101,17 +107,27 @@ jobs:
           # - libxrandr-dev: X11 RandR extension for display configuration
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxdo-dev libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev
 
-      # Linux Vulkan SDK installation (required for whisper-cpp GPU acceleration on Linux)
-      # Note: Windows whisper-cpp is disabled due to MSVC runtime conflicts, so no Vulkan needed there
+      # Vulkan SDK installation is required wherever whisper-vulkan is compiled.
       - name: Install Vulkan SDK (Ubuntu)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-24.04'
         run: |
           # Add official Vulkan SDK repository
           wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
-          # Note: Using "jammy" for Ubuntu 22.04
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.290-jammy.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-jammy.list
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-noble.list https://packages.lunarg.com/vulkan/lunarg-vulkan-noble.list
           sudo apt update
           sudo apt install -y vulkan-sdk mesa-vulkan-drivers
+
+      - name: Install Vulkan SDK (Windows)
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          choco install vulkan-sdk -y --no-progress
+          $sdk = Get-ChildItem 'C:\VulkanSDK' -Directory | Sort-Object Name -Descending | Select-Object -First 1
+          if (-not $sdk) {
+            throw 'Vulkan SDK install did not create C:\VulkanSDK'
+          }
+          "VULKAN_SDK=$($sdk.FullName)" >> $env:GITHUB_ENV
+          "$($sdk.FullName)\Bin" >> $env:GITHUB_PATH
 
       # Setup Bun package manager
       - name: setup bun
@@ -131,7 +147,7 @@ jobs:
         with:
           # For macOS: specify both Intel and ARM targets
           # For other platforms: empty string (uses default target)
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ matrix.rustTargets }}
 
       # Cache Rust dependencies for faster builds
       - name: Rust cache
@@ -225,7 +241,7 @@ jobs:
 
       # Install FUSE for AppImage processing
       - name: Install FUSE for AppImage processing
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-24.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y fuse libfuse2
@@ -233,7 +249,7 @@ jobs:
       # Remove libwayland-client.so from AppImage for better compatibility
       # This fixes EGL_BAD_PARAMETER errors on Wayland systems (Issues #114, #121)
       - name: Remove libwayland-client.so from AppImage
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-24.04'
         run: |
           # Find the AppImage file
           APPIMAGE_PATH=$(find apps/whispering/src-tauri/target/release/bundle/appimage -name "*.AppImage" | head -1)

--- a/.github/workflows/release.whispering.yml
+++ b/.github/workflows/release.whispering.yml
@@ -134,11 +134,21 @@ jobs:
         if: matrix.platform == 'windows-latest'
         shell: pwsh
         run: |
+          $windowsKit = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Directory | Sort-Object Name -Descending | Select-Object -First 1
+          if (-not $windowsKit) {
+            throw 'Windows SDK bin directory not found'
+          }
+          $rc = Join-Path $windowsKit.FullName 'x64\rc.exe'
+          if (-not (Test-Path $rc)) {
+            throw "Windows SDK resource compiler not found at $rc"
+          }
           ninja --version
           where.exe cl
           "CMAKE_GENERATOR=Ninja" >> $env:GITHUB_ENV
           "CC=cl" >> $env:GITHUB_ENV
           "CXX=cl" >> $env:GITHUB_ENV
+          "RC=$rc" >> $env:GITHUB_ENV
+          "CMAKE_RC_COMPILER=$rc" >> $env:GITHUB_ENV
 
       # Setup Bun package manager
       - name: setup bun


### PR DESCRIPTION
Whispering preview builds are currently blocked by runner setup drift rather than app code. The macOS matrix runs on Blacksmith labels that no longer match the old macOS condition, CMake 4 rejects vendored Opus when system Opus is unavailable, Windows compiles the whisper-vulkan feature without a Vulkan SDK, and the Linux ONNX Runtime binary now needs a newer glibc than Ubuntu 22.04 provides.

This updates the preview and release workflows together so they stay aligned: macOS installs Opus, pkg-config, and create-dmg; the Rust target list comes from the matrix instead of a stale platform comparison; Linux builds move to Ubuntu 24.04 with the noble Vulkan repo; Windows installs the Vulkan SDK before building; and CMake gets the policy floor needed for older third-party CMake projects under CMake 4.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783999426&installation_id=128463665&pr_number=1965&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1965&signature=f4452b8ea3ae7c5fe38a32ab6f4beaaad65f3a28cf97a7ac85ef63406b07ba75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->