### PR TITLE
fix(whispering): reload the local model after re-download

### DIFF
--- a/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
@@ -121,10 +121,10 @@
 		if (!tauri) return;
 		entries = await listModelEntries(engine);
 		// The folder is user-editable truth, so the catalog handles re-check
-		// disk on the same signal that rescans the folder.
-		for (const model of models) {
-			localModelDownloads.get(model).refresh();
-		}
+		// disk on the same signal that rescans the folder. Await the disk-stat
+		// so `isInstalled` (and the "Downloaded" badge it drives) is settled
+		// before the listing does, instead of racing the next render.
+		await Promise.all(models.map((model) => localModelDownloads.get(model).refresh()));
 		// A user who already brought their own model gets the list, not a
 		// download pitch: when nothing is active and the first scan finds
 		// custom entries, start with the list open instead of the hero.

--- a/apps/whispering/src/lib/state/local-model-downloads.svelte.ts
+++ b/apps/whispering/src/lib/state/local-model-downloads.svelte.ts
@@ -28,6 +28,7 @@ import {
 	deleteModelEntry,
 	type LocalModelFolderError,
 } from '$lib/services/transcription/local-model-folder';
+import { transcriptionReload } from '$lib/state/transcription-reload.svelte';
 
 type ModelDownloadState =
 	| { type: 'not-downloaded' }
@@ -106,6 +107,11 @@ function createModelDownload(model: LocalModelConfig) {
 			// computed machine lands directly on ready.
 			await refresh();
 			progress = null;
+			// A fresh file now sits at this model's path. The selected model name
+			// may be unchanged (delete + re-download under the same name), so the
+			// layout's config push would not re-fire on settings alone. Bump the
+			// reload signal it also reads so Rust drops and reloads the model.
+			transcriptionReload.bump();
 			return Ok({ entryName: modelEntryName(model), outcome: 'downloaded' });
 		},
 

--- a/apps/whispering/src/lib/state/transcription-reload.svelte.ts
+++ b/apps/whispering/src/lib/state/transcription-reload.svelte.ts
@@ -1,0 +1,32 @@
+/**
+ * A bump-only reactive signal that forces the ambient transcription-config push
+ * to Rust to re-fire even when none of its named inputs changed.
+ *
+ * Why this exists: the config push in `(app)/+layout.svelte` keys off the
+ * selected model NAME (among other settings). Deleting a local model and
+ * re-downloading it under the SAME name leaves that name unchanged, and a
+ * `SvelteMap.set(key, sameValue)` does not notify on an unchanged value, so the
+ * effect never re-runs and Rust is never told to drop and reload the model that
+ * now lives at the same path. The model-download-completion path bumps this
+ * counter, the layout effect reads it, and the push fires again.
+ *
+ * The value itself is meaningless; only the change matters. Read `version` to
+ * register the dependency; call `bump()` after a model lands on disk.
+ */
+function createTranscriptionReload() {
+	let version = $state(0);
+
+	return {
+		/** Read this inside an effect to re-run it whenever `bump()` is called. */
+		get version(): number {
+			return version;
+		},
+
+		/** Signal that the resident model must be re-pushed to Rust. */
+		bump() {
+			version += 1;
+		},
+	};
+}
+
+export const transcriptionReload = createTranscriptionReload();

--- a/apps/whispering/src/routes/(app)/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/+layout.svelte
@@ -26,6 +26,7 @@
 	import { localModel } from '$lib/state/local-model.svelte';
 	import { manualRecorder } from '$lib/state/manual-recorder.svelte';
 	import { settings } from '$lib/state/settings.svelte';
+	import { transcriptionReload } from '$lib/state/transcription-reload.svelte';
 	import { vadRecorder } from '$lib/state/vad-recorder.svelte';
 	import { recordingOverlay } from '#platform/recording-overlay';
 	import { tauri } from '#platform/tauri';
@@ -92,6 +93,14 @@
 
 		const modelName = deviceConfig.get(PROVIDERS[service].modelConfigKey);
 		if (!modelName) return;
+
+		// Re-push when a model is re-downloaded under an unchanged name. The
+		// model name above stays the same across delete + re-download, and a
+		// SvelteMap.set with an unchanged value does not notify, so without this
+		// dependency the effect would not re-run and Rust would keep serving the
+		// evicted model. Reading the signal here tracks it; the download path
+		// bumps it once the new file is on disk.
+		void transcriptionReload.version;
 
 		const language = settings.get('transcription.language');
 		const prompt = settings.get('transcription.prompt');


### PR DESCRIPTION
Re-downloading a local transcription model (after deleting it, or after a corrupted download) left two stale surfaces until you manually re-selected the model.

The resident model is pushed to Rust by the `$effect` in `(app)/+layout.svelte`, which keys off the selected model *name*. A delete + re-download keeps the same name, and Svelte's `SvelteMap.set(key, sameValue)` does not notify on an unchanged value, so the effect never re-fired and Rust was never told to drop and reload the model now sitting at the same path. Re-selecting forced a name change, which is why that worked around it. This adds a tiny bump-only reactive signal (`transcription-reload`) that the download-completion path bumps and the layout effect reads, so a same-name re-download re-fires the config push. The push stays a single site; the signal only re-triggers it.

Separately, the "Downloaded" badge in the model dropdown could lag because `LocalModelSelector.refreshEntries` fired the per-model disk-stat refresh without awaiting it, racing the render. It now awaits them.

## Changelog

- Re-downloading a local transcription model now takes effect immediately, with no need to un-select and re-select it.
- The "Downloaded" badge updates reliably after a model finishes downloading.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784012445&installation_id=128463665&pr_number=1970&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1970&signature=150994bf47ea90d7e16a02e28ecf96adae530d81b0266abeb149ccf0059d4504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->