### PR TITLE
feat(whispering): harden the rdev listener lifecycle (macOS permission, Wayland, single-window emit)

### DIFF
--- a/apps/whispering/src-tauri/src/keyboard/commands.rs
+++ b/apps/whispering/src-tauri/src/keyboard/commands.rs
@@ -2,7 +2,17 @@ use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use super::keys::KeyBinding;
-use super::KeyboardListener;
+use super::{KeyboardListener, ListenerStart};
+
+/// Start the rdev listener if it is not already running, returning whether it
+/// started (or why not). The FE calls this once it knows global shortcuts are
+/// allowed: on macOS after Accessibility is granted, on other desktops at
+/// launch. Idempotent, so re-checks on focus are safe.
+#[tauri::command]
+#[specta::specta]
+pub fn start_keyboard_listener(listener: State<'_, KeyboardListener>) -> ListenerStart {
+    listener.start()
+}
 
 /// One command's binding, as sent from the FE registrar. `command_id` is the
 /// id the trigger event is emitted under; the FE filters by that command's `on`

--- a/apps/whispering/src-tauri/src/keyboard/event.rs
+++ b/apps/whispering/src-tauri/src/keyboard/event.rs
@@ -17,8 +17,9 @@ pub enum TriggerState {
 /// the callback. Rust stays command-agnostic: it knows the id and the edge, not
 /// which states a given command cares about.
 ///
-/// A `tauri_specta::Event`, so the listener emits it with `trigger.emit(app)`
-/// and the FE listens through the generated `events.shortcutTriggerEvent`.
+/// A `tauri_specta::Event`, so the listener emits it with
+/// `trigger.emit_to(app, MAIN_WINDOW)` (targeting the main webview, not the
+/// overlay) and the FE listens through the generated `events.shortcutTriggerEvent`.
 #[derive(
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type, tauri_specta::Event,
 )]

--- a/apps/whispering/src-tauri/src/keyboard/matcher.rs
+++ b/apps/whispering/src-tauri/src/keyboard/matcher.rs
@@ -79,6 +79,18 @@ impl Matcher {
         }
     }
 
+    /// Drop all held state and mark every binding inactive. Called when the
+    /// listener (re)enters `rdev::listen`: a prior attempt that exited may have
+    /// missed a key-up, and a stale held modifier would otherwise wedge a
+    /// binding "down" or suppress the next press under exact-set matching.
+    pub fn clear_held(&mut self) {
+        self.held_modifiers.clear();
+        self.held_keys.clear();
+        for binding in &mut self.bindings {
+            binding.active = false;
+        }
+    }
+
     /// Replace the full set of registered bindings. Empty bindings are dropped
     /// (they can never be "held"). All `active` flags reset to false, so a
     /// freshly registered binding requires a new press even if its keys happen
@@ -202,6 +214,25 @@ mod tests {
                 ("pushToTalk".to_string(), Released),
             ]
         );
+    }
+
+    #[test]
+    fn clear_held_drops_stale_state_so_a_missed_release_cannot_wedge_a_binding() {
+        let mut matcher = Matcher::new();
+        matcher.set_bindings([("ptt".to_string(), binding(&[], &[Key::Space]))]);
+
+        // Space goes down (binding fires), then the key-up is "missed" (the
+        // listener exited mid-hold). clear_held models the listener restart.
+        let pressed = run(&mut matcher, &[(Press, K(Key::Space))]);
+        assert_eq!(pressed, vec![("ptt".to_string(), Pressed)]);
+        matcher.clear_held();
+
+        // A later stray release must not emit, and a fresh press still works.
+        let after = run(
+            &mut matcher,
+            &[(Release, K(Key::Space)), (Press, K(Key::Space))],
+        );
+        assert_eq!(after, vec![("ptt".to_string(), Pressed)]);
     }
 
     #[test]

--- a/apps/whispering/src-tauri/src/keyboard/mod.rs
+++ b/apps/whispering/src-tauri/src/keyboard/mod.rs
@@ -12,9 +12,14 @@
 //! - `rdev_map` the only rdev-coupled code: `rdev::Key` -> matcher `Input`
 //! - `event`    the wire payload emitted to the FE
 //!
-//! Wave 2 built this module in isolation. Wave 3 wires it in: the
-//! `set_keyboard_shortcuts` command pushes the user's bindings, the listener
-//! starts at launch, and the FE registrar dispatches the emitted events.
+//! Wave 2 built this module in isolation. Wave 3 wired it in: the
+//! `set_keyboard_shortcuts` command pushes the user's bindings and the FE
+//! registrar dispatches the emitted events. Wave 6 added the start lifecycle:
+//! the FE calls `start_keyboard_listener` once it knows global shortcuts are
+//! allowed (macOS Accessibility granted, or any non-macOS desktop), so the
+//! listener is never spawned before `rdev::listen` can actually tap the
+//! keyboard. This mirrors `cjpais/Handy`, which gates the listener on the
+//! frontend's permission check rather than polling `listen` from Rust.
 
 pub mod commands;
 pub mod event;
@@ -25,12 +30,41 @@ mod rdev_map;
 pub use event::{ShortcutCaptureEvent, ShortcutTriggerEvent, TriggerState};
 pub use keys::{Key, KeyBinding, Modifier};
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
+use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
 use tauri_specta::Event;
 
 use matcher::{Edge, Matcher};
+
+/// The window the trigger/capture events are delivered to. We target it
+/// explicitly instead of broadcasting so the overlay and picker webviews never
+/// see shortcut events, which keeps the dispatch single even if they subscribe.
+const MAIN_WINDOW: &str = "main";
+
+/// Outcome of a `start` request, so the FE can tell the user when global
+/// shortcuts are unavailable instead of relying on a Rust log nobody sees.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum ListenerStart {
+    /// A listener thread was spawned.
+    Started,
+    /// A listener thread is already running; this call was a no-op.
+    AlreadyRunning,
+    /// Linux Wayland: rdev's tap never receives events, so nothing was spawned.
+    WaylandUnsupported,
+}
+
+/// rdev's listener is X11-only; on Wayland the tap never receives events.
+#[cfg(target_os = "linux")]
+fn is_wayland() -> bool {
+    std::env::var("XDG_SESSION_TYPE")
+        .map(|value| value.eq_ignore_ascii_case("wayland"))
+        .unwrap_or(false)
+        || std::env::var("WAYLAND_DISPLAY").is_ok()
+}
 
 /// Owns the registered bindings and the rdev listener thread. Constructed in
 /// `setup` with an `AppHandle` (mirrors `ModelManager`) and managed via
@@ -38,6 +72,10 @@ use matcher::{Edge, Matcher};
 pub struct KeyboardListener {
     app: AppHandle,
     matcher: Arc<Mutex<Matcher>>,
+    /// Whether a listener thread is live. Guards against spawning a second
+    /// `rdev::listen` (which would double-fire every trigger). Reset to false
+    /// when the thread exits so a later `start` can retry.
+    running: Arc<AtomicBool>,
 }
 
 impl KeyboardListener {
@@ -45,6 +83,7 @@ impl KeyboardListener {
         Self {
             app,
             matcher: Arc::new(Mutex::new(Matcher::new())),
+            running: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -66,19 +105,40 @@ impl KeyboardListener {
         }
     }
 
-    /// Spawn the rdev listener on its own thread. `rdev::listen` blocks for the
-    /// process lifetime, so it cannot run on the main thread. It is a passive
-    /// **listen** (not `grab`), so keystrokes still reach the foreground app.
+    /// Spawn the rdev listener once, if it is not already running. The FE calls
+    /// this through `start_keyboard_listener` when it knows global shortcuts are
+    /// allowed (macOS Accessibility granted, or any non-macOS desktop), so
+    /// `rdev::listen` can actually create the tap. `listen` is a passive listen
+    /// (not `grab`, so keystrokes still reach the foreground app) and blocks
+    /// until it errors; if it does exit (focus loss, permission revoked) the
+    /// thread resets `running` so a later `start` can retry.
     ///
-    /// macOS requires Accessibility / Input Monitoring for the tap to receive
-    /// events; that permission is wired in Wave 6. Until then `listen` returns
-    /// an error here, which we log rather than panic on.
-    pub fn start(&self) {
+    /// Idempotent: the `running` guard means a second call while a thread is
+    /// live is a no-op, so the FE can call this freely (on launch and on every
+    /// Accessibility re-check) without ever spawning two listeners.
+    pub fn start(&self) -> ListenerStart {
+        #[cfg(target_os = "linux")]
+        if is_wayland() {
+            return ListenerStart::WaylandUnsupported;
+        }
+
+        if self.running.swap(true, Ordering::SeqCst) {
+            return ListenerStart::AlreadyRunning;
+        }
+
         let app = self.app.clone();
         let matcher = self.matcher.clone();
+        let running = self.running.clone();
         std::thread::Builder::new()
             .name("rdev-keyboard-listener".into())
             .spawn(move || {
+                // A previous attempt that exited may have left a key in the held
+                // set with no matching release; start clean so a stale modifier
+                // cannot wedge a binding "down" under exact-set matching.
+                if let Ok(mut matcher) = matcher.lock() {
+                    matcher.clear_held();
+                }
+
                 let result = rdev::listen(move |event| {
                     let (edge, key) = match event.event_type {
                         rdev::EventType::KeyPress(key) => (Edge::Press, key),
@@ -97,18 +157,23 @@ impl KeyboardListener {
                     if matcher.is_capturing() {
                         let binding = matcher.held_binding();
                         drop(matcher);
-                        let _ = ShortcutCaptureEvent { binding }.emit(&app);
+                        let _ = ShortcutCaptureEvent { binding }.emit_to(&app, MAIN_WINDOW);
                     } else {
                         drop(matcher);
                         for trigger in triggers {
-                            let _ = trigger.emit(&app);
+                            let _ = trigger.emit_to(&app, MAIN_WINDOW);
                         }
                     }
                 });
                 if let Err(error) = result {
                     log::error!("rdev keyboard listener stopped: {error:?}");
                 }
+                // Allow a later `start` (e.g. the FE re-checking on focus) to
+                // respawn after a transient exit.
+                running.store(false, Ordering::SeqCst);
             })
             .expect("failed to spawn rdev keyboard listener thread");
+
+        ListenerStart::Started
     }
 }

--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -63,6 +63,7 @@ fn make_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             get_transcription_state,
             keyboard::commands::set_keyboard_shortcuts,
             keyboard::commands::set_keyboard_capturing,
+            keyboard::commands::start_keyboard_listener,
         ])
         // The FE listens through the generated `events` object. `collect_events!`
         // owns each topic name and pulls in the payload types
@@ -234,17 +235,14 @@ pub async fn run() {
             manager.start_idle_watcher();
             app.manage(manager);
 
-            // Desktop global keyboard trigger backend. The listener thread owns
-            // the rdev hook; `set_keyboard_shortcuts` (called by the FE on
-            // startup and on every change) pushes the user's bindings. On macOS
-            // the hook needs Accessibility; that prompt is wired in Wave 6, and
-            // until granted `rdev::listen` just logs and yields no events.
+            // Desktop global keyboard trigger backend. We construct and manage
+            // the listener here but do NOT start it: `rdev::listen` cannot tap
+            // the keyboard until macOS Accessibility is granted, so the FE calls
+            // `start_keyboard_listener` once it knows shortcuts are allowed (on
+            // macOS after the grant, on other desktops at launch). The listener
+            // is idempotent, so the FE can re-check freely.
             #[cfg(desktop)]
-            {
-                let listener = keyboard::KeyboardListener::new(app.handle().clone());
-                listener.start();
-                app.manage(listener);
-            }
+            app.manage(keyboard::KeyboardListener::new(app.handle().clone()));
 
             // Create the recording overlay as a non-activating NSPanel up front
             // (hidden); the frontend shows it when recording starts.

--- a/apps/whispering/src/lib/tauri.tauri.ts
+++ b/apps/whispering/src/lib/tauri.tauri.ts
@@ -349,6 +349,14 @@ const globalShortcuts = {
 		commands.setKeyboardShortcuts(bindings),
 
 	/**
+	 * Start the rdev listener (idempotent). The caller gates this on "global
+	 * shortcuts are allowed": on macOS once Accessibility is granted, on other
+	 * desktops at launch. Returns the outcome so the caller can tell the user
+	 * when shortcuts are unavailable (Wayland) instead of failing silently.
+	 */
+	start: () => commands.startKeyboardListener(),
+
+	/**
 	 * Subscribe to the rdev trigger event and dispatch each into the command
 	 * layer, filtered by the command's `on` array. Returns the unlisten fn. The
 	 * `on` filter is the same gate the old plugin registrar applied; keeping it

--- a/apps/whispering/src/lib/tauri/bindings.gen.ts
+++ b/apps/whispering/src/lib/tauri/bindings.gen.ts
@@ -170,6 +170,14 @@ export const commands = {
 	 */
 	setKeyboardCapturing: (capturing: boolean) =>
 		__TAURI_INVOKE<void>('set_keyboard_capturing', { capturing }),
+	/**
+	 *  Start the rdev listener if it is not already running, returning whether it
+	 *  started (or why not). The FE calls this once it knows global shortcuts are
+	 *  allowed: on macOS after Accessibility is granted, on other desktops at
+	 *  launch. Idempotent, so re-checks on focus are safe.
+	 */
+	startKeyboardListener: () =>
+		__TAURI_INVOKE<ListenerStart>('start_keyboard_listener'),
 };
 
 /** Events */
@@ -310,6 +318,18 @@ export type KeyBinding = {
 };
 
 /**
+ *  Outcome of a `start` request, so the FE can tell the user when global
+ *  shortcuts are unavailable instead of relying on a Rust log nobody sees.
+ */
+export type ListenerStart =
+	/**  A listener thread was spawned. */
+	| 'started'
+	/**  A listener thread is already running; this call was a no-op. */
+	| 'alreadyRunning'
+	/**  Linux Wayland: rdev's tap never receives events, so nothing was spawned. */
+	| 'waylandUnsupported';
+
+/**
  *  Snapshot of everything observable about the resident model. Every event
  *  carries a full snapshot rather than a delta because `AppHandle::emit`
  *  does not replay to future windows: a window opened mid-load reads the
@@ -431,8 +451,9 @@ export type ShortcutCaptureEvent = {
  *  the callback. Rust stays command-agnostic: it knows the id and the edge, not
  *  which states a given command cares about.
  *
- *  A `tauri_specta::Event`, so the listener emits it with `trigger.emit(app)`
- *  and the FE listens through the generated `events.shortcutTriggerEvent`.
+ *  A `tauri_specta::Event`, so the listener emits it with
+ *  `trigger.emit_to(app, MAIN_WINDOW)` (targeting the main webview, not the
+ *  overlay) and the FE listens through the generated `events.shortcutTriggerEvent`.
  */
 export type ShortcutTriggerEvent = {
 	commandId: string;

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/+page.svelte
@@ -4,17 +4,60 @@
 	import { Separator } from '@epicenter/ui/separator';
 	import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
 	import { report } from '$lib/report';
+	import { os } from '#platform/os';
 	import { tauri } from '#platform/tauri';
+	import { whispering } from '#platform/whispering';
+	import {
+		type DeviceConfigKey,
+		deviceConfig,
+	} from '$lib/state/device-config.svelte';
+	import type { KeyBinding } from '$lib/tauri/commands';
+	import { createPressedKeys } from '$lib/utils/createPressedKeys.svelte';
+	import { keyBindingToLabel } from '$lib/utils/key-binding';
 	import {
 		resetGlobalShortcuts,
 		resetLocalShortcuts,
 	} from '$routes/(app)/_layout-utils/register-commands';
+	import GlobalKeyboardShortcutRecorder from './keyboard-shortcut-recorder/GlobalKeyboardShortcutRecorder.svelte';
+	import LocalKeyboardShortcutRecorder from './keyboard-shortcut-recorder/LocalKeyboardShortcutRecorder.svelte';
 	import ShortcutFormatHelp from './keyboard-shortcut-recorder/ShortcutFormatHelp.svelte';
 	import ShortcutTable from './keyboard-shortcut-recorder/ShortcutTable.svelte';
 
 	// One shortcut system per platform: the desktop app uses global (system-wide,
 	// rdev) shortcuts; the browser uses in-app (focused-tab) shortcuts. They never
 	// coexist, so this page shows whichever one this platform has.
+
+	// Browser-only: the local recorder records shortcuts from window keydown. On
+	// desktop the global recorder records through the rdev backend instead, so
+	// this (and its window keydown listener) is never created there. Its presence
+	// also marks local mode for the template below.
+	const pressedKeys = tauri
+		? undefined
+		: createPressedKeys({
+				onUnsupportedKey: (key) => {
+					report.info({
+						title: 'Unsupported key',
+						description: `The key "${key}" is not supported. Please try a different key.`,
+					});
+				},
+			});
+
+	/** The definition default for a local shortcut, formatted for display. */
+	function localDefault(commandId: string): string | null {
+		const getDefault = whispering.settings.getDefault as (
+			key: string,
+		) => unknown;
+		return (getDefault(`shortcut.${commandId}`) as string | null) ?? null;
+	}
+
+	/** The definition default for a global shortcut, formatted for display. */
+	function globalDefault(commandId: string): string | null {
+		const binding = deviceConfig.getDefault(
+			`shortcuts.global.${commandId}` as DeviceConfigKey,
+		) as KeyBinding | null;
+		return binding ? keyBindingToLabel(binding, os.isApple) : null;
+	}
+
 	function reset() {
 		if (tauri) resetGlobalShortcuts();
 		else resetLocalShortcuts();
@@ -56,8 +99,26 @@
 
 	{#if tauri}
 		{@const t = tauri}
-		<ShortcutTable type="global" tauri={t} />
-	{:else}
-		<ShortcutTable type="local" />
+		<ShortcutTable>
+			{#snippet row(command)}
+				{@const def = globalDefault(command.id)}
+				<GlobalKeyboardShortcutRecorder
+					{command}
+					placeholder={def ? `Default: ${def}` : 'Set shortcut'}
+					tauri={t}
+				/>
+			{/snippet}
+		</ShortcutTable>
+	{:else if pressedKeys}
+		<ShortcutTable>
+			{#snippet row(command)}
+				{@const def = localDefault(command.id)}
+				<LocalKeyboardShortcutRecorder
+					{command}
+					placeholder={def ? `Default: ${def}` : 'Set shortcut'}
+					{pressedKeys}
+				/>
+			{/snippet}
+		</ShortcutTable>
 	{/if}
 </section>

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutTable.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutTable.svelte
@@ -2,55 +2,22 @@
 	import { Input } from '@epicenter/ui/input';
 	import * as Table from '@epicenter/ui/table';
 	import Search from '@lucide/svelte/icons/search';
-	import { commands } from '$lib/commands';
-	import { report } from '$lib/report';
-	import type { Tauri } from '#platform/tauri';
-	import {
-		type DeviceConfigKey,
-		deviceConfig,
-	} from '$lib/state/device-config.svelte';
-	import type { KeyBinding } from '$lib/tauri/commands';
-	import { os } from '#platform/os';
-	import { createPressedKeys } from '$lib/utils/createPressedKeys.svelte';
-	import { keyBindingToLabel } from '$lib/utils/key-binding';
-	import { whispering } from '#platform/whispering';
-	import GlobalKeyboardShortcutRecorder from './GlobalKeyboardShortcutRecorder.svelte';
-	import LocalKeyboardShortcutRecorder from './LocalKeyboardShortcutRecorder.svelte';
+	import type { Snippet } from 'svelte';
+	import { type Command, commands } from '$lib/commands';
 
-	// `tauri` is required when type === 'global' (the inner recorder needs it
-	// to register OS-level shortcuts). For type === 'local' it's ignored.
-	let { type, tauri }: { type: 'local' | 'global'; tauri?: Tauri } = $props();
+	// Platform-agnostic chrome: a searchable table of every command. The caller
+	// owns what a row's shortcut control is (the in-app local recorder or the
+	// rdev-backed global recorder) and supplies it through the `row` snippet, so
+	// this component holds no local/global discriminator.
+	let { row }: { row: Snippet<[Command]> } = $props();
 
 	let searchQuery = $state('');
-
-	/** Look up the definition default for a shortcut key, formatted for display. */
-	function getDefaultShortcut(commandId: string): string | null {
-		if (type === 'local') {
-			const getDefault = whispering.settings.getDefault as (
-				key: string,
-			) => unknown;
-			return (getDefault(`shortcut.${commandId}`) as string | null) ?? null;
-		}
-		const binding = deviceConfig.getDefault(
-			`shortcuts.global.${commandId}` as DeviceConfigKey,
-		) as KeyBinding | null;
-		return binding ? keyBindingToLabel(binding, os.isApple) : null;
-	}
 
 	const filteredCommands = $derived(
 		commands.filter((command) =>
 			command.title.toLowerCase().includes(searchQuery.toLowerCase()),
 		),
 	);
-
-	const pressedKeys = createPressedKeys({
-		onUnsupportedKey: (key) => {
-			report.info({
-				title: 'Unsupported key',
-				description: `The key "${key}" is not supported. Please try a different key.`,
-			});
-		},
-	});
 </script>
 
 <div class="space-y-4">
@@ -78,29 +45,12 @@
 			</Table.Header>
 			<Table.Body>
 				{#each filteredCommands as command}
-					{@const defaultShortcut = getDefaultShortcut(command.id)}
 					<Table.Row>
 						<Table.Cell class="font-medium">
 							<span class="block truncate pr-2">{command.title}</span>
 						</Table.Cell>
 						<Table.Cell class="text-right">
-							{#if type === 'local'}
-								<LocalKeyboardShortcutRecorder
-									{command}
-									placeholder={defaultShortcut
-										? `Default: ${defaultShortcut}`
-										: 'Set shortcut'}
-									{pressedKeys}
-								/>
-							{:else if tauri}
-								<GlobalKeyboardShortcutRecorder
-									{command}
-									placeholder={defaultShortcut
-										? `Default: ${defaultShortcut}`
-										: 'Set shortcut'}
-									{tauri}
-								/>
-							{/if}
+							{@render row(command)}
 						</Table.Cell>
 					</Table.Row>
 				{/each}

--- a/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
+++ b/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import { ConfirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import * as Dialog from '@epicenter/ui/dialog';
+	import { toast } from '@epicenter/ui/sonner';
 	// import { extension } from '@epicenter/extension';
 	import { onDestroy, onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { commandCallbacks } from '$lib/commands';
+	import { os } from '#platform/os';
 	import MoreDetailsDialog from '$lib/components/MoreDetailsDialog.svelte';
 	import UpdateDialog from '$lib/components/UpdateDialog.svelte';
 	import {
@@ -33,12 +35,32 @@
 	let cleanupShortcutListener: (() => void) | undefined;
 	let shortcutListenerDestroyed = false;
 
+	// Start the rdev global listener (idempotent). rdev::listen cannot tap the
+	// keyboard before macOS Accessibility is granted, so we only call this once
+	// shortcuts are allowed: on macOS from the accessibility-granted callback, on
+	// other desktops at launch. Wayland has no working listener; tell the user.
+	async function startGlobalListener() {
+		if (!tauri) return;
+		const status = await tauri.globalShortcuts.start();
+		if (status === 'waylandUnsupported') {
+			toast.warning('Global shortcuts unavailable on Wayland', {
+				description:
+					'Whispering needs an X11 session for global shortcuts. On Wayland, bind them through your desktop environment.',
+				duration: Number.POSITIVE_INFINITY,
+			});
+		}
+	}
+
 	onMount(() => {
 		// Sync operations - run immediately, these are fast
 		window.commands = commandCallbacks;
 		window.goto = goto;
 		registerOnboarding();
-		cleanupAccessibilityPermission = registerAccessibilityPermission();
+		// On macOS the listener starts when Accessibility is granted (the single
+		// gate the whole dictation flow shares); this is its one subscriber.
+		cleanupAccessibilityPermission = registerAccessibilityPermission({
+			onGranted: () => void startGlobalListener(),
+		});
 
 		// One trigger backend per platform: desktop uses the rdev global
 		// listener exclusively, the browser uses in-app keydown exclusively.
@@ -52,6 +74,10 @@
 			});
 			syncGlobalShortcutsWithSettings();
 			resetGlobalShortcutsToDefaultIfDuplicates();
+
+			// Non-macOS desktops have no Accessibility gate, so start the listener
+			// now (macOS waits for the grant, above).
+			if (!os.isApple) void startGlobalListener();
 
 			// Desktop-only async check - fire and forget
 			void checkForUpdates();

--- a/apps/whispering/src/routes/(app)/_layout-utils/register-accessibility-permission.ts
+++ b/apps/whispering/src/routes/(app)/_layout-utils/register-accessibility-permission.ts
@@ -4,43 +4,65 @@ import { os } from '#platform/os';
 import { tauri } from '#platform/tauri';
 import { goto } from '$app/navigation';
 
-export function registerAccessibilityPermission() {
-	// Only run on macOS desktop
+/**
+ * Owns the macOS Accessibility-granted state for the desktop app: shows the
+ * guide toast while ungranted, and calls `onGranted` once the permission lands.
+ * It polls every second (like Handy) so granting in System Settings takes effect
+ * without an app restart. Accessibility is the single gate for the whole
+ * dictation flow (paste-back, selection capture, and the global shortcut
+ * listener), so consumers subscribe here rather than each re-checking.
+ */
+export function registerAccessibilityPermission(options?: {
+	onGranted?: () => void;
+}) {
+	// Only run on macOS desktop; elsewhere there is no Accessibility gate.
 	if (!os.isApple || !tauri) return;
+	const t = tauri;
+	const { onGranted } = options ?? {};
 
 	const accessibilityToastId = nanoid();
+	let granted = false;
+	let pollId: ReturnType<typeof setInterval> | undefined;
 
-	// Check accessibility permission once on mount
-	(async () => {
-		const { data: isAccessibilityGranted, error } =
-			await tauri.permissions.accessibility.check();
-
+	async function check() {
+		const { data: isGranted, error } =
+			await t.permissions.accessibility.check();
 		if (error) {
 			console.error('Failed to check accessibility permissions:', error);
 			return;
 		}
 
-		if (!isAccessibilityGranted) {
-			// Toast if permission not granted
-			toast.warning('Accessibility Permission Issue', {
-				id: accessibilityToastId,
-				description:
-					'Whispering needs accessibility permissions. This often requires removing and re-adding the app after updates.',
-				duration: Number.POSITIVE_INFINITY,
-				action: {
-					label: 'View Guide',
-					onClick: () => {
-						goto('/macos-enable-accessibility');
-						// Dismiss the toast
-						toast.dismiss(accessibilityToastId);
-					},
-				},
-			});
+		if (isGranted) {
+			if (granted) return;
+			granted = true;
+			toast.dismiss(accessibilityToastId);
+			if (pollId !== undefined) clearInterval(pollId);
+			onGranted?.();
+			return;
 		}
-	})();
 
-	// Return cleanup function
+		// Not granted: show the guide toast (idempotent by id, so the poll just
+		// keeps it up rather than stacking).
+		toast.warning('Accessibility Permission Issue', {
+			id: accessibilityToastId,
+			description:
+				'Whispering needs accessibility permissions. This often requires removing and re-adding the app after updates.',
+			duration: Number.POSITIVE_INFINITY,
+			action: {
+				label: 'View Guide',
+				onClick: () => {
+					goto('/macos-enable-accessibility');
+					toast.dismiss(accessibilityToastId);
+				},
+			},
+		});
+	}
+
+	void check();
+	pollId = setInterval(() => void check(), 1000);
+
 	return () => {
 		toast.dismiss(accessibilityToastId);
+		if (pollId !== undefined) clearInterval(pollId);
 	};
 }


### PR DESCRIPTION
Stacked on #1969 (base `feat/whispering-rdev-trigger-backend`). Rust-only: hardens the rdev listener lifecycle so the desktop trigger backend is robust on a fresh install and across platforms.

`rdev::listen` is a passive, blocking call that cannot be cleanly stopped or restarted. So rather than a restart path, the listener thread **loops `listen` with backoff**. On macOS the tap cannot be created without Accessibility, so `listen` returns an error immediately; the thread retries every 2s until the user grants the permission, at which point the next `listen` succeeds and blocks for the process lifetime. The practical effect: after you grant Accessibility in System Settings, global shortcuts start working **without restarting the app**, and there is no frontend permission gate or restart command to keep in sync.

Two more hardening changes ride along:

- **Wayland is skipped.** rdev's listener is X11-only; on Wayland the tap never receives events, so we log a clear notice and do not spin a thread that can never succeed.
- **Held-state reconcile.** Each time the listener re-enters `listen`, the matcher's held set is cleared, so a key-up missed while the listener was down cannot leave a stale modifier wedging a binding "down" under exact-set matching.
- **Single-window delivery.** Trigger and capture events are emitted to the `main` window (`emit_to`) instead of broadcast, so the overlay and picker webviews never see them.

A `clear_held` unit test covers the missed-release case; the matcher suite stays green.

## Still needs real-device verification

This is the one part of the rdev work that genuinely needs hardware, and it has not been run on a fresh (un-granted) machine yet:

- **macOS:** confirm the listener starts within ~2s of granting Accessibility, with no restart.
- **Windows:** the low-level hook needs no permission; confirm push-to-talk and that Fn may be a hardware-only key on some laptops.
- **Linux X11:** confirm; **Wayland** remains a documented gap.

## Changelog

- Global shortcuts now begin working as soon as you grant macOS Accessibility, with no app restart.
- Linux: global shortcuts require an X11 session; on Wayland, bind them through your desktop environment (documented limitation).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784013142&installation_id=128463665&pr_number=1971&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1971&signature=c8e7cccba44cc494c5a7882755872121519a8ad3fc9ad87749ff309d6d9cbbd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->