### PR TITLE
refactor(workspace): trim the daemon public surface

### DIFF
--- a/.changeset/trim-daemon-public-surface.md
+++ b/.changeset/trim-daemon-public-surface.md
@@ -1,0 +1,5 @@
+---
+'@epicenter/workspace': minor
+---
+
+Trim three zero-consumer exports off the public surface: `readMetadataFromPath` and `buildDaemonActions` leave the `./node` barrel (both stay as internal helpers), and `typedDispatch` / `TypedDispatch` leave the root barrel (the named `as` cast had no shipped consumer).

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -1616,8 +1616,6 @@ import {
 	DispatchError,
 	type DispatchRequest,
 	type PresenceDevice,
-	type TypedDispatch,
-	typedDispatch,
 } from '@epicenter/workspace';
 ```
 
@@ -1629,7 +1627,6 @@ import {
 Cross-device calls:
 
 - `collaboration.dispatch(req)`: `Promise<Result<unknown, DispatchError>>`
-- `typedDispatch<TActions>(collaboration.dispatch)`: typed overlay for a known target registry
 
 ### Introspection
 

--- a/packages/workspace/SYNC_ARCHITECTURE.md
+++ b/packages/workspace/SYNC_ARCHITECTURE.md
@@ -177,21 +177,18 @@ The caller's `signal` (or a ~90 s caller-side ceiling) settles the promise if no
 
 Because the relay answers reachability inline (its `connections` Map decides, on the same socket that routes the call), callers that need to tell "addressed an offline install" apart from "the call reached the peer and failed" branch on `RecipientOffline` directly. There is no separate liveness pre-check, and no window where a client cache disagrees with the relay.
 
-For a type-narrowed success payload against a known target registry, lift through `typedDispatch`:
+`dispatch` returns `Result<unknown, DispatchError>`; the caller narrows the success payload against the shape the target action returns:
 
 ```ts
-import { typedDispatch } from '@epicenter/workspace';
-import type { TabManagerActions } from '@epicenter/tab-manager';
-
-const tabManager = typedDispatch<TabManagerActions>(collaboration.dispatch);
-const { data } = await tabManager({
+const { data } = await collaboration.dispatch({
     to: phone.deviceId,
     action: 'tabs_close',
     input: { tabIds: [1, 2] },
 });
+const closed = data as { tabIds: number[] };
 ```
 
-With manifests on the presence wire, the same narrowing is *runtime-verifiable*: walk `device.actions` and confirm the action key exists. The `typedDispatch` wrapper is ergonomic sugar; the wire payload is the ground truth.
+With manifests on the presence wire, that narrowing is *runtime-verifiable*: walk `device.actions` and confirm the action key exists before dispatching. The wire payload is the ground truth.
 
 The recipient side is `runInboundDispatch`: the supervisor routes inbound text frames to it, it looks up the action in the local registry, runs it, and emits the `dispatch_response`. A content doc with `actions: {}` always replies `ActionNotFound`.
 

--- a/packages/workspace/src/daemon/metadata.ts
+++ b/packages/workspace/src/daemon/metadata.ts
@@ -45,7 +45,7 @@ export function readMetadata(dir: string): DaemonMetadata | null {
 	return readMetadataFromPath(metadataPathFor(dir));
 }
 
-export function readMetadataFromPath(path: string): DaemonMetadata | null {
+function readMetadataFromPath(path: string): DaemonMetadata | null {
 	if (!existsSync(path)) return null;
 	try {
 		const raw = readFileSync(path, 'utf8');

--- a/packages/workspace/src/daemon/server.test.ts
+++ b/packages/workspace/src/daemon/server.test.ts
@@ -1,13 +1,11 @@
 /**
  * Daemon Server Tests
  *
- * Verifies that `startDaemonServer` validates mount names, binds exactly one
- * socket for an already-claimed daemon lease, and exposes an idempotent close
- * operation.
+ * Verifies that `startDaemonServer` binds exactly one socket for an
+ * already-claimed daemon lease and exposes an idempotent close operation.
  *
  * Key behaviors:
  * - valid mounts are served over the daemon client
- * - invalid mount declarations fail before binding a socket
  * - close stops the listener, removes the socket file, and can run twice
  * - /run executes a real action handler over the Unix socket, and
  *   forwards peer calls when `to` is present
@@ -88,49 +86,6 @@ describe('startDaemonServer', () => {
 			expect(data).toEqual([]);
 		} finally {
 			if (serverResult.error === null) await serverResult.data.close();
-			lease.release();
-		}
-	});
-
-	test('returns MountNameRejected before binding duplicate mounts', async () => {
-		const lease = claimTestLease();
-		try {
-			const error = expectErr(
-				await startDaemonServer({
-					lease,
-					mounts: [
-						{ mount: 'demo', runtime: makeRuntime() },
-						{ mount: 'demo', runtime: makeRuntime() },
-					],
-				}),
-			);
-			expect(error).toMatchObject({
-				name: 'MountNameRejected',
-				mount: 'demo',
-				reason: 'duplicate',
-			});
-			expect(existsSync(lease.socketPath)).toBe(false);
-		} finally {
-			lease.release();
-		}
-	});
-
-	test('returns MountNameRejected before binding invalid mounts', async () => {
-		const lease = claimTestLease();
-		try {
-			const error = expectErr(
-				await startDaemonServer({
-					lease,
-					mounts: [{ mount: 'bad.mount', runtime: makeRuntime() }],
-				}),
-			);
-			expect(error).toMatchObject({
-				name: 'MountNameRejected',
-				mount: 'bad.mount',
-				reason: 'invalid',
-			});
-			expect(existsSync(lease.socketPath)).toBe(false);
-		} finally {
 			lease.release();
 		}
 	});

--- a/packages/workspace/src/daemon/server.ts
+++ b/packages/workspace/src/daemon/server.ts
@@ -16,7 +16,6 @@ import { Ok, type Result, tryAsync, trySync } from 'wellcrafted/result';
 
 import { buildDaemonApp } from './app.js';
 import type { DaemonLease } from './lease.js';
-import { validateMountNames } from './mount-validation.js';
 import { unlinkSocketFile } from './runtime-files.js';
 import { StartupError } from './startup-errors.js';
 import type { DaemonServedMount } from './types.js';
@@ -61,8 +60,9 @@ export type DaemonServer = ReturnType<typeof createDaemonServer>;
 
 /**
  * Start a daemon server for already-started mounts. The caller must claim the
- * daemon lease before mount startup; this function owns only mount-name
- * validation and socket binding.
+ * daemon lease before mount startup; this function owns only socket binding.
+ * Mount names are validated upstream by `openEpicenterRoot` before any mount
+ * opens, so by the time mounts reach here they are already known-good.
  *
  * The lease (`lease.ts`) is the sole ownership primitive: holding it means no
  * other daemon is live, so any leftover socket file is stale and `Bun.serve`
@@ -73,11 +73,6 @@ export async function startDaemonServer({
 	mounts,
 }: DaemonServerOptions): Promise<Result<DaemonServer, StartupError>> {
 	const { socketPath } = lease;
-	const issue = validateMountNames(mounts.map((entry) => entry.mount));
-	if (issue !== null) {
-		return StartupError.MountNameRejected(issue);
-	}
-
 	const app = buildDaemonApp(mounts);
 	const bindResult = trySync({
 		try: () => bindUnixSocket({ socketPath, fetch: app.fetch }),

--- a/packages/workspace/src/daemon/startup-errors.ts
+++ b/packages/workspace/src/daemon/startup-errors.ts
@@ -3,7 +3,6 @@ import {
 	extractErrorMessage,
 	type InferErrors,
 } from 'wellcrafted/error';
-import type { MountNameIssue } from './mount-validation.js';
 
 /**
  * Tagged-error variants for daemon startup.
@@ -11,7 +10,6 @@ import type { MountNameIssue } from './mount-validation.js';
  * - `AlreadyRunning`: another daemon owns this project lease or answers ping.
  * - `LeaseFailed`: the SQLite lease could not be opened or locked.
  * - `BindFailed`: `Bun.serve` raised on an unrecoverable bind error.
- * - `MountNameRejected`: embedded callers passed invalid mount names.
  * - `MetadataWriteFailed`: startup could not publish its metadata sidecar.
  *
  * Auth-construction failures are surfaced as `MachineAuthStorageError`
@@ -30,14 +28,6 @@ export const StartupError = defineErrors({
 	BindFailed: ({ cause }: { cause: unknown }) => ({
 		message: `bind failed: ${extractErrorMessage(cause)}`,
 		cause,
-	}),
-	MountNameRejected: ({ mount, reason }: MountNameIssue) => ({
-		message:
-			reason === 'duplicate'
-				? `duplicate mount '${mount}'`
-				: `invalid mount name '${mount}'`,
-		mount,
-		reason,
 	}),
 	MetadataWriteFailed: ({ cause }: { cause: unknown }) => ({
 		message: `daemon metadata write failed: ${extractErrorMessage(cause)}`,

--- a/packages/workspace/src/document/dispatch.test.ts
+++ b/packages/workspace/src/document/dispatch.test.ts
@@ -25,7 +25,6 @@ import {
 	DispatchError,
 	interpretDispatchResult,
 	runInboundDispatch,
-	typedDispatch,
 } from './dispatch.js';
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -209,10 +208,6 @@ describe('DispatchError variant factory', () => {
 });
 
 // ════════════════════════════════════════════════════════════════════════════
-// typedDispatch (typed overlay)
-// ════════════════════════════════════════════════════════════════════════════
-
-// ════════════════════════════════════════════════════════════════════════════
 // Type-level tests for ActionInput / ActionOutput
 // ════════════════════════════════════════════════════════════════════════════
 
@@ -255,22 +250,6 @@ const _typeTests = () => {
 	const _o3: Equals<ActionOutput<typeof asyncRaw>, number> = true;
 	const _o4: Equals<ActionOutput<typeof syncResult>, 'done'> = true;
 	const _o5: Equals<ActionOutput<typeof asyncResult>, { a: number }> = true;
-
-	// Call-site shape via the typed overlay.
-	const dx = typedDispatch<{
-		ping: typeof noInput;
-		tabs_close: typeof withInput;
-	}>(async () => Ok(undefined));
-
-	// No-input action: `input` field is forbidden.
-	void dx({ to: 'x', action: 'ping' });
-	// @ts-expect-error -- `input` not allowed on no-input action.
-	void dx({ to: 'x', action: 'ping', input: 'nope' });
-
-	// With-input action: `input` field is required and typed.
-	void dx({ to: 'x', action: 'tabs_close', input: { tabIds: [1, 2] } });
-	// @ts-expect-error -- missing required input.
-	void dx({ to: 'x', action: 'tabs_close' });
 
 	// Discourage `_typeTests` from being flagged as unused; the function is
 	// only evaluated by the TypeScript compiler.

--- a/packages/workspace/src/document/dispatch.test.ts
+++ b/packages/workspace/src/document/dispatch.test.ts
@@ -15,13 +15,10 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import Type from 'typebox';
-import { Err, Ok, type Result } from 'wellcrafted/result';
+import { Err, Ok } from 'wellcrafted/result';
 import { expectErr, expectOk } from 'wellcrafted/testing';
 import { defineMutation, defineQuery } from '../shared/actions.js';
 import {
-	type ActionInput,
-	type ActionOutput,
 	DispatchError,
 	interpretDispatchResult,
 	runInboundDispatch,
@@ -206,53 +203,3 @@ describe('DispatchError variant factory', () => {
 		expect(error?.message).toBe('Recipient "R_phone" is offline');
 	});
 });
-
-// ════════════════════════════════════════════════════════════════════════════
-// Type-level tests for ActionInput / ActionOutput
-// ════════════════════════════════════════════════════════════════════════════
-
-// `bun test` runs these as runtime no-ops; they exist for the TypeScript
-// compiler to enforce the type-level claims via assignability.
-
-type Equals<A, B> =
-	(<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
-		? true
-		: false;
-
-const _typeTests = () => {
-	const noInput = defineQuery({ handler: () => 'pong' });
-	const withInput = defineMutation({
-		input: Type.Object({ tabIds: Type.Array(Type.Number()) }),
-		handler: ({ tabIds }) => ({ closedCount: tabIds.length }),
-	});
-	const asyncRaw = defineQuery({ handler: async () => 42 });
-	const syncResult = defineMutation({
-		handler: () => Ok('done') as Result<'done', { name: 'AppError' }>,
-	});
-	const asyncResult = defineQuery({
-		handler: async () =>
-			Ok({ a: 1 }) as Result<{ a: number }, { name: 'AppError' }>,
-	});
-
-	// ActionInput
-	const _i1: Equals<ActionInput<typeof noInput>, { input?: never }> = true;
-	const _i2: Equals<
-		ActionInput<typeof withInput>,
-		{ input: { tabIds: number[] } }
-	> = true;
-
-	// ActionOutput: peels Promise and Result down to T.
-	const _o1: Equals<ActionOutput<typeof noInput>, string> = true;
-	const _o2: Equals<
-		ActionOutput<typeof withInput>,
-		{ closedCount: number }
-	> = true;
-	const _o3: Equals<ActionOutput<typeof asyncRaw>, number> = true;
-	const _o4: Equals<ActionOutput<typeof syncResult>, 'done'> = true;
-	const _o5: Equals<ActionOutput<typeof asyncResult>, { a: number }> = true;
-
-	// Discourage `_typeTests` from being flagged as unused; the function is
-	// only evaluated by the TypeScript compiler.
-	return { _i1, _i2, _o1, _o2, _o3, _o4, _o5 };
-};
-void _typeTests;

--- a/packages/workspace/src/document/dispatch.ts
+++ b/packages/workspace/src/document/dispatch.ts
@@ -106,48 +106,6 @@ export const DispatchError = defineErrors({
 });
 export type DispatchError = InferErrors<typeof DispatchError>;
 
-/**
- * Project an action's handler parameters into the dispatch request's
- * `input` slot.
- *
- *   - Handler `() => R`           ->  `{ input?: never }` (field forbidden)
- *   - Handler `(i: I) => R`       ->  `{ input: I }`      (field required)
- *
- * Reads from the callable side of the action (`ActionHandler`'s variadic
- * tuple, which is `[input: Static<TInput>] | []`). Designed for object
- * spread into the typed dispatch request so the field is literally absent
- * at the call site when the action takes no argument.
- */
-// biome-ignore lint/suspicious/noExplicitAny: structural callable check.
-export type ActionInput<A extends (...args: any[]) => unknown> =
-	Parameters<A> extends []
-		? { input?: never }
-		: // biome-ignore lint/suspicious/noExplicitAny: rest spread.
-			Parameters<A> extends [infer I, ...any[]]
-			? { input: I }
-			: { input?: never };
-
-/**
- * Project an action's handler return type into the dispatch success
- * payload, peeling the `Result<T, E>` layer (sync or async) that the wire
- * boundary consumes.
- *
- *   - `() => T`                       ->  `T`
- *   - `() => Promise<T>`              ->  `T`
- *   - `() => Result<T, E>`            ->  `T`
- *   - `() => Promise<Result<T, E>>`   ->  `T`
- *
- * `runInboundDispatch` Ok-wraps raw returns, preserves existing Results,
- * and converts `Err(E)` -> `ActionFailed` over the wire. Successful
- * remote calls always carry the inner `T` in the `data` field, never a
- * doubly-nested `Result<Result<T, E>, DispatchError>`.
- */
-// biome-ignore lint/suspicious/noExplicitAny: structural callable for ReturnType.
-export type ActionOutput<A extends (...args: any[]) => unknown> =
-	Awaited<ReturnType<A>> extends Result<infer T, unknown>
-		? T
-		: Awaited<ReturnType<A>>;
-
 // ════════════════════════════════════════════════════════════════════════════
 // CALLER-SIDE DISPATCH
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/workspace/src/document/dispatch.ts
+++ b/packages/workspace/src/document/dispatch.ts
@@ -148,50 +148,6 @@ export type ActionOutput<A extends (...args: any[]) => unknown> =
 		? T
 		: Awaited<ReturnType<A>>;
 
-/**
- * Typed overlay on `dispatch` for a known target registry. Same runtime
- * function, narrower types: action keys are constrained to `keyof
- * TTargetActions`, the `input` field is required/forbidden by the action's
- * schema, and the success branch carries the unwrapped handler return
- * (Result peeled to `T`).
- *
- * Caller-asserted: the relay routes by `deviceId` only; it does not
- * prove a given device implements `TTargetActions`.
- */
-export type TypedDispatch<TTargetActions extends ActionRegistry> = <
-	TAction extends keyof TTargetActions & string,
->(
-	req: {
-		to: string;
-		action: TAction;
-		signal?: AbortSignal;
-	} & ActionInput<TTargetActions[TAction]>,
-) => Promise<Result<ActionOutput<TTargetActions[TAction]>, DispatchError>>;
-
-/**
- * Lift the untyped `dispatch` function into a typed overlay for a known
- * target registry. The runtime call is unchanged; the helper exists to
- * make the caller-side assertion explicit and named instead of buried in
- * a variable annotation.
- *
- * ```ts
- * import { typedDispatch } from '@epicenter/workspace';
- * import type { TabManagerActions } from '@epicenter/tab-manager';
- *
- * const tabManager = typedDispatch<TabManagerActions>(collab.dispatch);
- * await tabManager({
- *   to: tabManagerDeviceId,
- *   action: 'tabs_close',
- *   input: { tabIds: [1, 2] },
- * });
- * ```
- */
-export function typedDispatch<TTargetActions extends ActionRegistry>(
-	dispatch: (req: DispatchRequest) => Promise<Result<unknown, DispatchError>>,
-): TypedDispatch<TTargetActions> {
-	return dispatch as TypedDispatch<TTargetActions>;
-}
-
 // ════════════════════════════════════════════════════════════════════════════
 // CALLER-SIDE DISPATCH
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -170,8 +170,6 @@ export { defineTable } from './document/define-table.js';
 export {
 	DispatchError,
 	type DispatchRequest,
-	type TypedDispatch,
-	typedDispatch,
 } from './document/dispatch.js';
 export { docGuid } from './document/doc-guid.js';
 // One-shot HTTP read of a hosted room: GET the snapshot into a throwaway doc.

--- a/packages/workspace/src/node.ts
+++ b/packages/workspace/src/node.ts
@@ -7,7 +7,6 @@
 
 export { connectDaemonActions } from './client/connect-daemon-actions.js';
 export type { DaemonActions } from './client/daemon-actions.js';
-export { buildDaemonActions } from './client/daemon-actions.js';
 export { findEpicenterRoot } from './client/find-epicenter-root.js';
 export { DEFAULT_EPICENTER_CONFIG_SOURCE } from './config/epicenter-config-source.js';
 export { EpicenterConfigError } from './config/load-epicenter-config.js';
@@ -46,7 +45,6 @@ export {
 	type DaemonMetadata,
 	enumerateDaemons,
 	readMetadata,
-	readMetadataFromPath,
 	unlinkMetadata,
 	writeMetadata,
 } from './daemon/metadata.js';


### PR DESCRIPTION
Small follow-up to #1968 (daemon session collapse), now rebased onto main. Two independent surface trims, one commit each.

## Trim three zero-consumer exports off the published surface
Each export had zero in-repo consumers but sat on a published barrel:

- `readMetadataFromPath`: dropped from the `./node` barrel and made file-local in `metadata.ts`. Its two internal callers (`readMetadata`, `enumerateDaemons`) stay.
- `buildDaemonActions`: dropped from the `./node` barrel. The function stays; `connectDaemonActions` is its one internal caller.
- `typedDispatch` / `TypedDispatch`: dropped from the root barrel. It was a named `as` cast with no runtime behavior and no shipped consumer.

Ships as a `minor` changeset.

## Make openEpicenterRoot the single mount-name validation owner
`openEpicenterRoot` validates mount names before opening any mount (the fail-fast, load-bearing gate). `startDaemonServer` re-validated the identical names after the mounts were already open, which is both redundant and too late. Removed that second pass plus the `MountNameRejected` startup-error variant, whose only matchers were this server's own tests.

The standalone-transport seam that `server.ts` documented (validate its own inputs for "CLI, vault, embedded" callers) is YAGNI, so the upstream gate is now the sole owner.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784014864&installation_id=128463665&pr_number=1973&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1973&signature=8196fdc12ba0f3d306b2c43cb04de0535c2d540fa16c8a12894da23586aa7889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->