### PR TITLE
fix(whispering): revalidate resident model against disk identity

### DIFF
--- a/apps/whispering/specs/local-model-disk-identity.md
+++ b/apps/whispering/specs/local-model-disk-identity.md
@@ -1,0 +1,74 @@
+# Local model reload on re-download: cache the bytes, not just the path
+
+## Problem
+
+Deleting a local transcription model and re-downloading it under the same name
+(or replacing the file in the models folder by hand) left Rust serving the
+**old** resident model. The user saw broken or stale transcription until they
+manually re-selected the model in settings.
+
+## Root cause (Rust, not the frontend)
+
+`ModelManager` caches one resident engine as `(PathBuf, Engine)` and decides
+reuse on **path equality alone**:
+
+```rust
+// model_manager.rs, ensure_loaded
+let reuse = matches!(&*guard, Some((p, e)) if p == &model_path && can_reuse(e));
+```
+
+The models folder is explicitly "user-editable truth": entries can be deleted,
+re-downloaded, or swapped in place. The path stays the same across all of those,
+so the cache never notices the bytes changed and keeps serving the resident copy.
+
+`should_preload` compounds it: it keys on `(engine, model_name)` only, so a
+re-pushed *identical* config (same name) returns `false` and triggers no reload.
+That is why the frontend "re-fire the config push" workaround does not actually
+force a reload, and why the manual fix that *did* work (re-select a different
+model, then back) worked: it changed `model_name`, making `should_preload` true.
+
+A frontend signal also cannot cover the whole promise: it can only observe
+in-app downloads, never a file the user replaces in Finder. The fix belongs in
+the layer that owns disk truth.
+
+## Fix
+
+Give the resident cache eyes. Fingerprint the bytes the engine was loaded from,
+store the fingerprint next to the cached engine, and revalidate it on reuse.
+
+```rust
+type Cached = Option<(PathBuf, Option<DiskIdentity>, Engine)>;
+
+struct DiskIdentity { len: u64, mtime: Option<SystemTime> }
+```
+
+- File model: `(len, mtime)` of the file. `len` catches a swap to a different
+  model; `mtime` catches a same-size rewrite.
+- Directory model: aggregate `len` (sum) and `mtime` (max) over the contained
+  files, because overwriting a file in place leaves the directory's own mtime
+  untouched.
+
+Reuse only when path, engine kind, **and** disk identity all match; otherwise
+drop and reload. A delete + re-download (new mtime, often new size) now
+invalidates the cache automatically. No frontend coordination, no bump signal.
+
+## Behavior after the fix
+
+- Same-name re-download: next transcription recomputes identity, sees a
+  mismatch, reloads fresh from disk. Correct without any FE push.
+- External file swap in the models folder: same revalidation path covers it.
+- Identical re-download (byte-for-byte same model): identity may match, cache is
+  reused. This is correct: the resident bytes are the same bytes.
+
+## Deliberately out of scope
+
+Eager preload after a same-name re-download. `should_preload` stays name-only,
+so a re-download reloads lazily on the next transcription (one cold start)
+rather than eagerly. Correctness over a one-time latency shave; the eager path
+was never reliable here anyway.
+
+## Cost
+
+One `fs::metadata` per file transcription/preload, plus a shallow directory walk
+(a handful of ONNX files) for directory models. Negligible against model load
+and inference.

--- a/apps/whispering/src-tauri/src/transcription/model_manager.rs
+++ b/apps/whispering/src-tauri/src/transcription/model_manager.rs
@@ -22,9 +22,14 @@ enum Engine {
     Moonshine(MoonshineModel),
 }
 
-/// The (path, engine) pair is inseparable: engine X is always loaded from
-/// path Y. One mutex slot holds both.
-type Cached = Option<(PathBuf, Engine)>;
+/// The (path, identity, engine) triple is inseparable: engine X is always
+/// loaded from path Y, and `identity` fingerprints the bytes at Y at load time
+/// so the cache can notice the file changed underneath a stable path (a delete
+/// then re-download under the same name, or an external edit of the
+/// user-editable models folder). `None` identity means bytes could not be stat'd at load
+/// time, which never compares equal to a fresh read, so the cache reloads. One
+/// mutex slot holds all three.
+type Cached = Option<(PathBuf, Option<DiskIdentity>, Engine)>;
 
 /// Owns the resident engine's lifecycle and the state observers see while it
 /// runs. Cache + ambient config + policy + status snapshot + lifecycle event
@@ -514,7 +519,19 @@ impl ModelManager {
             return Ok(EnsureLoaded::Stale);
         }
 
-        let reuse = matches!(&*guard, Some((p, e)) if p == &model_path && can_reuse(e));
+        // Fingerprint the bytes on disk now and reuse only when they match what
+        // the resident engine was loaded from. A delete + re-download under the
+        // same name, or an external edit, changes the identity even though the
+        // path is unchanged, so the stale resident model is dropped and reloaded.
+        let current_identity = disk_identity(&model_path);
+        let reuse = matches!(
+            &*guard,
+            Some((p, id, e))
+                if p == &model_path
+                    && can_reuse(e)
+                    && current_identity.is_some()
+                    && &current_identity == id
+        );
 
         if !reuse {
             let _ = guard.take();
@@ -540,7 +557,7 @@ impl ModelManager {
                         if !self.is_current_model_generation(caller.generation()) {
                             return Ok(EnsureLoaded::Stale);
                         }
-                        *guard = Some((model_path, engine));
+                        *guard = Some((model_path, current_identity, engine));
                         let Some(()) = self.publish_if_current(
                             caller.generation(),
                             config,
@@ -551,7 +568,7 @@ impl ModelManager {
                             return Ok(EnsureLoaded::Stale);
                         };
                     } else {
-                        *guard = Some((model_path, engine));
+                        *guard = Some((model_path, current_identity, engine));
                         let _ = self.publish_if_current(
                             caller.generation(),
                             config,
@@ -602,7 +619,7 @@ impl ModelManager {
             EnsureLoaded::Stale => unreachable!("stale cache loads only abort preloads"),
         };
 
-        let (_, engine) = guard.as_mut().expect("cache slot populated above");
+        let (_, _, engine) = guard.as_mut().expect("cache slot populated above");
         let _ = self.publish_if_current(
             caller.generation(),
             config,
@@ -668,7 +685,7 @@ impl ModelManager {
         if generation.is_some_and(|generation| !self.is_current_model_generation(generation)) {
             return;
         }
-        if let Some((path, _engine)) = guard.take() {
+        if let Some((path, _identity, _engine)) = guard.take() {
             debug!(
                 "[Transcription] unloaded model ({:?}): {}",
                 reason,
@@ -719,7 +736,7 @@ impl ModelManager {
         let Ok(mut guard) = self.cached.try_lock() else {
             return;
         };
-        if let Some((path, _engine)) = guard.take() {
+        if let Some((path, _identity, _engine)) = guard.take() {
             let idle_secs = idle.as_secs();
             debug!(
                 "[Transcription] unloaded model (idle {}s): {}",
@@ -900,6 +917,55 @@ fn lock_cached(cached: &Mutex<Cached>) -> MutexGuard<'_, Cached> {
     })
 }
 
+/// Cheap fingerprint of the bytes a resident model was loaded from, used to
+/// notice when the file or directory at a stable path changed underneath the
+/// cache (a delete + re-download under the same name, or an external edit of
+/// the user-editable models folder). `len` catches a swap to a different model;
+/// `mtime` catches a same-size rewrite.
+#[derive(Clone, PartialEq, Eq, Debug)]
+struct DiskIdentity {
+    len: u64,
+    mtime: Option<SystemTime>,
+}
+
+/// Read the disk identity of a resolved model path, following symlinks so the
+/// identity reflects the bytes the engine loaders actually read. For a
+/// directory model the fields aggregate over the contained files (sum of sizes,
+/// latest mtime), because a file overwritten in place leaves the directory's
+/// own mtime untouched. Returns `None` when the path cannot be stat'd, which
+/// the cache treats as "cannot confirm reuse" and reloads.
+fn disk_identity(path: &Path) -> Option<DiskIdentity> {
+    let meta = std::fs::metadata(path).ok()?;
+    if !meta.is_dir() {
+        return Some(DiskIdentity {
+            len: meta.len(),
+            mtime: meta.modified().ok(),
+        });
+    }
+    let mut len = 0u64;
+    let mut mtime = meta.modified().ok();
+    let mut stack = vec![path.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(child) = entry.metadata() else {
+                continue;
+            };
+            if child.is_dir() {
+                stack.push(entry.path());
+            } else {
+                len = len.saturating_add(child.len());
+                if let Ok(t) = child.modified() {
+                    mtime = Some(mtime.map_or(t, |cur| cur.max(t)));
+                }
+            }
+        }
+    }
+    Some(DiskIdentity { len, mtime })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -944,6 +1010,79 @@ mod tests {
     fn parse_moonshine_variant_rejects_unknown_names() {
         assert!(parse_moonshine_variant("moonshine-large-en").is_err());
         assert!(parse_moonshine_variant("whisper-tiny").is_err());
+    }
+
+    #[test]
+    fn disk_identity_stable_when_unchanged() {
+        let dir =
+            std::env::temp_dir().join(format!("whispering-id-stable-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("model.bin");
+        std::fs::write(&path, b"steady").unwrap();
+
+        let a = disk_identity(&path).expect("identity for existing file");
+        let b = disk_identity(&path).expect("identity on second read");
+        assert_eq!(a, b, "identity is stable across reads when bytes are unchanged");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn disk_identity_changes_on_file_rewrite() {
+        let dir = std::env::temp_dir().join(format!("whispering-id-file-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("model.bin");
+
+        // A swap to a different model: a different size alone changes identity.
+        std::fs::write(&path, b"first").unwrap();
+        let first = disk_identity(&path).expect("identity");
+        std::fs::write(&path, b"second-and-longer").unwrap();
+        let second = disk_identity(&path).expect("identity after size change");
+        assert_ne!(first, second, "a size change changes identity");
+
+        // A same-size re-download a tick later: equal length, so only mtime can
+        // carry the difference. "thirdx-and-longer" matches "second-and-longer".
+        std::thread::sleep(Duration::from_millis(20));
+        std::fs::write(&path, b"thirdx-and-longer").unwrap();
+        let third = disk_identity(&path).expect("identity after same-size rewrite");
+        assert_eq!(
+            b"second-and-longer".len(),
+            b"thirdx-and-longer".len(),
+            "test fixture must be same-size to exercise the mtime path"
+        );
+        assert_ne!(second, third, "a same-size rewrite changes identity via mtime");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn disk_identity_detects_in_place_edit_in_directory_model() {
+        let root = std::env::temp_dir().join(format!("whispering-id-dir-{}", std::process::id()));
+        let model_dir = root.join("parakeet-model");
+        std::fs::create_dir_all(&model_dir).unwrap();
+        std::fs::write(model_dir.join("encoder.onnx"), b"enc").unwrap();
+        std::fs::write(model_dir.join("decoder.onnx"), b"dec").unwrap();
+
+        let before = disk_identity(&model_dir).expect("identity for directory model");
+
+        // Overwrite one contained file in place with same-length content: the
+        // directory's own mtime would not move, but the aggregated mtime must.
+        std::thread::sleep(Duration::from_millis(20));
+        std::fs::write(model_dir.join("encoder.onnx"), b"ENC").unwrap();
+        let after = disk_identity(&model_dir).expect("identity after in-place edit");
+        assert_ne!(
+            before, after,
+            "an in-place file edit changes the directory model's identity"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn disk_identity_none_for_missing_path() {
+        let path = std::env::temp_dir().join("whispering-id-missing-does-not-exist");
+        std::fs::remove_file(&path).ok();
+        assert!(disk_identity(&path).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Deleting a local transcription model and re-downloading it under the same name (or swapping the file in the models folder by hand) left Rust serving the **old** resident model until the user manually re-selected it in settings.

## Root cause (Rust, not the frontend)

`ModelManager` cached its resident engine as `(PathBuf, Engine)` and decided reuse on **path equality alone**:

```rust
let reuse = matches!(&*guard, Some((p, e)) if p == &model_path && can_reuse(e));
```

The models folder is "user-editable truth": the bytes at a path can change while the path stays the same. The cache never noticed and kept serving the resident copy. `should_preload` compounds it by keying on `(engine, model_name)` only, so a re-pushed identical config triggers no reload. That is why a frontend "re-fire the config push" cannot fix this, and why re-selecting a *different* model and back (which changes `model_name`) was the working workaround.

## Fix

Fingerprint the bytes the engine was loaded from and store the fingerprint next to it. Reuse only when path, engine kind, **and** disk identity all match; otherwise drop and reload.

- File model: `(len, mtime)`. `len` catches a swap to a different model; `mtime` catches a same-size rewrite.
- Directory model: aggregate `len` (sum) and `mtime` (max) over the contained files, so an in-place file overwrite (which leaves the directory's own mtime untouched) is still observed.

A delete + re-download now invalidates the cache on the next transcription with no frontend coordination, and the same path covers an external file swap the frontend cannot observe. Lazy revalidation only: a same-name re-download reloads on the next transcription rather than eagerly preloading.

Cost: one `fs::metadata` per transcription/preload, plus a shallow directory walk for directory models. Negligible against model load and inference.

## Relationship to #1970

This addresses the same symptom as #1970 at the layer that owns the resident lifecycle. It makes #1970's reload mechanism (the `transcription-reload` bump signal, its layout dependency, and the `bump()` call) unnecessary; that approach also could not cover an external file swap, which this does. The one unrelated piece of #1970 worth keeping is its `await Promise.all(...refresh())` fix for the "Downloaded" badge race.

See `apps/whispering/specs/local-model-disk-identity.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784017099&installation_id=128463665&pr_number=1974&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1974&signature=121fb68db31308353e3b3f1cb9411e94a4707d526e6a79382d218a084c31b660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->