### PR TITLE
refactor(whispering): collapse model lifecycle to lazy load-on-use

### DIFF
--- a/apps/whispering/specs/model-lifecycle-lazy-collapse.md
+++ b/apps/whispering/specs/model-lifecycle-lazy-collapse.md
@@ -1,0 +1,142 @@
+# Collapse the local model lifecycle to lazy load-on-use
+
+## The asymmetric win in one line
+
+Delete eager preload. Then the entire `model_generation` subsystem (the hardest
+code in `model_manager.rs`) has nothing left to guard, so it goes too. We lose
+one latency optimization (a warm model before the first transcription) and
+delete the most error-prone concurrency reasoning in the Tauri backend.
+
+Estimated: `model_manager.rs` drops from ~960 to ~550 lines, `config.rs` loses
+`should_preload`, and zero out-of-order async model loads remain to reason about.
+
+## Why this is the right altitude (grounding)
+
+Handy (`cjpais/handy`) is the closest comparable: a minimal Tauri transcription
+app built on the **same `transcribe-rs` library** Whispering uses. Its resident
+model lifecycle:
+
+- **Lazy load.** The model loads when transcription is attempted and it is not
+  already loaded, not when the user selects it.
+- **Single resident model** (`engine: Arc<Mutex<Option<LoadedEngine>>>`), reused
+  across transcriptions.
+- **Idle unload** via a `ModelUnloadTimeout` setting and a 10s watcher, with an
+  `Immediately` variant. Refreshed during active recording.
+- **No generation/version token.** Concurrency is handled by a `LoadingGuard`
+  RAII (one load at a time), not by reconciling which selection is newest.
+- No disk-change detection at all (so Handy still has the re-download-stale bug
+  that our disk-identity change fixes).
+
+Handy delivers the same product (pick a model, transcribe, model stays warm,
+unloads when idle) with materially less machinery. The delta is exactly
+Whispering's eager preload and its generation token. That delta is the cut.
+
+## What eager preload costs us today
+
+`set_transcription_config` does not just store config. On an `(engine, name)`
+change it bumps `model_generation`, spawns a blocking thread, evicts the old
+model, and preloads the new one, all while newer pushes may arrive. To keep a
+stale background preload from publishing "Ready" after a newer selection, the
+file threads a generation token through nearly every method:
+
+- `model_generation: Arc<AtomicU64>`
+- `should_preload()` (config.rs) and `read_config_with_generation()`
+- `preload()` (~70 lines)
+- `LoadCaller` enum + impl, `EnsureLoaded::Stale`
+- `is_current_model_generation()`, `with_current_model_generation()`
+- a generation argument on `publish_if_current()`, `ensure_loaded()`,
+  `evict_with_reason_if_current()`, and the `with_*` engine helpers
+- the `spawn_blocking` block and the `Switching` status
+
+Every one of those exists to make eager background preload safe. None is needed
+if the model loads synchronously on the transcription that needs it. Whispering
+already loads-on-use for the transcription path (`with_engine` -> `ensure_loaded`
+with `LoadCaller::Transcription`); preload is a second, eager copy of that path
+with all the staleness scaffolding bolted on.
+
+## Target design
+
+### Config push becomes pure state
+
+```rust
+pub fn set_transcription_config(&self, config: TranscriptionConfig) {
+    // Validate eagerly (cheap, no model load) so a bad selection surfaces now.
+    if let Err(message) = self.model_path_for(&config) {
+        *self.write_config() = None;
+        self.evict(UnloadReason::ConfigChanged);
+        self.set_status(ModelStatus::Error { message: message.clone() });
+        self.emit(ModelStateEvent::LoadingFailed { state: self.snapshot(), error: message });
+        return;
+    }
+    *self.write_config() = Some(config);
+    self.emit(ModelStateEvent::SelectionChanged { state: self.snapshot() });
+}
+```
+
+No generation bump, no thread, no eager evict, no preload. Switching models just
+updates config; the old engine is dropped when the next transcription loads the
+new one (the cache already does `guard.take()` before loading a non-matching
+model), or by the idle watcher if no transcription comes.
+
+We keep **eager validation** (it is a path check, not a model load) so an invalid
+selection still errors at selection time, not mid-recording.
+
+### Transcribe loads on demand (already true)
+
+`transcribe()` -> `with_engine` -> `ensure_loaded` already reuses the resident
+engine or loads it under the cache lock, emitting `LoadingStarted` /
+`LoadingCompleted`. After the cut this is the *only* load path. The FE still sees
+loading events; they fire on the first transcription instead of on selection.
+
+### ensure_loaded collapses
+
+With no preload caller, `ensure_loaded` loses the `LoadCaller`/generation
+parameter, every `is_current_model_generation` guard, and the `EnsureLoaded::Stale`
+return. It becomes: lock, compute disk identity, reuse if (path, identity, kind)
+match else drop-and-load, emit, return the guard.
+
+### Keep
+
+- **Single resident cache** with **disk-identity revalidation** (the prior PR).
+  This is the correctness core and even Handy lacks it; keep it.
+- **Idle unload** (`ModelManager::start_idle_watcher`, `tick_idle`,
+  `evict_if_immediate`). Genuine memory hygiene for multi-GB models. The watcher
+  needs no generation token; it just unloads whatever is resident when idle.
+- **Inference lifecycle events** the FE status UI consumes (Loading, Inferring,
+  Ready, Error). They now all originate from the transcribe path.
+
+## What changes for the user
+
+- First transcription of a session (or first after an idle unload) pays the model
+  load latency once, behind the spinner the FE already shows during transcription.
+  Subsequent transcriptions are warm.
+- Selecting a model no longer warms it in the background. An invalid selection
+  still errors immediately (validation is kept).
+- Switching models frees the old one on the next transcription or idle tick
+  rather than instantly. A brief extra memory hold, never a leak.
+
+That is the ~10% we give up: pre-warming, and instant eviction on switch.
+
+## Deliberate non-goals
+
+- **No background load thread / loading guard.** Handy uses one for UI
+  responsiveness; Whispering's transcription is already async from the FE's view,
+  so loading inline under the cache lock is simpler and sufficient. Do not add a
+  half-measure that reintroduces races. If pre-warming is ever wanted back, add it
+  as one explicit, cache-checked background load, decided on its own merits.
+- **Unload-policy enum trimming.** The four-way `Never / Immediately /
+  After5Minutes / After30Minutes` could collapse to a single default, but that is
+  a separate, more debatable cut. Out of scope here.
+
+## Sequencing
+
+1. (Done) Disk-identity revalidation in the cache. Correctness, composes forward.
+2. Delete eager preload: `preload()`, the `spawn_blocking` in
+   `set_transcription_config`, `should_preload`, `LoadCaller`, `EnsureLoaded::Stale`,
+   `model_generation` and its helpers, the generation args, the `Switching` status.
+3. Simplify `ensure_loaded` / `with_engine` signatures to drop the caller param.
+4. Confirm the FE still renders status correctly from the transcribe-path events;
+   remove any FE handling that only existed for preload/Switching.
+
+Each step compiles and keeps tests green independently.
+```

--- a/apps/whispering/src-tauri/src/transcription/config.rs
+++ b/apps/whispering/src-tauri/src/transcription/config.rs
@@ -2,9 +2,9 @@ use serde::{Deserialize, Serialize};
 
 /// Ambient configuration the frontend pushes once per change. The Rust side
 /// reads this on every `transcribe_recording` call instead of receiving
-/// a per-call payload. Drift in `(engine, model_name)` triggers a preload;
-/// drift in other fields takes effect on the next transcription with no
-/// reload.
+/// a per-call payload. The model loads lazily on the next transcription, so a
+/// changed `(engine, model_name)` is picked up then; drift in other fields
+/// takes effect on the next transcription with no reload.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct TranscriptionConfig {
@@ -52,14 +52,4 @@ pub enum UnloadPolicy {
 
 impl UnloadPolicy {
     pub const DEFAULT: Self = Self::AfterFiveMinutes;
-}
-
-/// True when the new config asks for a different resident model than the old
-/// one. Identity is `(engine, model_name)` only: language/prompt/policy
-/// changes never trigger a reload because they take effect on next inference.
-pub fn should_preload(old: Option<&TranscriptionConfig>, new: &TranscriptionConfig) -> bool {
-    match old {
-        None => true,
-        Some(prev) => prev.engine != new.engine || prev.model_name != new.model_name,
-    }
 }

--- a/apps/whispering/src-tauri/src/transcription/events.rs
+++ b/apps/whispering/src-tauri/src/transcription/events.rs
@@ -25,9 +25,6 @@ pub enum ModelStatus {
     /// No model resident and none loading. Initial state, and reached after
     /// `Unloaded`.
     Idle,
-    /// A different model is selected, but the manager is still draining the
-    /// previous resident model before the new model can start loading.
-    Switching,
     /// `with_engine` is currently inside the `load(&model_path)` call.
     Loading,
     /// A model is resident and not currently in use.
@@ -149,14 +146,6 @@ mod tests {
                 "kind": "idle",
                 "idleSecs": 30
             })
-        );
-    }
-
-    #[test]
-    fn switching_status_has_a_stable_wire_tag() {
-        assert_eq!(
-            serde_json::to_value(ModelStatus::Switching).unwrap(),
-            json!({ "kind": "switching" })
         );
     }
 }

--- a/apps/whispering/src-tauri/src/transcription/model_manager.rs
+++ b/apps/whispering/src-tauri/src/transcription/model_manager.rs
@@ -1,4 +1,4 @@
-use super::config::{should_preload, Engine as EngineKind, TranscriptionConfig, UnloadPolicy};
+use super::config::{Engine as EngineKind, TranscriptionConfig, UnloadPolicy};
 use super::error::TranscriptionError;
 use super::events::{LocalModelState, ModelStateEvent, ModelStatus, UnloadReason};
 use log::{debug, info, warn};
@@ -58,11 +58,6 @@ pub struct ModelManager {
     /// so snapshot never blocks behind a transcription.
     status: Arc<RwLock<ModelStatus>>,
 
-    /// Logical identity token for the selected `(engine, model_name)`. Older
-    /// operations may finish, but they must not publish state after a newer
-    /// model selection.
-    model_generation: Arc<AtomicU64>,
-
     /// Handle used for `Emitter::emit` on the lifecycle event channel.
     /// Constructed once in `setup` and cloned cheaply through `Clone` on
     /// the manager.
@@ -76,87 +71,56 @@ impl ModelManager {
             last_activity_ms: Arc::new(AtomicU64::new(now_millis())),
             config: Arc::new(RwLock::new(None)),
             status: Arc::new(RwLock::new(ModelStatus::Idle)),
-            model_generation: Arc::new(AtomicU64::new(0)),
             app,
         }
     }
 
     // ── Ambient config ────────────────────────────────────────────────
 
-    /// Push the FE-side configuration. If `(engine, model_name)` changed
-    /// since the last push, the previous resident model is dropped (with a
-    /// `ConfigChanged` unload event) and a background preload kicks off so
-    /// the next transcription does not pay cold-start latency. Other field
-    /// changes (language, prompt, policy) take effect on next transcription
-    /// without a reload.
+    /// Push the FE-side configuration. This only stores state: the model
+    /// loads lazily on the next transcription, so there is no background
+    /// preload to race and no generation token to track. A changed
+    /// `(engine, model_name)` drops the now-stale resident model if the cache
+    /// is free; the next transcription loads the new selection from disk.
+    /// Other field changes (language, prompt, policy) take effect on the next
+    /// transcription with no reload.
     pub fn set_transcription_config(&self, config: TranscriptionConfig) {
-        // Validate eagerly so a bad selection surfaces as a LoadingFailed
-        // event at push time instead of an error mid-transcription.
-        match self.model_path_for(&config) {
-            Ok(_) => {}
-            Err(message) => {
-                warn!("[Transcription] rejected local model config: {}", message);
-                {
-                    let mut guard = self.write_config();
-                    *guard = None;
-                }
-                self.evict_with_reason(UnloadReason::ConfigChanged);
-                self.set_status(ModelStatus::Error {
-                    message: message.clone(),
-                });
-                self.emit(ModelStateEvent::LoadingFailed {
-                    state: self.snapshot(),
-                    error: message,
-                });
-                return;
-            }
+        // Validate eagerly. This is a path check, not a model load, so it is
+        // cheap and surfaces a bad selection now instead of mid-transcription.
+        if let Err(message) = self.model_path_for(&config) {
+            warn!("[Transcription] rejected local model config: {}", message);
+            *self.write_config() = None;
+            self.evict(UnloadReason::ConfigChanged);
+            self.set_status(ModelStatus::Error {
+                message: message.clone(),
+            });
+            self.emit(ModelStateEvent::LoadingFailed {
+                state: self.snapshot(),
+                error: message,
+            });
+            return;
         }
 
-        let (preload_generation, selection_state) = {
+        let model_changed = {
             let mut guard = self.write_config();
-            let needs_preload = should_preload(guard.as_ref(), &config);
-            let was_waiting_for_previous_model = !matches!(self.read_status(), ModelStatus::Idle);
-            let generation =
-                needs_preload.then(|| self.model_generation.fetch_add(1, Ordering::SeqCst) + 1);
-            *guard = Some(config.clone());
-            let selection_state = needs_preload.then(|| {
-                let status = if was_waiting_for_previous_model {
-                    ModelStatus::Switching
-                } else {
-                    ModelStatus::Idle
-                };
-                self.set_status(status.clone());
-                state_for_config(&config, status)
+            let changed = guard.as_ref().is_none_or(|prev| {
+                prev.engine != config.engine || prev.model_name != config.model_name
             });
-            (generation, selection_state)
+            *guard = Some(config);
+            changed
         };
 
+        // A different model means the resident one is stale. Drop it (Idle,
+        // not loaded) so the FE reflects the new selection honestly; the next
+        // transcription loads it. `evict` skips a cache busy with an in-flight
+        // transcription, which the next transcription reloads anyway.
+        if model_changed {
+            self.evict(UnloadReason::ConfigChanged);
+        }
         // Always notify: SelectionChanged is the FE's signal to refresh model
         // identity displays even when the engine/path are the same.
         self.emit(ModelStateEvent::SelectionChanged {
-            state: selection_state.unwrap_or_else(|| self.snapshot()),
-        });
-
-        let Some(generation) = preload_generation else {
-            return;
-        };
-
-        // Hand off the eviction + preload to a background thread so this
-        // command returns immediately. The eviction itself takes the cache
-        // lock; if a transcribe is in-flight, the eviction waits for it
-        // (correct: don't yank a model out from under an active inference).
-        // The preload then loads the new model. The FE sees a sequence of
-        // events on `transcription://model-state`: Unloaded(ConfigChanged)
-        // → LoadingStarted → LoadingCompleted | LoadingFailed.
-        let this = self.clone();
-        tauri::async_runtime::spawn_blocking(move || {
-            if !this.is_current_model_generation(generation) {
-                return;
-            }
-            this.evict_with_reason_if_current(UnloadReason::ConfigChanged, Some(generation));
-            if let Err(err) = this.preload(config, generation) {
-                warn!("[Transcription] preload failed: {}", err);
-            }
+            state: self.snapshot(),
         });
     }
 
@@ -209,13 +173,6 @@ impl ModelManager {
             .unwrap_or_else(|poisoned| poisoned.into_inner().clone())
     }
 
-    fn read_config_with_generation(&self) -> Option<(TranscriptionConfig, u64)> {
-        let guard = self.read_config_guard();
-        let config = guard.clone()?;
-        let generation = self.model_generation.load(Ordering::SeqCst);
-        Some((config, generation))
-    }
-
     fn read_config_guard(&self) -> RwLockReadGuard<'_, Option<TranscriptionConfig>> {
         self.config
             .read()
@@ -264,7 +221,7 @@ impl ModelManager {
     /// validates the samples, then routes to the engine-specific path.
     /// Called from a blocking-pool thread.
     pub fn transcribe(&self, samples: Vec<f32>) -> Result<String, TranscriptionError> {
-        let Some((config, generation)) = self.read_config_with_generation() else {
+        let Some(config) = self.read_config() else {
             return Err(TranscriptionError::NoConfig {
                 message:
                     "Transcription config not set. The frontend must call setTranscriptionConfig first."
@@ -302,7 +259,7 @@ impl ModelManager {
                 params.suppress_non_speech_tokens = true;
                 params.no_speech_thold = 0.2;
 
-                self.with_whisper(&config, generation, model_path, |engine| {
+                self.with_whisper(&config, model_path, |engine| {
                     let result = engine
                         .transcribe_with(&samples, &params)
                         .map_err(transcription_err)?;
@@ -314,7 +271,7 @@ impl ModelManager {
                     timestamp_granularity: Some(TimestampGranularity::Segment),
                     ..Default::default()
                 };
-                self.with_parakeet(&config, generation, model_path, |engine| {
+                self.with_parakeet(&config, model_path, |engine| {
                     let result = engine
                         .transcribe_with(&samples, &params)
                         .map_err(transcription_err)?;
@@ -323,7 +280,7 @@ impl ModelManager {
             }
             EngineKind::Moonshine => {
                 let variant = parse_moonshine_variant(&config.model_name)?;
-                self.with_moonshine(&config, generation, model_path, variant, |engine| {
+                self.with_moonshine(&config, model_path, variant, |engine| {
                     let result = engine
                         .transcribe(&samples, &TranscribeOptions::default())
                         .map_err(transcription_err)?;
@@ -338,83 +295,8 @@ impl ModelManager {
             transcript.len(),
             inference_started.elapsed().as_millis(),
         );
-        self.evict_if_immediate(config.unload_policy, generation);
+        self.evict_if_immediate(config.unload_policy);
         Ok(transcript)
-    }
-
-    // ── Preload ───────────────────────────────────────────────────────
-
-    /// Load the configured model without running inference. Preload drives
-    /// loading events only; inference events are reserved for real
-    /// transcriptions.
-    fn preload(
-        &self,
-        config: TranscriptionConfig,
-        generation: u64,
-    ) -> Result<(), TranscriptionError> {
-        if !self.is_current_model_generation(generation) {
-            return Ok(());
-        }
-        let model_path = match self.model_path_for(&config) {
-            Ok(path) => path,
-            Err(message) => {
-                let _ = self.publish_if_current(
-                    generation,
-                    &config,
-                    ModelStatus::Error {
-                        message: message.clone(),
-                    },
-                    |state| ModelStateEvent::LoadingFailed {
-                        state,
-                        error: message.clone(),
-                    },
-                );
-                return Err(TranscriptionError::ModelLoadError { message });
-            }
-        };
-        match config.engine {
-            EngineKind::Whispercpp => {
-                self.ensure_loaded(
-                    &config,
-                    model_path,
-                    |e| matches!(e, Engine::Whisper(_)),
-                    |path| {
-                        WhisperEngine::load(path)
-                            .map(Engine::Whisper)
-                            .map_err(|e| format!("Failed to load Whisper model: {}", e))
-                    },
-                    LoadCaller::Preload { generation },
-                )?;
-            }
-            EngineKind::Parakeet => {
-                self.ensure_loaded(
-                    &config,
-                    model_path,
-                    |e| matches!(e, Engine::Parakeet(_)),
-                    |path| {
-                        ParakeetModel::load(path, &Quantization::Int8)
-                            .map(Engine::Parakeet)
-                            .map_err(|e| format!("Failed to load Parakeet model: {}", e))
-                    },
-                    LoadCaller::Preload { generation },
-                )?;
-            }
-            EngineKind::Moonshine => {
-                let variant = parse_moonshine_variant(&config.model_name)?;
-                self.ensure_loaded(
-                    &config,
-                    model_path,
-                    |e| matches!(e, Engine::Moonshine(_)),
-                    |path| {
-                        MoonshineModel::load(path, variant, &Quantization::default())
-                            .map(Engine::Moonshine)
-                            .map_err(|e| format!("Failed to load Moonshine model: {}", e))
-                    },
-                    LoadCaller::Preload { generation },
-                )?;
-            }
-        }
-        Ok(())
     }
 
     // ── Engine cache + eviction ───────────────────────────────────────
@@ -422,7 +304,6 @@ impl ModelManager {
     fn with_whisper<T>(
         &self,
         config: &TranscriptionConfig,
-        generation: u64,
         model_path: PathBuf,
         f: impl FnOnce(&mut WhisperEngine) -> Result<T, TranscriptionError>,
     ) -> Result<T, TranscriptionError> {
@@ -435,7 +316,6 @@ impl ModelManager {
                     .map(Engine::Whisper)
                     .map_err(|e| format!("Failed to load Whisper model: {}", e))
             },
-            LoadCaller::Transcription { generation },
             |engine| match engine {
                 Engine::Whisper(e) => f(e),
                 _ => unreachable!("can_reuse guarantees Whisper variant"),
@@ -446,7 +326,6 @@ impl ModelManager {
     fn with_parakeet<T>(
         &self,
         config: &TranscriptionConfig,
-        generation: u64,
         model_path: PathBuf,
         f: impl FnOnce(&mut ParakeetModel) -> Result<T, TranscriptionError>,
     ) -> Result<T, TranscriptionError> {
@@ -459,7 +338,6 @@ impl ModelManager {
                     .map(Engine::Parakeet)
                     .map_err(|e| format!("Failed to load Parakeet model: {}", e))
             },
-            LoadCaller::Transcription { generation },
             |engine| match engine {
                 Engine::Parakeet(e) => f(e),
                 _ => unreachable!("can_reuse guarantees Parakeet variant"),
@@ -470,7 +348,6 @@ impl ModelManager {
     fn with_moonshine<T>(
         &self,
         config: &TranscriptionConfig,
-        generation: u64,
         model_path: PathBuf,
         variant: MoonshineVariant,
         f: impl FnOnce(&mut MoonshineModel) -> Result<T, TranscriptionError>,
@@ -484,7 +361,6 @@ impl ModelManager {
                     .map(Engine::Moonshine)
                     .map_err(|e| format!("Failed to load Moonshine model: {}", e))
             },
-            LoadCaller::Transcription { generation },
             |engine| match engine {
                 Engine::Moonshine(e) => f(e),
                 _ => unreachable!("can_reuse guarantees Moonshine variant"),
@@ -492,11 +368,9 @@ impl ModelManager {
         )
     }
 
-    /// Hold the cache lock across load. If `(path, engine kind)` matches the
-    /// cache, reuse; otherwise drop and load fresh under the same lock.
-    /// Stale background preloads drop their loaded engine instead of
-    /// publishing or caching it; stale transcriptions keep their engine long
-    /// enough to preserve transcript behavior, but stop publishing state.
+    /// Hold the cache lock across load. If `(path, identity, engine kind)`
+    /// matches the cache, reuse; otherwise drop and load fresh under the same
+    /// lock. The model loads lazily here, on the transcription that needs it.
     ///
     /// Holding the cache lock across `emit` is safe: Tauri's emit is sync
     /// and FE handlers run on the JS event loop, so no Rust caller can
@@ -507,17 +381,8 @@ impl ModelManager {
         model_path: PathBuf,
         can_reuse: impl Fn(&Engine) -> bool,
         load: impl FnOnce(&Path) -> Result<Engine, String>,
-        caller: LoadCaller,
-    ) -> Result<EnsureLoaded<'_>, TranscriptionError> {
-        if caller.is_preload() && !self.is_current_model_generation(caller.generation()) {
-            return Ok(EnsureLoaded::Stale);
-        }
-
+    ) -> Result<MutexGuard<'_, Cached>, TranscriptionError> {
         let mut guard = lock_cached(&self.cached);
-
-        if caller.is_preload() && !self.is_current_model_generation(caller.generation()) {
-            return Ok(EnsureLoaded::Stale);
-        }
 
         // Fingerprint the bytes on disk now and reuse only when they match what
         // the resident engine was loaded from. A delete + re-download under the
@@ -535,15 +400,9 @@ impl ModelManager {
 
         if !reuse {
             let _ = guard.take();
-            let loading_started = self.publish_if_current(
-                caller.generation(),
-                config,
-                ModelStatus::Loading,
-                |state| ModelStateEvent::LoadingStarted { state },
-            );
-            if caller.is_preload() && loading_started.is_none() {
-                return Ok(EnsureLoaded::Stale);
-            }
+            self.publish(config, ModelStatus::Loading, |state| {
+                ModelStateEvent::LoadingStarted { state }
+            });
             let started = Instant::now();
             match load(&model_path) {
                 Ok(engine) => {
@@ -553,37 +412,13 @@ impl ModelManager {
                         model_path.display(),
                         elapsed_ms
                     );
-                    if caller.is_preload() {
-                        if !self.is_current_model_generation(caller.generation()) {
-                            return Ok(EnsureLoaded::Stale);
-                        }
-                        *guard = Some((model_path, current_identity, engine));
-                        let Some(()) = self.publish_if_current(
-                            caller.generation(),
-                            config,
-                            ModelStatus::Ready,
-                            |state| ModelStateEvent::LoadingCompleted { state, elapsed_ms },
-                        ) else {
-                            let _ = guard.take();
-                            return Ok(EnsureLoaded::Stale);
-                        };
-                    } else {
-                        *guard = Some((model_path, current_identity, engine));
-                        let _ = self.publish_if_current(
-                            caller.generation(),
-                            config,
-                            ModelStatus::Ready,
-                            |state| ModelStateEvent::LoadingCompleted { state, elapsed_ms },
-                        );
-                    }
+                    *guard = Some((model_path, current_identity, engine));
+                    self.publish(config, ModelStatus::Ready, |state| {
+                        ModelStateEvent::LoadingCompleted { state, elapsed_ms }
+                    });
                 }
                 Err(message) => {
-                    if caller.is_preload() && !self.is_current_model_generation(caller.generation())
-                    {
-                        return Ok(EnsureLoaded::Stale);
-                    }
-                    let _ = self.publish_if_current(
-                        caller.generation(),
+                    self.publish(
                         config,
                         ModelStatus::Error {
                             message: message.clone(),
@@ -598,46 +433,35 @@ impl ModelManager {
             }
         }
 
-        Ok(EnsureLoaded::Loaded(guard))
+        Ok(guard)
     }
 
-    /// Hold the cache lock across load and use. Preloading calls only
-    /// `ensure_loaded`; real transcriptions additionally emit semantic
-    /// inference events around the user closure.
+    /// Hold the cache lock across load and use, emitting semantic inference
+    /// events around the user closure.
     fn with_engine<T>(
         &self,
         config: &TranscriptionConfig,
         model_path: PathBuf,
         can_reuse: impl Fn(&Engine) -> bool,
         load: impl FnOnce(&Path) -> Result<Engine, String>,
-        caller: LoadCaller,
         use_engine: impl FnOnce(&mut Engine) -> Result<T, TranscriptionError>,
     ) -> Result<T, TranscriptionError> {
         self.touch_activity();
-        let mut guard = match self.ensure_loaded(config, model_path, can_reuse, load, caller)? {
-            EnsureLoaded::Loaded(guard) => guard,
-            EnsureLoaded::Stale => unreachable!("stale cache loads only abort preloads"),
-        };
+        let mut guard = self.ensure_loaded(config, model_path, can_reuse, load)?;
 
         let (_, _, engine) = guard.as_mut().expect("cache slot populated above");
-        let _ = self.publish_if_current(
-            caller.generation(),
-            config,
-            ModelStatus::Inferring,
-            |state| ModelStateEvent::InferenceStarted { state },
-        );
+        self.publish(config, ModelStatus::Inferring, |state| {
+            ModelStateEvent::InferenceStarted { state }
+        });
         let started = Instant::now();
         let result = use_engine(engine);
         let elapsed_ms = started.elapsed().as_millis() as u64;
         self.touch_activity();
         match &result {
             Ok(_) => {
-                let _ = self.publish_if_current(
-                    caller.generation(),
-                    config,
-                    ModelStatus::Ready,
-                    |state| ModelStateEvent::InferenceCompleted { state, elapsed_ms },
-                );
+                self.publish(config, ModelStatus::Ready, |state| {
+                    ModelStateEvent::InferenceCompleted { state, elapsed_ms }
+                });
             }
             Err(e) => {
                 // Don't clear the cache on inference failure: the engine is
@@ -645,8 +469,7 @@ impl ModelManager {
                 // or input issue). The status reflects the last result; a
                 // successful next call flips it back to Ready.
                 let message = e.to_string();
-                let _ = self.publish_if_current(
-                    caller.generation(),
+                self.publish(
                     config,
                     ModelStatus::Error {
                         message: message.clone(),
@@ -667,24 +490,22 @@ impl ModelManager {
 
     /// Drop the resident model now if the current policy is `Immediately`.
     /// Called at the end of every successful transcription.
-    fn evict_if_immediate(&self, policy: UnloadPolicy, generation: u64) {
+    fn evict_if_immediate(&self, policy: UnloadPolicy) {
         if matches!(policy, UnloadPolicy::Immediately) {
-            self.evict_with_reason_if_current(UnloadReason::Immediate, Some(generation));
+            self.evict(UnloadReason::Immediate);
         }
     }
 
     /// Drop the resident model and emit an `Unloaded` event with the given
-    /// reason. Idempotent: a no-op when the cache is already empty.
-    fn evict_with_reason(&self, reason: UnloadReason) {
-        self.evict_with_reason_if_current(reason, None);
-    }
-
-    fn evict_with_reason_if_current(&self, reason: UnloadReason, generation: Option<u64>) {
-        let mut guard = lock_cached(&self.cached);
-        let config_guard = self.read_config_guard();
-        if generation.is_some_and(|generation| !self.is_current_model_generation(generation)) {
+    /// reason, leaving status `Idle`. Uses `try_lock` so it never blocks behind
+    /// an in-flight transcription: a busy cache keeps its model, which the next
+    /// transcription reloads against the current config anyway. A no-op when the
+    /// cache is already empty.
+    fn evict(&self, reason: UnloadReason) {
+        let Ok(mut guard) = self.cached.try_lock() else {
             return;
-        }
+        };
+        let config_guard = self.read_config_guard();
         if let Some((path, _identity, _engine)) = guard.take() {
             debug!(
                 "[Transcription] unloaded model ({:?}): {}",
@@ -695,13 +516,8 @@ impl ModelManager {
             // on the cache lock (they should not lock it anyway, but defensive
             // ordering is cheap).
             drop(guard);
-            let status = if matches!(reason, UnloadReason::ConfigChanged) {
-                ModelStatus::Switching
-            } else {
-                ModelStatus::Idle
-            };
-            self.set_status(status.clone());
-            let state = state_for_config_option(config_guard.as_ref(), status);
+            self.set_status(ModelStatus::Idle);
+            let state = state_for_config_option(config_guard.as_ref(), ModelStatus::Idle);
             self.emit(ModelStateEvent::Unloaded { state, reason });
         }
     }
@@ -760,58 +576,17 @@ impl ModelManager {
         }
     }
 
-    fn is_current_model_generation(&self, generation: u64) -> bool {
-        self.model_generation.load(Ordering::SeqCst) == generation
-    }
-
-    fn with_current_model_generation<T>(
+    /// Set the resident status and emit the matching lifecycle event built
+    /// from the current config and that status.
+    fn publish(
         &self,
-        generation: u64,
-        f: impl FnOnce() -> T,
-    ) -> Option<T> {
-        // The read lock closes the check-then-publish gap against
-        // set_transcription_config, whose write lock bumps the generation.
-        let _guard = self.read_config_guard();
-        self.is_current_model_generation(generation).then(f)
-    }
-
-    fn publish_if_current(
-        &self,
-        generation: u64,
         config: &TranscriptionConfig,
         status: ModelStatus,
         build_event: impl FnOnce(LocalModelState) -> ModelStateEvent,
-    ) -> Option<()> {
-        self.with_current_model_generation(generation, || {
-            self.set_status(status.clone());
-            self.emit(build_event(state_for_config(config, status)));
-        })
+    ) {
+        self.set_status(status.clone());
+        self.emit(build_event(state_for_config(config, status)));
     }
-}
-
-#[derive(Clone, Copy)]
-enum LoadCaller {
-    Preload { generation: u64 },
-    Transcription { generation: u64 },
-}
-
-impl LoadCaller {
-    fn generation(self) -> u64 {
-        match self {
-            LoadCaller::Preload { generation } | LoadCaller::Transcription { generation } => {
-                generation
-            }
-        }
-    }
-
-    fn is_preload(self) -> bool {
-        matches!(self, LoadCaller::Preload { .. })
-    }
-}
-
-enum EnsureLoaded<'a> {
-    Loaded(MutexGuard<'a, Cached>),
-    Stale,
 }
 
 /// Replace NaN/Inf with 0.0 and cap length so a malformed sample buffer

--- a/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
@@ -121,10 +121,10 @@
 		if (!tauri) return;
 		entries = await listModelEntries(engine);
 		// The folder is user-editable truth, so the catalog handles re-check
-		// disk on the same signal that rescans the folder.
-		for (const model of models) {
-			localModelDownloads.get(model).refresh();
-		}
+		// disk on the same signal that rescans the folder. Await the disk-stat
+		// so `isInstalled` (and the "Downloaded" badge it drives) is settled
+		// before the listing renders, instead of racing the next render.
+		await Promise.all(models.map((model) => localModelDownloads.get(model).refresh()));
 		// A user who already brought their own model gets the list, not a
 		// download pitch: when nothing is active and the first scan finds
 		// custom entries, start with the list open instead of the hero.

--- a/apps/whispering/src/lib/state/local-model.svelte.ts
+++ b/apps/whispering/src/lib/state/local-model.svelte.ts
@@ -35,8 +35,7 @@ function createLocalModel() {
 		/** True while the model manager cannot start another local operation. */
 		get isBusy(): boolean {
 			return (
-				state.status.kind === 'loading' ||
-				state.status.kind === 'inferring'
+				state.status.kind === 'loading' || state.status.kind === 'inferring'
 			);
 		},
 

--- a/apps/whispering/src/lib/state/local-model.svelte.ts
+++ b/apps/whispering/src/lib/state/local-model.svelte.ts
@@ -35,7 +35,6 @@ function createLocalModel() {
 		/** True while the model manager cannot start another local operation. */
 		get isBusy(): boolean {
 			return (
-				state.status.kind === 'switching' ||
 				state.status.kind === 'loading' ||
 				state.status.kind === 'inferring'
 			);

--- a/apps/whispering/src/lib/tauri/bindings.gen.ts
+++ b/apps/whispering/src/lib/tauri/bindings.gen.ts
@@ -361,11 +361,6 @@ export type ModelStatus =
 	 *  `Unloaded`.
 	 */
 	| { kind: 'idle' }
-	/**
-	 *  A different model is selected, but the manager is still draining the
-	 *  previous resident model before the new model can start loading.
-	 */
-	| { kind: 'switching' }
 	/**  `with_engine` is currently inside the `load(&model_path)` call. */
 	| { kind: 'loading' }
 	/**  A model is resident and not currently in use. */

--- a/apps/whispering/src/lib/tauri/commands.test-d.ts
+++ b/apps/whispering/src/lib/tauri/commands.test-d.ts
@@ -99,7 +99,6 @@ type _ModelStatusShape = Expect<
 	Equal<
 		ModelStatus,
 		| { kind: 'idle' }
-		| { kind: 'switching' }
 		| { kind: 'loading' }
 		| { kind: 'ready' }
 		| { kind: 'inferring' }


### PR DESCRIPTION
**Stacked on #1974** (disk-identity reload fix). Review/merge that first; GitHub retargets this to `main` once it lands. The diff shown here is only the incremental collapse.

What and why:

Delete eager preload. With no background preload to race, the entire `model_generation` subsystem, which existed only to stop a stale preload from publishing state after a newer selection, has nothing left to guard, so it goes too.

This is the asymmetric win: we give up pre-warming (one latency optimization) and delete the most intricate concurrency reasoning in the Tauri backend. `model_manager.rs` drops ~320 lines and loses all out-of-order async model loads.

## Grounding: Handy

`cjpais/handy` is the closest comparable and runs the **same `transcribe-rs` library**. Its lifecycle is lazy load on first transcription, single resident model, idle unload, and crucially **no generation token** (just mutual exclusion). It ships the same product without this subsystem. The delta between the two apps is exactly Whispering's eager preload, which this removes.

## Removed

- `preload()` and the `spawn_blocking` handoff in `set_transcription_config`
- `model_generation` and `is_current_model_generation` / `with_current_model_generation` / `read_config_with_generation`
- `should_preload` (config.rs)
- `LoadCaller`, `EnsureLoaded::Stale`, and the generation/caller args threaded through `ensure_loaded` / `with_engine` / the `with_*` helpers
- the two-variant `evict_with_reason` / `evict_with_reason_if_current`

## After

- `set_transcription_config` only stores config and validates the path (a cheap check, not a load) so a bad selection still errors at selection time. A changed `(engine, model_name)` drops the stale resident model if the cache is free; the next transcription loads the new selection. `evict()` uses `try_lock`, so config push never blocks behind an in-flight transcription.
- `ensure_loaded` reuses on `(path, identity, kind)` or drops-and-loads. This is now the only load path.
- Behavior change: the first transcription of a session (or first after idle unload) pays the model load once, behind the spinner the FE already shows. Subsequent transcriptions are warm. Idle unload and the resident cache with disk-identity revalidation are unchanged.

## Supersedes #1970

The last commit salvages the one orthogonal fix from #1970 (awaiting the per-model disk refresh so the "Downloaded" badge settles). With that carried over, **#1970 should be closed**: its reload mechanism is superseded by #1974, and could not cover an external file swap besides.

`Switching` is no longer emitted (eviction reports `Idle`). This PR also prunes the dead variant, the test that asserted its wire tag, the regenerated binding member, and the FE `isBusy` branch that could never be true (commit ce97e9082), completing step 2/4 of the spec.

See `apps/whispering/specs/model-lifecycle-lazy-collapse.md`.

Note: FE typecheck not run locally (worktree has no node_modules); the one-line `await Promise.all` is a verbatim salvage from #1970. CI verifies.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784017797&installation_id=128463665&pr_number=1975&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1975&signature=a51cecc8b253a1456a59dfb97a5b69fc4641622441a020c6de7d210ba049b8a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
