### PR TITLE
feat(setup): auto-start recommended model download on the engine step

### DIFF
--- a/apps/whispering/src/routes/(app)/(config)/setup/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/setup/+page.svelte
@@ -4,10 +4,39 @@
 	import { Link } from '@epicenter/ui/link';
 	import CheckCircle2Icon from '@lucide/svelte/icons/check-circle-2';
 	import AlertCircleIcon from '@lucide/svelte/icons/alert-circle';
+	import { onMount } from 'svelte';
+	import { announceModelDownload } from '$lib/components/settings/local-model-toasts';
 	import TranscriptionRuntimeSetup from '$lib/components/settings/TranscriptionRuntimeSetup.svelte';
+	import { RECOMMENDED_MODELS } from '$lib/constants/local-models';
+	import {
+		isLocalProviderId,
+		PROVIDERS,
+	} from '$lib/services/transcription/providers';
 	import { getTranscriptionSetupReadiness } from '$lib/settings/transcription-validation';
+	import { deviceConfig } from '$lib/state/device-config.svelte';
+	import { localModelDownloads } from '$lib/state/local-model-downloads.svelte';
+	import { settings } from '$lib/state/settings.svelte';
+	import { tauri } from '#platform/tauri';
 
 	const runtime = $derived(getTranscriptionSetupReadiness());
+
+	// Zero-click recommended path: on a desktop first run, when the selected
+	// engine is local but its model isn't on disk yet, download the recommended
+	// model in the background and select it, so a first-timer reaches a ready
+	// runtime without a click. Fires once on mount, so it never re-triggers on
+	// engine switches; progress shows in the model card's hero, which reads the
+	// same shared download handle. (Download runs in Rust via plugin-upload and
+	// has no cancel yet — see follow-up.)
+	onMount(async () => {
+		if (!tauri) return;
+		const service = settings.get('transcription.service');
+		if (!isLocalProviderId(service)) return;
+		const handle = localModelDownloads.get(RECOMMENDED_MODELS[service]);
+		await handle.refresh();
+		if (handle.state.type !== 'not-downloaded') return;
+		const entryName = announceModelDownload(await handle.download());
+		if (entryName) deviceConfig.set(PROVIDERS[service].modelConfigKey, entryName);
+	});
 </script>
 
 <div class="space-y-4">


### PR DESCRIPTION
Stacked on #1976 (base `codex/whispering-setup-wizard`); auto-retargets to `main` when that merges.

A first-timer on the recommended path picks Parakeet (the default local engine) and then has to notice the model isn't downloaded, find the Download button, and click it before anything works. This closes that gap: on the engine step, if the selected engine is local and its recommended model isn't on disk yet, the download starts in the background on mount and the model is selected when it lands — zero clicks to a configured runtime.

It runs through the same shared download handle the model card uses, so progress shows in the card's hero and a started download is never duplicated. It fires once on mount, so switching engines or navigating away never re-triggers it.

Scope note: this is desktop-only (web has no local engine) and intentionally does **not** include a cancel control. Main downloads via `@tauri-apps/plugin-upload` (the bytes move in Rust), whose JS API exposes no `AbortSignal`, so a real cancel needs a Rust cancel command and a binding regen — a separate follow-up rather than a JS-side fake.

## Changelog
- On desktop first-run setup, the recommended local model now downloads automatically in the background, so the default path reaches a ready transcription engine without a manual download click.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784047528&installation_id=128463665&pr_number=1977&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1977&signature=1d65661fde83ed06d1fd29bb0d4c1bcc67b121a4f9bdde97796d1c4a032fcc07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->