### PR TITLE
fix(whispering): fail transformation runs on thrown step errors

### DIFF
--- a/apps/whispering/src/lib/operations/transform.ts
+++ b/apps/whispering/src/lib/operations/transform.ts
@@ -250,7 +250,18 @@ export async function runTransformation({
 	} satisfies TransformationRun;
 	transformationRuns.set(transformationRun);
 
-	const result = await executeTransformation({ input, transformation });
+	// A thrown provider or execution error must still land as a failed terminal
+	// result. Without this, a throw escapes past the persistence below and the
+	// kickoff row stays stuck at `result: null`, so the run reads as forever
+	// running. Normalize any throw into an Err the failure branch records.
+	let result: Result<string, TransformError>;
+	try {
+		result = await executeTransformation({ input, transformation });
+	} catch (error) {
+		result = TransformError.PromptFailed({
+			message: extractErrorMessage(error),
+		});
+	}
 
 	if (isErr(result)) {
 		transformationRuns.set({


### PR DESCRIPTION
Thrown provider or execution errors could escape `runTransformation`'s persistence. A run writes a kickoff row with `result: null`, awaits execution, then writes the terminal `completed`/`failed` row. When the provider call threw instead of returning an `Err`, the rejection propagated past both the failure write and the function itself, leaving the kickoff row at `result: null`. Liveness is derived from that null result, so the run read as forever running and never reached a `failed` state.

The fix wraps the `executeTransformation` call in `try/catch` and normalizes any throw into an `Err`, so the existing failure branch persists a `failed` terminal result with the error message. (A plain `try/catch` rather than `tryAsync` is deliberate: `executeTransformation` already returns a `Result`, so `tryAsync` would nest it as `Result<Result<...>>`.)

Supersedes #1903, which carried the same fix against an older `transform.ts`, before the `executeTransformation` / `runTransformation` split landed on `main`. The original author's work is preserved via a `Co-authored-by` trailer on the commit.

## Changelog
- Fix transformation runs getting stuck as "running" when a provider call throws; they now end as failed with the error message