### PR TITLE
ci(whispering): Linux on Blacksmith + macOS Intel preview spike

### DIFF
--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -54,6 +54,19 @@ jobs:
             artifactSuffix: 'macos-arm64'
             rustTargets: 'aarch64-apple-darwin'
 
+          # macOS Intel (x86_64) PREVIEW-ONLY spike: cross-compiled from the Apple
+          # Silicon runner above. Neither Microsoft nor pyke publishes a prebuilt
+          # x86_64 macOS ONNX Runtime, so the ORT step below temporarily pulls a
+          # community build from Handy's blob purely to prove the cross-compile +
+          # dylib-bundle pipeline. Do NOT copy this row into release.whispering.yml
+          # until we host our own x86_64 ORT build (the third-party blob is not a
+          # durable release dependency).
+          - platform: 'blacksmith-6vcpu-macos-15'
+            os: 'macos'
+            tauriArgs: '--target x86_64-apple-darwin'
+            artifactSuffix: 'macos-intel'
+            rustTargets: 'x86_64-apple-darwin'
+
           # Linux on Blacksmith: GA drop-in runner, same base image as GitHub-hosted
           # ubuntu-24.04. `os: 'linux'` still drives every apt/Vulkan/FUSE step.
           - platform: 'blacksmith-8vcpu-ubuntu-2404'
@@ -146,6 +159,29 @@ jobs:
       - name: Build frontend
         run: bun --filter @epicenter/whispering build
 
+      # macOS Intel only: provision a dynamically linked x86_64 ONNX Runtime and
+      # bundle it into the .app. The `ort` crate (2.0.0-rc.12, via transcribe-rs)
+      # targets ONNX Runtime 1.24.2, but no official x86_64 macOS build exists, so
+      # this pulls a community build. ORT_LIB_LOCATION + ORT_PREFER_DYNAMIC_LINK
+      # make ort-sys link against it dynamically; the jq patch embeds the dylib in
+      # the bundle so it resolves at runtime. PREVIEW-ONLY: replace the blob source
+      # before any release use.
+      - name: Provision x86_64 ONNX Runtime (macOS Intel only)
+        if: ${{ matrix.artifactSuffix == 'macos-intel' }}
+        shell: bash
+        run: |
+          ORT_VERSION="1.24.2"
+          curl -fSL -o ort.tgz "https://blob.handy.computer/onnxruntime-osx-x86_64-${ORT_VERSION}.tgz"
+          tar xzf ort.tgz
+          ORT_DIR="$PWD/onnxruntime-osx-x86_64-${ORT_VERSION}"
+          echo "ORT_LIB_LOCATION=$ORT_DIR/lib" >> "$GITHUB_ENV"
+          echo "ORT_PREFER_DYNAMIC_LINK=1" >> "$GITHUB_ENV"
+          DYLIB="$ORT_DIR/lib/libonnxruntime.${ORT_VERSION}.dylib"
+          test -f "$DYLIB" || { echo "::error::expected dylib not found: $DYLIB"; ls -la "$ORT_DIR/lib"; exit 1; }
+          file "$DYLIB"
+          CONF="apps/whispering/src-tauri/tauri.conf.json"
+          jq --arg lib "$DYLIB" '.bundle.macOS.frameworks = [$lib]' "$CONF" > "$CONF.tmp" && mv "$CONF.tmp" "$CONF"
+
       # Preview builds are unsigned: --no-sign skips Apple codesigning,
       # Windows Authenticode, and Tauri updater signing. All bundle artifacts
       # (.dmg, .AppImage, .deb, .msi, .exe) are still produced normally.
@@ -159,6 +195,24 @@ jobs:
           projectPath: 'apps/whispering'
           tagName: ''
           args: '${{ matrix.tauriArgs }} --no-sign'
+
+      # macOS Intel only: confirm the build is actually x86_64 and that the
+      # onnxruntime dylib is both linked and bundled into the .app. Fails loudly
+      # if the cross-compile silently produced an arm64 binary or dropped the dylib.
+      - name: Verify x86_64 build and ONNX Runtime bundling (macOS Intel only)
+        if: ${{ matrix.artifactSuffix == 'macos-intel' }}
+        shell: bash
+        run: |
+          APP=$(find apps/whispering/src-tauri/target/x86_64-apple-darwin/release/bundle -name '*.app' -type d | head -1)
+          test -n "$APP" || { echo "::error::no .app bundle found for x86_64-apple-darwin"; exit 1; }
+          # Tauri names the executable after productName ("Whispering"), not the crate.
+          BIN="$APP/Contents/MacOS/Whispering"
+          echo "Binary architecture:"; file "$BIN"
+          file "$BIN" | grep -q 'x86_64' || { echo "::error::binary is not x86_64"; exit 1; }
+          echo "Frameworks bundled:"; ls -la "$APP/Contents/Frameworks/" || true
+          echo "onnxruntime linkage:"; otool -L "$BIN" | grep -i onnxruntime || { echo "::error::binary not linked against onnxruntime"; exit 1; }
+          ls "$APP/Contents/Frameworks/" | grep -qi onnxruntime || { echo "::error::onnxruntime dylib missing from Frameworks/"; exit 1; }
+          echo "macOS Intel ONNX Runtime bundling verified."
 
       - name: Copy Windows artifacts into workspace
         if: ${{ matrix.os == 'windows' }}

--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -54,7 +54,9 @@ jobs:
             artifactSuffix: 'macos-arm64'
             rustTargets: 'aarch64-apple-darwin'
 
-          - platform: 'ubuntu-24.04'
+          # Linux on Blacksmith: GA drop-in runner, same base image as GitHub-hosted
+          # ubuntu-24.04. `os: 'linux'` still drives every apt/Vulkan/FUSE step.
+          - platform: 'blacksmith-8vcpu-ubuntu-2404'
             os: 'linux'
             tauriArgs: ''
             artifactSuffix: 'linux'

--- a/.github/workflows/release.whispering.yml
+++ b/.github/workflows/release.whispering.yml
@@ -62,8 +62,10 @@ jobs:
             tauriArgs: '--target aarch64-apple-darwin'
             rustTargets: 'aarch64-apple-darwin'
 
-          # Linux (Ubuntu)
-          - platform: 'ubuntu-24.04'
+          # Linux (Ubuntu) on Blacksmith: GA drop-in runner, same base image as
+          # GitHub-hosted ubuntu-24.04. The `os: 'linux'` field below still drives
+          # every apt/Vulkan/FUSE conditional step, so only the runner changes.
+          - platform: 'blacksmith-8vcpu-ubuntu-2404'
             os: 'linux'
             tauriArgs: ''  # No specific target needed for Linux
             rustTargets: ''


### PR DESCRIPTION
Whispering's desktop CI has two separate pressures: Linux builds should move onto the faster Blacksmith runner now, while macOS Intel support needs a careful preview-only probe before it can become a release artifact.

```txt
Preview workflow
  macOS arm64   -> Blacksmith macOS runner    -> existing preview artifact
  macOS Intel   -> Blacksmith macOS runner    -> cross-compile probe only
  Linux         -> Blacksmith Ubuntu runner   -> normal preview artifact
  Windows       -> GitHub Windows runner      -> unchanged

Release workflow
  macOS arm64   -> existing release path
  Linux         -> Blacksmith Ubuntu runner
  Windows       -> GitHub Windows runner
  macOS Intel   -> absent until ORT is owned and hardware is verified
```

The Linux part is the durable change. Both `pr-preview.whispering.yml` and `release.whispering.yml` now run the Linux build row on `blacksmith-8vcpu-ubuntu-2404` instead of GitHub-hosted `ubuntu-24.04`. The matrix still says `os: 'linux'`, so the existing apt, Vulkan SDK, FUSE, and AppImage conditionals stay on the same path; only the runner label changes.

```txt
Before
  Linux build -> ubuntu-24.04 -> os: linux conditionals

After
  Linux build -> blacksmith-8vcpu-ubuntu-2404 -> same os: linux conditionals
```

---

**The Intel macOS row is a preview-only spike, not a release path.**

The preview workflow now tries `x86_64-apple-darwin` from the Apple Silicon Blacksmith runner. A plain matrix row is not enough here: the `onnx` and `ort-coreml` features need an architecture-matched ONNX Runtime, and the `ort 2.0.0-rc.12` line expects ORT 1.24.x. Since there is no official x86_64 macOS prebuilt for that combination, the workflow temporarily downloads Handy's community 1.24.2 build, points `ort-sys` at it with `ORT_LIB_LOCATION` and `ORT_PREFER_DYNAMIC_LINK`, and patches `tauri.conf.json` so the dylib is bundled into the `.app`.

```txt
macOS Intel preview build
  -> download x86_64 ONNX Runtime 1.24.2 dylib
  -> export ORT_LIB_LOCATION
  -> export ORT_PREFER_DYNAMIC_LINK=1
  -> patch tauri.conf.json bundle.macOS.frameworks
  -> tauri build --target x86_64-apple-darwin --no-sign
  -> verify binary arch, otool linkage, and bundled Frameworks dylib
```

The verify step is intentionally strict. It checks that the generated binary is x86_64, that `otool` sees the ONNX Runtime linkage, and that the dylib made it into `Contents/Frameworks`. A failed cross-compile is useful signal for this PR; a silently wrong artifact is not.

---

**Release stays conservative.**

Intel macOS is not added to `release.whispering.yml` because the spike depends on `blob.handy.computer`. Promoting it to release should wait until Epicenter hosts its own x86_64 ORT build and someone verifies the artifact on real Intel hardware, especially with #1166 still open.

```txt
Can merge now
  |-- Linux runner change in preview and release
  `-- Intel preview probe with a temporary ORT source

Must wait
  |-- Intel release row
  |-- Epicenter-owned x86_64 ORT artifact
  `-- real Intel Mac validation for the recording path
```

Windows also stays on GitHub-hosted `windows-latest`; this PR only moves Linux to Blacksmith and probes the Intel preview path.