### PR TITLE
feat(whispering): write recordings to Markdown sidecars as you capture them

### DIFF
--- a/apps/fuji/src/lib/workspace/project.ts
+++ b/apps/fuji/src/lib/workspace/project.ts
@@ -26,15 +26,14 @@ import {
 	readRoomOverHttp,
 } from '@epicenter/workspace';
 import { defineSessionMount } from '@epicenter/workspace/daemon';
-import {
-	attachGitAutosave,
-	attachMarkdownExport,
-	type GitAutosaveConfig,
-} from '@epicenter/workspace/document/materializer/markdown';
+import { attachMarkdownExport } from '@epicenter/workspace/document/materializer/markdown';
 import { attachBunSqliteMaterializer } from '@epicenter/workspace/document/materializer/sqlite';
 import {
+	attachGitAutosave,
 	attachMountInfrastructure,
+	type GitAutosaveConfig,
 	mountMarkdownPath,
+	nodeMarkdownDeps,
 	sqlitePath,
 } from '@epicenter/workspace/node';
 import { createLogger } from 'wellcrafted/logger';
@@ -83,6 +82,7 @@ export function fuji(opts: FujiMountOptions = {}) {
 
 			const markdown = attachMarkdownExport(workspace, {
 				dir: mdDir,
+				...nodeMarkdownDeps,
 				log: createLogger(`${mount}-markdown`),
 				tables: {
 					entries: {

--- a/apps/honeycrisp/project.ts
+++ b/apps/honeycrisp/project.ts
@@ -11,15 +11,14 @@
 import { EPICENTER_API_URL } from '@epicenter/constants/apps';
 import { defineActions, defineWorkspace } from '@epicenter/workspace';
 import { defineSessionMount } from '@epicenter/workspace/daemon';
-import {
-	attachGitAutosave,
-	attachMarkdownExport,
-	type GitAutosaveConfig,
-} from '@epicenter/workspace/document/materializer/markdown';
+import { attachMarkdownExport } from '@epicenter/workspace/document/materializer/markdown';
 import { attachBunSqliteMaterializer } from '@epicenter/workspace/document/materializer/sqlite';
 import {
+	attachGitAutosave,
 	attachMountInfrastructure,
+	type GitAutosaveConfig,
 	mountMarkdownPath,
+	nodeMarkdownDeps,
 	sqlitePath,
 } from '@epicenter/workspace/node';
 import { createLogger } from 'wellcrafted/logger';
@@ -46,6 +45,7 @@ export function honeycrisp(opts: HoneycrispMountOptions = {}) {
 
 			const markdown = attachMarkdownExport(workspace, {
 				dir: mdDir,
+				...nodeMarkdownDeps,
 				tables: { notes: {} },
 			});
 			if (opts.git) {

--- a/apps/tab-manager/project.ts
+++ b/apps/tab-manager/project.ts
@@ -9,15 +9,14 @@
 import { EPICENTER_API_URL } from '@epicenter/constants/apps';
 import { defineActions, defineWorkspace } from '@epicenter/workspace';
 import { defineSessionMount } from '@epicenter/workspace/daemon';
-import {
-	attachGitAutosave,
-	attachMarkdownExport,
-	type GitAutosaveConfig,
-} from '@epicenter/workspace/document/materializer/markdown';
+import { attachMarkdownExport } from '@epicenter/workspace/document/materializer/markdown';
 import { attachBunSqliteMaterializer } from '@epicenter/workspace/document/materializer/sqlite';
 import {
+	attachGitAutosave,
 	attachMountInfrastructure,
+	type GitAutosaveConfig,
 	mountMarkdownPath,
+	nodeMarkdownDeps,
 	sqlitePath,
 } from '@epicenter/workspace/node';
 import { createLogger } from 'wellcrafted/logger';
@@ -48,6 +47,7 @@ export function tabManager(opts: TabManagerMountOptions = {}) {
 			});
 			const markdown = attachMarkdownExport(workspace, {
 				dir: mdDir,
+				...nodeMarkdownDeps,
 				tables: {
 					bookmarks: {},
 					devices: {},

--- a/apps/whispering/src/lib/whispering/whispering.tauri.ts
+++ b/apps/whispering/src/lib/whispering/whispering.tauri.ts
@@ -12,16 +12,22 @@ import {
 	defineMutation,
 	defineWorkspace,
 } from '@epicenter/workspace';
+import { attachMarkdownExport } from '@epicenter/workspace/document/materializer/markdown';
 import { open } from '@tauri-apps/plugin-dialog';
-import yaml from 'js-yaml';
 import {
 	defineErrors,
 	extractErrorMessage,
 	type InferErrors,
 } from 'wellcrafted/error';
+import { createLogger } from 'wellcrafted/logger';
 import { type Result, tryAsync } from 'wellcrafted/result';
+import { PATHS } from '$lib/services/fs-paths';
 import { commands } from '$lib/tauri/commands';
 import { createWhispering, type Recording } from '$lib/workspace';
+import {
+	assembleMarkdown,
+	tauriMarkdownDeps,
+} from '$lib/workspace/markdown-export-fs';
 
 const RecordingMarkdownExportError = defineErrors({
 	WriteFailed: ({ cause }: { cause: unknown }) => ({
@@ -32,6 +38,8 @@ const RecordingMarkdownExportError = defineErrors({
 type RecordingMarkdownExportError = InferErrors<
 	typeof RecordingMarkdownExportError
 >;
+
+const log = createLogger('whispering/markdown-export');
 
 type RecordingMarkdownExportResult =
 	| {
@@ -50,6 +58,44 @@ export function openWhispering() {
 
 	const idb = attachIndexedDb(workspace.ydoc);
 	attachBroadcastChannel(workspace.ydoc);
+
+	// Continuously materialize each recording to a plain-Markdown sidecar beside
+	// its audio in the appdata `recordings/` folder: `{id}.md` next to `{id}.wav`.
+	// One-way Yjs -> disk; the observer rewrites on edit and removes the file when
+	// a recording is deleted. This is the always-on counterpart to the manual
+	// `recordings_export_markdown` action below, which snapshots to a folder the
+	// user picks. Gated on local hydration so the first flush sees every recording,
+	// not an empty doc. The Rust artifact layer already preserves these sidecars
+	// when audio is cleared.
+	const recordingMarkdown = attachMarkdownExport(workspace, {
+		dir: () => PATHS.DB.RECORDINGS(),
+		...tauriMarkdownDeps,
+		waitFor: idb.whenLoaded,
+		log,
+		tables: {
+			recordings: {
+				// No per-table subdir: write straight into `recordings/` so the
+				// sidecar sits beside the audio file of the same id.
+				dir: '',
+				// Mirror the manual export's shape: the transcript is the file body,
+				// every other column is frontmatter.
+				toMarkdown: (recording) => {
+					const { transcript, ...frontmatter } = recording;
+					return { frontmatter, body: transcript || undefined };
+				},
+			},
+		},
+	});
+	// Per-row write failures log inside the export; a cold-start flush rejection
+	// (e.g. the batch write command erroring) surfaces here instead of as an
+	// unhandled rejection.
+	recordingMarkdown.whenFlushed.catch((cause) => {
+		log.warn(
+			new Error(
+				`initial recording markdown flush failed: ${extractErrorMessage(cause)}`,
+			),
+		);
+	});
 
 	return defineWorkspace({
 		...workspace,
@@ -81,10 +127,12 @@ export function openWhispering() {
 								.scan()
 								.rows.map((row: Recording) => {
 									const { transcript, ...frontmatter } = row;
-									const yamlStr = yaml.dump(frontmatter, { lineWidth: -1 });
 									return {
 										filename: `${row.id}.md`,
-										content: `---\n${yamlStr}---\n${transcript || ''}\n`,
+										content: assembleMarkdown(
+											frontmatter,
+											transcript || undefined,
+										),
 									};
 								});
 							const { error } = await commands.writeMarkdownFiles(

--- a/apps/whispering/src/lib/workspace/markdown-export-fs.ts
+++ b/apps/whispering/src/lib/workspace/markdown-export-fs.ts
@@ -1,0 +1,133 @@
+/**
+ * Tauri-backed injection deps for `attachMarkdownExport`: a `MarkdownExportFs`
+ * over `@tauri-apps/plugin-fs`, paired with a browser-safe `js-yaml` serializer.
+ *
+ * The workspace markdown engine carries no filesystem or YAML runtime of its own
+ * (see `@epicenter/workspace/document/materializer/markdown`); the daemon injects
+ * the `node:fs`/`Bun.YAML` pair, and the Whispering desktop app injects this one
+ * so it can continuously materialize recordings to disk inside the webview, where
+ * `node:*` and `bun` are unavailable.
+ *
+ * This module eagerly imports Tauri plugins, so it is only ever imported from
+ * `whispering.tauri.ts` (the desktop runtime), never from browser code.
+ */
+
+import type {
+	AssembleMarkdown,
+	MarkdownExportFs,
+} from '@epicenter/workspace/document/materializer/markdown';
+import { dirname, join } from '@tauri-apps/api/path';
+import {
+	exists,
+	mkdir,
+	readDir,
+	remove,
+	writeTextFile,
+} from '@tauri-apps/plugin-fs';
+import yaml from 'js-yaml';
+import { commands } from '$lib/tauri/commands';
+
+/** Resolve a "/"-relative export path to an absolute path under `baseDir`. */
+function toAbsolute(baseDir: string, relPath: string): Promise<string> {
+	return join(baseDir, ...relPath.split('/'));
+}
+
+/**
+ * List every file under `absDir`, recursively, as "/"-relative paths. Tauri's
+ * `readDir` is single-level, so the recursion is explicit. A missing directory
+ * resolves to `[]`, matching the engine's orphan-sweep contract.
+ */
+async function listFilesRecursive(absDir: string): Promise<string[]> {
+	let entries: Awaited<ReturnType<typeof readDir>>;
+	try {
+		entries = await readDir(absDir);
+	} catch {
+		return [];
+	}
+	const files: string[] = [];
+	for (const entry of entries) {
+		if (entry.isDirectory) {
+			const childDir = await join(absDir, entry.name);
+			for (const nested of await listFilesRecursive(childDir)) {
+				files.push(`${entry.name}/${nested}`);
+			}
+		} else {
+			files.push(entry.name);
+		}
+	}
+	return files;
+}
+
+/**
+ * The markdown export's filesystem surface, backed by `@tauri-apps/plugin-fs`.
+ * `writeFiles` routes a flat (leaf-filename) batch through the existing
+ * `write_markdown_files` Rust command for an atomic, single-invoke cold-start
+ * flush, falling back to per-file writes for any nested relPath.
+ */
+export function createTauriFs(): MarkdownExportFs {
+	const fs: MarkdownExportFs = {
+		async ensureDir(baseDir, subDir) {
+			const target = subDir ? await toAbsolute(baseDir, subDir) : baseDir;
+			await mkdir(target, { recursive: true });
+		},
+		async writeFile(baseDir, relPath, content) {
+			const abs = await toAbsolute(baseDir, relPath);
+			await mkdir(await dirname(abs), { recursive: true });
+			await writeTextFile(abs, content);
+		},
+		async removeFile(baseDir, relPath) {
+			// `exists` first so an already-gone file is a no-op, satisfying the
+			// engine's best-effort delete contract without swallowing real errors.
+			const abs = await toAbsolute(baseDir, relPath);
+			if (await exists(abs)) await remove(abs);
+		},
+		async listFiles(baseDir) {
+			return listFilesRecursive(baseDir);
+		},
+		async writeFiles(baseDir, files) {
+			const leaves = files.filter((file) => !file.relPath.includes('/'));
+			const nested = files.filter((file) => file.relPath.includes('/'));
+			if (leaves.length > 0) {
+				const { error } = await commands.writeMarkdownFiles(
+					baseDir,
+					leaves.map((file) => ({
+						filename: file.relPath,
+						content: file.content,
+					})),
+				);
+				if (error !== null) throw error;
+			}
+			for (const file of nested) {
+				await fs.writeFile(baseDir, file.relPath, file.content);
+			}
+		},
+	};
+	return fs;
+}
+
+/**
+ * Serialize frontmatter + body into a `---`-fenced markdown file using `js-yaml`
+ * (the browser-safe sibling of the daemon's `Bun.YAML` assembler). `skipInvalid`
+ * drops `undefined` frontmatter values, the same way the daemon assembler strips
+ * missing keys; `null` is preserved as YAML `null`.
+ */
+export const assembleMarkdown: AssembleMarkdown = (frontmatter, body) => {
+	const frontmatterYaml = yaml.dump(frontmatter, {
+		lineWidth: -1,
+		skipInvalid: true,
+	});
+	return `---\n${frontmatterYaml}---\n${body ?? ''}\n`;
+};
+
+/**
+ * The Tauri injection bundle for `attachMarkdownExport`. Spread into the options
+ * at the call site: `attachMarkdownExport(workspace, { dir, ...tauriMarkdownDeps,
+ * tables })`.
+ */
+export const tauriMarkdownDeps: {
+	fs: MarkdownExportFs;
+	assemble: AssembleMarkdown;
+} = {
+	fs: createTauriFs(),
+	assemble: assembleMarkdown,
+};

--- a/apps/wiki/src/lib/workspace/markdown.ts
+++ b/apps/wiki/src/lib/workspace/markdown.ts
@@ -14,6 +14,7 @@
  */
 
 import { attachMarkdownExport } from '@epicenter/workspace/document/materializer/markdown';
+import { nodeMarkdownDeps } from '@epicenter/workspace/node';
 import type { WikiWorkspace } from './index';
 
 /**
@@ -29,6 +30,7 @@ export function attachWikiVault(
 		{ ydoc: wiki.ydoc, tables: wiki.tables },
 		{
 			dir,
+			...nodeMarkdownDeps,
 			tables: {
 				types: {},
 				pages: {

--- a/packages/workspace/src/document/materializer/markdown/export.test.ts
+++ b/packages/workspace/src/document/materializer/markdown/export.test.ts
@@ -13,6 +13,7 @@ import { join } from 'node:path';
 import { field } from '@epicenter/field';
 import { createWorkspace, defineTable } from '../../../index.js';
 import { attachMarkdownExport } from './export.js';
+import { nodeMarkdownDeps } from './node-fs.js';
 
 const postsTable = defineTable({
 	id: field.string(),
@@ -49,6 +50,7 @@ describe('attachMarkdownExport', () => {
 		});
 		const exporter = attachMarkdownExport(workspace, {
 			dir: TEST_DIR,
+			...nodeMarkdownDeps,
 			tables: {
 				posts: { filename: (row) => `${row.title}-${row.id}.md` },
 			},
@@ -72,6 +74,7 @@ describe('attachMarkdownExport', () => {
 		});
 		const exporter = attachMarkdownExport(workspace, {
 			dir: TEST_DIR,
+			...nodeMarkdownDeps,
 			tables: {
 				posts: {
 					toMarkdown: (row) => ({
@@ -105,6 +108,7 @@ describe('attachMarkdownExport', () => {
 		});
 		const exporter = attachMarkdownExport(workspace, {
 			dir: TEST_DIR,
+			...nodeMarkdownDeps,
 			tables: { posts: { dir: 'published' } },
 		});
 		await exporter.whenFlushed;
@@ -129,6 +133,7 @@ describe('attachMarkdownExport', () => {
 			});
 			const exporter = attachMarkdownExport(workspace, {
 				dir: TEST_DIR,
+				...nodeMarkdownDeps,
 				tables: { posts: {} },
 			});
 
@@ -149,6 +154,7 @@ describe('attachMarkdownExport', () => {
 			});
 			const exporter = attachMarkdownExport(workspace, {
 				dir: TEST_DIR,
+				...nodeMarkdownDeps,
 				tables: { posts: {} },
 			});
 			await exporter.whenFlushed;
@@ -170,6 +176,7 @@ describe('attachMarkdownExport', () => {
 			});
 			const exporter = attachMarkdownExport(workspace, {
 				dir: TEST_DIR,
+				...nodeMarkdownDeps,
 				disposeTimeoutMs: 50,
 				tables: {
 					posts: { toMarkdown: () => new Promise<never>(() => {}) },
@@ -192,6 +199,7 @@ describe('attachMarkdownExport', () => {
 			});
 			const exporter = attachMarkdownExport(workspace, {
 				dir: TEST_DIR,
+				...nodeMarkdownDeps,
 				waitFor: gate.promise,
 				tables: { posts: {} },
 			});
@@ -220,6 +228,7 @@ describe('attachMarkdownExport', () => {
 			});
 			const exporter = attachMarkdownExport(workspace, {
 				dir: TEST_DIR,
+				...nodeMarkdownDeps,
 				tables: {
 					posts: { filename: () => '../../escape.md' },
 				},
@@ -250,6 +259,7 @@ describe('attachMarkdownExport', () => {
 			});
 			const exporter = attachMarkdownExport(workspace, {
 				dir: TEST_DIR,
+				...nodeMarkdownDeps,
 				tables: {
 					posts: { filename: () => '/tmp/epicenter-escape-absolute.md' },
 				},
@@ -272,6 +282,7 @@ describe('attachMarkdownExport', () => {
 			});
 			const exporter = attachMarkdownExport(workspace, {
 				dir: TEST_DIR,
+				...nodeMarkdownDeps,
 				tables: {
 					posts: { filename: (row) => `archive/${row.id}.md` },
 				},
@@ -295,6 +306,7 @@ describe('attachMarkdownExport', () => {
 			});
 			const exporter = attachMarkdownExport(workspace, {
 				dir: TEST_DIR,
+				...nodeMarkdownDeps,
 				tables: { posts: { dir: '../escape-dir' } },
 			});
 
@@ -314,6 +326,7 @@ describe('attachMarkdownExport', () => {
 		});
 		const exporter = attachMarkdownExport(workspace, {
 			dir: TEST_DIR,
+			...nodeMarkdownDeps,
 			tables: { posts: {} },
 		});
 		await exporter.whenFlushed;

--- a/packages/workspace/src/document/materializer/markdown/export.ts
+++ b/packages/workspace/src/document/materializer/markdown/export.ts
@@ -1,9 +1,6 @@
-import { mkdir, readdir, unlink, writeFile } from 'node:fs/promises';
-import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
 import { Type } from 'typebox';
 import { defineErrors, extractErrorMessage } from 'wellcrafted/error';
 import { createLogger, type Logger } from 'wellcrafted/logger';
-import { assembleMarkdown } from '../../../markdown/assemble-markdown.js';
 import { defineActions, defineMutation } from '../../../shared/actions.js';
 import type { MaybePromise } from '../../../shared/types.js';
 import type { BaseRow, Table } from '../../table.js';
@@ -25,6 +22,14 @@ import {
 // validated actions instead, never by editing the materialized `.md`. The sqlite
 // materializer is the read-only sibling for a relational projection.
 //
+// The engine carries NO filesystem or YAML runtime of its own: both the
+// `MarkdownExportFs` and the `assemble` serializer are injected. That keeps this
+// module free of any `node:*` or `bun` import, so it loads in a Tauri webview
+// (with a `@tauri-apps/plugin-fs` adapter) exactly as it does in the daemon (with
+// the node adapter). All path *policy* lives here (confinement, table scoping);
+// the adapter owns path *mechanics* (joining the "/"-relative path onto the base
+// directory with the platform separator) and the actual reads and writes.
+//
 // The observe/flush/rebuild machinery (materializeTable, rebuildTable) lives at
 // the bottom of this file: it was a shared substrate back when an editable vault
 // seam also consumed it; with that seam deleted, this export is its only caller,
@@ -37,9 +42,58 @@ export type MarkdownShape = {
 	body: string | undefined;
 };
 
+/**
+ * Serialize frontmatter + an optional body into a markdown file's contents.
+ * Injected so the engine carries no YAML runtime: the daemon passes the
+ * `Bun.YAML`-backed `assembleMarkdown`; a webview passes a browser-safe one.
+ */
+export type AssembleMarkdown = (
+	frontmatter: Record<string, unknown>,
+	body: string | undefined,
+) => string;
+
+/**
+ * The filesystem surface the markdown export writes through. Every `relPath` is a
+ * validated, "/"-separated path relative to `baseDir` with no `.`/`..` segment and
+ * no leading separator; the adapter translates "/" to the platform separator (and
+ * `listFiles` translates back). Keeping the surface to these few verbs lets one
+ * `node:fs`/`bun` adapter serve the daemon and a `@tauri-apps/plugin-fs` adapter
+ * serve the desktop app, with the confinement policy living in the engine, not
+ * duplicated per adapter.
+ */
+export interface MarkdownExportFs {
+	/** `mkdir -p` of `baseDir`, or of `baseDir/subDir` when `subDir` is given. */
+	ensureDir(baseDir: string, subDir?: string): Promise<void>;
+	/**
+	 * Write `content` at `baseDir/relPath`, creating any intermediate directories
+	 * the relPath implies (e.g. `archive/old.md`).
+	 */
+	writeFile(baseDir: string, relPath: string, content: string): Promise<void>;
+	/**
+	 * Remove `baseDir/relPath`. MUST resolve (not reject) when the file is already
+	 * gone; the engine treats deletes as best-effort.
+	 */
+	removeFile(baseDir: string, relPath: string): Promise<void>;
+	/**
+	 * Every file under `baseDir`, recursively, as "/"-relative paths. Resolves to
+	 * `[]` when `baseDir` does not exist. Drives the destructive rebuild's sweep.
+	 */
+	listFiles(baseDir: string): Promise<string[]>;
+	/**
+	 * Optional bulk write for the cold-start flush. Adapters that can batch (a
+	 * single Tauri invoke, `Bun.write`) implement it; the engine falls back to
+	 * looping `writeFile` when it is absent. Only ever called with a fresh,
+	 * rename-free set (the initial flush), so it carries no ordering obligation.
+	 */
+	writeFiles?(
+		baseDir: string,
+		files: ReadonlyArray<{ relPath: string; content: string }>,
+	): Promise<void>;
+}
+
 /** Per-table customization for the read-only export. Every field is optional. */
 export type ExportTableConfig<TRow extends BaseRow> = {
-	/** Subdirectory (joined onto the base `dir`) for this table. Default: `table.name`. */
+	/** Subdirectory (joined onto the base `dir`) for this table. Default: `table.name`. Pass `''` or `'.'` to write into the base dir directly. */
 	dir?: string;
 	/** Compute the on-disk filename for a row. Default: `${row.id}.md`. */
 	filename?: (row: TRow) => MaybePromise<string>;
@@ -77,6 +131,8 @@ export function attachMarkdownExport<TTableHandles extends TablesRecord>(
 	workspace: MaterializerInput<TTableHandles>,
 	{
 		dir,
+		fs,
+		assemble,
 		tables: tablesConfig,
 		waitFor,
 		disposeTimeoutMs = 10_000,
@@ -84,6 +140,10 @@ export function attachMarkdownExport<TTableHandles extends TablesRecord>(
 	}: {
 		/** Base output directory. A string or async getter for lazy path resolution. */
 		dir: string | (() => MaybePromise<string>);
+		/** Filesystem adapter (node/bun or Tauri). The engine carries none of its own. */
+		fs: MarkdownExportFs;
+		/** Frontmatter + body serializer. The engine carries no YAML runtime of its own. */
+		assemble: AssembleMarkdown;
 		/**
 		 * Per-table customization keyed by `workspace.tables` name. Presence selects:
 		 * only tables named here are exported. Pass `{}` for an entry to export with
@@ -120,15 +180,21 @@ export function attachMarkdownExport<TTableHandles extends TablesRecord>(
 				: `${row.id}.md`;
 			return {
 				filename,
-				content: assembleMarkdown(shape.frontmatter, shape.body),
+				content: assemble(shape.frontmatter, shape.body),
 			};
 		};
+		// Normalize the table's subdirectory: `''`/`'.'` mean "the base dir
+		// itself". A non-empty subdir is validated lazily, at flush time, so a bad
+		// `config.dir` surfaces through `whenFlushed` rather than throwing from this
+		// constructor.
+		const rawSubdir = config.dir ?? name;
+		const subdir = rawSubdir === '' || rawSubdir === '.' ? '' : rawSubdir;
 		registered.set(name, {
 			table: anyTable,
 			config,
 			fileState: new Map(),
 			render,
-			subdir: config.dir ?? name,
+			subdir,
 		});
 	}
 	let isDisposed = false;
@@ -191,12 +257,14 @@ export function attachMarkdownExport<TTableHandles extends TablesRecord>(
 		if (isFlushAbandoned) return;
 
 		const baseDir = await resolveDir();
-		await mkdir(baseDir, { recursive: true });
+		await fs.ensureDir(baseDir);
 
 		for (const entry of registered.values()) {
 			const unsubscribe = await materializeTable({
+				fs,
+				baseDir,
+				subdir: entry.subdir,
 				table: entry.table,
-				directory: confineToDir(baseDir, entry.subdir),
 				render: entry.render,
 				fileState: entry.fileState,
 				track: trackPendingWrite,
@@ -218,8 +286,10 @@ export function attachMarkdownExport<TTableHandles extends TablesRecord>(
 
 		async function rebuildOne(entry: RegisteredTable) {
 			return rebuildTable({
+				fs,
+				baseDir,
+				subdir: entry.subdir,
 				table: entry.table,
-				directory: confineToDir(baseDir, entry.subdir),
 				render: entry.render,
 				fileState: entry.fileState,
 				log,
@@ -280,7 +350,8 @@ export type MarkdownExport = ReturnType<typeof attachMarkdownExport>;
 // Materialize machinery: Yjs -> disk observe/flush/rebuild
 //
 // HOW a row renders to a file (custom filename + serialization) is injected as a
-// `RenderRow`; everything below is the generic write loop the export drives.
+// `RenderRow`; everything below is the generic write loop the export drives,
+// through the injected `MarkdownExportFs`.
 // ════════════════════════════════════════════════════════════════════════════
 
 /** Render a row to its on-disk artifact: the export's injected serialization. */
@@ -290,7 +361,7 @@ type RenderRow = (
 
 /**
  * What materialize last wrote for a row, keyed by id. Drives rename cleanup:
- * when a row's filename changes, unlink the previous file before writing the new
+ * when a row's filename changes, remove the previous file before writing the new
  * one so a rename does not leave an orphan behind.
  */
 type FileState = Map<string, { filename: string; content: string }>;
@@ -345,43 +416,44 @@ const MaterializerWriteError = defineErrors({
 });
 
 /**
- * Resolve an untrusted path `segment` (a table `dir`, or a row's rendered
- * filename, which may include subdirectories like `archive/old.md`) against a
- * trusted `root`, and return the absolute target only if it stays strictly
- * inside `root`. Throws otherwise.
+ * Validate a "/"-relative export path, the confinement boundary the export
+ * relies on now that the namespace root, not a hardcoded `apps/` segment, is the
+ * ownership claim. Rejects absolute paths (a leading separator or a Windows drive
+ * letter) and any `.`, `..`, or empty segment, so a `render` that returns
+ * `../../notes/x.md`, an absolute path, or a table `dir` of `..` can never resolve
+ * outside the export root (spec invariants 7 and 9). Both separators are checked
+ * defensively in case a renderer emits `\`.
  *
- * This is the confinement boundary the export relies on now that the namespace
- * root, not a hardcoded `apps/` segment, is the ownership claim. Every write and
- * every delete (initial flush, rename cleanup, and the `markdown_rebuild` sweep)
- * goes through here, so a `render` that returns `../../notes/x.md`, an absolute
- * path, or a table `dir` of `..` is rejected before it can touch disk outside the
- * mount projection (spec invariants 7 and 9).
- *
- * Throws a plain `Error` (not a `defineErrors` variant): these propagate through
- * the same throw/catch path as the rest of the write code, and a `defineErrors`
- * value is an `Err` Result meant for logging or returning, never for `throw`.
- *
- * An absolute `segment` is rejected outright: a relative join would drop the
- * leading slash, but an absolute filename is never legitimate output and signals
- * a broken renderer.
+ * Returns the "/"-normalized path so the adapter always receives one separator
+ * flavor. Throws a plain `Error` (not a `defineErrors` variant): these propagate
+ * through the same throw/catch path as the rest of the write code, and a
+ * `defineErrors` value is an `Err` Result meant for logging or returning, never
+ * for `throw`.
  */
-function confineToDir(root: string, segment: string): string {
-	const resolvedRoot = resolve(root);
-	const reject = () => {
-		throw new Error(
-			`[markdown] refusing path "${segment}": it resolves outside the export root "${resolvedRoot}"`,
-		);
-	};
-	if (isAbsolute(segment)) reject();
-	const target = resolve(resolvedRoot, segment);
-	const rel = relative(resolvedRoot, target);
-	// Inside the root iff the relative path neither climbs out (`..`) nor jumps
-	// to another absolute root (Windows drive change). An empty `rel` means the
-	// segment resolved to the root itself, which is also not a valid file target.
+function assertSafeRelPath(relPath: string): string {
+	const normalized = relPath.replace(/\\/g, '/');
+	const segments = normalized.split('/');
 	const escapes =
-		rel === '' || rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel);
-	if (escapes) reject();
-	return target;
+		normalized === '' ||
+		normalized.startsWith('/') ||
+		/^[A-Za-z]:/.test(normalized) ||
+		segments.some((s) => s === '' || s === '.' || s === '..');
+	if (escapes) {
+		throw new Error(
+			`[markdown] refusing path "${relPath}": it resolves outside the export root`,
+		);
+	}
+	return normalized;
+}
+
+/**
+ * Compose a table's subdirectory and a row's rendered filename into one validated
+ * "/"-relative path. The filename may itself contain subdirectories (e.g.
+ * `archive/old.md`); the whole composed path is validated, so an escaping filename
+ * is rejected before any byte is written.
+ */
+function joinRel(subdir: string, filename: string): string {
+	return assertSafeRelPath(subdir ? `${subdir}/${filename}` : filename);
 }
 
 /**
@@ -416,45 +488,28 @@ function logSkippedRows(
 }
 
 /**
- * Best-effort unlink of a file under `directory`; a missing file or a failed
- * remove is ignored. The target is confined to `directory` first, so a rename
- * whose previous filename somehow escaped can never delete outside the mount
- * projection (`confineToDir` throws, which propagates past the best-effort
- * catch deliberately: an escaping delete is a bug, not a routine miss).
+ * Best-effort remove of an already-confined `relPath` under `baseDir`; a missing
+ * file or a failed remove is ignored. The caller composes `relPath` through
+ * `joinRel` first, so an escaping previous filename throws there (before this
+ * best-effort catch): an escaping delete is a bug, not a routine miss.
  */
-async function tryUnlink(directory: string, filename: string): Promise<void> {
-	const fullPath = confineToDir(directory, filename);
+async function tryRemove(
+	fs: MarkdownExportFs,
+	baseDir: string,
+	relPath: string,
+): Promise<void> {
 	try {
-		await unlink(fullPath);
+		await fs.removeFile(baseDir, relPath);
 	} catch {
 		// already gone, or the remove failed; nothing to do
 	}
 }
 
 /**
- * Write a markdown file under `directory`, creating any intermediate
- * subdirectories implied by a filename like `"archive/old.md"`. The resolved
- * target is confined to `directory`; a filename that escapes (`../x.md`, an
- * absolute path) is rejected before any directory is created or any byte is
- * written.
- */
-async function writeMarkdownFile(
-	directory: string,
-	filename: string,
-	content: string,
-): Promise<void> {
-	const fullPath = confineToDir(directory, filename);
-	const parent = dirname(fullPath);
-	if (parent !== resolve(directory)) {
-		await mkdir(parent, { recursive: true });
-	}
-	await writeFile(fullPath, content);
-}
-
-/**
- * Continuously materialize one table to `directory`: an initial flush of every
- * valid row, then an observe that rewrites a row's file on change and unlinks it
- * when the row goes invalid or is deleted. Returns the observer unsubscribe.
+ * Continuously materialize one table under `baseDir/subdir`: an initial flush of
+ * every valid row, then an observe that rewrites a row's file on change and
+ * removes it when the row goes invalid or is deleted. Returns the observer
+ * unsubscribe.
  *
  * Only CONTENT PRODUCTION is guarded: a throwing `render` (e.g. a body read
  * hitting its connect deadline) skips that one row and leaves its existing `.md`
@@ -463,17 +518,24 @@ async function writeMarkdownFile(
  * the initial flush rejects and the observer's outer catch surfaces it.
  */
 async function materializeTable(opts: {
+	fs: MarkdownExportFs;
+	baseDir: string;
+	subdir: string;
 	table: AnyTable;
-	directory: string;
 	render: RenderRow;
 	fileState: FileState;
 	/** Register an observer batch with the attachment's teardown drain. */
 	track: (work: Promise<void>) => void;
 	log: Logger;
 }): Promise<() => void> {
-	const { table, directory, render, fileState, track, log } = opts;
+	const { fs, baseDir, subdir, table, render, fileState, track, log } = opts;
 
-	await mkdir(directory, { recursive: true });
+	// Validate the table's subdir here (not at registration) so an escaping
+	// `config.dir` rejects through `whenFlushed` instead of throwing from the
+	// constructor, and never reaches `ensureDir` to create a directory outside
+	// the export root.
+	if (subdir) assertSafeRelPath(subdir);
+	await fs.ensureDir(baseDir, subdir || undefined);
 
 	// Write one valid row to disk, shared by the initial flush and the observer.
 	// The rename branch is a no-op on first write (`fileState` starts empty), so
@@ -495,16 +557,48 @@ async function materializeTable(opts: {
 		const { filename, content } = rendered;
 		const previous = fileState.get(id);
 		if (previous && previous.filename !== filename) {
-			await tryUnlink(directory, previous.filename);
+			await tryRemove(fs, baseDir, joinRel(subdir, previous.filename));
 		}
-		await writeMarkdownFile(directory, filename, content);
+		await fs.writeFile(baseDir, joinRel(subdir, filename), content);
 		fileState.set(id, { filename, content });
 	}
 
 	const initialScan = table.scan();
 	logSkippedRows(log, table.name, initialScan);
-	for (const row of initialScan.rows) {
-		await writeRow(row.id, row);
+
+	// Cold-start flush. `fileState` is empty, so there are no renames to sequence:
+	// when the adapter can batch, render the whole set and hand it over in one call
+	// (one Tauri invoke instead of N), else fall back to the per-row path.
+	if (fs.writeFiles && initialScan.rows.length > 0) {
+		const batch: { id: string; filename: string; content: string }[] = [];
+		for (const row of initialScan.rows) {
+			try {
+				const rendered = await render(row);
+				batch.push({ id: row.id, ...rendered });
+			} catch (cause) {
+				log.warn(
+					MaterializerWriteError.TableWriteFailed({
+						tableName: table.name,
+						id: row.id,
+						cause,
+					}),
+				);
+			}
+		}
+		await fs.writeFiles(
+			baseDir,
+			batch.map((b) => ({
+				relPath: joinRel(subdir, b.filename),
+				content: b.content,
+			})),
+		);
+		for (const b of batch) {
+			fileState.set(b.id, { filename: b.filename, content: b.content });
+		}
+	} else {
+		for (const row of initialScan.rows) {
+			await writeRow(row.id, row);
+		}
 	}
 
 	// Sequential writes inside the observer avoid rename races; a parallel
@@ -514,11 +608,11 @@ async function materializeTable(opts: {
 			for (const id of changedIds) {
 				const { data: row, error } = table.get(id);
 
-				// Invalid or missing → unlink any previously-written file.
+				// Invalid or missing → remove any previously-written file.
 				if (error || row === null) {
 					const previous = fileState.get(id);
 					if (previous) {
-						await tryUnlink(directory, previous.filename);
+						await tryRemove(fs, baseDir, joinRel(subdir, previous.filename));
 						fileState.delete(id);
 					}
 					continue;
@@ -541,22 +635,28 @@ async function materializeTable(opts: {
 }
 
 /**
- * Destructive re-export of one table to `directory`: render every valid row
- * BEFORE touching disk (a throwing render aborts the rebuild with the existing
- * files intact, rather than deleting everything and then failing to rewrite),
- * then sweep existing `.md` files and write the rendered set. Updates `fileState`
- * so the live observer stays consistent.
+ * Destructive re-export of one table under `baseDir/subdir`: render every valid
+ * row BEFORE touching disk (a throwing render aborts the rebuild with the existing
+ * files intact, rather than deleting everything and then failing to rewrite), then
+ * sweep the existing `.md` files in this table's subtree and write the rendered
+ * set. Updates `fileState` so the live observer stays consistent.
  */
 async function rebuildTable(opts: {
+	fs: MarkdownExportFs;
+	baseDir: string;
+	subdir: string;
 	table: AnyTable;
-	directory: string;
 	render: RenderRow;
 	fileState: FileState;
 	log: Logger;
 }): Promise<{ deleted: number; written: number }> {
-	const { table, directory, render, fileState, log } = opts;
+	const { fs, baseDir, subdir, table, render, fileState, log } = opts;
 	let deleted = 0;
 	let written = 0;
+
+	// Confine the subdir before any sweep or write, so a rebuild of an
+	// escaping-`dir` table cannot delete or create outside the export root.
+	if (subdir) assertSafeRelPath(subdir);
 
 	const scan = table.scan();
 	logSkippedRows(log, table.name, scan);
@@ -566,35 +666,33 @@ async function rebuildTable(opts: {
 		rendered.push({ id: row.id, filename: r.filename, content: r.content });
 	}
 
-	try {
-		const files = await readdir(directory, { recursive: true });
-		for (const filename of files) {
-			if (!filename.endsWith('.md')) continue;
-			// Confine every swept path to `directory`. readdir entries are relative
-			// to it and so resolve inside under normal conditions; confinement is the
-			// guard for a symlink or other entry that resolves out of the projection.
-			// An escaping entry is skipped, not unlinked (spec invariant 9).
-			let path: string;
-			try {
-				path = confineToDir(directory, filename);
-			} catch {
-				continue;
-			}
-			await unlink(path).then(
-				() => {
-					deleted++;
-				},
-				() => undefined,
-			);
+	// Sweep existing `.md` files in this table's subtree. `listFiles` returns
+	// "/"-relative paths under `baseDir`; scope to this table by its subdir prefix
+	// (empty subdir = the base dir, so every file is in scope, matching the old
+	// per-table-directory readdir). An entry that fails confinement (a symlink
+	// resolving out of the projection) is skipped, not removed (spec invariant 9).
+	const prefix = subdir ? `${subdir}/` : '';
+	for (const rel of await fs.listFiles(baseDir)) {
+		if (!rel.endsWith('.md')) continue;
+		if (prefix && !rel.startsWith(prefix)) continue;
+		let safe: string;
+		try {
+			safe = assertSafeRelPath(rel);
+		} catch {
+			continue;
 		}
-	} catch {
-		// Directory doesn't exist yet. Fine.
+		try {
+			await fs.removeFile(baseDir, safe);
+			deleted++;
+		} catch {
+			// best-effort: a file that vanished or failed to remove is not fatal
+		}
 	}
 
 	fileState.clear();
-	await mkdir(directory, { recursive: true });
+	await fs.ensureDir(baseDir, subdir || undefined);
 	for (const { id, filename, content } of rendered) {
-		await writeMarkdownFile(directory, filename, content);
+		await fs.writeFile(baseDir, joinRel(subdir, filename), content);
 		fileState.set(id, { filename, content });
 		written++;
 	}

--- a/packages/workspace/src/document/materializer/markdown/git.test.ts
+++ b/packages/workspace/src/document/materializer/markdown/git.test.ts
@@ -31,7 +31,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Logger } from 'wellcrafted/logger';
 import { createWorkspace } from '../../../index.js';
-import { attachGitAutosave, type GitAutosaveConfig } from './index.js';
+import { attachGitAutosave, type GitAutosaveConfig } from './git-autosave.js';
 
 type GitResult = {
 	exitCode: number;

--- a/packages/workspace/src/document/materializer/markdown/index.ts
+++ b/packages/workspace/src/document/materializer/markdown/index.ts
@@ -1,12 +1,13 @@
+// Webview-safe barrel: the export engine carries no `node:*`/`bun` import, so it
+// loads in a Tauri webview as readily as in the daemon. The node/bun-only pieces
+// (the `createNodeFs` adapter, `attachGitAutosave`) are exported from
+// `@epicenter/workspace/node` instead, to keep them out of browser bundles.
 export {
+	type AssembleMarkdown,
 	attachMarkdownExport,
 	type ExportTableConfig,
 	type ExportTablesConfig,
 	type MarkdownExport,
+	type MarkdownExportFs,
 	type MarkdownShape,
 } from './export.js';
-export {
-	attachGitAutosave,
-	type GitAutosave,
-	type GitAutosaveConfig,
-} from './git-autosave.js';

--- a/packages/workspace/src/document/materializer/markdown/node-fs.ts
+++ b/packages/workspace/src/document/materializer/markdown/node-fs.ts
@@ -1,0 +1,68 @@
+/**
+ * Node/Bun filesystem adapter for the markdown export, plus the convenience
+ * `nodeMarkdownDeps` bundle that pairs it with the `Bun.YAML`-backed serializer.
+ *
+ * This module imports `node:*` (and, through `assembleMarkdown`, `bun`), so it is
+ * exported only from `@epicenter/workspace/node`, never from the webview-safe
+ * markdown barrel. A Tauri webview supplies its own `MarkdownExportFs` instead
+ * (see Whispering's `createTauriFs`).
+ */
+
+import { mkdir, readdir, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, sep } from 'node:path';
+import { assembleMarkdown } from '../../../markdown/assemble-markdown.js';
+import type { AssembleMarkdown, MarkdownExportFs } from './export.js';
+
+/** Join a "/"-relative export path onto a base dir with the platform separator. */
+function toAbsolute(baseDir: string, relPath: string): string {
+	return join(baseDir, ...relPath.split('/'));
+}
+
+/**
+ * The markdown export's filesystem surface, backed by `node:fs/promises`. Bun
+ * implements the same `node:fs` API, so this one adapter serves both runtimes;
+ * there is no separate Bun adapter unless `Bun.write` throughput ever warrants it.
+ */
+export function createNodeFs(): MarkdownExportFs {
+	return {
+		async ensureDir(baseDir, subDir) {
+			const target = subDir ? toAbsolute(baseDir, subDir) : baseDir;
+			await mkdir(target, { recursive: true });
+		},
+		async writeFile(baseDir, relPath, content) {
+			const abs = toAbsolute(baseDir, relPath);
+			await mkdir(dirname(abs), { recursive: true });
+			await writeFile(abs, content);
+		},
+		async removeFile(baseDir, relPath) {
+			// `force` makes an already-gone file a no-op, satisfying the engine's
+			// best-effort delete contract; other errors propagate to its catch.
+			await rm(toAbsolute(baseDir, relPath), { force: true });
+		},
+		async listFiles(baseDir) {
+			try {
+				const entries = await readdir(baseDir, { recursive: true });
+				// `readdir` returns platform-separated paths relative to baseDir;
+				// normalize to the engine's "/" canon. Directory entries are harmless:
+				// the engine filters to `.md`, and a remove of a stray dir is caught.
+				return entries.map((e) => e.split(sep).join('/'));
+			} catch {
+				// baseDir does not exist yet.
+				return [];
+			}
+		},
+	};
+}
+
+/**
+ * The node/bun injection bundle for `attachMarkdownExport`: the node filesystem
+ * adapter paired with the `Bun.YAML` serializer. Spread into the options at a call
+ * site: `attachMarkdownExport(workspace, { dir, ...nodeMarkdownDeps, tables })`.
+ */
+export const nodeMarkdownDeps: {
+	fs: MarkdownExportFs;
+	assemble: AssembleMarkdown;
+} = {
+	fs: createNodeFs(),
+	assemble: assembleMarkdown,
+};

--- a/packages/workspace/src/node.ts
+++ b/packages/workspace/src/node.ts
@@ -75,6 +75,15 @@ export {
 	type YjsLogReaderAttachment,
 } from './document/attach-yjs-log-reader.js';
 export {
+	attachGitAutosave,
+	type GitAutosave,
+	type GitAutosaveConfig,
+} from './document/materializer/markdown/git-autosave.js';
+export {
+	createNodeFs,
+	nodeMarkdownDeps,
+} from './document/materializer/markdown/node-fs.js';
+export {
 	type OpenSqliteReaderOptions,
 	openSqliteReader,
 	type SqliteReader,


### PR DESCRIPTION
Whispering kept every transcript inside the app's IndexedDB. The only way to get a plain file out was the manual "Export recording markdown" action, which snapshots to a folder you pick and never updates again. So the files on disk were the audio (`recordings/{id}.wav`) and nothing else: the words themselves lived in a database only Whispering could open.

This makes the transcript a first-class file. Every recording is now continuously materialized to a plain `{id}.md` sidecar next to its audio in the appdata `recordings/` folder, one-way Yjs to disk: the observer rewrites the file when a recording is edited and removes it when the recording is deleted. The frontmatter is the recording's columns; the body is the transcript. The Rust artifact layer already preserves these sidecars when audio is cleared, so the two file types share a directory and a lifecycle cleanly.

The reason this could not just reuse the existing materializer: the markdown export engine in `@epicenter/workspace` statically imported `node:fs`, `node:path`, and (through `assembleMarkdown`) Bun's YAML, so it only ran in the daemon. A Tauri webview has none of those. So the engine is now environment-agnostic: it takes an injected filesystem adapter and serializer and carries no `node:*` or `bun` import of its own. Path policy (confinement, table scoping) stays in the engine as a pure `/`-relative validator; path mechanics (the platform join, the actual reads and writes) move to the adapter.

The daemon and CLI pass the node bundle; the desktop app passes a Tauri one:

```ts
// daemon / CLI (node and bun share one adapter)
import { nodeMarkdownDeps } from '@epicenter/workspace/node';
attachMarkdownExport(workspace, { dir, ...nodeMarkdownDeps, tables });

// Whispering desktop (Tauri webview, @tauri-apps/plugin-fs)
import { tauriMarkdownDeps } from '$lib/workspace/markdown-export-fs';
attachMarkdownExport(workspace, { dir, ...tauriMarkdownDeps, tables });
```

The adapter surface is four verbs plus one optional batch, expressed on `(baseDir, relPath)` pairs so the engine never touches an absolute platform path:

```ts
interface MarkdownExportFs {
  ensureDir(baseDir: string, subDir?: string): Promise<void>;
  writeFile(baseDir: string, relPath: string, content: string): Promise<void>;
  removeFile(baseDir: string, relPath: string): Promise<void>;
  listFiles(baseDir: string): Promise<string[]>;
  // optional: one batched cold-start flush. Tauri routes it through the
  // existing write_markdown_files Rust command; node loops writeFile.
  writeFiles?(
    baseDir: string,
    files: ReadonlyArray<{ relPath: string; content: string }>,
  ): Promise<void>;
}
```

Steady-state cost stays O(1) per change: the Yjs observer hands the engine the exact diff, so one edited row is one `writeFile`, not a re-dump of the table. The batch only fires once, on the initial flush.

### Breaking change

`attachMarkdownExport` now requires `fs` and `assemble`. Node behavior is unchanged; pass the bundle:

```ts
// before
attachMarkdownExport(workspace, { dir, tables });

// after
import { nodeMarkdownDeps } from '@epicenter/workspace/node';
attachMarkdownExport(workspace, { dir, ...nodeMarkdownDeps, tables });
```

`attachGitAutosave` moved from `@epicenter/workspace/document/materializer/markdown` to `@epicenter/workspace/node` (it is node/bun-only), so the markdown barrel is now safe to import from a webview.

## Changelog

- Whispering now saves every recording as a plain Markdown file next to its audio and keeps it in sync as you edit or delete recordings, so your transcripts are ordinary files on disk rather than rows in the app's database.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784052317&installation_id=128463665&pr_number=1981&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1981&signature=72d07abafa91ae69990d13eae5f939b682f72896f8112ecea18998814102f7cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->