### PR TITLE
ci(whispering): build Windows preview on Blacksmith

### DIFF
--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -138,12 +138,14 @@ jobs:
 
       # whisper-rs-sys runs bindgen, which needs libclang. GitHub-hosted
       # windows-latest preinstalls LLVM; the Blacksmith Windows image does not,
-      # so install it and point bindgen at it via LIBCLANG_PATH.
+      # so install it and point bindgen at it via LIBCLANG_PATH. Pin the version
+      # so a future LLVM release cannot silently break bindgen, matching the
+      # exact-version discipline of the Vulkan SDK step above.
       - name: Install LLVM (Windows, libclang for bindgen)
         if: ${{ matrix.os == 'windows' }}
         shell: pwsh
         run: |
-          choco install llvm --no-progress -y
+          choco install llvm --version=22.1.7 --no-progress -y
           "LIBCLANG_PATH=C:\Program Files\LLVM\bin" >> $env:GITHUB_ENV
 
       - name: setup bun

--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -75,7 +75,12 @@ jobs:
             artifactSuffix: 'linux'
             rustTargets: ''
 
-          - platform: 'windows-latest'
+          # Windows on Blacksmith: PREVIEW-ONLY beta-runner spike to cut the ~22m
+          # github-hosted build time. Windows Server 2025 image ships VS Build Tools
+          # 2022 (satisfies the MSVC dev-cmd step); Vulkan is still installed by the
+          # step below. `os: 'windows'` keeps driving every Windows-specific step.
+          # Release stays on github-hosted `windows-latest` until this is proven.
+          - platform: 'blacksmith-8vcpu-windows-2025'
             os: 'windows'
             tauriArgs: ''
             artifactSuffix: 'windows'

--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -136,6 +136,16 @@ jobs:
           New-Item -ItemType Directory -Force -Path $targetDir | Out-Null
           "CARGO_TARGET_DIR=$targetDir" >> $env:GITHUB_ENV
 
+      # whisper-rs-sys runs bindgen, which needs libclang. GitHub-hosted
+      # windows-latest preinstalls LLVM; the Blacksmith Windows image does not,
+      # so install it and point bindgen at it via LIBCLANG_PATH.
+      - name: Install LLVM (Windows, libclang for bindgen)
+        if: ${{ matrix.os == 'windows' }}
+        shell: pwsh
+        run: |
+          choco install llvm --no-progress -y
+          "LIBCLANG_PATH=C:\Program Files\LLVM\bin" >> $env:GITHUB_ENV
+
       - name: setup bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -121,12 +121,10 @@ jobs:
           "VULKAN_SDK=C:\VulkanSDK\$env:VULKAN_SDK_VERSION" >> $env:GITHUB_ENV
           "C:\VulkanSDK\$env:VULKAN_SDK_VERSION\Bin" >> $env:GITHUB_PATH
 
-      - name: Setup MSVC developer command prompt (Windows)
-        if: ${{ matrix.os == 'windows' }}
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
-
+      # No msvc-dev-cmd step: cargo and the cc crate locate the MSVC toolchain
+      # via vswhere at build time, so sourcing vcvars is unnecessary for the x64
+      # build (Handy ships the same whisper-rs-sys on x64 Windows without it).
+      # Dropping it also avoids the unmaintained, node20-only action.
       - name: Configure Windows native build
         if: ${{ matrix.os == 'windows' }}
         shell: pwsh


### PR DESCRIPTION
The Whispering preview matrix builds four targets. After #1979 moved Linux and both macOS targets to Blacksmith, github-hosted Windows was left as the long pole of every run: on the #1979 run it took 22m41s while every Blacksmith target finished in 3 to 6 minutes. This moves the **preview** Windows build to Blacksmith as well.

Proven on this branch:

| Windows runner | Build time |
| --- | --- |
| `blacksmith-8vcpu-windows-2025` (this PR) | 6m39s |
| `windows-latest` (before) | 22m41s |

About a 3.4x speedup, so 8 vCPU is already more than enough; 16 vCPU is available if we ever want it faster.

Two gaps had to be closed because the Blacksmith Windows image is deliberately slimmer than GitHub's:

- It ships **VS Build Tools 2022**, which satisfies the existing MSVC dev-cmd step, but it omits **LLVM**. `whisper-rs-sys` runs `bindgen`, which needs libclang, so without LLVM the build panicked with "Unable to find libclang". A Windows-only step now installs LLVM and exports `LIBCLANG_PATH` before the Tauri build.
- Vulkan is still provided by the existing self-install step (it is not preinstalled on either image), so nothing changed there.

The scope is intentionally bounded:

- **Preview only.** `release.whispering.yml` keeps building Windows on `windows-latest`.
- Blacksmith Windows is public beta, so the release workflow stays on the github-hosted runner until this has run green across more PRs and a Blacksmith-built artifact has been manually confirmed to run.

## Before promoting Windows to release

1. Several consecutive green preview runs on the Blacksmith Windows runner.
2. A manual run of the Blacksmith-built Windows installer confirming record to transcribe actually works on real x64 Windows (a faster but broken artifact is worthless).