### PR TITLE
ci: reduce obsolete workflow spend

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,7 +24,7 @@ Web apps (Cloudflare Workers) deploy **together in one workflow** because deploy
 | File | Trigger | What it does |
 |---|---|---|
 | `release.whispering.yml` | `v*` tags, manual | Builds Whispering for 3 platforms, publishes to GitHub Releases as draft. Includes code signing, notarization, and release notes from `docs/release-notes/`. |
-| `pr-preview.whispering.yml` | Pull requests | Builds Whispering for 3 platforms, uploads as PR artifacts. Cancels previous builds via concurrency groups. |
+| `pr-preview.whispering.yml` | Pull requests | Cancels previous runs via concurrency groups, then builds Whispering for 3 platforms only when the PR touches `apps/whispering/**` or `packages/**`. Uploads short-lived PR artifacts. |
 
 ### Web Deployment (Cloudflare Workers)
 
@@ -37,8 +37,8 @@ Web apps (Cloudflare Workers) deploy **together in one workflow** because deploy
 
 | File | Trigger | What it does |
 |---|---|---|
-| `ci.format.yml` | Push, pull requests | Runs `bun run lint:check` and `bun run typecheck`. |
-| `ci.autofix.yml` | Push, pull requests | Runs `bun run format` and commits fixes back via autofix-ci. |
+| `ci.format.yml` | Push to `main`, pull requests | Runs `bun run lint:check` and `bun run typecheck`. Cancels older runs for the same branch or PR. |
+| `ci.autofix.yml` | Push to `main`, pull requests | Runs `bun run format` and commits fixes back via autofix-ci. Cancels older runs for the same branch or PR. |
 
 ### Automation
 

--- a/.github/workflows/ci.autofix.yml
+++ b/.github/workflows/ci.autofix.yml
@@ -5,11 +5,16 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
   autofix:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci.format.yml
+++ b/.github/workflows/ci.format.yml
@@ -2,11 +2,17 @@ name: Code quality
 
 on:
   push:
+    branches: [main]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   quality:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -22,10 +28,6 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: 'package.json'
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Lint check

--- a/.github/workflows/deploy.cloudflare-preview.yml
+++ b/.github/workflows/deploy.cloudflare-preview.yml
@@ -17,6 +17,7 @@ jobs:
   preview:
     name: Deploy Previews
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -15,6 +15,7 @@ name: PR Preview Builds
 # - All workflow runs for the same PR share the same concurrency group (keyed by PR number)
 # - When a new run starts, GitHub Actions automatically cancels previous runs in that group
 # - The 'closed' trigger activates a fast dummy job that joins the concurrency group and triggers cancellation
+# - A cheap changed-files job decides whether the expensive 3-platform build is needed
 
 on:
   pull_request:
@@ -34,12 +35,38 @@ jobs:
   cancel-on-close:
     if: github.event.action == 'closed'
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
     steps:
       - run: echo "PR closed - cancelling in-progress builds via concurrency group"
 
+  changes:
+    if: github.event.action != 'closed'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    outputs:
+      build_preview: ${{ steps.changed_files.outputs.build_preview }}
+    steps:
+      - name: Check changed files
+        id: changed_files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          files=$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')
+
+          if echo "$files" | grep -Eq '^(apps/whispering/|packages/|\.github/workflows/pr-preview\.whispering\.yml$)'; then
+            echo "build_preview=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "build_preview=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # Main build job - runs on PR open and updates, skipped when PR is closed
   build-preview:
-    if: github.event.action != 'closed'
+    needs: changes
+    if: github.event.action != 'closed' && needs.changes.outputs.build_preview == 'true'
     permissions:
       contents: read
       pull-requests: write
@@ -82,6 +109,7 @@ jobs:
             rustTargets: ''
 
     runs-on: ${{ matrix.platform }}
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
 
@@ -276,3 +304,4 @@ jobs:
             target/release/bundle/**/*.exe
             target/release/bundle/**/*.msi
           if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -34,14 +34,14 @@ jobs:
   # any running builds for this PR, saving CI minutes
   cancel-on-close:
     if: github.event.action == 'closed'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - run: echo "PR closed - cancelling in-progress builds via concurrency group"
 
   changes:
     if: github.event.action != 'closed'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       pull-requests: read
@@ -55,9 +55,13 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          files=$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')
+          if ! files=$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename'); then
+            echo "::warning::Could not list PR files. Running preview build to avoid a false skip."
+            echo "build_preview=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-          if echo "$files" | grep -Eq '^(apps/whispering/|packages/|\.github/workflows/pr-preview\.whispering\.yml$)'; then
+          if echo "$files" | grep -Eq '^(apps/whispering/|packages/|package\.json$|bun\.lock$|tsconfig[^/]*\.json$|\.nvmrc$|\.github/workflows/pr-preview\.whispering\.yml$)'; then
             echo "build_preview=true" >> "$GITHUB_OUTPUT"
           else
             echo "build_preview=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
PR pushes and quick follow-up commits were running more workflow work than we need: stale quality jobs kept running, PR branch commits could run both push and pull-request quality checks, and Whispering preview builds could spend a full desktop matrix on changes that do not affect the app.

This keeps the merge checks intact while trimming waste. Quality workflows now cancel older runs for the same branch or PR, `ci.format.yml` only runs push checks on `main`, preview jobs have explicit timeouts, and Whispering PR previews use a cheap changed-files gate before starting the expensive three-platform Tauri build. The close-event cancellation path stays active so closing a PR can still stop an in-flight preview build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784053575&installation_id=128463665&pr_number=1983&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1983&signature=0f91cc00c09eb24094d6ba4dd806489781c0e49bb989510ba6c788e9edc9ff67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->