### PR TITLE
ci(whispering): drop msvc-dev-cmd from release Windows build

### DIFF
--- a/.github/workflows/release.whispering.yml
+++ b/.github/workflows/release.whispering.yml
@@ -128,12 +128,11 @@ jobs:
           "VULKAN_SDK=C:\VulkanSDK\$env:VULKAN_SDK_VERSION" >> $env:GITHUB_ENV
           "C:\VulkanSDK\$env:VULKAN_SDK_VERSION\Bin" >> $env:GITHUB_PATH
 
-      - name: Setup MSVC developer command prompt (Windows)
-        if: ${{ matrix.os == 'windows' }}
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
-
+      # No msvc-dev-cmd step: cargo and the cc crate locate the MSVC toolchain
+      # via vswhere at build time, so sourcing vcvars is unnecessary for the x64
+      # build (Handy ships the same whisper-rs-sys on windows-latest without it).
+      # Dropping it also sheds an unmaintained action that still runs on the
+      # deprecated node20. Verified green on the Blacksmith preview build first.
       - name: Configure Windows native build
         if: ${{ matrix.os == 'windows' }}
         shell: pwsh


### PR DESCRIPTION
Removes the `ilammy/msvc-dev-cmd` step from the release Windows build.

The reason for this shape is:

`cargo` and the `cc` crate locate the MSVC toolchain via `vswhere` at build time, so sourcing vcvars through this action is redundant for the x64 build. Removing it also sheds an action that is unmaintained (last release Jan 2024) and still declares `using: node20`, which GitHub deprecates on June 16 2026, so it cannot be fixed by bumping the version.

The reason for this shape is:

- Proven on the Blacksmith preview build: the same `whisper-rs-sys` compiled green with the action removed (PR #1982).
- The release job runs on `windows-latest`, where Handy ([cjpais/handy](https://github.com/cjpais/handy)) already ships this exact stack (Tauri + whisper-rs-sys + Vulkan) on x64 with no msvc-dev-cmd step.

The preview workflow's equivalent removal rides with #1982; this PR is scoped to `release.whispering.yml` only, so the two never touch the same file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784055965&installation_id=128463665&pr_number=1985&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1985&signature=41c95e0b8203e975b083f15a71e126a65eeb377ae9178232a9d2de8e7530e958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->