### PR TITLE
docs(spec): record Wave 3 decisions, the Wave 4 publish blocker, and mark Waves 1-2 landed

### DIFF
--- a/specs/20260614T120000-app-folder-as-root-and-jsrepo-blocks.md
+++ b/specs/20260614T120000-app-folder-as-root-and-jsrepo-blocks.md
@@ -178,7 +178,7 @@ DAEMON PATHS  already per-root (NO CHANGE)
 
 Sequenced so each wave is independently shippable and reviewable.
 
-### Wave 1: Projection convention + gitignore (behavior-preserving prep)
+### Wave 1: Projection convention + gitignore (behavior-preserving prep) [landed in #1980]
 
 1. Change the projection to root-relative. Mount factories pass `dir:
    epicenterRoot` (or a chosen content dir), letting the exporter's per-table
@@ -192,7 +192,7 @@ Sequenced so each wave is independently shippable and reviewable.
    Keep `.epicenter/.gitignore = *`. The jsrepo block MAY ship a tracked
    `.gitignore` for belt-and-suspenders, but vendored source is tracked by default.
 
-### Wave 2: Cardinality collapse (the #1957 idea, rebuilt against current main)
+### Wave 2: Cardinality collapse (the #1957 idea, rebuilt against current main) [landed in #1980]
 
 4. `loadEpicenterConfig` returns `Result<Mount>`. Accept a bare `Mount`, reject a
    `Mount[]` with a pointer to unwrap it. Move format validation
@@ -207,12 +207,44 @@ Sequenced so each wave is independently shippable and reviewable.
 7. `runUp` consumes the single outcome. `init` scaffolds a comment-only singular
    template. Update the 4 in-repo configs to `export default fuji()` etc.
 
-### Wave 3: Fan-out (opt-in, deferred)
+### Wave 3: Fan-out (opt-in, deferred until Wave 4 creates multiple installed apps)
 
-8. Keep `findEpicenterRoot` upward-only. Add an explicit `epicenter up --all`
-   (or the control-plane app) that scans down from a container, enumerates roots,
-   and supervises N daemons. This is the only scan-down path. Defer until daily
-   use demands it.
+The teardown and visibility sides are ALREADY container-global: `daemon ps`
+enumerates every running daemon for the user (`enumerateDaemons` over the runtime
+metadata dir) and `daemon down --all` stops them all in parallel. Only `up` is
+still single-root. Wave 3 closes that asymmetry by giving `up` the same fan-out
+the other two verbs already have.
+
+The one genuinely-new capability is downward discovery. `ps` / `down --all`
+enumerate RUNNING daemons from runtime metadata, but nothing is running before
+`up`, so `up --all` must enumerate ROOTS ON DISK by scanning down a container for
+`epicenter.config.ts`. Everything else (spawn, signal, teardown) reuses the
+existing single-root `daemon up`.
+
+8. Keep `findEpicenterRoot` upward-only. Add the explicit, opt-in scan-down
+   command. Decisions settled (2026-06-14):
+   - Process model: a FOREGROUND SUPERVISOR that spawns one child
+     `epicenter daemon up -C <root>` per discovered root, multiplexes their
+     stderr, propagates SIGINT/SIGTERM, and reports per-child health. Child
+     processes (not N mounts in one process) preserve the physical fault
+     isolation that is this topology's headline benefit, and reuse the
+     single-root lifecycle (lease, socket, metadata, teardown) unchanged.
+   - Partial failure: start-healthy-and-report. Start every root, keep the
+     healthy children running, report which failed and why; do not tear the
+     fleet down because one app failed to open.
+   - Discovery: this `--all` scan is the ONLY scan-down path. It descends from
+     the cwd container, stops descending at the first `epicenter.config.ts` on
+     each branch (a root is a leaf for this scan), and skips `.epicenter`,
+     `node_modules`, and `.git`.
+   - Naming forks on Open Question 2 (see below). A thin CLI fan-out is
+     `epicenter daemon up --all`, where `--all` is a PURE DISPATCH to a separate
+     `runSupervisor()`: it does not generalize `runUp`, so the single-root
+     `UpHandle` return is untouched and the array-of-one overload never returns.
+     A graduated control-plane gets its own noun, ultimately the app, not a flag.
+
+   Gate: defer until there are multiple installed apps to supervise. That
+   condition is downstream of Wave 4 (distribution), so Wave 4 precedes real
+   Wave 3 demand.
 
 ### Wave 4: jsrepo registry
 
@@ -254,8 +286,17 @@ Sequenced so each wave is independently shippable and reviewable.
 1. Projection visibility: gitignore the generated `.md` (default here) or let
    users commit their notes? Leaning gitignore + an explicit "export to tracked
    folder" action later.
-2. `--all` orchestrator: a CLI fan-out vs the separate control-plane app. Likely
-   start as a CLI command, graduate to the app.
+2. `--all` orchestrator: a thin CLI fan-out vs the separate control-plane app.
+   This fork is still live, and it controls Wave 3's NAME and whether the CLI
+   version is throwaway. Settled regardless of the fork (see Wave 3):
+   child-process supervision, start-healthy-and-report, and the downward-discovery
+   rules. What the fork still decides: if a control-plane app is coming
+   (persistent fleet state, auto-restart / start-on-login policy, a health UI,
+   cross-app queries through one surface), then a CLI `up --all` is throwaway
+   scaffolding and we should skip to the app. If "bring my apps up in one terminal
+   for dev" is the whole need, the `daemon up --all` dispatch is the complete
+   answer. Not decidable without living with multiple installed apps, which is the
+   Wave 3 gate.
 3. Keep the single-mount action prefix, or drop it for ergonomics?
 4. Registry hosting: GitHub-backed registry vs a custom HTTP registry for the
    first-party blocks.

--- a/specs/20260614T120000-app-folder-as-root-and-jsrepo-blocks.md
+++ b/specs/20260614T120000-app-folder-as-root-and-jsrepo-blocks.md
@@ -246,13 +246,63 @@ existing single-root `daemon up`.
    condition is downstream of Wave 4 (distribution), so Wave 4 precedes real
    Wave 3 demand.
 
-### Wave 4: jsrepo registry
+### Wave 4: jsrepo registry (BLOCKED on the npm publish pipeline)
 
-9. Spike: convert fuji into one vendored block in a registry repo with
-   `allowSubdirectories: true`. Prove end to end: `jsrepo add fuji` vendors the
-   folder, rewrites relative imports, installs npm deps, and `epicenter up`
-   inside it runs. Validate the gitignore story on a fresh clone.
-10. Convert honeycrisp, tab-manager, and the notes example to blocks.
+Audited 2026-06-14: the premise that "the framework stays an npm dependency;
+`jsrepo add` installs the npm packages" does NOT hold today. `jsrepo add fuji`
+cannot work end to end because the framework it would `npm install` is currently
+uninstallable. Two independent defects:
+
+DEFECT 1, incomplete publish set. `@epicenter/workspace` depends on
+`@epicenter/encryption`, `@epicenter/field`, `@epicenter/identity`,
+`@epicenter/sync`, `@epicenter/util`. Of these, `encryption`, `field`, `util`
+are `private: true` (so changesets skips them) and `identity` is non-private but
+was never given a changeset; all four are 404 on npm. Only `sync` and `workspace`
+are published. So installing `@epicenter/workspace` pulls four 404s.
+(`@epicenter/constants`, also `private: true`, blocks other apps the same way.)
+
+DEFECT 2, bun protocol strings ship unresolved. The published
+`@epicenter/workspace@0.1.0` manifest declares deps verbatim as
+`'@epicenter/sync': 'workspace:*'` and `wellcrafted: 'catalog:'`. The release
+path is `changeset version && changeset publish` (changesets over npm, per
+`.github/workflows/README.md`, which says not to run `bun publish` directly).
+`changeset version` rewrites `workspace:*` for managed packages, but `catalog:`
+is a bun-only protocol that neither changesets nor `npm publish` resolves, and no
+prepack step rewrites it. Every published `@epicenter/*` package with a
+`catalog:` dep therefore has a broken manifest.
+
+The block candidate is `examples/fuji/` (a clean Epicenter root:
+`epicenter.config.ts` + `export default fuji()`, its own gitignore and tsconfig),
+NOT the SvelteKit `apps/fuji`. But `examples/fuji` is stale: it predates this
+spec's merge (its `.gitignore` ignores the old `/fuji/` mount-name projection
+instead of the per-table `entries/` dir, and it cites the superseded layout spec
+`20260612T000201`). It needs a Wave 1 refresh regardless.
+
+Phased plan:
+
+9. PHASE 0 (prerequisite, the bulk of the work): make the `@epicenter/*` runtime
+   closure installable from npm. Two sub-decisions:
+   - Publish-the-closure vs bundle-the-closure. Either un-`private` and publish
+     `encryption`, `field`, `identity`, `util` (add them to the changesets
+     `fixed` group), or bundle them into `@epicenter/workspace` at build time so
+     they stop being separate npm deps. The spec names workspace, encryption, and
+     identity as the public framework, which argues for publishing those and
+     bundling the rest (`field`/`util` are implementation detail).
+   - Resolve `catalog:` (and any stray `workspace:*`) at publish: a catalog
+     rewrite step before `changeset publish` (a prepack rewrite, a changesets
+     catalog plugin, or a bun-publish-based tag step). Verify
+     `npm install @epicenter/workspace` in an empty dir actually resolves.
+   Until Phase 0 is green nothing downstream works, and the broken published
+   packages are a latent problem independent of jsrepo.
+10. PHASE 1 (jsrepo mechanics, de-riskable now WITHOUT npm): build the block over
+    a refreshed `examples/fuji`-shaped source with `allowSubdirectories: true`
+    and a `subdirectory: true` manifest, against locally-linked deps. Prove
+    vendoring rewrites relative imports and the gitignore story holds (vendored
+    source tracked; `.epicenter/` and `entries/` self-ignored).
+11. PHASE 2 (end to end, needs Phase 0 + 1): `jsrepo add fuji` in a real external
+    project; npm installs the framework; `epicenter daemon up` runs inside the
+    vendored folder. Validate on a fresh clone. This is the spec acceptance test.
+12. PHASE 3: convert honeycrisp, tab-manager, and the notes example to blocks.
 
 ## Edge Cases
 

--- a/specs/20260614T120000-app-folder-as-root-and-jsrepo-blocks.md
+++ b/specs/20260614T120000-app-folder-as-root-and-jsrepo-blocks.md
@@ -353,6 +353,31 @@ from `@epicenter/constants`. Then give `@epicenter/identity` a version and
 un-`private` `encryption` and `field`. After that the fuji block's npm closure is
 exactly workspace + field + (encryption, identity, sync transitively).
 
+### Publish policy (decided 2026-06-14)
+
+Mechanism: `bun publish` packs and uploads; `changeset version` owns version math
+and changelogs. `bun publish` resolves both `workspace:*` and `catalog:` at pack
+time (verified: it actively resolves `workspace:*`, erroring on identity's
+missing version), which is the fix for Defect 2. `changeset publish` (npm-based,
+the cause of the broken 0.1.0s) is replaced by a small script: version, then
+`bun publish` each bumped public package, then tag. GATE: before the first real
+publish, run `bun publish --dry-run` across the closure and confirm zero
+`catalog:` / `workspace:*` strings remain in the packed manifests.
+
+Versioning: stay 0.x (breaking changes are allowed pre-1.0). Default changesets
+to `patch`; use `minor` only for features or breaking changes; never `major` (a
+`major` changeset jumps 0.x to 1.0.0). Add `encryption`, `field`, `identity` to
+the changesets `fixed` group so the whole framework closure versions in lockstep
+with workspace / cli / sync / filesystem / skills / ui / svelte (one framework
+version; the known cost is version inflation and `field` / `encryption` jumping
+up to the group's current version).
+
+First correct publish: un-`private` `encryption` and `field`, add a `version` to
+`identity`, and add a `files` allowlist to each so published tarballs ship source
+(`src`), not tests or tsconfig. After correct versions are live, `npm deprecate`
+the broken `@epicenter/workspace@0.1.0`, `@epicenter/sync@0.1.0`, and
+`@epicenter/cli@0.1.0` with a pointer to `>=0.2.x`.
+
 ## Edge Cases
 
 - **clientID base.** `hashYDocClientId(path)` derives from the root path. More

--- a/specs/20260614T120000-app-folder-as-root-and-jsrepo-blocks.md
+++ b/specs/20260614T120000-app-folder-as-root-and-jsrepo-blocks.md
@@ -304,6 +304,55 @@ Phased plan:
     vendored folder. Validate on a fresh clone. This is the spec acceptance test.
 12. PHASE 3: convert honeycrisp, tab-manager, and the notes example to blocks.
 
+### Framework package decomposition (audited 2026-06-14)
+
+Before publishing anything, the package boundaries were traced (no dependency
+cycles; clean DAG). The framework is LAYERED, not flat, and the layering is what
+makes the boundaries correct:
+
+```txt
+encryption (no @epicenter deps)   identity (-> encryption)   foundation
+field (no @epicenter deps)                                   schema authoring
+sync (-> identity)                                           sync protocol
+workspace (-> encryption, field, identity, sync)             runtime / daemon
+```
+
+Proof the layering is real (not monorepo convenience): `auth` and `client`
+depend on `encryption` / `identity` / `sync` WITHOUT depending on `workspace`. So
+a mega-package (collapsing the foundation up into `workspace`) is REJECTED: it
+would force the auth client and the `client` package to drag the 14k-LOC
+workspace runtime just to get crypto and identity. The foundation sits BELOW
+workspace.
+
+Public framework set (publish these four; each is justified by multiple
+consumers that do not all route through workspace, so deprecation risk is low):
+- `@epicenter/encryption` (481 LOC): used by workspace, auth, server, identity.
+- `@epicenter/field` (866 LOC): used by workspace + 11 apps directly; the
+  schema-authoring surface (`field`, `Field`, `Kind`, `InstantString`, ...).
+- `@epicenter/identity` (64 LOC): used by 8+ packages; foundational. Missing a
+  `version` field today; add one.
+- `@epicenter/sync` (339 LOC): used by workspace, auth, server; already public.
+
+Do NOT publish (handle by shrinking the surface, not by committing a name):
+- `@epicenter/util` (61 LOC) is just `debounce()`. DISSOLVE into
+  `@epicenter/workspace` (all four importers already depend on workspace, so no
+  cycle). The `@epicenter/util` name never goes public.
+- `@epicenter/constants` (898 LOC) is Epicenter PRODUCT config (hosted API URLs,
+  OAuth, vite), not framework. Keep it internal. The fuji block couples to it
+  only for `EPICENTER_API_URL` (`apps/fuji/src/lib/workspace/project.ts`, used as
+  `baseURL` twice); decouple by injecting that URL as config so the block's
+  closure drops `constants`.
+
+False alarm checked: the published `@epicenter/cli` does NOT drag in apps.
+`@epicenter/api` / `honeycrisp` / `tab-manager` are devDependencies (tests), not
+runtime deps, and the CLI source never imports them.
+
+Two prep refactors precede the first publish (both reversible; nothing published
+yet): (1) dissolve `@epicenter/util` into workspace; (2) decouple the fuji block
+from `@epicenter/constants`. Then give `@epicenter/identity` a version and
+un-`private` `encryption` and `field`. After that the fuji block's npm closure is
+exactly workspace + field + (encryption, identity, sync transitively).
+
 ## Edge Cases
 
 - **clientID base.** `hashYDocClientId(path)` derives from the root path. More


### PR DESCRIPTION
Follow-up to #1980 (merged), which landed Waves 1 and 2 of the app-folder-as-root topology. Documentation only: updates `specs/20260614T120000-app-folder-as-root-and-jsrepo-blocks.md`.

## Wave 1 / Wave 2

Marked `[landed in #1980]`.

## Wave 3 (the `--all` fan-out): decisions recorded

- **Process model:** a foreground supervisor that spawns one child `epicenter daemon up -C <root>` per discovered root. Child processes (not N mounts in one process) preserve physical fault isolation and reuse the single-root lifecycle unchanged.
- **Partial failure:** start-healthy-and-report.
- **Discovery:** the `--all` scan is the only scan-down path; stops at the first config per branch; skips `.epicenter`, `node_modules`, `.git`.
- **Naming:** `daemon up --all` as a pure dispatch to a separate `runSupervisor()`, never generalizing `runUp`.
- Resolves the decided parts of **Open Question 2**.
- Records the asymmetry motivating Wave 3: `daemon ps` and `daemon down --all` are already container-global; only `up` is single-root.

Wave 3 stays **deferred**: real demand is downstream of Wave 4.

## Wave 4 (jsrepo distribution): BLOCKED on the npm publish pipeline

An audit found `jsrepo add fuji` cannot work end to end today because the `@epicenter/*` framework closure is uninstallable from npm:

- **Incomplete publish set:** `@epicenter/workspace` depends on `encryption`, `field`, `identity`, `util` (all 404 on npm: `private: true` or never changeset-published). Only `sync`/`workspace` ship.
- **Unresolved protocols:** published manifests ship `workspace:*` and `catalog:` verbatim. The release path is `changeset version && changeset publish` (changesets over npm), and `catalog:` is a bun-only protocol nothing in that path rewrites.

Wave 4 is rewritten as a four-phase plan gated on **Phase 0** (fix the publish pipeline: publish-or-bundle the closure, resolve `catalog:` at publish). Also records that the real block candidate is `examples/fuji` (currently stale, needs a Wave 1 refresh), not the SvelteKit `apps/fuji`.