### PR TITLE
ci(whispering): extract shared Tauri build setup into composite actions

### DIFF
--- a/.github/actions/process-whispering-appimage/action.yml
+++ b/.github/actions/process-whispering-appimage/action.yml
@@ -1,0 +1,46 @@
+name: Process Whispering AppImage
+description: >-
+  Strip libwayland-client.so out of the built Linux AppImage and repackage it.
+  Bundling that library breaks EGL on some Wayland systems with EGL_BAD_PARAMETER
+  (Whispering issues #114, #121); removing it lets the host's copy load instead.
+  Linux-only; call it from a step gated on the Linux runner.
+
+runs:
+  using: composite
+  steps:
+    - name: Install FUSE for AppImage processing
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y fuse libfuse2
+
+    - name: Remove libwayland-client.so from AppImage
+      shell: bash
+      run: |
+        APPIMAGE_PATH=$(find apps/whispering/src-tauri/target/release/bundle/appimage -name "*.AppImage" | head -1)
+
+        if [ -n "$APPIMAGE_PATH" ]; then
+          echo "Processing AppImage: $APPIMAGE_PATH"
+          chmod +x "$APPIMAGE_PATH"
+          cd "$(dirname "$APPIMAGE_PATH")"
+          APPIMAGE_NAME=$(basename "$APPIMAGE_PATH")
+          "./$APPIMAGE_NAME" --appimage-extract
+
+          echo "Removing libwayland-client.so files..."
+          find squashfs-root -name "libwayland-client.so*" -type f -delete
+
+          echo "Files remaining in lib directories:"
+          find squashfs-root -name "lib*" -type d | head -5 | while read dir; do
+            echo "Contents of $dir:"
+            ls "$dir" | grep -E "(wayland|fuse)" || echo "  No wayland/fuse libraries found"
+          done
+
+          wget -q https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+          chmod +x appimagetool-x86_64.AppImage
+          ARCH=x86_64 ./appimagetool-x86_64.AppImage --no-appstream squashfs-root "$APPIMAGE_NAME"
+          rm -rf squashfs-root appimagetool-x86_64.AppImage
+
+          echo "libwayland-client.so removed from AppImage successfully"
+        else
+          echo "No AppImage found to process"
+        fi

--- a/.github/actions/setup-whispering-build/action.yml
+++ b/.github/actions/setup-whispering-build/action.yml
@@ -1,0 +1,123 @@
+name: Setup Whispering build
+description: >-
+  Install every toolchain and native dependency the Whispering Tauri build needs
+  on macOS, Linux, and Windows, then build the SvelteKit frontend. This is the
+  shared setup half of both the preview and release workflows; their build,
+  signing, and packaging steps stay in the workflows themselves.
+
+inputs:
+  os:
+    description: 'macos | linux | windows'
+    required: true
+  rust-targets:
+    description: 'Extra rustup targets to install (e.g. aarch64-apple-darwin). Empty uses the host default.'
+    required: false
+    default: ''
+  windows-runner:
+    description: >-
+      The Windows runner label (matrix.platform). Used to decide whether LLVM
+      must be installed: github-hosted images preinstall it, Blacksmith images
+      do not.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Install create-dmg (macOS)
+      if: ${{ inputs.os == 'macos' }}
+      shell: bash
+      run: brew install create-dmg
+
+    - name: Install Linux build dependencies
+      if: ${{ inputs.os == 'linux' }}
+      shell: bash
+      run: |
+        sudo apt-get update
+        # libwebkit2gtk-4.1-dev: WebKit engine for Tauri v2
+        # libappindicator3-dev: system tray
+        # librsvg2-dev: SVG rendering
+        # patchelf: AppImage packaging
+        # libxdo-dev: keyboard/mouse automation
+        # libasound2-dev: audio
+        # libopenblas-dev: CPU BLAS for whisper
+        # libx11-dev / libxtst-dev / libxrandr-dev: X11 windowing, input, display
+        sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxdo-dev libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev
+
+    # Vulkan is the GPU backend for whisper-cpp and is not preinstalled on any
+    # runner image, so it is installed explicitly on Linux and Windows. The
+    # version is pinned so a registry change cannot move the build out from under us.
+    - name: Install Vulkan SDK (Linux)
+      if: ${{ inputs.os == 'linux' }}
+      shell: bash
+      run: |
+        wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
+        sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.290-noble.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-noble.list
+        sudo apt update
+        sudo apt install -y vulkan-sdk mesa-vulkan-drivers
+
+    - name: Install Vulkan SDK (Windows)
+      if: ${{ inputs.os == 'windows' }}
+      shell: pwsh
+      env:
+        VULKAN_SDK_VERSION: 1.3.290.0
+      run: |
+        $installer = Join-Path $env:RUNNER_TEMP "VulkanSDK-$env:VULKAN_SDK_VERSION.exe"
+        Invoke-WebRequest "https://sdk.lunarg.com/sdk/download/$env:VULKAN_SDK_VERSION/windows/VulkanSDK-$env:VULKAN_SDK_VERSION-Installer.exe" -OutFile $installer
+        Start-Process -FilePath $installer -ArgumentList "--accept-licenses --default-answer --confirm-command install" -Wait
+        "VULKAN_SDK=C:\VulkanSDK\$env:VULKAN_SDK_VERSION" >> $env:GITHUB_ENV
+        "C:\VulkanSDK\$env:VULKAN_SDK_VERSION\Bin" >> $env:GITHUB_PATH
+
+    # No MSVC setup step is needed: cargo and the cc crate locate the x64 MSVC
+    # toolchain via vswhere automatically, so the build never has to source vcvars.
+    - name: Shorten Windows build path
+      if: ${{ inputs.os == 'windows' }}
+      shell: pwsh
+      # whisper-rs-sys's cmake build creates paths that exceed Windows MAX_PATH,
+      # so redirect the cargo target dir to a short drive-root path (e.g. C:\t).
+      run: |
+        $drive = Split-Path -Qualifier $env:GITHUB_WORKSPACE
+        $targetDir = Join-Path $drive "t"
+        New-Item -ItemType Directory -Force -Path $targetDir | Out-Null
+        "CARGO_TARGET_DIR=$targetDir" >> $env:GITHUB_ENV
+
+    # whisper-rs-sys runs bindgen, which needs libclang. GitHub-hosted Windows
+    # images preinstall LLVM; Blacksmith images do not, so install it there and
+    # point bindgen at it via LIBCLANG_PATH. Pinned so a future LLVM release
+    # cannot silently break bindgen.
+    - name: Install LLVM for bindgen (Blacksmith Windows)
+      if: ${{ inputs.os == 'windows' && contains(inputs.windows-runner, 'blacksmith') }}
+      shell: pwsh
+      run: |
+        choco install llvm --version=22.1.7 --no-progress -y
+        "LIBCLANG_PATH=C:\Program Files\LLVM\bin" >> $env:GITHUB_ENV
+
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version-file: "package.json"
+
+    - name: Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: lts/*
+
+    - name: Install Rust stable
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: ${{ inputs.rust-targets }}
+
+    - name: Rust cache
+      uses: swatinem/rust-cache@v2
+      with:
+        workspaces: './apps/whispering/src-tauri -> target'
+        # Windows redirects CARGO_TARGET_DIR to a short drive-root path outside this workspace.
+        cache-targets: ${{ inputs.os != 'windows' }}
+
+    - name: Install frontend dependencies
+      shell: bash
+      run: bun install
+
+    - name: Build frontend
+      shell: bash
+      run: bun --filter @epicenter/whispering build

--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -15,6 +15,9 @@ name: PR Preview Builds
 # - All workflow runs for the same PR share the same concurrency group (keyed by PR number)
 # - When a new run starts, GitHub Actions automatically cancels previous runs in that group
 # - The 'closed' trigger activates a fast dummy job that joins the concurrency group and triggers cancellation
+#
+# The shared toolchain/dependency setup lives in .github/actions/setup-whispering-build
+# so this preview workflow and release.whispering.yml configure the build identically.
 
 on:
   pull_request:
@@ -68,18 +71,16 @@ jobs:
             rustTargets: 'x86_64-apple-darwin'
 
           # Linux on Blacksmith: GA drop-in runner, same base image as GitHub-hosted
-          # ubuntu-24.04. `os: 'linux'` still drives every apt/Vulkan/FUSE step.
+          # ubuntu-24.04. `os: 'linux'` still drives every linux-specific setup step.
           - platform: 'blacksmith-8vcpu-ubuntu-2404'
             os: 'linux'
             tauriArgs: ''
             artifactSuffix: 'linux'
             rustTargets: ''
 
-          # Windows on Blacksmith: PREVIEW-ONLY beta-runner spike to cut the ~22m
-          # github-hosted build time. Windows Server 2025 image ships VS Build Tools
-          # 2022 (satisfies the MSVC dev-cmd step); Vulkan is still installed by the
-          # step below. `os: 'windows'` keeps driving every Windows-specific step.
-          # Release stays on github-hosted `windows-latest` until this is proven.
+          # Windows preview builds on Blacksmith (~6m vs ~22m github-hosted). The
+          # image ships VS Build Tools 2022 but no LLVM and no Vulkan SDK; the setup
+          # action installs both. Release builds Windows on github-hosted windows-latest.
           - platform: 'blacksmith-8vcpu-windows-2025'
             os: 'windows'
             tauriArgs: ''
@@ -90,89 +91,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install create-dmg (macOS only)
-        if: ${{ matrix.os == 'macos' }}
-        run: brew install create-dmg
-
-      - name: install dependencies (ubuntu only)
-        if: ${{ matrix.os == 'linux' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxdo-dev libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev
-
-      # Linux Vulkan SDK installation (required for whisper-cpp GPU acceleration on Linux)
-      - name: Install Vulkan SDK (Ubuntu)
-        if: ${{ matrix.os == 'linux' }}
-        run: |
-          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.290-noble.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-noble.list
-          sudo apt update
-          sudo apt install -y vulkan-sdk mesa-vulkan-drivers
-
-      - name: Install Vulkan SDK (Windows)
-        if: ${{ matrix.os == 'windows' }}
-        shell: pwsh
-        env:
-          VULKAN_SDK_VERSION: 1.3.290.0
-        run: |
-          $installer = Join-Path $env:RUNNER_TEMP "VulkanSDK-$env:VULKAN_SDK_VERSION.exe"
-          Invoke-WebRequest "https://sdk.lunarg.com/sdk/download/$env:VULKAN_SDK_VERSION/windows/VulkanSDK-$env:VULKAN_SDK_VERSION-Installer.exe" -OutFile $installer
-          Start-Process -FilePath $installer -ArgumentList "--accept-licenses --default-answer --confirm-command install" -Wait
-          "VULKAN_SDK=C:\VulkanSDK\$env:VULKAN_SDK_VERSION" >> $env:GITHUB_ENV
-          "C:\VulkanSDK\$env:VULKAN_SDK_VERSION\Bin" >> $env:GITHUB_PATH
-
-      # No msvc-dev-cmd step: cargo and the cc crate locate the MSVC toolchain
-      # via vswhere at build time, so sourcing vcvars is unnecessary for the x64
-      # build (Handy ships the same whisper-rs-sys on x64 Windows without it).
-      # Dropping it also avoids the unmaintained, node20-only action.
-      - name: Configure Windows native build
-        if: ${{ matrix.os == 'windows' }}
-        shell: pwsh
-        run: |
-          $drive = Split-Path -Qualifier $env:GITHUB_WORKSPACE
-          $targetDir = Join-Path $drive "t"
-          New-Item -ItemType Directory -Force -Path $targetDir | Out-Null
-          "CARGO_TARGET_DIR=$targetDir" >> $env:GITHUB_ENV
-
-      # whisper-rs-sys runs bindgen, which needs libclang. GitHub-hosted
-      # windows-latest preinstalls LLVM; the Blacksmith Windows image does not,
-      # so install it and point bindgen at it via LIBCLANG_PATH. Pin the version
-      # so a future LLVM release cannot silently break bindgen, matching the
-      # exact-version discipline of the Vulkan SDK step above.
-      - name: Install LLVM (Windows, libclang for bindgen)
-        if: ${{ matrix.os == 'windows' }}
-        shell: pwsh
-        run: |
-          choco install llvm --version=22.1.7 --no-progress -y
-          "LIBCLANG_PATH=C:\Program Files\LLVM\bin" >> $env:GITHUB_ENV
-
-      - name: setup bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup Whispering build
+        uses: ./.github/actions/setup-whispering-build
         with:
-          bun-version-file: "package.json"
-
-      - name: setup node
-        uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
-
-      - name: install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.rustTargets }}
-
-      - name: Rust cache
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: './apps/whispering/src-tauri -> target'
-          # Windows redirects CARGO_TARGET_DIR to a short drive-root path outside this workspace.
-          cache-targets: ${{ matrix.os != 'windows' }}
-
-      - name: install frontend dependencies
-        run: bun install
-
-      - name: Build frontend
-        run: bun --filter @epicenter/whispering build
+          os: ${{ matrix.os }}
+          rust-targets: ${{ matrix.rustTargets }}
+          windows-runner: ${{ matrix.platform }}
 
       # macOS Intel only: provision a dynamically linked x86_64 ONNX Runtime and
       # bundle it into the .app. The `ort` crate (2.0.0-rc.12, via transcribe-rs)
@@ -238,42 +162,9 @@ jobs:
           New-Item -ItemType Directory -Force -Path $workspaceBundleDir | Out-Null
           Copy-Item -Path (Join-Path $bundleDir "*") -Destination $workspaceBundleDir -Recurse -Force
 
-      - name: Install FUSE for AppImage processing
+      - name: Process AppImage (Linux only)
         if: ${{ matrix.os == 'linux' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y fuse libfuse2
-
-      - name: Remove libwayland-client.so from AppImage
-        if: ${{ matrix.os == 'linux' }}
-        run: |
-          APPIMAGE_PATH=$(find apps/whispering/src-tauri/target/release/bundle/appimage -name "*.AppImage" | head -1)
-
-          if [ -n "$APPIMAGE_PATH" ]; then
-            echo "Processing AppImage: $APPIMAGE_PATH"
-            chmod +x "$APPIMAGE_PATH"
-            cd "$(dirname "$APPIMAGE_PATH")"
-            APPIMAGE_NAME=$(basename "$APPIMAGE_PATH")
-            "./$APPIMAGE_NAME" --appimage-extract
-
-            echo "Removing libwayland-client.so files..."
-            find squashfs-root -name "libwayland-client.so*" -type f -delete
-
-            echo "Files remaining in lib directories:"
-            find squashfs-root -name "lib*" -type d | head -5 | while read dir; do
-              echo "Contents of $dir:"
-              ls "$dir" | grep -E "(wayland|fuse)" || echo "  No wayland/fuse libraries found"
-            done
-
-            wget -q https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
-            chmod +x appimagetool-x86_64.AppImage
-            ARCH=x86_64 ./appimagetool-x86_64.AppImage --no-appstream squashfs-root "$APPIMAGE_NAME"
-            rm -rf squashfs-root appimagetool-x86_64.AppImage
-
-            echo "libwayland-client.so removed from AppImage successfully"
-          else
-            echo "No AppImage found to process"
-          fi
+        uses: ./.github/actions/process-whispering-appimage
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.whispering.yml
+++ b/.github/workflows/release.whispering.yml
@@ -1,5 +1,9 @@
 name: Publish Tauri Releases
 
+# The shared toolchain/dependency setup lives in .github/actions/setup-whispering-build
+# so this release workflow and pr-preview.whispering.yml configure the build identically.
+# Only the build, signing, and release-publishing steps differ and stay below.
+
 on:
   push:
     tags:
@@ -62,15 +66,18 @@ jobs:
             tauriArgs: '--target aarch64-apple-darwin'
             rustTargets: 'aarch64-apple-darwin'
 
-          # Linux (Ubuntu) on Blacksmith: GA drop-in runner, same base image as
-          # GitHub-hosted ubuntu-24.04. The `os: 'linux'` field below still drives
-          # every apt/Vulkan/FUSE conditional step, so only the runner changes.
+          # Linux on Blacksmith: GA drop-in runner, same base image as GitHub-hosted
+          # ubuntu-24.04. `os: 'linux'` still drives every linux-specific setup step.
           - platform: 'blacksmith-8vcpu-ubuntu-2404'
             os: 'linux'
             tauriArgs: ''  # No specific target needed for Linux
             rustTargets: ''
 
-          # Windows
+          # Windows on github-hosted windows-latest. Preview already builds Windows
+          # on Blacksmith; release stays here until that has run green across more
+          # PRs and a Blacksmith-built installer is manually confirmed to record and
+          # transcribe. Moving this to blacksmith-*-windows-* auto-engages the LLVM
+          # install in the setup action.
           - platform: 'windows-latest'
             os: 'windows'
             tauriArgs: ''  # No specific target needed for Windows
@@ -82,103 +89,18 @@ jobs:
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
-      # macOS specific: Install create-dmg for DMG bundling
-      - name: Install create-dmg (macOS only)
-        if: ${{ matrix.os == 'macos' }}
-        run: brew install create-dmg
-
-      # Ubuntu/Linux specific: Install system dependencies required by Tauri
-      - name: install dependencies (ubuntu only)
-        if: ${{ matrix.os == 'linux' }}
-        run: |
-          sudo apt-get update
-          # Dependencies explanation:
-          # - libwebkit2gtk-4.1-dev: WebKit engine for Tauri v2 (4.0 was for v1)
-          # - libappindicator3-dev: System tray support
-          # - librsvg2-dev: SVG rendering
-          # - patchelf: Required for AppImage packaging
-          # - libxdo-dev: Keyboard/mouse automation
-          # - libasound2-dev: Audio support
-          # - libopenblas-dev: GPU acceleration support
-          # - libx11-dev: X11 development files for window system interaction
-          # - libxtst-dev: X11 testing extensions for input simulation
-          # - libxrandr-dev: X11 RandR extension for display configuration
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxdo-dev libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev
-
-      # Linux Vulkan SDK installation (required for whisper-cpp GPU acceleration on Linux)
-      - name: Install Vulkan SDK (Ubuntu)
-        if: ${{ matrix.os == 'linux' }}
-        run: |
-          # Add official Vulkan SDK repository
-          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
-          # Note: Using "noble" for Ubuntu 24.04
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.290-noble.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-noble.list
-          sudo apt update
-          sudo apt install -y vulkan-sdk mesa-vulkan-drivers
-
-      - name: Install Vulkan SDK (Windows)
-        if: ${{ matrix.os == 'windows' }}
-        shell: pwsh
-        env:
-          VULKAN_SDK_VERSION: 1.3.290.0
-        run: |
-          $installer = Join-Path $env:RUNNER_TEMP "VulkanSDK-$env:VULKAN_SDK_VERSION.exe"
-          Invoke-WebRequest "https://sdk.lunarg.com/sdk/download/$env:VULKAN_SDK_VERSION/windows/VulkanSDK-$env:VULKAN_SDK_VERSION-Installer.exe" -OutFile $installer
-          Start-Process -FilePath $installer -ArgumentList "--accept-licenses --default-answer --confirm-command install" -Wait
-          "VULKAN_SDK=C:\VulkanSDK\$env:VULKAN_SDK_VERSION" >> $env:GITHUB_ENV
-          "C:\VulkanSDK\$env:VULKAN_SDK_VERSION\Bin" >> $env:GITHUB_PATH
-
-      - name: Setup MSVC developer command prompt (Windows)
-        if: ${{ matrix.os == 'windows' }}
-        uses: ilammy/msvc-dev-cmd@v1
+      # Referenced as owner/repo/...@main (not ./) so the action resolves from the
+      # default branch no matter which tag this job checks out. A local ./ action
+      # would be read from the checked-out tag's tree, which breaks re-releasing
+      # any tag that predates this action and changes the existing semantics
+      # (workflow_dispatch already runs the default branch's setup, not the tag's).
+      # Preview uses ./ instead, so a PR tests its own edits to this action.
+      - name: Setup Whispering build
+        uses: EpicenterHQ/epicenter/.github/actions/setup-whispering-build@main
         with:
-          arch: x64
-
-      - name: Configure Windows native build
-        if: ${{ matrix.os == 'windows' }}
-        shell: pwsh
-        run: |
-          $drive = Split-Path -Qualifier $env:GITHUB_WORKSPACE
-          $targetDir = Join-Path $drive "t"
-          New-Item -ItemType Directory -Force -Path $targetDir | Out-Null
-          "CARGO_TARGET_DIR=$targetDir" >> $env:GITHUB_ENV
-
-      # Setup Bun package manager
-      - name: setup bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version-file: "package.json"
-
-      # Setup Node.js for compatibility
-      - name: setup node
-        uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
-
-      # Install Rust toolchain required for building Tauri
-      - name: install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          # macOS rows specify the target they build.
-          # For other platforms: empty string (uses default target)
-          targets: ${{ matrix.rustTargets }}
-
-      # Cache Rust dependencies for faster builds
-      - name: Rust cache
-        uses: swatinem/rust-cache@v2
-        with:
-          # Point to the Rust project directory
-          workspaces: './apps/whispering/src-tauri -> target'
-          # Windows redirects CARGO_TARGET_DIR to a short drive-root path outside this workspace.
-          cache-targets: ${{ matrix.os != 'windows' }}
-
-      # Install all JavaScript dependencies
-      - name: install frontend dependencies
-        run: bun install
-
-      # Build the frontend (SvelteKit app) before Tauri packaging
-      - name: Build frontend
-        run: bun --filter @epicenter/whispering build  # Targets the specific workspace package
+          os: ${{ matrix.os }}
+          rust-targets: ${{ matrix.rustTargets }}
+          windows-runner: ${{ matrix.platform }}
 
       # Read and process release notes from the release-notes directory
       - name: Process release notes
@@ -258,54 +180,7 @@ jobs:
           # Platform-specific build arguments (e.g., --target for macOS)
           args: ${{ matrix.tauriArgs }}
 
-      # Install FUSE for AppImage processing
-      - name: Install FUSE for AppImage processing
+      # @main rather than ./ for the same reason as the setup action above.
+      - name: Process AppImage (Linux only)
         if: ${{ matrix.os == 'linux' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y fuse libfuse2
-
-      # Remove libwayland-client.so from AppImage for better compatibility
-      # This fixes EGL_BAD_PARAMETER errors on Wayland systems (Issues #114, #121)
-      - name: Remove libwayland-client.so from AppImage
-        if: ${{ matrix.os == 'linux' }}
-        run: |
-          # Find the AppImage file
-          APPIMAGE_PATH=$(find apps/whispering/src-tauri/target/release/bundle/appimage -name "*.AppImage" | head -1)
-
-          if [ -n "$APPIMAGE_PATH" ]; then
-            echo "Processing AppImage: $APPIMAGE_PATH"
-
-            # Make AppImage executable
-            chmod +x "$APPIMAGE_PATH"
-
-            # Extract using the AppImage itself
-            cd "$(dirname "$APPIMAGE_PATH")"
-            APPIMAGE_NAME=$(basename "$APPIMAGE_PATH")
-            "./$APPIMAGE_NAME" --appimage-extract
-
-            # Remove libwayland-client.so files
-            echo "Removing libwayland-client.so files..."
-            find squashfs-root -name "libwayland-client.so*" -type f -delete
-
-            # List what was removed for verification
-            echo "Files remaining in lib directories:"
-            find squashfs-root -name "lib*" -type d | head -5 | while read dir; do
-              echo "Contents of $dir:"
-              ls "$dir" | grep -E "(wayland|fuse)" || echo "  No wayland/fuse libraries found"
-            done
-
-            # Get appimagetool
-            wget -q https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
-            chmod +x appimagetool-x86_64.AppImage
-
-            # Repackage AppImage with no-appstream to avoid warnings
-            ARCH=x86_64 ./appimagetool-x86_64.AppImage --no-appstream squashfs-root "$APPIMAGE_NAME"
-
-            # Clean up
-            rm -rf squashfs-root appimagetool-x86_64.AppImage
-
-            echo "libwayland-client.so removed from AppImage successfully"
-          else
-            echo "No AppImage found to process"
-          fi
+        uses: EpicenterHQ/epicenter/.github/actions/process-whispering-appimage@main


### PR DESCRIPTION
Preview and release were keeping the same Whispering build setup in two places. That mattered because the Windows paths had already drifted: preview moved through the Blacksmith work while release stayed on `windows-latest`, LLVM only lived in one copy, and removing `msvc-dev-cmd` became a double-entry change.

This PR pulls the shared setup into composite actions while leaving each workflow's back half explicit:

```txt
pr-preview.whispering.yml
  -> ./.github/actions/setup-whispering-build
  -> ./.github/actions/process-whispering-appimage

release.whispering.yml
  -> EpicenterHQ/epicenter/.github/actions/setup-whispering-build@main
  -> EpicenterHQ/epicenter/.github/actions/process-whispering-appimage@main
```

The setup action owns create-dmg, apt dependencies, Vulkan, Windows path-shortening, LLVM, Bun, Node, Rust, rust-cache, frontend install, and frontend build. The AppImage action owns the `libwayland-client.so` strip and repackage step. The workflow files drop from duplicated setup blocks to the call sites that describe each target.

The release workflow intentionally calls the actions from `@main`. Release jobs check out the selected tag before building, so a local `./` action would resolve from that tag's tree. That would break re-releasing tags that predate these actions, and it would change the existing `workflow_dispatch` shape where the release workflow comes from the default branch. Preview still uses `./` so the PR validates its own action edits before merge.

Composite actions are the right size here. The two workflows share setup, but the back halves still mean different things: preview has the temporary macOS Intel ORT patch, unsigned builds, and artifact upload; release has signing, release notes, and GitHub release creation. A `workflow_call` would push those differences behind mode flags and make temporary scaffolding look permanent. Revisit that once the ORT patch is gone and the pipelines actually converge.

The only intended behavior change is that release Windows no longer runs `msvc-dev-cmd`. Cargo and the `cc` crate can find the x64 MSVC toolchain through `vswhere` on `windows-latest`, which is the same proof behind #1985. If this lands, #1985 should be closed as superseded.

Review path:

1. Start with `.github/actions/setup-whispering-build/action.yml` and check the inputs, environment exports, cache placement, and platform guards.
2. Compare the preview and release call sites to confirm the matrix values are passed through unchanged.
3. Skim `.github/actions/process-whispering-appimage/action.yml` against the old Linux block.
