### PR TITLE
feat(whispering): add held global shortcut gestures

### DIFF
--- a/apps/whispering/src-tauri/src/keyboard/keys.rs
+++ b/apps/whispering/src-tauri/src/keyboard/keys.rs
@@ -120,8 +120,10 @@ pub enum Key {
 /// exactly (see `Matcher`), matching the existing `arraysMatch` semantics of
 /// `local-shortcut-manager` and the plugin's exact-modifier behavior. An empty
 /// `keys` with non-empty `modifiers` is a modifier-only hold (for example hold
-/// Meta); empty `modifiers` with one key is a bare single-key push-to-talk.
-/// Both were impossible with the plugin.
+/// Meta), which was impossible with the plugin. The matcher also accepts a bare
+/// key with no modifiers, but the frontend refuses to *configure* one (a global
+/// gesture must carry a modifier or Fn so it cannot fire on an ordinary
+/// keypress); the matcher stays permissive so the policy lives in one place.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct KeyBinding {

--- a/apps/whispering/src-tauri/src/keyboard/matcher.rs
+++ b/apps/whispering/src-tauri/src/keyboard/matcher.rs
@@ -3,6 +3,13 @@ use std::collections::BTreeSet;
 use super::event::{ShortcutTriggerEvent, TriggerState};
 use super::keys::{Key, KeyBinding, Modifier};
 
+/// How long a shorter binding waits to see whether a longer binding that extends
+/// it completes. Kept small so a deliberate push-to-talk hold starts capturing
+/// almost immediately; long enough that pressing the extra key of a chord (for
+/// example the Space in `Fn` + `Space`) lands inside the window on real hardware.
+/// See the module note on the first-syllable trade-off.
+pub const PENDING_WINDOW_MS: u64 = 120;
+
 /// Edge of a single key event fed in from the rdev listener.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Edge {
@@ -19,31 +26,87 @@ pub enum Input {
     Key(Key),
 }
 
-/// One registered binding plus whether it is currently satisfied. `active` is
-/// the edge memory: the matcher recomputes satisfaction after every event and
-/// emits only on a transition (not-held -> held is `Pressed`, held -> not-held
-/// is `Released`). This makes auto-repeat a no-op (re-pressing an already-held
-/// key leaves `active` true) and makes the emit idempotent.
+/// One registered binding. Order-independent sets are precomputed so matching is
+/// a set comparison, not a `Vec` scan.
 struct Registered {
     command_id: String,
     modifiers: BTreeSet<Modifier>,
     keys: BTreeSet<Key>,
-    active: bool,
 }
 
-/// Tracks the set of currently-held modifiers and keys and turns the rdev event
-/// stream into `{ command_id, state }` transitions. Matching is **exact set
-/// equality**: a binding is held iff the held modifiers equal its modifiers and
-/// the held keys equal its keys. This mirrors `local-shortcut-manager`'s
-/// `arraysMatch` and the global plugin's exact-modifier behavior, so existing
-/// chords keep firing identically. A consequence of exact match: pressing an
-/// extra key while holding a binding releases it (held set no longer equal),
-/// which is the established behavior, not a regression.
+/// The single in-flight gesture. The desktop backend resolves **one** gesture at
+/// a time: a global push-to-talk hold owns the keyboard until it releases, so we
+/// never track two bindings as simultaneously held (that is what lets a
+/// resolved push-to-talk ignore extra keys instead of converting into a chord).
+enum Gesture {
+    /// Nothing held that matches or prefixes a binding.
+    Idle,
+    /// `index`'s binding is held exactly, but a longer binding extends it, so we
+    /// wait until `deadline` (a logical millisecond timestamp) to see if the
+    /// longer one completes. The listener schedules a `poll` for `deadline`.
+    Pending { index: usize, deadline: u64 },
+    /// `index`'s binding has fired `Pressed` and owns the gesture. It stays
+    /// active (extra keys ignored) until one of its own keys releases.
+    Active { index: usize },
+}
+
+/// Turns the rdev event stream into `{ command_id, state }` transitions with a
+/// **gesture resolver** for prefix bindings.
+///
+/// Matching is still set-based: a binding is "held exactly" iff the held
+/// modifiers equal its modifiers and the held keys equal its keys. On top of
+/// that, prefixes resolve through a short pending window so `Fn` (push-to-talk)
+/// and `Fn` + `Space` (toggle) can both be bound even though `Fn` arrives before
+/// `Space`:
+///
+/// - A binding that is held exactly and has **no** registered binding extending
+///   it fires immediately (the common case: a chord, a modifier-only hold).
+/// - A binding that is held exactly and **does** have a longer binding extending
+///   it enters a pending window. If the longer binding completes during the
+///   window it fires and the shorter one is suppressed; if the window expires the
+///   shorter one fires.
+/// - Once a binding is `Active`, it owns the gesture: pressing extra keys does
+///   not release it or convert it into a different binding. It releases (exactly
+///   once) when one of its own keys goes up.
+///
+/// First-syllable note: because `Fn` has an extender by default, push-to-talk
+/// waits up to `PENDING_WINDOW_MS` before `Pressed`, which delays audio capture
+/// by that much. The window is deliberately small, and it only applies when a
+/// real prefix conflict is configured (clear the toggle binding and `Fn` fires
+/// immediately). The proper fix (warm the recorder on the pending edge) is
+/// tracked separately; see the recorder's pre-roll discussion.
 pub struct Matcher {
     bindings: Vec<Registered>,
     held_modifiers: BTreeSet<Modifier>,
     held_keys: BTreeSet<Key>,
+    gesture: Gesture,
     capturing: bool,
+}
+
+/// What one event produced: the transitions to emit now, plus the deadline of a
+/// freshly-armed pending window (if any) so the listener can schedule a `poll`.
+pub struct MatchOutcome {
+    pub events: Vec<ShortcutTriggerEvent>,
+    /// `Some(deadline)` only when this event *armed* a new pending window. The
+    /// listener spawns a timer for `deadline`; `poll` is a no-op if the window
+    /// was already resolved or superseded, so a late timer is harmless.
+    pub pending_until: Option<u64>,
+}
+
+impl MatchOutcome {
+    fn nothing() -> Self {
+        Self {
+            events: Vec::new(),
+            pending_until: None,
+        }
+    }
+
+    fn fired(events: Vec<ShortcutTriggerEvent>) -> Self {
+        Self {
+            events,
+            pending_until: None,
+        }
+    }
 }
 
 impl Matcher {
@@ -52,19 +115,19 @@ impl Matcher {
             bindings: Vec::new(),
             held_modifiers: BTreeSet::new(),
             held_keys: BTreeSet::new(),
+            gesture: Gesture::Idle,
             capturing: false,
         }
     }
 
     /// Enter or leave capture mode. While capturing, `on_event` updates the held
-    /// set but emits no triggers; the listener reads `held_binding` instead and
-    /// forwards it to the settings recorder. Resets `active` flags so no binding
-    /// is left half-fired across the mode switch.
+    /// set but emits no triggers and arms no pending window; the listener reads
+    /// `held_binding` instead and forwards it to the settings recorder. The
+    /// in-flight gesture is reset so nothing is left half-fired across the
+    /// mode switch.
     pub fn set_capturing(&mut self, capturing: bool) {
         self.capturing = capturing;
-        for binding in &mut self.bindings {
-            binding.active = false;
-        }
+        self.gesture = Gesture::Idle;
     }
 
     pub fn is_capturing(&self) -> bool {
@@ -79,24 +142,36 @@ impl Matcher {
         }
     }
 
-    /// Drop all held state and mark every binding inactive. Called when the
-    /// listener (re)enters `rdev::listen`: a prior attempt that exited may have
-    /// missed a key-up, and a stale held modifier would otherwise wedge a
-    /// binding "down" or suppress the next press under exact-set matching.
+    /// Drop all held state and the in-flight gesture. Called when the listener
+    /// (re)enters `rdev::listen`: a prior attempt that exited may have missed a
+    /// key-up, and a stale held modifier would otherwise wedge a binding "down"
+    /// or suppress the next press.
     pub fn clear_held(&mut self) {
         self.held_modifiers.clear();
         self.held_keys.clear();
-        for binding in &mut self.bindings {
-            binding.active = false;
-        }
+        self.gesture = Gesture::Idle;
     }
 
     /// Replace the full set of registered bindings. Empty bindings are dropped
-    /// (they can never be "held"). All `active` flags reset to false, so a
-    /// freshly registered binding requires a new press even if its keys happen
-    /// to be physically down at registration time. The held sets are left
-    /// untouched: the physical keys really are still down.
+    /// (they can never be "held"). The held sets are left untouched: the physical
+    /// keys really are still down.
+    ///
+    /// A resolved (`Active`) gesture is carried across only if its exact binding
+    /// (same command, modifiers, and keys) survives the swap. This matters because
+    /// the FE re-pushes the full set mid-session (for example to register the
+    /// cancel gesture once recording starts); a held push-to-talk must keep owning
+    /// the gesture so its `Released` still pairs on key-up. Anything else resets to
+    /// `Idle`: a `Pending` window is dropped (the swap lands between sessions, never
+    /// mid-window, so the prefix just needs a fresh press), and a gesture whose
+    /// binding vanished cannot fire.
     pub fn set_bindings(&mut self, bindings: impl IntoIterator<Item = (String, KeyBinding)>) {
+        // Capture the active binding's identity before the swap; only a resolved
+        // gesture is carried (see the doc comment).
+        let active = match self.gesture {
+            Gesture::Active { index } => Some(self.identity(index)),
+            Gesture::Pending { .. } | Gesture::Idle => None,
+        };
+
         self.bindings = bindings
             .into_iter()
             .filter(|(_, binding)| !binding.is_empty())
@@ -106,55 +181,211 @@ impl Matcher {
                     command_id,
                     modifiers,
                     keys,
-                    active: false,
                 }
             })
             .collect();
+
+        self.gesture = match active {
+            None => Gesture::Idle,
+            Some((command_id, modifiers, keys)) => self
+                .bindings
+                .iter()
+                .position(|b| {
+                    b.command_id == command_id && b.modifiers == modifiers && b.keys == keys
+                })
+                .map_or(Gesture::Idle, |index| Gesture::Active { index }),
+        };
     }
 
-    /// Feed one key event. Updates the held sets, then returns every binding
-    /// that transitioned as a result (usually zero or one).
-    pub fn on_event(&mut self, edge: Edge, input: Input) -> Vec<ShortcutTriggerEvent> {
-        match (edge, input) {
-            (Edge::Press, Input::Modifier(m)) => {
-                self.held_modifiers.insert(m);
-            }
-            (Edge::Release, Input::Modifier(m)) => {
-                self.held_modifiers.remove(&m);
-            }
-            (Edge::Press, Input::Key(k)) => {
-                self.held_keys.insert(k);
-            }
-            (Edge::Release, Input::Key(k)) => {
-                self.held_keys.remove(&k);
-            }
+    /// The (command, modifiers, keys) identity of a registered binding, cloned so
+    /// it can outlive a binding-set swap.
+    fn identity(&self, index: usize) -> (String, BTreeSet<Modifier>, BTreeSet<Key>) {
+        let b = &self.bindings[index];
+        (b.command_id.clone(), b.modifiers.clone(), b.keys.clone())
+    }
+
+    /// Feed one key event. Updates the held sets, then resolves the gesture.
+    pub fn on_event(&mut self, now: u64, edge: Edge, input: Input) -> MatchOutcome {
+        // Apply the edge. `changed` is false for an auto-repeat press (the key is
+        // already held) or a stray release of an absent key. Those are no-ops:
+        // returning early keeps auto-repeat from re-firing a binding and, just as
+        // importantly, from resetting a pending window on every repeat tick.
+        let changed = match (edge, input) {
+            (Edge::Press, Input::Modifier(m)) => self.held_modifiers.insert(m),
+            (Edge::Release, Input::Modifier(m)) => self.held_modifiers.remove(&m),
+            (Edge::Press, Input::Key(k)) => self.held_keys.insert(k),
+            (Edge::Release, Input::Key(k)) => self.held_keys.remove(&k),
+        };
+        if !changed {
+            return MatchOutcome::nothing();
         }
 
         // In capture mode the listener forwards `held_binding()` to the recorder;
-        // it does not match registered bindings.
+        // it does not match registered bindings or arm pending windows.
         if self.capturing {
-            return Vec::new();
+            return MatchOutcome::nothing();
         }
 
-        let mut events = Vec::new();
-        for binding in &mut self.bindings {
-            let satisfied =
-                binding.modifiers == self.held_modifiers && binding.keys == self.held_keys;
-            if satisfied && !binding.active {
-                binding.active = true;
-                events.push(ShortcutTriggerEvent {
-                    command_id: binding.command_id.clone(),
-                    state: TriggerState::Pressed,
-                });
-            } else if !satisfied && binding.active {
-                binding.active = false;
-                events.push(ShortcutTriggerEvent {
-                    command_id: binding.command_id.clone(),
-                    state: TriggerState::Released,
-                });
+        match self.gesture {
+            Gesture::Active { index } => self.on_event_active(index),
+            Gesture::Pending { index, .. } => self.on_event_pending(index, edge, now),
+            Gesture::Idle => self.on_event_idle(edge, now),
+        }
+    }
+
+    /// A timer (scheduled by the listener for a pending window's deadline) calls
+    /// this. If the window is still open and has expired, the shorter binding
+    /// fires. Otherwise it is a no-op: the window may have already resolved (the
+    /// longer binding completed, the keys released) or been superseded by a newer
+    /// pending window with a later deadline.
+    pub fn poll(&mut self, now: u64) -> Vec<ShortcutTriggerEvent> {
+        let Gesture::Pending { index, deadline } = self.gesture else {
+            return Vec::new();
+        };
+        if now < deadline {
+            return Vec::new();
+        }
+        self.gesture = Gesture::Active { index };
+        vec![self.press(index)]
+    }
+
+    /// Deadline of the open pending window, if any. A read-only state query:
+    /// tests use it to assert a window armed, while production schedules off
+    /// `MatchOutcome::pending_until` returned by `on_event`.
+    pub fn pending_deadline(&self) -> Option<u64> {
+        match self.gesture {
+            Gesture::Pending { deadline, .. } => Some(deadline),
+            _ => None,
+        }
+    }
+
+    // ── Per-state handlers ────────────────────────────────────────────────────
+
+    /// An active binding owns the gesture. Extra presses are ignored; it releases
+    /// only when one of its own keys/modifiers goes up (so the held set is no
+    /// longer a superset of the binding).
+    fn on_event_active(&mut self, index: usize) -> MatchOutcome {
+        if self.held_is_superset_of(index) {
+            return MatchOutcome::nothing();
+        }
+        self.gesture = Gesture::Idle;
+        MatchOutcome::fired(vec![self.release(index)])
+    }
+
+    /// A pending window is open for `index`. A press either completes a longer
+    /// binding (resolve to it) or grows past the shorter one without matching
+    /// anything (commit the shorter one). A release either ends the shorter
+    /// gesture before it resolved (drop it: a sub-window tap is not a hold) or
+    /// drops an unrelated extra key (stay pending).
+    fn on_event_pending(&mut self, index: usize, edge: Edge, now: u64) -> MatchOutcome {
+        match edge {
+            Edge::Press => {
+                if let Some(exact) = self.find_exact() {
+                    // The held set grew to exactly match another binding. Because
+                    // the shorter binding was held exactly a moment ago and we only
+                    // added keys, that binding necessarily extends it. Resolve to
+                    // it (which may itself pend if it has a longer extender).
+                    self.activate_or_pend(exact, now)
+                } else {
+                    // Grew past the shorter binding without matching anything. The
+                    // shorter binding is still held (a subset), so commit it.
+                    self.gesture = Gesture::Active { index };
+                    MatchOutcome::fired(vec![self.press(index)])
+                }
+            }
+            Edge::Release => {
+                if self.held_is_superset_of(index) {
+                    // An extra key went up but the shorter binding is still fully
+                    // held; keep waiting. No new pending window is armed.
+                    MatchOutcome::nothing()
+                } else {
+                    // One of the shorter binding's own keys went up before the
+                    // window expired: a tap too brief to be a hold. Drop it rather
+                    // than fire a near-empty push-to-talk.
+                    self.gesture = Gesture::Idle;
+                    MatchOutcome::nothing()
+                }
             }
         }
-        events
+    }
+
+    /// Nothing in flight. A press that exactly matches a binding resolves it; a
+    /// press that only partially builds a chord waits silently.
+    fn on_event_idle(&mut self, edge: Edge, now: u64) -> MatchOutcome {
+        if edge == Edge::Press {
+            if let Some(index) = self.find_exact() {
+                return self.activate_or_pend(index, now);
+            }
+        }
+        MatchOutcome::nothing()
+    }
+
+    // ── Resolution helpers ────────────────────────────────────────────────────
+
+    /// Resolve a binding that is currently held exactly: pend if a longer binding
+    /// extends it, otherwise fire it now.
+    fn activate_or_pend(&mut self, index: usize, now: u64) -> MatchOutcome {
+        if self.has_extender(index) {
+            let deadline = now + PENDING_WINDOW_MS;
+            self.gesture = Gesture::Pending { index, deadline };
+            MatchOutcome {
+                events: Vec::new(),
+                pending_until: Some(deadline),
+            }
+        } else {
+            self.gesture = Gesture::Active { index };
+            MatchOutcome::fired(vec![self.press(index)])
+        }
+    }
+
+    /// First binding whose modifier and key sets equal the held sets exactly.
+    /// First-wins makes a duplicate binding (two commands on the same combo)
+    /// resolve deterministically to the one registered earlier, and fires a
+    /// single command rather than both.
+    fn find_exact(&self) -> Option<usize> {
+        self.bindings
+            .iter()
+            .position(|b| b.modifiers == self.held_modifiers && b.keys == self.held_keys)
+    }
+
+    /// Whether any *other* registered binding strictly extends `index`'s binding
+    /// (a superset of both its modifiers and its keys). `index`'s binding is held
+    /// exactly when this is called, so such a binding is reachable by pressing
+    /// more keys, which is exactly the prefix conflict the window disambiguates.
+    fn has_extender(&self, index: usize) -> bool {
+        let target = &self.bindings[index];
+        self.bindings.iter().enumerate().any(|(i, b)| {
+            i != index
+                && target.modifiers.is_subset(&b.modifiers)
+                && target.keys.is_subset(&b.keys)
+                // Strict: an equal binding (a duplicate combo) is a subset but not
+                // an extender, so a duplicate fires immediately rather than pending
+                // forever on a longer binding that does not exist.
+                && (b.modifiers.len() + b.keys.len()) > (target.modifiers.len() + target.keys.len())
+        })
+    }
+
+    /// Whether the held set still contains all of `index`'s modifiers and keys
+    /// (extra held keys allowed). This is the "still held" test for an active
+    /// binding: it tolerates extra keys so a resolved gesture is not broken by
+    /// later presses.
+    fn held_is_superset_of(&self, index: usize) -> bool {
+        let b = &self.bindings[index];
+        b.modifiers.is_subset(&self.held_modifiers) && b.keys.is_subset(&self.held_keys)
+    }
+
+    fn press(&self, index: usize) -> ShortcutTriggerEvent {
+        ShortcutTriggerEvent {
+            command_id: self.bindings[index].command_id.clone(),
+            state: TriggerState::Pressed,
+        }
+    }
+
+    fn release(&self, index: usize) -> ShortcutTriggerEvent {
+        ShortcutTriggerEvent {
+            command_id: self.bindings[index].command_id.clone(),
+            state: TriggerState::Released,
+        }
     }
 }
 
@@ -169,23 +400,58 @@ mod tests {
         }
     }
 
-    /// Drive a sequence of events and collect every emitted transition as
-    /// `(command_id, state)` pairs for terse assertions.
-    fn run(matcher: &mut Matcher, events: &[(Edge, Input)]) -> Vec<(String, TriggerState)> {
+    /// A logical clock for the event sequence. Each event advances time by
+    /// `step` ms, so tests can place key presses inside or outside the pending
+    /// window without any real sleeping.
+    struct Clock {
+        now: u64,
+        step: u64,
+    }
+
+    /// Drive a sequence of events through the matcher and collect every emitted
+    /// transition as `(command_id, state)` pairs. `poll` is run after each event
+    /// once the clock has passed the pending deadline, mirroring the listener's
+    /// timer: in production a real timer fires `poll` at the deadline; here we
+    /// fire it deterministically.
+    fn run(
+        matcher: &mut Matcher,
+        clock: &mut Clock,
+        events: &[(Edge, Input)],
+    ) -> Vec<(String, TriggerState)> {
         let mut out = Vec::new();
         for &(edge, input) in events {
-            for ev in matcher.on_event(edge, input) {
+            let outcome = matcher.on_event(clock.now, edge, input);
+            for ev in outcome.events {
                 out.push((ev.command_id, ev.state));
             }
+            clock.now += clock.step;
         }
         out
+    }
+
+    /// Advance the clock past any open pending deadline and flush it, the way the
+    /// scheduled timer would.
+    fn flush(matcher: &mut Matcher, clock: &mut Clock) -> Vec<(String, TriggerState)> {
+        if let Some(deadline) = matcher.pending_deadline() {
+            clock.now = clock.now.max(deadline);
+        }
+        matcher
+            .poll(clock.now)
+            .into_iter()
+            .map(|ev| (ev.command_id, ev.state))
+            .collect()
     }
 
     use Edge::{Press, Release};
     use Input::Key as K;
     use Input::Modifier as M;
-    use Modifier::{Meta, Shift};
+    use Modifier::{Fn, Meta, Shift};
     use TriggerState::{Pressed, Released};
+
+    fn fast() -> Clock {
+        // 10ms per event: a whole short chord lands well inside the window.
+        Clock { now: 0, step: 10 }
+    }
 
     #[test]
     fn chord_fires_once_when_the_last_key_completes_it_and_releases_when_it_breaks() {
@@ -195,9 +461,11 @@ mod tests {
             binding(&[Meta, Shift], &[Key::KeyD]),
         )]);
 
-        // Modifiers alone do not satisfy the chord; only the final key does.
+        // Modifiers alone do not satisfy the chord; only the final key does. With
+        // no binding extending Meta+Shift+D, it fires immediately on the D press.
         let events = run(
             &mut matcher,
+            &mut fast(),
             &[
                 (Press, M(Meta)),
                 (Press, M(Shift)),
@@ -220,16 +488,18 @@ mod tests {
     fn clear_held_drops_stale_state_so_a_missed_release_cannot_wedge_a_binding() {
         let mut matcher = Matcher::new();
         matcher.set_bindings([("ptt".to_string(), binding(&[], &[Key::Space]))]);
+        let mut clock = fast();
 
         // Space goes down (binding fires), then the key-up is "missed" (the
         // listener exited mid-hold). clear_held models the listener restart.
-        let pressed = run(&mut matcher, &[(Press, K(Key::Space))]);
+        let pressed = run(&mut matcher, &mut clock, &[(Press, K(Key::Space))]);
         assert_eq!(pressed, vec![("ptt".to_string(), Pressed)]);
         matcher.clear_held();
 
         // A later stray release must not emit, and a fresh press still works.
         let after = run(
             &mut matcher,
+            &mut clock,
             &[(Release, K(Key::Space)), (Press, K(Key::Space))],
         );
         assert_eq!(after, vec![("ptt".to_string(), Pressed)]);
@@ -242,6 +512,7 @@ mod tests {
         // Shift before Meta still completes on KeyD.
         let events = run(
             &mut matcher,
+            &mut fast(),
             &[(Press, M(Shift)), (Press, M(Meta)), (Press, K(Key::KeyD))],
         );
         assert_eq!(events, vec![("x".to_string(), Pressed)]);
@@ -251,7 +522,11 @@ mod tests {
     fn modifier_only_binding_presses_and_releases_on_the_modifier_alone() {
         let mut matcher = Matcher::new();
         matcher.set_bindings([("toggle".to_string(), binding(&[Meta], &[]))]);
-        let events = run(&mut matcher, &[(Press, M(Meta)), (Release, M(Meta))]);
+        let events = run(
+            &mut matcher,
+            &mut fast(),
+            &[(Press, M(Meta)), (Release, M(Meta))],
+        );
         assert_eq!(
             events,
             vec![
@@ -267,6 +542,7 @@ mod tests {
         matcher.set_bindings([("ptt".to_string(), binding(&[], &[Key::Space]))]);
         let events = run(
             &mut matcher,
+            &mut fast(),
             &[(Press, K(Key::Space)), (Release, K(Key::Space))],
         );
         assert_eq!(
@@ -278,10 +554,11 @@ mod tests {
     #[test]
     fn fn_modifier_binding_fires() {
         let mut matcher = Matcher::new();
-        matcher.set_bindings([("ptt".to_string(), binding(&[Modifier::Fn], &[]))]);
+        matcher.set_bindings([("ptt".to_string(), binding(&[Fn], &[]))]);
         let events = run(
             &mut matcher,
-            &[(Press, M(Modifier::Fn)), (Release, M(Modifier::Fn))],
+            &mut fast(),
+            &[(Press, M(Fn)), (Release, M(Fn))],
         );
         assert_eq!(
             events,
@@ -298,19 +575,20 @@ mod tests {
         // A registered binding must not fire while capturing.
         let events = run(
             &mut matcher,
-            &[(Press, M(Modifier::Fn)), (Press, K(Key::KeyD))],
+            &mut fast(),
+            &[(Press, M(Fn)), (Press, K(Key::KeyD))],
         );
         assert!(events.is_empty());
 
         // The held combo is what the recorder reads and commits (Fn + D, the
         // kind of binding the webview could never capture).
         let held = matcher.held_binding();
-        assert_eq!(held.modifiers, vec![Modifier::Fn]);
+        assert_eq!(held.modifiers, vec![Fn]);
         assert_eq!(held.keys, vec![Key::KeyD]);
 
         // Leaving capture mode re-arms normal matching.
         matcher.set_capturing(false);
-        let after = run(&mut matcher, &[(Release, M(Modifier::Fn))]);
+        let after = run(&mut matcher, &mut fast(), &[(Release, M(Fn))]);
         assert!(after.is_empty());
     }
 
@@ -319,9 +597,10 @@ mod tests {
         let mut matcher = Matcher::new();
         matcher.set_bindings([("ptt".to_string(), binding(&[], &[Key::KeyD]))]);
         // A held key auto-repeats: rdev delivers KeyPress(KeyD) again. The
-        // second press must not produce a second Pressed.
+        // second and third press must not produce a second Pressed.
         let events = run(
             &mut matcher,
+            &mut fast(),
             &[
                 (Press, K(Key::KeyD)),
                 (Press, K(Key::KeyD)),
@@ -336,22 +615,6 @@ mod tests {
     }
 
     #[test]
-    fn extra_modifier_breaks_exact_match_and_releases() {
-        let mut matcher = Matcher::new();
-        matcher.set_bindings([("x".to_string(), binding(&[Meta], &[Key::KeyD]))]);
-        // Holding Meta+D fires; adding Shift makes the held modifier set no
-        // longer equal {Meta}, so the binding releases (exact-match behavior).
-        let events = run(
-            &mut matcher,
-            &[(Press, M(Meta)), (Press, K(Key::KeyD)), (Press, M(Shift))],
-        );
-        assert_eq!(
-            events,
-            vec![("x".to_string(), Pressed), ("x".to_string(), Released)]
-        );
-    }
-
-    #[test]
     fn empty_bindings_are_dropped_and_never_fire() {
         let mut matcher = Matcher::new();
         matcher.set_bindings([("noop".to_string(), binding(&[], &[]))]);
@@ -359,6 +622,7 @@ mod tests {
         // binding. Feeding an unrelated key produces nothing.
         let events = run(
             &mut matcher,
+            &mut fast(),
             &[(Press, K(Key::KeyA)), (Release, K(Key::KeyA))],
         );
         assert!(events.is_empty());
@@ -373,6 +637,7 @@ mod tests {
         ]);
         let events = run(
             &mut matcher,
+            &mut fast(),
             &[
                 (Press, M(Meta)),
                 (Press, K(Key::KeyA)),   // a fires
@@ -393,17 +658,230 @@ mod tests {
     }
 
     #[test]
-    fn re_registering_bindings_resets_active_state() {
+    fn re_pushing_the_same_binding_keeps_a_held_gesture_so_release_still_pairs() {
+        // The FE re-pushes the full binding set mid-session (the cancel gesture is
+        // registered once recording starts). A held push-to-talk must survive that
+        // swap, or its Released would never fire and recording would never stop.
         let mut matcher = Matcher::new();
         matcher.set_bindings([("a".to_string(), binding(&[], &[Key::Space]))]);
-        let first = run(&mut matcher, &[(Press, K(Key::Space))]);
+        let mut clock = fast();
+        let first = run(&mut matcher, &mut clock, &[(Press, K(Key::Space))]);
         assert_eq!(first, vec![("a".to_string(), Pressed)]);
 
-        // Re-register while Space is still physically held. The new binding set
-        // starts inactive; releasing Space must not emit a Released for a
-        // binding that was never marked active in this set.
+        // Re-push the identical set while Space is still held. The active gesture
+        // is preserved, so releasing Space still emits exactly one Released.
         matcher.set_bindings([("a".to_string(), binding(&[], &[Key::Space]))]);
-        let after = run(&mut matcher, &[(Release, K(Key::Space))]);
+        let after = run(&mut matcher, &mut clock, &[(Release, K(Key::Space))]);
+        assert_eq!(after, vec![("a".to_string(), Released)]);
+    }
+
+    #[test]
+    fn re_pushing_without_the_active_binding_resets_it() {
+        // If the held binding is gone from the new set, the gesture resets: a
+        // later release must not emit for a binding that no longer exists.
+        let mut matcher = Matcher::new();
+        matcher.set_bindings([("a".to_string(), binding(&[], &[Key::Space]))]);
+        let mut clock = fast();
+        let first = run(&mut matcher, &mut clock, &[(Press, K(Key::Space))]);
+        assert_eq!(first, vec![("a".to_string(), Pressed)]);
+
+        // Swap to a different binding while Space is held; "a" is gone.
+        matcher.set_bindings([("b".to_string(), binding(&[Meta], &[Key::KeyD]))]);
+        let after = run(&mut matcher, &mut clock, &[(Release, K(Key::Space))]);
         assert!(after.is_empty());
+    }
+
+    // ── Gesture-resolver tests ────────────────────────────────────────────────
+
+    /// Register the macOS default prefix pair: Fn = push-to-talk, Fn+Space =
+    /// toggle. Fn is a prefix of Fn+Space, so Fn must wait out the window.
+    fn fn_prefix_pair() -> Matcher {
+        let mut matcher = Matcher::new();
+        matcher.set_bindings([
+            ("pushToTalk".to_string(), binding(&[Fn], &[])),
+            ("toggle".to_string(), binding(&[Fn], &[Key::Space])),
+        ]);
+        matcher
+    }
+
+    #[test]
+    fn fn_alone_resolves_to_push_to_talk_after_the_pending_window() {
+        let mut matcher = fn_prefix_pair();
+        let mut clock = fast();
+
+        // Pressing Fn must NOT fire immediately: Fn+Space extends it.
+        let pressed = run(&mut matcher, &mut clock, &[(Press, M(Fn))]);
+        assert!(pressed.is_empty());
+        assert!(matcher.pending_deadline().is_some());
+
+        // When the window expires, push-to-talk fires (and only push-to-talk).
+        let flushed = flush(&mut matcher, &mut clock);
+        assert_eq!(flushed, vec![("pushToTalk".to_string(), Pressed)]);
+    }
+
+    #[test]
+    fn fn_space_resolves_to_toggle_and_never_fires_push_to_talk() {
+        let mut matcher = fn_prefix_pair();
+        let mut clock = fast();
+
+        // Fn then Space, both inside the window: the longer binding wins and the
+        // shorter one is suppressed. No push-to-talk event ever appears.
+        let events = run(
+            &mut matcher,
+            &mut clock,
+            &[
+                (Press, M(Fn)),
+                (Press, K(Key::Space)),
+                (Release, K(Key::Space)),
+                (Release, M(Fn)),
+            ],
+        );
+        assert_eq!(
+            events,
+            vec![
+                ("toggle".to_string(), Pressed),
+                ("toggle".to_string(), Released),
+            ]
+        );
+        // A late timer firing now must do nothing.
+        assert!(matcher.poll(clock.now + 1_000).is_empty());
+    }
+
+    #[test]
+    fn releasing_fn_after_push_to_talk_emits_released_exactly_once() {
+        let mut matcher = fn_prefix_pair();
+        let mut clock = fast();
+
+        run(&mut matcher, &mut clock, &[(Press, M(Fn))]);
+        let pressed = flush(&mut matcher, &mut clock);
+        assert_eq!(pressed, vec![("pushToTalk".to_string(), Pressed)]);
+
+        // Exactly one Released on Fn up, and a stray timer afterwards adds nothing.
+        let released = run(&mut matcher, &mut clock, &[(Release, M(Fn))]);
+        assert_eq!(released, vec![("pushToTalk".to_string(), Released)]);
+        assert!(matcher.poll(clock.now + 1_000).is_empty());
+    }
+
+    #[test]
+    fn pressing_an_extra_key_after_push_to_talk_resolves_does_not_convert_it() {
+        let mut matcher = fn_prefix_pair();
+        let mut clock = fast();
+
+        // Resolve to push-to-talk first.
+        run(&mut matcher, &mut clock, &[(Press, M(Fn))]);
+        let pressed = flush(&mut matcher, &mut clock);
+        assert_eq!(pressed, vec![("pushToTalk".to_string(), Pressed)]);
+
+        // Now press Space. The held set is exactly Fn+Space (toggle), but the
+        // already-active push-to-talk owns the gesture: no toggle, no release.
+        let extra = run(
+            &mut matcher,
+            &mut clock,
+            &[(Press, K(Key::Space)), (Release, K(Key::Space))],
+        );
+        assert!(extra.is_empty());
+
+        // Releasing Fn still ends push-to-talk exactly once.
+        let released = run(&mut matcher, &mut clock, &[(Release, M(Fn))]);
+        assert_eq!(released, vec![("pushToTalk".to_string(), Released)]);
+    }
+
+    #[test]
+    fn a_prefix_binding_with_no_extender_fires_immediately() {
+        // Same Fn push-to-talk, but no toggle registered: nothing extends Fn, so
+        // it must fire on press with no window (no first-syllable penalty).
+        let mut matcher = Matcher::new();
+        matcher.set_bindings([("pushToTalk".to_string(), binding(&[Fn], &[]))]);
+        let mut clock = fast();
+
+        let pressed = run(&mut matcher, &mut clock, &[(Press, M(Fn))]);
+        assert_eq!(pressed, vec![("pushToTalk".to_string(), Pressed)]);
+        assert!(matcher.pending_deadline().is_none());
+    }
+
+    #[test]
+    fn a_quick_tap_inside_the_window_is_dropped_not_fired() {
+        // Press and release Fn before the window expires. Too brief to be a hold,
+        // and not a chord, so nothing fires (avoids a near-empty push-to-talk).
+        let mut matcher = fn_prefix_pair();
+        let mut clock = fast();
+
+        let events = run(
+            &mut matcher,
+            &mut clock,
+            &[(Press, M(Fn)), (Release, M(Fn))],
+        );
+        assert!(events.is_empty());
+        assert!(matcher.poll(clock.now + 1_000).is_empty());
+    }
+
+    #[test]
+    fn pressing_an_unrelated_key_inside_the_window_commits_the_shorter_binding() {
+        // Fn pending, then a key that completes no binding. The shorter binding is
+        // still held, so it commits rather than getting lost.
+        let mut matcher = fn_prefix_pair();
+        let mut clock = fast();
+
+        let events = run(
+            &mut matcher,
+            &mut clock,
+            &[(Press, M(Fn)), (Press, K(Key::KeyJ))],
+        );
+        assert_eq!(events, vec![("pushToTalk".to_string(), Pressed)]);
+
+        // And it still releases cleanly when Fn goes up.
+        let released = run(
+            &mut matcher,
+            &mut clock,
+            &[(Release, K(Key::KeyJ)), (Release, M(Fn))],
+        );
+        assert_eq!(released, vec![("pushToTalk".to_string(), Released)]);
+    }
+
+    #[test]
+    fn duplicate_bindings_on_the_same_combo_fire_only_the_first_registered() {
+        let mut matcher = Matcher::new();
+        matcher.set_bindings([
+            ("first".to_string(), binding(&[Meta], &[Key::KeyD])),
+            ("second".to_string(), binding(&[Meta], &[Key::KeyD])),
+        ]);
+        let events = run(
+            &mut matcher,
+            &mut fast(),
+            &[(Press, M(Meta)), (Press, K(Key::KeyD))],
+        );
+        assert_eq!(events, vec![("first".to_string(), Pressed)]);
+    }
+
+    #[test]
+    fn windows_ctrl_win_prefix_pair_resolves_like_the_fn_pair() {
+        // The Windows defaults: Ctrl+Win = push-to-talk, Ctrl+Win+Space = toggle.
+        let mut matcher = Matcher::new();
+        matcher.set_bindings([
+            (
+                "pushToTalk".to_string(),
+                binding(&[Modifier::Ctrl, Meta], &[]),
+            ),
+            (
+                "toggle".to_string(),
+                binding(&[Modifier::Ctrl, Meta], &[Key::Space]),
+            ),
+        ]);
+        let mut clock = fast();
+
+        // Ctrl then Win: partial, nothing fires and no window yet (Ctrl alone
+        // matches no binding).
+        let partial = run(&mut matcher, &mut clock, &[(Press, M(Modifier::Ctrl))]);
+        assert!(partial.is_empty());
+        assert!(matcher.pending_deadline().is_none());
+
+        // Win completes Ctrl+Win exactly, which has an extender: pend.
+        let armed = run(&mut matcher, &mut clock, &[(Press, M(Meta))]);
+        assert!(armed.is_empty());
+        assert!(matcher.pending_deadline().is_some());
+
+        // Space inside the window resolves to toggle, not push-to-talk.
+        let toggled = run(&mut matcher, &mut clock, &[(Press, K(Key::Space))]);
+        assert_eq!(toggled, vec![("toggle".to_string(), Pressed)]);
     }
 }

--- a/apps/whispering/src-tauri/src/keyboard/matcher.rs
+++ b/apps/whispering/src-tauri/src/keyboard/matcher.rs
@@ -111,6 +111,16 @@ impl Matcher {
     /// so it cannot survive the swap anyway). The FE only re-pushes between
     /// sessions, on launch, on a settings edit, or on reset, never while a global
     /// gesture is physically held, so there is no resolved gesture to carry across.
+    ///
+    /// Precondition: the bindings must be pairwise non-overlapping (no key set a
+    /// subset of another's). This matcher assumes it but does not enforce it; the
+    /// invariant is owned by the FE recorder (`bindingsOverlap` in
+    /// `key-binding.ts`), which refuses to save an overlapping gesture, and by the
+    /// disjoint shipped defaults. If a binding ever overlaps anyway (a hand-edited
+    /// settings file, a future migration), the consequence is benign and
+    /// deterministic, not a panic: the shorter binding fires first and shadows the
+    /// longer, which can never be reached. See the
+    /// `an_overlapping_longer_binding_is_unreachable` test for that behavior.
     pub fn set_bindings(&mut self, bindings: impl IntoIterator<Item = (String, KeyBinding)>) {
         self.bindings = bindings
             .into_iter()

--- a/apps/whispering/src-tauri/src/keyboard/matcher.rs
+++ b/apps/whispering/src-tauri/src/keyboard/matcher.rs
@@ -107,6 +107,13 @@ impl MatchOutcome {
             pending_until: None,
         }
     }
+
+    fn pending(deadline: u64) -> Self {
+        Self {
+            events: Vec::new(),
+            pending_until: Some(deadline),
+        }
+    }
 }
 
 impl Matcher {
@@ -165,10 +172,14 @@ impl Matcher {
     /// mid-window, so the prefix just needs a fresh press), and a gesture whose
     /// binding vanished cannot fire.
     pub fn set_bindings(&mut self, bindings: impl IntoIterator<Item = (String, KeyBinding)>) {
-        // Capture the active binding's identity before the swap; only a resolved
-        // gesture is carried (see the doc comment).
+        // Capture the active binding's match key before the swap; only a resolved
+        // gesture is carried across (see the doc comment), cloned so it can
+        // outlive the binding vec being replaced.
         let active = match self.gesture {
-            Gesture::Active { index } => Some(self.identity(index)),
+            Gesture::Active { index } => {
+                let b = &self.bindings[index];
+                Some((b.command_id.clone(), b.modifiers.clone(), b.keys.clone()))
+            }
             Gesture::Pending { .. } | Gesture::Idle => None,
         };
 
@@ -195,13 +206,6 @@ impl Matcher {
                 })
                 .map_or(Gesture::Idle, |index| Gesture::Active { index }),
         };
-    }
-
-    /// The (command, modifiers, keys) identity of a registered binding, cloned so
-    /// it can outlive a binding-set swap.
-    fn identity(&self, index: usize) -> (String, BTreeSet<Modifier>, BTreeSet<Key>) {
-        let b = &self.bindings[index];
-        (b.command_id.clone(), b.modifiers.clone(), b.keys.clone())
     }
 
     /// Feed one key event. Updates the held sets, then resolves the gesture.
@@ -249,10 +253,11 @@ impl Matcher {
         vec![self.press(index)]
     }
 
-    /// Deadline of the open pending window, if any. A read-only state query:
-    /// tests use it to assert a window armed, while production schedules off
-    /// `MatchOutcome::pending_until` returned by `on_event`.
-    pub fn pending_deadline(&self) -> Option<u64> {
+    /// Deadline of the open pending window, if any. Test-only state query used to
+    /// assert a window armed; production schedules off `MatchOutcome::pending_until`
+    /// returned by `on_event`, so this is compiled out of release builds.
+    #[cfg(test)]
+    fn pending_deadline(&self) -> Option<u64> {
         match self.gesture {
             Gesture::Pending { deadline, .. } => Some(deadline),
             _ => None,
@@ -328,10 +333,7 @@ impl Matcher {
         if self.has_extender(index) {
             let deadline = now + PENDING_WINDOW_MS;
             self.gesture = Gesture::Pending { index, deadline };
-            MatchOutcome {
-                events: Vec::new(),
-                pending_until: Some(deadline),
-            }
+            MatchOutcome::pending(deadline)
         } else {
             self.gesture = Gesture::Active { index };
             MatchOutcome::fired(vec![self.press(index)])

--- a/apps/whispering/src-tauri/src/keyboard/matcher.rs
+++ b/apps/whispering/src-tauri/src/keyboard/matcher.rs
@@ -27,18 +27,6 @@ struct Registered {
     keys: BTreeSet<Key>,
 }
 
-/// The single in-flight gesture. The desktop backend resolves **one** gesture at
-/// a time: a global push-to-talk hold owns the keyboard until it releases, so we
-/// never track two bindings as simultaneously held (that is what lets a resolved
-/// push-to-talk ignore extra keys instead of converting into a chord).
-enum Gesture {
-    /// Nothing held that matches a binding.
-    Idle,
-    /// `index`'s binding is held and owns the gesture. It stays active (extra
-    /// keys ignored) until one of its own keys releases.
-    Active { index: usize },
-}
-
 /// Turns the rdev event stream into `{ command_id, state }` transitions.
 ///
 /// Matching is exact set equality: a binding fires the instant the held
@@ -63,7 +51,13 @@ pub struct Matcher {
     bindings: Vec<Registered>,
     held_modifiers: BTreeSet<Modifier>,
     held_keys: BTreeSet<Key>,
-    gesture: Gesture,
+    /// Index of the binding that currently owns the gesture, or `None` when idle.
+    /// The desktop backend resolves **one** gesture at a time: a global
+    /// push-to-talk hold owns the keyboard until it releases, so we never track
+    /// two bindings as simultaneously held (that is what lets a resolved
+    /// push-to-talk ignore extra keys instead of converting into a chord). It
+    /// stays active (extra keys ignored) until one of its own keys releases.
+    active: Option<usize>,
     capturing: bool,
 }
 
@@ -73,7 +67,7 @@ impl Matcher {
             bindings: Vec::new(),
             held_modifiers: BTreeSet::new(),
             held_keys: BTreeSet::new(),
-            gesture: Gesture::Idle,
+            active: None,
             capturing: false,
         }
     }
@@ -84,7 +78,7 @@ impl Matcher {
     /// nothing is left half-fired across the mode switch.
     pub fn set_capturing(&mut self, capturing: bool) {
         self.capturing = capturing;
-        self.gesture = Gesture::Idle;
+        self.active = None;
     }
 
     pub fn is_capturing(&self) -> bool {
@@ -106,14 +100,14 @@ impl Matcher {
     pub fn clear_held(&mut self) {
         self.held_modifiers.clear();
         self.held_keys.clear();
-        self.gesture = Gesture::Idle;
+        self.active = None;
     }
 
     /// Replace the full set of registered bindings. Empty bindings are dropped
     /// (they can never be "held"). The held sets are left untouched: the physical
     /// keys really are still down.
     ///
-    /// Any in-flight gesture resets to `Idle` (its index points into the old vec,
+    /// Any in-flight gesture resets to idle (its index points into the old vec,
     /// so it cannot survive the swap anyway). The FE only re-pushes between
     /// sessions, on launch, on a settings edit, or on reset, never while a global
     /// gesture is physically held, so there is no resolved gesture to carry across.
@@ -130,7 +124,7 @@ impl Matcher {
                 }
             })
             .collect();
-        self.gesture = Gesture::Idle;
+        self.active = None;
     }
 
     /// Feed one key event. Updates the held sets, then resolves the gesture and
@@ -155,24 +149,24 @@ impl Matcher {
             return Vec::new();
         }
 
-        match self.gesture {
+        match self.active {
             // An active binding owns the gesture. Extra presses are ignored; it
             // releases only when one of its own keys/modifiers goes up (so the
             // held set is no longer a superset of the binding).
-            Gesture::Active { index } => {
+            Some(index) => {
                 if self.held_is_superset_of(index) {
                     Vec::new()
                 } else {
-                    self.gesture = Gesture::Idle;
+                    self.active = None;
                     vec![self.release(index)]
                 }
             }
             // Nothing in flight. A press that exactly matches a binding fires it;
             // a partial chord (or any release) waits silently.
-            Gesture::Idle => {
+            None => {
                 if edge == Edge::Press {
                     if let Some(index) = self.find_exact() {
-                        self.gesture = Gesture::Active { index };
+                        self.active = Some(index);
                         return vec![self.press(index)];
                     }
                 }

--- a/apps/whispering/src-tauri/src/keyboard/matcher.rs
+++ b/apps/whispering/src-tauri/src/keyboard/matcher.rs
@@ -163,26 +163,11 @@ impl Matcher {
     /// (they can never be "held"). The held sets are left untouched: the physical
     /// keys really are still down.
     ///
-    /// A resolved (`Active`) gesture is carried across only if its exact binding
-    /// (same command, modifiers, and keys) survives the swap. This matters because
-    /// the FE re-pushes the full set mid-session (for example to register the
-    /// cancel gesture once recording starts); a held push-to-talk must keep owning
-    /// the gesture so its `Released` still pairs on key-up. Anything else resets to
-    /// `Idle`: a `Pending` window is dropped (the swap lands between sessions, never
-    /// mid-window, so the prefix just needs a fresh press), and a gesture whose
-    /// binding vanished cannot fire.
+    /// Any in-flight gesture resets to `Idle` (its index points into the old vec,
+    /// so it cannot survive the swap anyway). The FE only re-pushes between
+    /// sessions, on launch, on a settings edit, or on reset, never while a global
+    /// gesture is physically held, so there is no resolved gesture to carry across.
     pub fn set_bindings(&mut self, bindings: impl IntoIterator<Item = (String, KeyBinding)>) {
-        // Capture the active binding's match key before the swap; only a resolved
-        // gesture is carried across (see the doc comment), cloned so it can
-        // outlive the binding vec being replaced.
-        let active = match self.gesture {
-            Gesture::Active { index } => {
-                let b = &self.bindings[index];
-                Some((b.command_id.clone(), b.modifiers.clone(), b.keys.clone()))
-            }
-            Gesture::Pending { .. } | Gesture::Idle => None,
-        };
-
         self.bindings = bindings
             .into_iter()
             .filter(|(_, binding)| !binding.is_empty())
@@ -195,17 +180,7 @@ impl Matcher {
                 }
             })
             .collect();
-
-        self.gesture = match active {
-            None => Gesture::Idle,
-            Some((command_id, modifiers, keys)) => self
-                .bindings
-                .iter()
-                .position(|b| {
-                    b.command_id == command_id && b.modifiers == modifiers && b.keys == keys
-                })
-                .map_or(Gesture::Idle, |index| Gesture::Active { index }),
-        };
+        self.gesture = Gesture::Idle;
     }
 
     /// Feed one key event. Updates the held sets, then resolves the gesture.
@@ -660,35 +635,18 @@ mod tests {
     }
 
     #[test]
-    fn re_pushing_the_same_binding_keeps_a_held_gesture_so_release_still_pairs() {
-        // The FE re-pushes the full binding set mid-session (the cancel gesture is
-        // registered once recording starts). A held push-to-talk must survive that
-        // swap, or its Released would never fire and recording would never stop.
+    fn re_pushing_bindings_resets_any_in_flight_gesture() {
+        // The FE re-pushes the full set only between sessions, never while a
+        // gesture is physically held, so a swap always restarts resolution from
+        // Idle. A key still down when the swap lands does not emit on release:
+        // the gesture that owned it is gone (even when the binding itself stays).
         let mut matcher = Matcher::new();
         matcher.set_bindings([("a".to_string(), binding(&[], &[Key::Space]))]);
         let mut clock = fast();
         let first = run(&mut matcher, &mut clock, &[(Press, K(Key::Space))]);
         assert_eq!(first, vec![("a".to_string(), Pressed)]);
 
-        // Re-push the identical set while Space is still held. The active gesture
-        // is preserved, so releasing Space still emits exactly one Released.
         matcher.set_bindings([("a".to_string(), binding(&[], &[Key::Space]))]);
-        let after = run(&mut matcher, &mut clock, &[(Release, K(Key::Space))]);
-        assert_eq!(after, vec![("a".to_string(), Released)]);
-    }
-
-    #[test]
-    fn re_pushing_without_the_active_binding_resets_it() {
-        // If the held binding is gone from the new set, the gesture resets: a
-        // later release must not emit for a binding that no longer exists.
-        let mut matcher = Matcher::new();
-        matcher.set_bindings([("a".to_string(), binding(&[], &[Key::Space]))]);
-        let mut clock = fast();
-        let first = run(&mut matcher, &mut clock, &[(Press, K(Key::Space))]);
-        assert_eq!(first, vec![("a".to_string(), Pressed)]);
-
-        // Swap to a different binding while Space is held; "a" is gone.
-        matcher.set_bindings([("b".to_string(), binding(&[Meta], &[Key::KeyD]))]);
         let after = run(&mut matcher, &mut clock, &[(Release, K(Key::Space))]);
         assert!(after.is_empty());
     }

--- a/apps/whispering/src-tauri/src/keyboard/matcher.rs
+++ b/apps/whispering/src-tauri/src/keyboard/matcher.rs
@@ -3,13 +3,6 @@ use std::collections::BTreeSet;
 use super::event::{ShortcutTriggerEvent, TriggerState};
 use super::keys::{Key, KeyBinding, Modifier};
 
-/// How long a shorter binding waits to see whether a longer binding that extends
-/// it completes. Kept small so a deliberate push-to-talk hold starts capturing
-/// almost immediately; long enough that pressing the extra key of a chord (for
-/// example the Space in `Fn` + `Space`) lands inside the window on real hardware.
-/// See the module note on the first-syllable trade-off.
-pub const PENDING_WINDOW_MS: u64 = 120;
-
 /// Edge of a single key event fed in from the rdev listener.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Edge {
@@ -36,84 +29,42 @@ struct Registered {
 
 /// The single in-flight gesture. The desktop backend resolves **one** gesture at
 /// a time: a global push-to-talk hold owns the keyboard until it releases, so we
-/// never track two bindings as simultaneously held (that is what lets a
-/// resolved push-to-talk ignore extra keys instead of converting into a chord).
+/// never track two bindings as simultaneously held (that is what lets a resolved
+/// push-to-talk ignore extra keys instead of converting into a chord).
 enum Gesture {
-    /// Nothing held that matches or prefixes a binding.
+    /// Nothing held that matches a binding.
     Idle,
-    /// `index`'s binding is held exactly, but a longer binding extends it, so we
-    /// wait until `deadline` (a logical millisecond timestamp) to see if the
-    /// longer one completes. The listener schedules a `poll` for `deadline`.
-    Pending { index: usize, deadline: u64 },
-    /// `index`'s binding has fired `Pressed` and owns the gesture. It stays
-    /// active (extra keys ignored) until one of its own keys releases.
+    /// `index`'s binding is held and owns the gesture. It stays active (extra
+    /// keys ignored) until one of its own keys releases.
     Active { index: usize },
 }
 
-/// Turns the rdev event stream into `{ command_id, state }` transitions with a
-/// **gesture resolver** for prefix bindings.
+/// Turns the rdev event stream into `{ command_id, state }` transitions.
 ///
-/// Matching is still set-based: a binding is "held exactly" iff the held
-/// modifiers equal its modifiers and the held keys equal its keys. On top of
-/// that, prefixes resolve through a short pending window so `Fn` (push-to-talk)
-/// and `Fn` + `Space` (toggle) can both be bound even though `Fn` arrives before
-/// `Space`:
+/// Matching is exact set equality: a binding fires the instant the held
+/// modifiers equal its modifiers and the held keys equal its keys. There is no
+/// pending window and no prefix resolution, so a gesture fires with zero latency
+/// (push-to-talk starts capturing audio on the very first edge).
 ///
-/// - A binding that is held exactly and has **no** registered binding extending
-///   it fires immediately (the common case: a chord, a modifier-only hold).
-/// - A binding that is held exactly and **does** have a longer binding extending
-///   it enters a pending window. If the longer binding completes during the
-///   window it fires and the shorter one is suppressed; if the window expires the
-///   shorter one fires.
-/// - Once a binding is `Active`, it owns the gesture: pressing extra keys does
-///   not release it or convert it into a different binding. It releases (exactly
-///   once) when one of its own keys goes up.
+/// The cost of dropping prefix resolution is that bindings must not overlap: if
+/// one binding's keys are a subset of another's (for example `Fn` and
+/// `Fn` + `Space`), the shorter one fires first and the longer one can never be
+/// reached, because once the shorter binding is `Active` it owns the gesture and
+/// ignores the extra key. The frontend enforces this by refusing to save a
+/// gesture that contains, or is contained by, another configured gesture, and
+/// the shipped defaults are deliberately disjoint. That is why push-to-talk is a
+/// dedicated key (`Fn`): nothing else may use it.
 ///
-/// First-syllable note: because `Fn` has an extender by default, push-to-talk
-/// waits up to `PENDING_WINDOW_MS` before `Pressed`, which delays audio capture
-/// by that much. The window is deliberately small, and it only applies when a
-/// real prefix conflict is configured (clear the toggle binding and `Fn` fires
-/// immediately). The proper fix (warm the recorder on the pending edge) is
-/// tracked separately; see the recorder's pre-roll discussion.
+/// - A binding held exactly fires immediately (`Pressed`) and becomes `Active`.
+/// - An `Active` binding owns the gesture: pressing extra keys does not release
+///   it or convert it. It releases (exactly once) when one of its own keys goes
+///   up.
 pub struct Matcher {
     bindings: Vec<Registered>,
     held_modifiers: BTreeSet<Modifier>,
     held_keys: BTreeSet<Key>,
     gesture: Gesture,
     capturing: bool,
-}
-
-/// What one event produced: the transitions to emit now, plus the deadline of a
-/// freshly-armed pending window (if any) so the listener can schedule a `poll`.
-pub struct MatchOutcome {
-    pub events: Vec<ShortcutTriggerEvent>,
-    /// `Some(deadline)` only when this event *armed* a new pending window. The
-    /// listener spawns a timer for `deadline`; `poll` is a no-op if the window
-    /// was already resolved or superseded, so a late timer is harmless.
-    pub pending_until: Option<u64>,
-}
-
-impl MatchOutcome {
-    fn nothing() -> Self {
-        Self {
-            events: Vec::new(),
-            pending_until: None,
-        }
-    }
-
-    fn fired(events: Vec<ShortcutTriggerEvent>) -> Self {
-        Self {
-            events,
-            pending_until: None,
-        }
-    }
-
-    fn pending(deadline: u64) -> Self {
-        Self {
-            events: Vec::new(),
-            pending_until: Some(deadline),
-        }
-    }
 }
 
 impl Matcher {
@@ -128,10 +79,9 @@ impl Matcher {
     }
 
     /// Enter or leave capture mode. While capturing, `on_event` updates the held
-    /// set but emits no triggers and arms no pending window; the listener reads
-    /// `held_binding` instead and forwards it to the settings recorder. The
-    /// in-flight gesture is reset so nothing is left half-fired across the
-    /// mode switch.
+    /// set but emits no triggers; the listener reads `held_binding` instead and
+    /// forwards it to the settings recorder. The in-flight gesture is reset so
+    /// nothing is left half-fired across the mode switch.
     pub fn set_capturing(&mut self, capturing: bool) {
         self.capturing = capturing;
         self.gesture = Gesture::Idle;
@@ -183,12 +133,12 @@ impl Matcher {
         self.gesture = Gesture::Idle;
     }
 
-    /// Feed one key event. Updates the held sets, then resolves the gesture.
-    pub fn on_event(&mut self, now: u64, edge: Edge, input: Input) -> MatchOutcome {
+    /// Feed one key event. Updates the held sets, then resolves the gesture and
+    /// returns the transitions to emit (empty when nothing changes).
+    pub fn on_event(&mut self, edge: Edge, input: Input) -> Vec<ShortcutTriggerEvent> {
         // Apply the edge. `changed` is false for an auto-repeat press (the key is
         // already held) or a stray release of an absent key. Those are no-ops:
-        // returning early keeps auto-repeat from re-firing a binding and, just as
-        // importantly, from resetting a pending window on every repeat tick.
+        // returning early keeps auto-repeat from re-firing a binding.
         let changed = match (edge, input) {
             (Edge::Press, Input::Modifier(m)) => self.held_modifiers.insert(m),
             (Edge::Release, Input::Modifier(m)) => self.held_modifiers.remove(&m),
@@ -196,122 +146,38 @@ impl Matcher {
             (Edge::Release, Input::Key(k)) => self.held_keys.remove(&k),
         };
         if !changed {
-            return MatchOutcome::nothing();
+            return Vec::new();
         }
 
         // In capture mode the listener forwards `held_binding()` to the recorder;
-        // it does not match registered bindings or arm pending windows.
+        // it does not match registered bindings.
         if self.capturing {
-            return MatchOutcome::nothing();
+            return Vec::new();
         }
 
         match self.gesture {
-            Gesture::Active { index } => self.on_event_active(index),
-            Gesture::Pending { index, .. } => self.on_event_pending(index, edge, now),
-            Gesture::Idle => self.on_event_idle(edge, now),
-        }
-    }
-
-    /// A timer (scheduled by the listener for a pending window's deadline) calls
-    /// this. If the window is still open and has expired, the shorter binding
-    /// fires. Otherwise it is a no-op: the window may have already resolved (the
-    /// longer binding completed, the keys released) or been superseded by a newer
-    /// pending window with a later deadline.
-    pub fn poll(&mut self, now: u64) -> Vec<ShortcutTriggerEvent> {
-        let Gesture::Pending { index, deadline } = self.gesture else {
-            return Vec::new();
-        };
-        if now < deadline {
-            return Vec::new();
-        }
-        self.gesture = Gesture::Active { index };
-        vec![self.press(index)]
-    }
-
-    /// Deadline of the open pending window, if any. Test-only state query used to
-    /// assert a window armed; production schedules off `MatchOutcome::pending_until`
-    /// returned by `on_event`, so this is compiled out of release builds.
-    #[cfg(test)]
-    fn pending_deadline(&self) -> Option<u64> {
-        match self.gesture {
-            Gesture::Pending { deadline, .. } => Some(deadline),
-            _ => None,
-        }
-    }
-
-    // ── Per-state handlers ────────────────────────────────────────────────────
-
-    /// An active binding owns the gesture. Extra presses are ignored; it releases
-    /// only when one of its own keys/modifiers goes up (so the held set is no
-    /// longer a superset of the binding).
-    fn on_event_active(&mut self, index: usize) -> MatchOutcome {
-        if self.held_is_superset_of(index) {
-            return MatchOutcome::nothing();
-        }
-        self.gesture = Gesture::Idle;
-        MatchOutcome::fired(vec![self.release(index)])
-    }
-
-    /// A pending window is open for `index`. A press either completes a longer
-    /// binding (resolve to it) or grows past the shorter one without matching
-    /// anything (commit the shorter one). A release either ends the shorter
-    /// gesture before it resolved (drop it: a sub-window tap is not a hold) or
-    /// drops an unrelated extra key (stay pending).
-    fn on_event_pending(&mut self, index: usize, edge: Edge, now: u64) -> MatchOutcome {
-        match edge {
-            Edge::Press => {
-                if let Some(exact) = self.find_exact() {
-                    // The held set grew to exactly match another binding. Because
-                    // the shorter binding was held exactly a moment ago and we only
-                    // added keys, that binding necessarily extends it. Resolve to
-                    // it (which may itself pend if it has a longer extender).
-                    self.activate_or_pend(exact, now)
-                } else {
-                    // Grew past the shorter binding without matching anything. The
-                    // shorter binding is still held (a subset), so commit it.
-                    self.gesture = Gesture::Active { index };
-                    MatchOutcome::fired(vec![self.press(index)])
-                }
-            }
-            Edge::Release => {
+            // An active binding owns the gesture. Extra presses are ignored; it
+            // releases only when one of its own keys/modifiers goes up (so the
+            // held set is no longer a superset of the binding).
+            Gesture::Active { index } => {
                 if self.held_is_superset_of(index) {
-                    // An extra key went up but the shorter binding is still fully
-                    // held; keep waiting. No new pending window is armed.
-                    MatchOutcome::nothing()
+                    Vec::new()
                 } else {
-                    // One of the shorter binding's own keys went up before the
-                    // window expired: a tap too brief to be a hold. Drop it rather
-                    // than fire a near-empty push-to-talk.
                     self.gesture = Gesture::Idle;
-                    MatchOutcome::nothing()
+                    vec![self.release(index)]
                 }
             }
-        }
-    }
-
-    /// Nothing in flight. A press that exactly matches a binding resolves it; a
-    /// press that only partially builds a chord waits silently.
-    fn on_event_idle(&mut self, edge: Edge, now: u64) -> MatchOutcome {
-        if edge == Edge::Press {
-            if let Some(index) = self.find_exact() {
-                return self.activate_or_pend(index, now);
+            // Nothing in flight. A press that exactly matches a binding fires it;
+            // a partial chord (or any release) waits silently.
+            Gesture::Idle => {
+                if edge == Edge::Press {
+                    if let Some(index) = self.find_exact() {
+                        self.gesture = Gesture::Active { index };
+                        return vec![self.press(index)];
+                    }
+                }
+                Vec::new()
             }
-        }
-        MatchOutcome::nothing()
-    }
-
-    // ── Resolution helpers ────────────────────────────────────────────────────
-
-    /// Resolve a binding that is currently held exactly: pend if a longer binding
-    /// extends it, otherwise fire it now.
-    fn activate_or_pend(&mut self, index: usize, now: u64) -> MatchOutcome {
-        if self.has_extender(index) {
-            let deadline = now + PENDING_WINDOW_MS;
-            self.gesture = Gesture::Pending { index, deadline };
-            MatchOutcome::pending(deadline)
-        } else {
-            self.gesture = Gesture::Active { index };
-            MatchOutcome::fired(vec![self.press(index)])
         }
     }
 
@@ -323,23 +189,6 @@ impl Matcher {
         self.bindings
             .iter()
             .position(|b| b.modifiers == self.held_modifiers && b.keys == self.held_keys)
-    }
-
-    /// Whether any *other* registered binding strictly extends `index`'s binding
-    /// (a superset of both its modifiers and its keys). `index`'s binding is held
-    /// exactly when this is called, so such a binding is reachable by pressing
-    /// more keys, which is exactly the prefix conflict the window disambiguates.
-    fn has_extender(&self, index: usize) -> bool {
-        let target = &self.bindings[index];
-        self.bindings.iter().enumerate().any(|(i, b)| {
-            i != index
-                && target.modifiers.is_subset(&b.modifiers)
-                && target.keys.is_subset(&b.keys)
-                // Strict: an equal binding (a duplicate combo) is a subset but not
-                // an extender, so a duplicate fires immediately rather than pending
-                // forever on a longer binding that does not exist.
-                && (b.modifiers.len() + b.keys.len()) > (target.modifiers.len() + target.keys.len())
-        })
     }
 
     /// Whether the held set still contains all of `index`'s modifiers and keys
@@ -377,46 +226,16 @@ mod tests {
         }
     }
 
-    /// A logical clock for the event sequence. Each event advances time by
-    /// `step` ms, so tests can place key presses inside or outside the pending
-    /// window without any real sleeping.
-    struct Clock {
-        now: u64,
-        step: u64,
-    }
-
     /// Drive a sequence of events through the matcher and collect every emitted
-    /// transition as `(command_id, state)` pairs. `poll` is run after each event
-    /// once the clock has passed the pending deadline, mirroring the listener's
-    /// timer: in production a real timer fires `poll` at the deadline; here we
-    /// fire it deterministically.
-    fn run(
-        matcher: &mut Matcher,
-        clock: &mut Clock,
-        events: &[(Edge, Input)],
-    ) -> Vec<(String, TriggerState)> {
+    /// transition as `(command_id, state)` pairs.
+    fn run(matcher: &mut Matcher, events: &[(Edge, Input)]) -> Vec<(String, TriggerState)> {
         let mut out = Vec::new();
         for &(edge, input) in events {
-            let outcome = matcher.on_event(clock.now, edge, input);
-            for ev in outcome.events {
+            for ev in matcher.on_event(edge, input) {
                 out.push((ev.command_id, ev.state));
             }
-            clock.now += clock.step;
         }
         out
-    }
-
-    /// Advance the clock past any open pending deadline and flush it, the way the
-    /// scheduled timer would.
-    fn flush(matcher: &mut Matcher, clock: &mut Clock) -> Vec<(String, TriggerState)> {
-        if let Some(deadline) = matcher.pending_deadline() {
-            clock.now = clock.now.max(deadline);
-        }
-        matcher
-            .poll(clock.now)
-            .into_iter()
-            .map(|ev| (ev.command_id, ev.state))
-            .collect()
     }
 
     use Edge::{Press, Release};
@@ -424,11 +243,6 @@ mod tests {
     use Input::Modifier as M;
     use Modifier::{Fn, Meta, Shift};
     use TriggerState::{Pressed, Released};
-
-    fn fast() -> Clock {
-        // 10ms per event: a whole short chord lands well inside the window.
-        Clock { now: 0, step: 10 }
-    }
 
     #[test]
     fn chord_fires_once_when_the_last_key_completes_it_and_releases_when_it_breaks() {
@@ -438,11 +252,10 @@ mod tests {
             binding(&[Meta, Shift], &[Key::KeyD]),
         )]);
 
-        // Modifiers alone do not satisfy the chord; only the final key does. With
-        // no binding extending Meta+Shift+D, it fires immediately on the D press.
+        // Modifiers alone do not satisfy the chord; only the final key does, and
+        // it fires immediately on the D press (no window).
         let events = run(
             &mut matcher,
-            &mut fast(),
             &[
                 (Press, M(Meta)),
                 (Press, M(Shift)),
@@ -465,18 +278,16 @@ mod tests {
     fn clear_held_drops_stale_state_so_a_missed_release_cannot_wedge_a_binding() {
         let mut matcher = Matcher::new();
         matcher.set_bindings([("ptt".to_string(), binding(&[], &[Key::Space]))]);
-        let mut clock = fast();
 
         // Space goes down (binding fires), then the key-up is "missed" (the
         // listener exited mid-hold). clear_held models the listener restart.
-        let pressed = run(&mut matcher, &mut clock, &[(Press, K(Key::Space))]);
+        let pressed = run(&mut matcher, &[(Press, K(Key::Space))]);
         assert_eq!(pressed, vec![("ptt".to_string(), Pressed)]);
         matcher.clear_held();
 
         // A later stray release must not emit, and a fresh press still works.
         let after = run(
             &mut matcher,
-            &mut clock,
             &[(Release, K(Key::Space)), (Press, K(Key::Space))],
         );
         assert_eq!(after, vec![("ptt".to_string(), Pressed)]);
@@ -489,7 +300,6 @@ mod tests {
         // Shift before Meta still completes on KeyD.
         let events = run(
             &mut matcher,
-            &mut fast(),
             &[(Press, M(Shift)), (Press, M(Meta)), (Press, K(Key::KeyD))],
         );
         assert_eq!(events, vec![("x".to_string(), Pressed)]);
@@ -499,11 +309,7 @@ mod tests {
     fn modifier_only_binding_presses_and_releases_on_the_modifier_alone() {
         let mut matcher = Matcher::new();
         matcher.set_bindings([("toggle".to_string(), binding(&[Meta], &[]))]);
-        let events = run(
-            &mut matcher,
-            &mut fast(),
-            &[(Press, M(Meta)), (Release, M(Meta))],
-        );
+        let events = run(&mut matcher, &[(Press, M(Meta)), (Release, M(Meta))]);
         assert_eq!(
             events,
             vec![
@@ -519,7 +325,6 @@ mod tests {
         matcher.set_bindings([("ptt".to_string(), binding(&[], &[Key::Space]))]);
         let events = run(
             &mut matcher,
-            &mut fast(),
             &[(Press, K(Key::Space)), (Release, K(Key::Space))],
         );
         assert_eq!(
@@ -529,14 +334,10 @@ mod tests {
     }
 
     #[test]
-    fn fn_modifier_binding_fires() {
+    fn fn_modifier_binding_fires_immediately() {
         let mut matcher = Matcher::new();
         matcher.set_bindings([("ptt".to_string(), binding(&[Fn], &[]))]);
-        let events = run(
-            &mut matcher,
-            &mut fast(),
-            &[(Press, M(Fn)), (Release, M(Fn))],
-        );
+        let events = run(&mut matcher, &[(Press, M(Fn)), (Release, M(Fn))]);
         assert_eq!(
             events,
             vec![("ptt".to_string(), Pressed), ("ptt".to_string(), Released)]
@@ -550,11 +351,7 @@ mod tests {
         matcher.set_capturing(true);
 
         // A registered binding must not fire while capturing.
-        let events = run(
-            &mut matcher,
-            &mut fast(),
-            &[(Press, M(Fn)), (Press, K(Key::KeyD))],
-        );
+        let events = run(&mut matcher, &[(Press, M(Fn)), (Press, K(Key::KeyD))]);
         assert!(events.is_empty());
 
         // The held combo is what the recorder reads and commits (Fn + D, the
@@ -565,7 +362,7 @@ mod tests {
 
         // Leaving capture mode re-arms normal matching.
         matcher.set_capturing(false);
-        let after = run(&mut matcher, &mut fast(), &[(Release, M(Fn))]);
+        let after = run(&mut matcher, &[(Release, M(Fn))]);
         assert!(after.is_empty());
     }
 
@@ -577,7 +374,6 @@ mod tests {
         // second and third press must not produce a second Pressed.
         let events = run(
             &mut matcher,
-            &mut fast(),
             &[
                 (Press, K(Key::KeyD)),
                 (Press, K(Key::KeyD)),
@@ -599,7 +395,6 @@ mod tests {
         // binding. Feeding an unrelated key produces nothing.
         let events = run(
             &mut matcher,
-            &mut fast(),
             &[(Press, K(Key::KeyA)), (Release, K(Key::KeyA))],
         );
         assert!(events.is_empty());
@@ -614,7 +409,6 @@ mod tests {
         ]);
         let events = run(
             &mut matcher,
-            &mut fast(),
             &[
                 (Press, M(Meta)),
                 (Press, K(Key::KeyA)),   // a fires
@@ -635,6 +429,57 @@ mod tests {
     }
 
     #[test]
+    fn an_active_gesture_ignores_extra_keys_and_releases_once() {
+        // Push-to-talk on Fn, plus a disjoint toggle. While Fn is active, pressing
+        // Space (which alone matches nothing here) is ignored, and Fn up releases
+        // push-to-talk exactly once. This is the invariant the no-overlap policy
+        // relies on: one gesture owns the keyboard until its own key lifts.
+        let mut matcher = Matcher::new();
+        matcher.set_bindings([("ptt".to_string(), binding(&[Fn], &[]))]);
+
+        let events = run(
+            &mut matcher,
+            &[
+                (Press, M(Fn)),          // ptt fires immediately
+                (Press, K(Key::Space)),  // extra key: ignored
+                (Release, K(Key::Space)),
+                (Release, M(Fn)),        // ptt releases
+            ],
+        );
+        assert_eq!(
+            events,
+            vec![("ptt".to_string(), Pressed), ("ptt".to_string(), Released)]
+        );
+    }
+
+    #[test]
+    fn an_overlapping_longer_binding_is_unreachable() {
+        // Documents the cost of dropping prefix resolution: when one binding is a
+        // subset of another (Fn vs Fn+Space), the shorter fires first and owns the
+        // gesture, so the longer one never fires. The FE refuses to save such a
+        // pair; this proves why.
+        let mut matcher = Matcher::new();
+        matcher.set_bindings([
+            ("ptt".to_string(), binding(&[Fn], &[])),
+            ("toggle".to_string(), binding(&[Fn], &[Key::Space])),
+        ]);
+
+        let events = run(
+            &mut matcher,
+            &[
+                (Press, M(Fn)),         // ptt fires; Fn is held exactly
+                (Press, K(Key::Space)), // would complete toggle, but ptt owns it
+                (Release, K(Key::Space)),
+                (Release, M(Fn)),
+            ],
+        );
+        assert_eq!(
+            events,
+            vec![("ptt".to_string(), Pressed), ("ptt".to_string(), Released)]
+        );
+    }
+
+    #[test]
     fn re_pushing_bindings_resets_any_in_flight_gesture() {
         // The FE re-pushes the full set only between sessions, never while a
         // gesture is physically held, so a swap always restarts resolution from
@@ -642,160 +487,12 @@ mod tests {
         // the gesture that owned it is gone (even when the binding itself stays).
         let mut matcher = Matcher::new();
         matcher.set_bindings([("a".to_string(), binding(&[], &[Key::Space]))]);
-        let mut clock = fast();
-        let first = run(&mut matcher, &mut clock, &[(Press, K(Key::Space))]);
+        let first = run(&mut matcher, &[(Press, K(Key::Space))]);
         assert_eq!(first, vec![("a".to_string(), Pressed)]);
 
         matcher.set_bindings([("a".to_string(), binding(&[], &[Key::Space]))]);
-        let after = run(&mut matcher, &mut clock, &[(Release, K(Key::Space))]);
+        let after = run(&mut matcher, &[(Release, K(Key::Space))]);
         assert!(after.is_empty());
-    }
-
-    // ── Gesture-resolver tests ────────────────────────────────────────────────
-
-    /// Register the macOS default prefix pair: Fn = push-to-talk, Fn+Space =
-    /// toggle. Fn is a prefix of Fn+Space, so Fn must wait out the window.
-    fn fn_prefix_pair() -> Matcher {
-        let mut matcher = Matcher::new();
-        matcher.set_bindings([
-            ("pushToTalk".to_string(), binding(&[Fn], &[])),
-            ("toggle".to_string(), binding(&[Fn], &[Key::Space])),
-        ]);
-        matcher
-    }
-
-    #[test]
-    fn fn_alone_resolves_to_push_to_talk_after_the_pending_window() {
-        let mut matcher = fn_prefix_pair();
-        let mut clock = fast();
-
-        // Pressing Fn must NOT fire immediately: Fn+Space extends it.
-        let pressed = run(&mut matcher, &mut clock, &[(Press, M(Fn))]);
-        assert!(pressed.is_empty());
-        assert!(matcher.pending_deadline().is_some());
-
-        // When the window expires, push-to-talk fires (and only push-to-talk).
-        let flushed = flush(&mut matcher, &mut clock);
-        assert_eq!(flushed, vec![("pushToTalk".to_string(), Pressed)]);
-    }
-
-    #[test]
-    fn fn_space_resolves_to_toggle_and_never_fires_push_to_talk() {
-        let mut matcher = fn_prefix_pair();
-        let mut clock = fast();
-
-        // Fn then Space, both inside the window: the longer binding wins and the
-        // shorter one is suppressed. No push-to-talk event ever appears.
-        let events = run(
-            &mut matcher,
-            &mut clock,
-            &[
-                (Press, M(Fn)),
-                (Press, K(Key::Space)),
-                (Release, K(Key::Space)),
-                (Release, M(Fn)),
-            ],
-        );
-        assert_eq!(
-            events,
-            vec![
-                ("toggle".to_string(), Pressed),
-                ("toggle".to_string(), Released),
-            ]
-        );
-        // A late timer firing now must do nothing.
-        assert!(matcher.poll(clock.now + 1_000).is_empty());
-    }
-
-    #[test]
-    fn releasing_fn_after_push_to_talk_emits_released_exactly_once() {
-        let mut matcher = fn_prefix_pair();
-        let mut clock = fast();
-
-        run(&mut matcher, &mut clock, &[(Press, M(Fn))]);
-        let pressed = flush(&mut matcher, &mut clock);
-        assert_eq!(pressed, vec![("pushToTalk".to_string(), Pressed)]);
-
-        // Exactly one Released on Fn up, and a stray timer afterwards adds nothing.
-        let released = run(&mut matcher, &mut clock, &[(Release, M(Fn))]);
-        assert_eq!(released, vec![("pushToTalk".to_string(), Released)]);
-        assert!(matcher.poll(clock.now + 1_000).is_empty());
-    }
-
-    #[test]
-    fn pressing_an_extra_key_after_push_to_talk_resolves_does_not_convert_it() {
-        let mut matcher = fn_prefix_pair();
-        let mut clock = fast();
-
-        // Resolve to push-to-talk first.
-        run(&mut matcher, &mut clock, &[(Press, M(Fn))]);
-        let pressed = flush(&mut matcher, &mut clock);
-        assert_eq!(pressed, vec![("pushToTalk".to_string(), Pressed)]);
-
-        // Now press Space. The held set is exactly Fn+Space (toggle), but the
-        // already-active push-to-talk owns the gesture: no toggle, no release.
-        let extra = run(
-            &mut matcher,
-            &mut clock,
-            &[(Press, K(Key::Space)), (Release, K(Key::Space))],
-        );
-        assert!(extra.is_empty());
-
-        // Releasing Fn still ends push-to-talk exactly once.
-        let released = run(&mut matcher, &mut clock, &[(Release, M(Fn))]);
-        assert_eq!(released, vec![("pushToTalk".to_string(), Released)]);
-    }
-
-    #[test]
-    fn a_prefix_binding_with_no_extender_fires_immediately() {
-        // Same Fn push-to-talk, but no toggle registered: nothing extends Fn, so
-        // it must fire on press with no window (no first-syllable penalty).
-        let mut matcher = Matcher::new();
-        matcher.set_bindings([("pushToTalk".to_string(), binding(&[Fn], &[]))]);
-        let mut clock = fast();
-
-        let pressed = run(&mut matcher, &mut clock, &[(Press, M(Fn))]);
-        assert_eq!(pressed, vec![("pushToTalk".to_string(), Pressed)]);
-        assert!(matcher.pending_deadline().is_none());
-    }
-
-    #[test]
-    fn a_quick_tap_inside_the_window_is_dropped_not_fired() {
-        // Press and release Fn before the window expires. Too brief to be a hold,
-        // and not a chord, so nothing fires (avoids a near-empty push-to-talk).
-        let mut matcher = fn_prefix_pair();
-        let mut clock = fast();
-
-        let events = run(
-            &mut matcher,
-            &mut clock,
-            &[(Press, M(Fn)), (Release, M(Fn))],
-        );
-        assert!(events.is_empty());
-        assert!(matcher.poll(clock.now + 1_000).is_empty());
-    }
-
-    #[test]
-    fn pressing_an_unrelated_key_inside_the_window_commits_the_shorter_binding() {
-        // Fn pending, then a key that completes no binding. The shorter binding is
-        // still held, so it commits rather than getting lost.
-        let mut matcher = fn_prefix_pair();
-        let mut clock = fast();
-
-        let events = run(
-            &mut matcher,
-            &mut clock,
-            &[(Press, M(Fn)), (Press, K(Key::KeyJ))],
-        );
-        assert_eq!(events, vec![("pushToTalk".to_string(), Pressed)]);
-
-        // And it still releases cleanly when Fn goes up.
-        let released = run(
-            &mut matcher,
-            &mut clock,
-            &[(Release, K(Key::KeyJ)), (Release, M(Fn))],
-        );
-        assert_eq!(released, vec![("pushToTalk".to_string(), Released)]);
     }
 
     #[test]
@@ -807,41 +504,8 @@ mod tests {
         ]);
         let events = run(
             &mut matcher,
-            &mut fast(),
             &[(Press, M(Meta)), (Press, K(Key::KeyD))],
         );
         assert_eq!(events, vec![("first".to_string(), Pressed)]);
-    }
-
-    #[test]
-    fn windows_ctrl_win_prefix_pair_resolves_like_the_fn_pair() {
-        // The Windows defaults: Ctrl+Win = push-to-talk, Ctrl+Win+Space = toggle.
-        let mut matcher = Matcher::new();
-        matcher.set_bindings([
-            (
-                "pushToTalk".to_string(),
-                binding(&[Modifier::Ctrl, Meta], &[]),
-            ),
-            (
-                "toggle".to_string(),
-                binding(&[Modifier::Ctrl, Meta], &[Key::Space]),
-            ),
-        ]);
-        let mut clock = fast();
-
-        // Ctrl then Win: partial, nothing fires and no window yet (Ctrl alone
-        // matches no binding).
-        let partial = run(&mut matcher, &mut clock, &[(Press, M(Modifier::Ctrl))]);
-        assert!(partial.is_empty());
-        assert!(matcher.pending_deadline().is_none());
-
-        // Win completes Ctrl+Win exactly, which has an extender: pend.
-        let armed = run(&mut matcher, &mut clock, &[(Press, M(Meta))]);
-        assert!(armed.is_empty());
-        assert!(matcher.pending_deadline().is_some());
-
-        // Space inside the window resolves to toggle, not push-to-talk.
-        let toggled = run(&mut matcher, &mut clock, &[(Press, K(Key::Space))]);
-        assert_eq!(toggled, vec![("toggle".to_string(), Pressed)]);
     }
 }

--- a/apps/whispering/src-tauri/src/keyboard/mod.rs
+++ b/apps/whispering/src-tauri/src/keyboard/mod.rs
@@ -12,14 +12,13 @@
 //! - `rdev_map` the only rdev-coupled code: `rdev::Key` -> matcher `Input`
 //! - `event`    the wire payload emitted to the FE
 //!
-//! Wave 2 built this module in isolation. Wave 3 wired it in: the
-//! `set_keyboard_shortcuts` command pushes the user's bindings and the FE
-//! registrar dispatches the emitted events. Wave 6 added the start lifecycle:
-//! the FE calls `start_keyboard_listener` once it knows global shortcuts are
-//! allowed (macOS Accessibility granted, or any non-macOS desktop), so the
-//! listener is never spawned before `rdev::listen` can actually tap the
-//! keyboard. This mirrors `cjpais/Handy`, which gates the listener on the
-//! frontend's permission check rather than polling `listen` from Rust.
+//! Wiring: the `set_keyboard_shortcuts` command pushes the user's bindings and
+//! the FE registrar dispatches the emitted events. The FE calls
+//! `start_keyboard_listener` once it knows global shortcuts are allowed (macOS
+//! Accessibility granted, or any non-macOS desktop), so the listener is never
+//! spawned before `rdev::listen` can actually tap the keyboard. This mirrors
+//! `cjpais/Handy`, which gates the listener on the frontend's permission check
+//! rather than polling `listen` from Rust.
 
 pub mod commands;
 pub mod event;
@@ -95,8 +94,8 @@ impl KeyboardListener {
     }
 
     /// Replace the full set of registered bindings. Called from the FE registrar
-    /// (Wave 3) whenever the user's configured global shortcuts change. Poisoned
-    /// lock is swallowed: a panicked matcher thread should not take the app down.
+    /// whenever the user's configured global shortcuts change. Poisoned lock is
+    /// swallowed: a panicked matcher thread should not take the app down.
     pub fn set_bindings(&self, bindings: Vec<(String, KeyBinding)>) {
         if let Ok(mut matcher) = self.matcher.lock() {
             matcher.set_bindings(bindings);
@@ -181,18 +180,21 @@ impl KeyboardListener {
                     }
 
                     // A shorter binding entered its pending window. Schedule a
-                    // timer to flush it once the window expires, in case no
-                    // further key event arrives to resolve it (the user just holds
-                    // the prefix). `poll` is guarded by the deadline, so a timer
-                    // that fires after the window already resolved is a no-op.
+                    // task to flush it once the window expires, in case no further
+                    // key event arrives to resolve it (the user just holds the
+                    // prefix). Runs on Tauri's async runtime (the crate idiom; see
+                    // model_manager) so the wait is a multiplexed timer, not an OS
+                    // thread parked per arm. `poll` is guarded by the deadline, so
+                    // a task that wakes after the window already resolved is a
+                    // no-op, which is also why a superseded window needs no abort.
                     if let Some(deadline) = outcome.pending_until {
                         let matcher = matcher.clone();
                         let app = app.clone();
-                        std::thread::spawn(move || {
+                        tauri::async_runtime::spawn(async move {
                             let now = base.elapsed().as_millis() as u64;
-                            if deadline > now {
-                                std::thread::sleep(Duration::from_millis(deadline - now));
-                            }
+                            tokio::time::sleep(Duration::from_millis(deadline.saturating_sub(now)))
+                                .await;
+                            // Take the lock only after the sleep; never across an await.
                             let events = {
                                 let Ok(mut matcher) = matcher.lock() else {
                                     return;

--- a/apps/whispering/src-tauri/src/keyboard/mod.rs
+++ b/apps/whispering/src-tauri/src/keyboard/mod.rs
@@ -31,7 +31,6 @@ pub use keys::{Key, KeyBinding, Modifier};
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
@@ -76,11 +75,6 @@ pub struct KeyboardListener {
     /// `rdev::listen` (which would double-fire every trigger). Reset to false
     /// when the thread exits so a later `start` can retry.
     running: Arc<AtomicBool>,
-    /// Monotonic clock base. The matcher's pending-window logic runs on logical
-    /// millisecond timestamps; `base.elapsed()` is the single source of "now"
-    /// shared by the event callback and the pending-window timers. Created once
-    /// and reused across listener restarts so timestamps never go backwards.
-    base: Instant,
 }
 
 impl KeyboardListener {
@@ -89,7 +83,6 @@ impl KeyboardListener {
             app,
             matcher: Arc::new(Mutex::new(Matcher::new())),
             running: Arc::new(AtomicBool::new(false)),
-            base: Instant::now(),
         }
     }
 
@@ -135,7 +128,6 @@ impl KeyboardListener {
         let app = self.app.clone();
         let matcher = self.matcher.clone();
         let running = self.running.clone();
-        let base = self.base;
         std::thread::Builder::new()
             .name("rdev-keyboard-listener".into())
             .spawn(move || {
@@ -155,15 +147,14 @@ impl KeyboardListener {
                     let Some(input) = rdev_map::classify(key) else {
                         return;
                     };
-                    let now = base.elapsed().as_millis() as u64;
 
                     // Hold the lock only to resolve the event; emit after dropping
                     // it so a subscriber callback can never deadlock the listener.
-                    let outcome = {
+                    let triggers = {
                         let Ok(mut matcher) = matcher.lock() else {
                             return;
                         };
-                        let outcome = matcher.on_event(now, edge, input);
+                        let triggers = matcher.on_event(edge, input);
                         // In capture mode the recorder wants the live held combo,
                         // not command triggers (which `on_event` suppresses).
                         if matcher.is_capturing() {
@@ -172,39 +163,11 @@ impl KeyboardListener {
                             let _ = ShortcutCaptureEvent { binding }.emit_to(&app, MAIN_WINDOW);
                             return;
                         }
-                        outcome
+                        triggers
                     };
 
-                    for trigger in outcome.events {
+                    for trigger in triggers {
                         let _ = trigger.emit_to(&app, MAIN_WINDOW);
-                    }
-
-                    // A shorter binding entered its pending window. Schedule a
-                    // task to flush it once the window expires, in case no further
-                    // key event arrives to resolve it (the user just holds the
-                    // prefix). Runs on Tauri's async runtime (the crate idiom; see
-                    // model_manager) so the wait is a multiplexed timer, not an OS
-                    // thread parked per arm. `poll` is guarded by the deadline, so
-                    // a task that wakes after the window already resolved is a
-                    // no-op, which is also why a superseded window needs no abort.
-                    if let Some(deadline) = outcome.pending_until {
-                        let matcher = matcher.clone();
-                        let app = app.clone();
-                        tauri::async_runtime::spawn(async move {
-                            let now = base.elapsed().as_millis() as u64;
-                            tokio::time::sleep(Duration::from_millis(deadline.saturating_sub(now)))
-                                .await;
-                            // Take the lock only after the sleep; never across an await.
-                            let events = {
-                                let Ok(mut matcher) = matcher.lock() else {
-                                    return;
-                                };
-                                matcher.poll(base.elapsed().as_millis() as u64)
-                            };
-                            for ev in events {
-                                let _ = ev.emit_to(&app, MAIN_WINDOW);
-                            }
-                        });
                     }
                 });
                 if let Err(error) = result {

--- a/apps/whispering/src-tauri/src/keyboard/mod.rs
+++ b/apps/whispering/src-tauri/src/keyboard/mod.rs
@@ -32,6 +32,7 @@ pub use keys::{Key, KeyBinding, Modifier};
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
@@ -76,6 +77,11 @@ pub struct KeyboardListener {
     /// `rdev::listen` (which would double-fire every trigger). Reset to false
     /// when the thread exits so a later `start` can retry.
     running: Arc<AtomicBool>,
+    /// Monotonic clock base. The matcher's pending-window logic runs on logical
+    /// millisecond timestamps; `base.elapsed()` is the single source of "now"
+    /// shared by the event callback and the pending-window timers. Created once
+    /// and reused across listener restarts so timestamps never go backwards.
+    base: Instant,
 }
 
 impl KeyboardListener {
@@ -84,6 +90,7 @@ impl KeyboardListener {
             app,
             matcher: Arc::new(Mutex::new(Matcher::new())),
             running: Arc::new(AtomicBool::new(false)),
+            base: Instant::now(),
         }
     }
 
@@ -129,6 +136,7 @@ impl KeyboardListener {
         let app = self.app.clone();
         let matcher = self.matcher.clone();
         let running = self.running.clone();
+        let base = self.base;
         std::thread::Builder::new()
             .name("rdev-keyboard-listener".into())
             .spawn(move || {
@@ -148,21 +156,53 @@ impl KeyboardListener {
                     let Some(input) = rdev_map::classify(key) else {
                         return;
                     };
-                    let Ok(mut matcher) = matcher.lock() else {
-                        return;
-                    };
-                    let triggers = matcher.on_event(edge, input);
-                    // In capture mode the recorder wants the live held combo, not
-                    // command triggers (which `on_event` suppresses anyway).
-                    if matcher.is_capturing() {
-                        let binding = matcher.held_binding();
-                        drop(matcher);
-                        let _ = ShortcutCaptureEvent { binding }.emit_to(&app, MAIN_WINDOW);
-                    } else {
-                        drop(matcher);
-                        for trigger in triggers {
-                            let _ = trigger.emit_to(&app, MAIN_WINDOW);
+                    let now = base.elapsed().as_millis() as u64;
+
+                    // Hold the lock only to resolve the event; emit after dropping
+                    // it so a subscriber callback can never deadlock the listener.
+                    let outcome = {
+                        let Ok(mut matcher) = matcher.lock() else {
+                            return;
+                        };
+                        let outcome = matcher.on_event(now, edge, input);
+                        // In capture mode the recorder wants the live held combo,
+                        // not command triggers (which `on_event` suppresses).
+                        if matcher.is_capturing() {
+                            let binding = matcher.held_binding();
+                            drop(matcher);
+                            let _ = ShortcutCaptureEvent { binding }.emit_to(&app, MAIN_WINDOW);
+                            return;
                         }
+                        outcome
+                    };
+
+                    for trigger in outcome.events {
+                        let _ = trigger.emit_to(&app, MAIN_WINDOW);
+                    }
+
+                    // A shorter binding entered its pending window. Schedule a
+                    // timer to flush it once the window expires, in case no
+                    // further key event arrives to resolve it (the user just holds
+                    // the prefix). `poll` is guarded by the deadline, so a timer
+                    // that fires after the window already resolved is a no-op.
+                    if let Some(deadline) = outcome.pending_until {
+                        let matcher = matcher.clone();
+                        let app = app.clone();
+                        std::thread::spawn(move || {
+                            let now = base.elapsed().as_millis() as u64;
+                            if deadline > now {
+                                std::thread::sleep(Duration::from_millis(deadline - now));
+                            }
+                            let events = {
+                                let Ok(mut matcher) = matcher.lock() else {
+                                    return;
+                                };
+                                matcher.poll(base.elapsed().as_millis() as u64)
+                            };
+                            for ev in events {
+                                let _ = ev.emit_to(&app, MAIN_WINDOW);
+                            }
+                        });
                     }
                 });
                 if let Err(error) = result {

--- a/apps/whispering/src/lib/commands.ts
+++ b/apps/whispering/src/lib/commands.ts
@@ -1,5 +1,5 @@
 import {
-	cancelManualRecording,
+	cancelRecording,
 	startManualRecording,
 	stopManualRecording,
 	toggleManualRecording,
@@ -60,10 +60,10 @@ export const commands = [
 		callback: () => toggleManualRecording(),
 	},
 	{
-		id: 'cancelManualRecording',
+		id: 'cancelRecording',
 		title: 'Cancel recording',
 		on: ['Pressed'],
-		callback: () => cancelManualRecording(),
+		callback: () => cancelRecording(),
 	},
 	{
 		id: 'toggleVadRecording',

--- a/apps/whispering/src/lib/operations/recording.ts
+++ b/apps/whispering/src/lib/operations/recording.ts
@@ -125,6 +125,10 @@ export function toggleManualRecording() {
 }
 
 export async function cancelRecording() {
+	// Note: distinct from the low-level Tauri `commands.cancelRecording()` (CPAL
+	// stream teardown). This is the user-facing command: it decides what "cancel"
+	// means across the manual and VAD recorders.
+	//
 	// Cancel aborts whichever capture is live, without touching `recording.mode`:
 	// the chosen input mode (manual vs VAD) is a deliberate preference, not
 	// something a cancel keystroke should flip, so cancelling in VAD mode leaves

--- a/apps/whispering/src/lib/operations/recording.ts
+++ b/apps/whispering/src/lib/operations/recording.ts
@@ -125,36 +125,53 @@ export function toggleManualRecording() {
 }
 
 export async function cancelManualRecording() {
-	const loading = report.loading({
-		title: '⏸️ Canceling recording...',
-		description: 'Cleaning up recording session...',
-	});
+	// Cancel aborts whichever capture is live, without touching `recording.mode`:
+	// the chosen input mode (manual vs VAD) is a deliberate preference, not
+	// something a cancel keystroke should flip, so cancelling in VAD mode leaves
+	// you in VAD mode, idle and ready to listen again. This is also the global
+	// cancel chord (Cmd + . on macOS), which the rdev hook observes on every
+	// system press without swallowing it, so when nothing is live it stays silent
+	// rather than toasting on an unrelated press.
 
+	// A manual recording is the live capture: discard it.
 	const { data, error } = await manualRecorder.cancelRecording();
-
 	if (error) {
-		loading.reject({ cause: error });
+		report.error({ title: 'Failed to cancel recording', cause: error });
+		return;
+	}
+	if (data.status === 'cancelled') {
+		sound.playSoundIfEnabled('manual-cancel');
+		report.success({
+			title: '✅ Recording cancelled',
+			description: 'Recording cancelled successfully',
+		});
+		log.info('Recording cancelled');
 		return;
 	}
 
-	switch (data.status) {
-		case 'no-recording': {
-			loading.resolve({
-				title: 'No active recording',
-				description: 'There is no recording in progress to cancel.',
+	// No manual recording, but a VAD session may be the live capture instead.
+	const isVadActive =
+		vadRecorder.state === 'LISTENING' ||
+		vadRecorder.state === 'SPEECH_DETECTED';
+	if (isVadActive) {
+		const { error: vadError } = await vadRecorder.stopActiveListening();
+		if (vadError) {
+			report.error({
+				title: 'Failed to cancel voice activated capture',
+				cause: vadError,
 			});
-			break;
+			return;
 		}
-		case 'cancelled': {
-			loading.resolve({
-				title: '✅ All Done!',
-				description: 'Recording cancelled successfully',
-			});
-			sound.playSoundIfEnabled('manual-cancel');
-			log.info('Recording cancelled');
-			break;
-		}
+		sound.playSoundIfEnabled('manual-cancel');
+		report.success({
+			title: '✅ Voice activated capture cancelled',
+			description: 'Voice activated capture cancelled successfully',
+		});
+		log.info('Voice activated capture cancelled');
+		return;
 	}
+
+	// Nothing live: silent no-op (see the note above).
 }
 
 export async function startVadRecording() {

--- a/apps/whispering/src/lib/operations/recording.ts
+++ b/apps/whispering/src/lib/operations/recording.ts
@@ -141,37 +141,21 @@ export async function cancelManualRecording() {
 	}
 	if (data.status === 'cancelled') {
 		sound.playSoundIfEnabled('manual-cancel');
-		report.success({
-			title: '✅ Recording cancelled',
-			description: 'Recording cancelled successfully',
-		});
+		report.success({ title: '✅ Recording cancelled' });
 		log.info('Recording cancelled');
 		return;
 	}
 
-	// No manual recording, but a VAD session may be the live capture instead.
+	// No manual recording, but a VAD session may be live. VAD has no
+	// discard-vs-finalize split: tearing the session down is the only way to
+	// abort it, which is exactly what stopVadRecording already does (same
+	// stopActiveListening call, same end state, mode left on `vad`). So cancel a
+	// live VAD session by stopping it, rather than cloning the teardown with a
+	// second toast and a manual-recording sound. Nothing live: silent no-op.
 	const isVadActive =
 		vadRecorder.state === 'LISTENING' ||
 		vadRecorder.state === 'SPEECH_DETECTED';
-	if (isVadActive) {
-		const { error: vadError } = await vadRecorder.stopActiveListening();
-		if (vadError) {
-			report.error({
-				title: 'Failed to cancel voice activated capture',
-				cause: vadError,
-			});
-			return;
-		}
-		sound.playSoundIfEnabled('manual-cancel');
-		report.success({
-			title: '✅ Voice activated capture cancelled',
-			description: 'Voice activated capture cancelled successfully',
-		});
-		log.info('Voice activated capture cancelled');
-		return;
-	}
-
-	// Nothing live: silent no-op (see the note above).
+	if (isVadActive) await stopVadRecording();
 }
 
 export async function startVadRecording() {

--- a/apps/whispering/src/lib/operations/recording.ts
+++ b/apps/whispering/src/lib/operations/recording.ts
@@ -124,7 +124,7 @@ export function toggleManualRecording() {
 	return startManualRecording();
 }
 
-export async function cancelManualRecording() {
+export async function cancelRecording() {
 	// Cancel aborts whichever capture is live, without touching `recording.mode`:
 	// the chosen input mode (manual vs VAD) is a deliberate preference, not
 	// something a cancel keystroke should flip, so cancelling in VAD mode leaves

--- a/apps/whispering/src/lib/state/device-config.svelte.ts
+++ b/apps/whispering/src/lib/state/device-config.svelte.ts
@@ -21,24 +21,30 @@ const globalBinding = type({
 	keys: 'string[]',
 }).or('null');
 
-// Default bindings, platform-resolved (Command on macOS, Control/Alt elsewhere),
-// matching the spirit of the old accelerator defaults. Exported so the reset
-// path in register-commands shares this one source of truth.
-const PRIMARY: KeyBinding['modifiers'][number] = os.isApple ? 'meta' : 'ctrl';
-const PUSH_TO_TALK: KeyBinding['modifiers'][number] = os.isApple
-	? 'meta'
-	: 'alt';
+// Default bindings as global gestures, not mnemonic app hotkeys. The push-to-talk
+// gesture and the toggle gesture share a prefix on purpose: the rdev gesture
+// resolver fires the shorter one (hold) unless the longer one (hold + Space)
+// completes inside a short window.
+//
+//   macOS:   Fn = push-to-talk,        Fn + Space        = toggle
+//   Windows: Ctrl+Win = push-to-talk,  Ctrl+Win + Space  = toggle
+//
+// Fn is a single physical key on Apple keyboards; elsewhere we reach for
+// Ctrl+Win, a held chord that no common OS shortcut claims. Cancel is a bare
+// Escape, registered only while a session is live (see the cancel-gating in
+// register-commands). Transformation gestures ship unbound: opt-in only.
+// Exported so the reset path in register-commands shares this one source of truth.
+const PUSH_TO_TALK_MODIFIERS: KeyBinding['modifiers'] = os.isApple
+	? ['fn']
+	: ['ctrl', 'meta'];
 
 export const DEFAULT_GLOBAL_BINDINGS = {
-	pushToTalk: { modifiers: [PUSH_TO_TALK, 'shift'], keys: ['keyD'] },
-	toggleManualRecording: { modifiers: [PRIMARY, 'shift'], keys: ['semiColon'] },
-	cancelManualRecording: { modifiers: [PRIMARY, 'shift'], keys: ['quote'] },
+	pushToTalk: { modifiers: PUSH_TO_TALK_MODIFIERS, keys: [] },
+	toggleManualRecording: { modifiers: PUSH_TO_TALK_MODIFIERS, keys: ['space'] },
+	cancelManualRecording: { modifiers: [], keys: ['escape'] },
 	toggleVadRecording: null,
-	openTransformationPicker: { modifiers: [PRIMARY, 'shift'], keys: ['keyX'] },
-	runTransformationOnClipboard: {
-		modifiers: [PRIMARY, 'shift'],
-		keys: ['keyR'],
-	},
+	openTransformationPicker: null,
+	runTransformationOnClipboard: null,
 } satisfies Record<string, KeyBinding | null>;
 
 // ── Per-key definitions ──────────────────────────────────────────────────────

--- a/apps/whispering/src/lib/state/device-config.svelte.ts
+++ b/apps/whispering/src/lib/state/device-config.svelte.ts
@@ -30,18 +30,26 @@ const globalBinding = type({
 //   Windows: Ctrl+Win = push-to-talk,  Ctrl+Win + Space  = toggle
 //
 // Fn is a single physical key on Apple keyboards; elsewhere we reach for
-// Ctrl+Win, a held chord that no common OS shortcut claims. Cancel is a bare
-// Escape, registered only while a session is live (see the cancel-gating in
-// register-commands). Transformation gestures ship unbound: opt-in only.
-// Exported so the reset path in register-commands shares this one source of truth.
+// Ctrl+Win, a held chord that no common OS shortcut claims. Cancel is the
+// platform cancel chord (Cmd + . on macOS, the system cancel gesture since
+// classic Mac OS; Ctrl + Shift + . elsewhere). A modifier-carrying chord is
+// safe to hold globally, so cancel registers like any other gesture with no
+// session gating, and it deliberately avoids the push-to-talk prefix so it
+// never forces that hold into a pending window. Transformation gestures ship
+// unbound: opt-in only. Exported so the reset path in register-commands shares
+// this one source of truth.
 const PUSH_TO_TALK_MODIFIERS: KeyBinding['modifiers'] = os.isApple
 	? ['fn']
 	: ['ctrl', 'meta'];
 
+const CANCEL_MODIFIERS: KeyBinding['modifiers'] = os.isApple
+	? ['meta']
+	: ['ctrl', 'shift'];
+
 export const DEFAULT_GLOBAL_BINDINGS = {
 	pushToTalk: { modifiers: PUSH_TO_TALK_MODIFIERS, keys: [] },
 	toggleManualRecording: { modifiers: PUSH_TO_TALK_MODIFIERS, keys: ['space'] },
-	cancelManualRecording: { modifiers: [], keys: ['escape'] },
+	cancelManualRecording: { modifiers: CANCEL_MODIFIERS, keys: ['dot'] },
 	toggleVadRecording: null,
 	openTransformationPicker: null,
 	runTransformationOnClipboard: null,

--- a/apps/whispering/src/lib/state/device-config.svelte.ts
+++ b/apps/whispering/src/lib/state/device-config.svelte.ts
@@ -21,26 +21,30 @@ const globalBinding = type({
 	keys: 'string[]',
 }).or('null');
 
-// Default bindings as global gestures, not mnemonic app hotkeys. The push-to-talk
-// gesture and the toggle gesture share a prefix on purpose: the rdev gesture
-// resolver fires the shorter one (hold) unless the longer one (hold + Space)
-// completes inside a short window.
+// Default bindings as global gestures, not mnemonic app hotkeys. Every gesture
+// is a distinct, non-overlapping combo: the rdev matcher fires on exact set
+// equality with no prefix resolution, so no gesture's keys may be a subset of
+// another's (the shorter one would fire first and shadow the longer). That is
+// why push-to-talk gets its own dedicated key and nothing else reuses it.
 //
-//   macOS:   Fn = push-to-talk,        Fn + Space        = toggle
-//   Windows: Ctrl+Win = push-to-talk,  Ctrl+Win + Space  = toggle
+//   macOS:   Fn = push-to-talk,        Cmd + Shift + Space  = toggle
+//   Windows: Ctrl+Win = push-to-talk,  Ctrl + Shift + Space = toggle
 //
 // Fn is a single physical key on Apple keyboards; elsewhere we reach for
-// Ctrl+Win, a held chord that no common OS shortcut claims. Cancel is the
-// platform cancel chord (Cmd + . on macOS, the system cancel gesture since
-// classic Mac OS; Ctrl + Shift + . elsewhere). A modifier-carrying chord is
-// safe to hold globally, so cancel registers like any other gesture with no
-// session gating, and it deliberately avoids the push-to-talk prefix so it
-// never forces that hold into a pending window. Transformation gestures ship
-// unbound: opt-in only. Exported so the reset path in register-commands shares
-// this one source of truth.
+// Ctrl+Win, a held chord that no common OS shortcut claims. Toggle adds Shift
+// so it shares no prefix with push-to-talk while keeping Space as the "record"
+// affordance. Cancel is the platform cancel chord (Cmd + . on macOS, the system
+// cancel gesture since classic Mac OS; Ctrl + Shift + . elsewhere); it carries a
+// modifier so it is safe to hold globally and registers like any other gesture
+// with no session gating. Transformation gestures ship unbound: opt-in only.
+// Exported so the reset path in register-commands shares this one source of truth.
 const PUSH_TO_TALK_MODIFIERS: KeyBinding['modifiers'] = os.isApple
 	? ['fn']
 	: ['ctrl', 'meta'];
+
+const TOGGLE_MODIFIERS: KeyBinding['modifiers'] = os.isApple
+	? ['meta', 'shift']
+	: ['ctrl', 'shift'];
 
 const CANCEL_MODIFIERS: KeyBinding['modifiers'] = os.isApple
 	? ['meta']
@@ -48,7 +52,7 @@ const CANCEL_MODIFIERS: KeyBinding['modifiers'] = os.isApple
 
 export const DEFAULT_GLOBAL_BINDINGS = {
 	pushToTalk: { modifiers: PUSH_TO_TALK_MODIFIERS, keys: [] },
-	toggleManualRecording: { modifiers: PUSH_TO_TALK_MODIFIERS, keys: ['space'] },
+	toggleManualRecording: { modifiers: TOGGLE_MODIFIERS, keys: ['space'] },
 	cancelRecording: { modifiers: CANCEL_MODIFIERS, keys: ['dot'] },
 	toggleVadRecording: null,
 	openTransformationPicker: null,

--- a/apps/whispering/src/lib/state/device-config.svelte.ts
+++ b/apps/whispering/src/lib/state/device-config.svelte.ts
@@ -49,7 +49,7 @@ const CANCEL_MODIFIERS: KeyBinding['modifiers'] = os.isApple
 export const DEFAULT_GLOBAL_BINDINGS = {
 	pushToTalk: { modifiers: PUSH_TO_TALK_MODIFIERS, keys: [] },
 	toggleManualRecording: { modifiers: PUSH_TO_TALK_MODIFIERS, keys: ['space'] },
-	cancelManualRecording: { modifiers: CANCEL_MODIFIERS, keys: ['dot'] },
+	cancelRecording: { modifiers: CANCEL_MODIFIERS, keys: ['dot'] },
 	toggleVadRecording: null,
 	openTransformationPicker: null,
 	runTransformationOnClipboard: null,
@@ -144,9 +144,9 @@ const DEVICE_DEFINITIONS = {
 		globalBinding,
 		DEFAULT_GLOBAL_BINDINGS.toggleManualRecording,
 	),
-	'shortcuts.global.cancelManualRecording': defineEntry(
+	'shortcuts.global.cancelRecording': defineEntry(
 		globalBinding,
-		DEFAULT_GLOBAL_BINDINGS.cancelManualRecording,
+		DEFAULT_GLOBAL_BINDINGS.cancelRecording,
 	),
 	'shortcuts.global.toggleVadRecording': defineEntry(
 		globalBinding,

--- a/apps/whispering/src/lib/utils/key-binding.test.ts
+++ b/apps/whispering/src/lib/utils/key-binding.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from 'bun:test';
+import { type BindingLike, bindingsOverlap } from './key-binding';
+
+test('a binding overlaps a superset of itself', () => {
+	// Fn (push-to-talk) is contained by Fn+Space, so the pair is unusable.
+	expect(
+		bindingsOverlap(
+			{ modifiers: ['fn'], keys: [] },
+			{ modifiers: ['fn'], keys: ['space'] },
+		),
+	).toBe(true);
+});
+
+test('overlap is symmetric', () => {
+	expect(
+		bindingsOverlap(
+			{ modifiers: ['fn'], keys: ['space'] },
+			{ modifiers: ['fn'], keys: [] },
+		),
+	).toBe(true);
+});
+
+test('equal bindings overlap', () => {
+	expect(
+		bindingsOverlap(
+			{ modifiers: ['meta'], keys: ['dot'] },
+			{ modifiers: ['meta'], keys: ['dot'] },
+		),
+	).toBe(true);
+});
+
+test('a modifier-only hold is contained by any chord that adds to it', () => {
+	expect(
+		bindingsOverlap(
+			{ modifiers: ['meta'], keys: [] },
+			{ modifiers: ['meta'], keys: ['dot'] },
+		),
+	).toBe(true);
+});
+
+test('the shipped defaults do not overlap each other', () => {
+	const ptt: BindingLike = { modifiers: ['fn'], keys: [] };
+	const toggle: BindingLike = { modifiers: ['meta', 'shift'], keys: ['space'] };
+	const cancel: BindingLike = { modifiers: ['meta'], keys: ['dot'] };
+	expect(bindingsOverlap(ptt, toggle)).toBe(false);
+	expect(bindingsOverlap(ptt, cancel)).toBe(false);
+	expect(bindingsOverlap(toggle, cancel)).toBe(false);
+});
+
+test('sibling chords sharing a modifier but differing in key do not overlap', () => {
+	// Ctrl+Shift+Space and Ctrl+Shift+. (Windows toggle vs cancel).
+	expect(
+		bindingsOverlap(
+			{ modifiers: ['ctrl', 'shift'], keys: ['space'] },
+			{ modifiers: ['ctrl', 'shift'], keys: ['dot'] },
+		),
+	).toBe(false);
+});

--- a/apps/whispering/src/lib/utils/key-binding.ts
+++ b/apps/whispering/src/lib/utils/key-binding.ts
@@ -10,7 +10,10 @@ import type { Key, KeyBinding, Modifier } from '$lib/tauri/commands';
  * (`keys: Key[]`) and the stored shape (`keys: string[]`, validated structurally
  * in device-config and by name in Rust), so the same helpers serve both.
  */
-type BindingLike = { modifiers: Modifier[]; keys: readonly string[] };
+export type BindingLike = {
+	modifiers: readonly Modifier[];
+	keys: readonly string[];
+};
 
 const MODIFIER_LABELS_APPLE: Record<Modifier, string> = {
 	ctrl: '⌃',
@@ -90,6 +93,26 @@ export function keyBindingToLabel(
 /** A binding with no modifiers and no keys can never fire; treat it as unset. */
 export function isEmptyBinding(binding: BindingLike): boolean {
 	return binding.modifiers.length === 0 && binding.keys.length === 0;
+}
+
+/** Whether every modifier and key of `subset` is also present in `superset`. */
+function isContainedBy(subset: BindingLike, superset: BindingLike): boolean {
+	return (
+		subset.modifiers.every((m) => superset.modifiers.includes(m)) &&
+		subset.keys.every((k) => superset.keys.includes(k))
+	);
+}
+
+/**
+ * Whether two gestures overlap: one is a subset of the other (including equal).
+ * The rdev matcher fires on exact set equality with no prefix resolution, so an
+ * overlapping pair is unusable: the shorter gesture fires first and shadows the
+ * longer. The recorder refuses to save a gesture that overlaps another, which is
+ * why a key bound to one gesture (such as push-to-talk's Fn) cannot appear in
+ * any other.
+ */
+export function bindingsOverlap(a: BindingLike, b: BindingLike): boolean {
+	return isContainedBy(a, b) || isContainedBy(b, a);
 }
 
 const MANUAL_MODIFIER_ALIASES: Record<string, Modifier> = {

--- a/apps/whispering/src/lib/utils/reserved-shortcuts.test.ts
+++ b/apps/whispering/src/lib/utils/reserved-shortcuts.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from 'bun:test';
+import { validateGlobalBinding } from './reserved-shortcuts';
+
+test('an empty binding is treated as unset and passes', () => {
+	expect(validateGlobalBinding({ modifiers: [], keys: [] })).toBeNull();
+});
+
+test('shipped defaults pass the policy', () => {
+	// macOS defaults.
+	expect(validateGlobalBinding({ modifiers: ['fn'], keys: [] })).toBeNull();
+	expect(
+		validateGlobalBinding({ modifiers: ['meta', 'shift'], keys: ['space'] }),
+	).toBeNull();
+	expect(
+		validateGlobalBinding({ modifiers: ['meta'], keys: ['dot'] }),
+	).toBeNull();
+	// Windows/Linux defaults.
+	expect(
+		validateGlobalBinding({ modifiers: ['ctrl', 'meta'], keys: [] }),
+	).toBeNull();
+	expect(
+		validateGlobalBinding({ modifiers: ['ctrl', 'shift'], keys: ['space'] }),
+	).toBeNull();
+});
+
+test('a reserved combo is refused with its label', () => {
+	const reason = validateGlobalBinding({ modifiers: ['meta'], keys: ['keyR'] });
+	expect(reason).toContain('Reload');
+});
+
+test('primary expands to control as well as command', () => {
+	// Ctrl+R must be blocked too, not just Cmd+R, from the single `primary` entry.
+	expect(
+		validateGlobalBinding({ modifiers: ['ctrl'], keys: ['keyR'] }),
+	).toContain('Reload');
+});
+
+test('literal meta+space (Spotlight) is reserved but meta+shift+space is not', () => {
+	expect(
+		validateGlobalBinding({ modifiers: ['meta'], keys: ['space'] }),
+	).toContain('System search');
+	// The toggle default adds Shift, a different set, so it stays allowed.
+	expect(
+		validateGlobalBinding({ modifiers: ['meta', 'shift'], keys: ['space'] }),
+	).toBeNull();
+});
+
+test('a bare key with no modifier is refused', () => {
+	const reason = validateGlobalBinding({ modifiers: [], keys: ['space'] });
+	expect(reason).toContain('modifier');
+});
+
+test('a superset of a reserved chord is allowed (exact-set matching)', () => {
+	// Ctrl+Win+Space is not the literal meta+space Spotlight chord.
+	expect(
+		validateGlobalBinding({ modifiers: ['ctrl', 'meta'], keys: ['space'] }),
+	).toBeNull();
+});

--- a/apps/whispering/src/lib/utils/reserved-shortcuts.ts
+++ b/apps/whispering/src/lib/utils/reserved-shortcuts.ts
@@ -7,9 +7,8 @@
  * shadowing something the OS or foreground app owns:
  * - A short list of common OS/app chords (reload, clipboard, undo/redo, close,
  *   quit, app switch, screenshots, system search) is refused outright.
- * - A non-cancel gesture must carry a modifier or Fn, so it cannot fire on an
- *   ordinary keypress.
- * - A bare Escape is allowed only for the cancel gesture (its one exception).
+ * - A gesture must carry a modifier or Fn, so it cannot fire on an ordinary
+ *   keypress.
  */
 
 import type { Modifier } from '$lib/tauri/commands';
@@ -108,13 +107,9 @@ function matchesReserved(binding: BindingLike, chord: ReservedChord): boolean {
  * Validate a desktop global gesture against the reserved-shortcut policy.
  *
  * An empty binding (no modifiers, no keys) is treated as "unset" and passes;
- * clearing a gesture is the caller's job, not this check's. `isCancel` relaxes
- * the bare-Escape rule for the cancel gesture only.
+ * clearing a gesture is the caller's job, not this check's.
  */
-export function validateGlobalBinding(
-	binding: BindingLike,
-	{ isCancel }: { isCancel: boolean },
-): ReservedCheck {
+export function validateGlobalBinding(binding: BindingLike): ReservedCheck {
 	const hasNothing =
 		binding.modifiers.length === 0 && binding.keys.length === 0;
 	if (hasNothing) return { ok: true };
@@ -126,18 +121,6 @@ export function validateGlobalBinding(
 				reason: `That combination is reserved by the system or app (${chord.label}). Pick another.`,
 			};
 		}
-	}
-
-	const isStandaloneEscape =
-		binding.modifiers.length === 0 &&
-		binding.keys.length === 1 &&
-		binding.keys[0] === 'escape';
-	if (isStandaloneEscape) {
-		if (isCancel) return { ok: true };
-		return {
-			ok: false,
-			reason: 'Escape on its own is reserved for canceling a recording.',
-		};
 	}
 
 	if (binding.modifiers.length === 0) {

--- a/apps/whispering/src/lib/utils/reserved-shortcuts.ts
+++ b/apps/whispering/src/lib/utils/reserved-shortcuts.ts
@@ -12,14 +12,7 @@
  */
 
 import type { Modifier } from '$lib/tauri/commands';
-
-type ReservedCheck = { ok: true } | { ok: false; reason: string };
-
-/** A binding for validation: accepts the stored shape (`keys: string[]`). */
-type BindingLike = {
-	modifiers: readonly Modifier[];
-	keys: readonly string[];
-};
+import type { BindingLike } from '$lib/utils/key-binding';
 
 /**
  * `primary` stands for the platform's command modifier: Command on macOS,
@@ -105,31 +98,27 @@ function matchesReserved(binding: BindingLike, chord: ReservedChord): boolean {
 
 /**
  * Validate a desktop global gesture against the reserved-shortcut policy.
+ * Returns `null` when the gesture is allowed, or a human-readable reason when it
+ * is refused. (Domain state, not an operation failure, so a plain `string | null`
+ * rather than a `Result`.)
  *
  * An empty binding (no modifiers, no keys) is treated as "unset" and passes;
  * clearing a gesture is the caller's job, not this check's.
  */
-export function validateGlobalBinding(binding: BindingLike): ReservedCheck {
+export function validateGlobalBinding(binding: BindingLike): string | null {
 	const hasNothing =
 		binding.modifiers.length === 0 && binding.keys.length === 0;
-	if (hasNothing) return { ok: true };
+	if (hasNothing) return null;
 
 	for (const chord of RESERVED_CHORDS) {
 		if (matchesReserved(binding, chord)) {
-			return {
-				ok: false,
-				reason: `That combination is reserved by the system or app (${chord.label}). Pick another.`,
-			};
+			return `That combination is reserved by the system or app (${chord.label}). Pick another.`;
 		}
 	}
 
 	if (binding.modifiers.length === 0) {
-		return {
-			ok: false,
-			reason:
-				'Add a modifier or Fn so the gesture cannot fire on an ordinary keypress.',
-		};
+		return 'Add a modifier or Fn so the gesture cannot fire on an ordinary keypress.';
 	}
 
-	return { ok: true };
+	return null;
 }

--- a/apps/whispering/src/lib/utils/reserved-shortcuts.ts
+++ b/apps/whispering/src/lib/utils/reserved-shortcuts.ts
@@ -14,7 +14,7 @@
 
 import type { Modifier } from '$lib/tauri/commands';
 
-export type ReservedCheck = { ok: true } | { ok: false; reason: string };
+type ReservedCheck = { ok: true } | { ok: false; reason: string };
 
 /** A binding for validation: accepts the stored shape (`keys: string[]`). */
 type BindingLike = {

--- a/apps/whispering/src/lib/utils/reserved-shortcuts.ts
+++ b/apps/whispering/src/lib/utils/reserved-shortcuts.ts
@@ -1,0 +1,152 @@
+/**
+ * Reserved-shortcut policy for desktop global gestures (the structured
+ * `KeyBinding` the rdev backend matches on, in physical-key space). Pure: no
+ * Tauri or DOM dependency.
+ *
+ * Desktop bindings fire system-wide, so a few rules keep a gesture from
+ * shadowing something the OS or foreground app owns:
+ * - A short list of common OS/app chords (reload, clipboard, undo/redo, close,
+ *   quit, app switch, screenshots, system search) is refused outright.
+ * - A non-cancel gesture must carry a modifier or Fn, so it cannot fire on an
+ *   ordinary keypress.
+ * - A bare Escape is allowed only for the cancel gesture (its one exception).
+ */
+
+import type { Modifier } from '$lib/tauri/commands';
+
+export type ReservedCheck = { ok: true } | { ok: false; reason: string };
+
+/** A binding for validation: accepts the stored shape (`keys: string[]`). */
+type BindingLike = {
+	modifiers: readonly Modifier[];
+	keys: readonly string[];
+};
+
+/**
+ * `primary` stands for the platform's command modifier: Command on macOS,
+ * Control on Windows/Linux. A reserved entry using it expands to both, so the
+ * same table covers Cmd+R and Ctrl+R without per-platform branching.
+ */
+type ModifierToken = Modifier | 'primary';
+
+type ReservedChord = {
+	modifiers: ModifierToken[];
+	keys: string[];
+	/** What the chord does, shown to the user when their pick is refused. */
+	label: string;
+};
+
+/**
+ * Common chords a global gesture must not shadow. Matched as exact set equality
+ * (after expanding `primary`), so a precise combo is blocked while a superset
+ * the user deliberately built (for example the Windows toggle Ctrl+Win+Space) is
+ * not. Keys are physical-position names from the `Key` vocabulary.
+ */
+const RESERVED_CHORDS: ReservedChord[] = [
+	// Reload
+	{ modifiers: ['primary'], keys: ['keyR'], label: 'Reload' },
+	{ modifiers: ['primary', 'shift'], keys: ['keyR'], label: 'Hard reload' },
+	{ modifiers: [], keys: ['f5'], label: 'Reload' },
+	// Clipboard
+	{ modifiers: ['primary'], keys: ['keyC'], label: 'Copy' },
+	{ modifiers: ['primary'], keys: ['keyV'], label: 'Paste' },
+	{ modifiers: ['primary'], keys: ['keyX'], label: 'Cut' },
+	// Undo / redo
+	{ modifiers: ['primary'], keys: ['keyZ'], label: 'Undo' },
+	{ modifiers: ['primary', 'shift'], keys: ['keyZ'], label: 'Redo' },
+	{ modifiers: ['ctrl'], keys: ['keyY'], label: 'Redo' },
+	// Document basics
+	{ modifiers: ['primary'], keys: ['keyA'], label: 'Select all' },
+	{ modifiers: ['primary'], keys: ['keyS'], label: 'Save' },
+	{ modifiers: ['primary'], keys: ['keyF'], label: 'Find' },
+	{ modifiers: ['primary'], keys: ['keyP'], label: 'Print' },
+	// Windows, tabs, app lifecycle
+	{ modifiers: ['primary'], keys: ['keyN'], label: 'New window' },
+	{ modifiers: ['primary'], keys: ['keyT'], label: 'New tab' },
+	{ modifiers: ['primary'], keys: ['keyW'], label: 'Close window or tab' },
+	{ modifiers: ['primary'], keys: ['keyQ'], label: 'Quit application' },
+	{ modifiers: ['alt'], keys: ['f4'], label: 'Close window' },
+	// Application / window switching
+	{ modifiers: ['primary'], keys: ['tab'], label: 'Switch application' },
+	{ modifiers: ['alt'], keys: ['tab'], label: 'Switch window' },
+	// System search (macOS Spotlight / input source). Literal `meta`, so the
+	// Windows Ctrl+Win+Space toggle (a different set) stays allowed.
+	{ modifiers: ['meta'], keys: ['space'], label: 'System search' },
+	// Screenshots
+	{ modifiers: ['primary', 'shift'], keys: ['num3'], label: 'Screenshot' },
+	{ modifiers: ['primary', 'shift'], keys: ['num4'], label: 'Screenshot' },
+	{ modifiers: ['primary', 'shift'], keys: ['num5'], label: 'Screenshot' },
+	{ modifiers: ['meta', 'shift'], keys: ['keyS'], label: 'Screenshot' },
+];
+
+function sameSet(a: readonly string[], b: readonly string[]): boolean {
+	if (a.length !== b.length) return false;
+	const set = new Set(a);
+	return b.every((value) => set.has(value));
+}
+
+/** Expand a reserved chord's `primary` token into concrete modifier sets. */
+function expandModifiers(modifiers: ModifierToken[]): Modifier[][] {
+	if (!modifiers.includes('primary')) {
+		return [modifiers as Modifier[]];
+	}
+	const base = modifiers.filter((m): m is Modifier => m !== 'primary');
+	return [
+		[...base, 'meta'],
+		[...base, 'ctrl'],
+	];
+}
+
+function matchesReserved(binding: BindingLike, chord: ReservedChord): boolean {
+	if (!sameSet(binding.keys, chord.keys)) return false;
+	return expandModifiers(chord.modifiers).some((modifiers) =>
+		sameSet(binding.modifiers, modifiers),
+	);
+}
+
+/**
+ * Validate a desktop global gesture against the reserved-shortcut policy.
+ *
+ * An empty binding (no modifiers, no keys) is treated as "unset" and passes;
+ * clearing a gesture is the caller's job, not this check's. `isCancel` relaxes
+ * the bare-Escape rule for the cancel gesture only.
+ */
+export function validateGlobalBinding(
+	binding: BindingLike,
+	{ isCancel }: { isCancel: boolean },
+): ReservedCheck {
+	const hasNothing =
+		binding.modifiers.length === 0 && binding.keys.length === 0;
+	if (hasNothing) return { ok: true };
+
+	for (const chord of RESERVED_CHORDS) {
+		if (matchesReserved(binding, chord)) {
+			return {
+				ok: false,
+				reason: `That combination is reserved by the system or app (${chord.label}). Pick another.`,
+			};
+		}
+	}
+
+	const isStandaloneEscape =
+		binding.modifiers.length === 0 &&
+		binding.keys.length === 1 &&
+		binding.keys[0] === 'escape';
+	if (isStandaloneEscape) {
+		if (isCancel) return { ok: true };
+		return {
+			ok: false,
+			reason: 'Escape on its own is reserved for canceling a recording.',
+		};
+	}
+
+	if (binding.modifiers.length === 0) {
+		return {
+			ok: false,
+			reason:
+				'Add a modifier or Fn so the gesture cannot fire on an ordinary keypress.',
+		};
+	}
+
+	return { ok: true };
+}

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -312,6 +312,9 @@ const shortcuts = {
 		nullable(field.string()),
 		(): string | null => ' ',
 	),
+	// Renamed from `shortcut.cancelManualRecording` (cancel now aborts manual or
+	// VAD capture, so the "manual" qualifier is gone). No migration: pre-release,
+	// the old key is simply orphaned and this falls back to its default.
 	'shortcut.cancelRecording': defineKv(
 		nullable(field.string()),
 		(): string | null => 'c',

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -312,7 +312,7 @@ const shortcuts = {
 		nullable(field.string()),
 		(): string | null => ' ',
 	),
-	'shortcut.cancelManualRecording': defineKv(
+	'shortcut.cancelRecording': defineKv(
 		nullable(field.string()),
 		(): string | null => 'c',
 	),

--- a/apps/whispering/src/routes/(app)/(config)/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/+layout.svelte
@@ -38,7 +38,7 @@
 				{#if manualRecorder.state === 'RECORDING'}
 					<Button
 						tooltip="Cancel recording"
-						onclick={() => commandCallbacks.cancelManualRecording()}
+						onclick={() => commandCallbacks.cancelRecording()}
 						variant="ghost"
 						size="icon"
 						style="view-transition-name: {viewTransition.global.cancel};"

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/+page.svelte
@@ -81,9 +81,10 @@
 			</div>
 			<SectionHeader.Description>
 				{#if tauri}
-					System-wide gestures that trigger from anywhere, even when Whispering
-					is not focused. Hold the Fn key or a modifier chord; the recording
-					gestures resolve a hold against a hold-plus-key automatically.
+					System-wide gestures that fire from anywhere, even when Whispering is
+					not focused. Hold the Fn key or a modifier chord. Each gesture needs
+					its own keys, so the key you use for push-to-talk cannot be part of
+					another shortcut.
 				{:else}
 					Shortcuts that trigger while the Whispering tab is focused.
 				{/if}

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/+page.svelte
@@ -81,9 +81,9 @@
 			</div>
 			<SectionHeader.Description>
 				{#if tauri}
-					System-wide shortcuts that trigger from anywhere, even when Whispering
-					is not focused. The Fn key, modifier-only holds, and single keys all
-					work.
+					System-wide gestures that trigger from anywhere, even when Whispering
+					is not focused. Hold the Fn key or a modifier chord; the recording
+					gestures resolve a hold against a hold-plus-key automatically.
 				{:else}
 					Shortcuts that trigger while the Whispering tab is focused.
 				{/if}

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/GlobalKeyboardShortcutRecorder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/GlobalKeyboardShortcutRecorder.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import type { Command } from '$lib/commands';
+	import { onDestroy } from 'svelte';
+	import { type Command, commands } from '$lib/commands';
 	import { report } from '$lib/report';
 	import type { Tauri } from '#platform/tauri';
 	import { syncGlobalShortcutsWithSettings } from '$routes/(app)/_layout-utils/register-commands';
@@ -7,6 +8,7 @@
 	import type { Key, KeyBinding, Modifier } from '$lib/tauri/commands';
 	import { os } from '#platform/os';
 	import {
+		bindingsOverlap,
 		isEmptyBinding,
 		keyBindingToLabel,
 		parseManualBinding,
@@ -64,18 +66,42 @@
 		await tauri.globalShortcuts.setCapturing(false);
 	}
 
-	// Reject reserved or unsafe gestures before saving. Returns true when the
+	// If the recorder is torn down mid-capture (route change, or the popover
+	// dismissed by unmount rather than by onOpenChange), nothing else exits
+	// capture mode, so Rust would stay capturing and silently swallow every
+	// global shortcut. Always leave capture on destroy.
+	onDestroy(() => {
+		if (isListening) void stopCapture();
+	});
+
+	// A gesture's keys must be unique to it. The matcher fires on exact set
+	// equality with no prefix resolution, so a gesture that contains (or is
+	// contained by) another would shadow it or be unreachable. Refuse the overlap
+	// and name the gesture it collides with.
+	function overlapReason(next: KeyBinding): string | null {
+		for (const other of commands) {
+			if (other.id === command.id) continue;
+			const otherBinding = deviceConfig.get(`shortcuts.global.${other.id}`);
+			if (!otherBinding || isEmptyBinding(otherBinding)) continue;
+			if (bindingsOverlap(next, otherBinding)) {
+				return `Those keys are already part of the "${other.title}" gesture (${keyBindingToLabel(otherBinding, os.isApple)}). Each global gesture needs its own keys, so a key used by one gesture cannot be part of another.`;
+			}
+		}
+		return null;
+	}
+
+	// Reject reserved or overlapping gestures before saving. Returns true when the
 	// binding is allowed; otherwise reports why and leaves the current binding
 	// untouched.
 	function validateAndReport(next: KeyBinding): boolean {
-		const result = validateGlobalBinding(next);
-		if (result.ok) return true;
+		const reason = validateGlobalBinding(next) ?? overlapReason(next);
+		if (!reason) return true;
 		report.error({
 			title: 'That shortcut is not available',
-			description: result.reason,
+			description: reason,
 			cause: {
-				name: 'ReservedShortcut',
-				message: `${keyBindingToLabel(next, os.isApple)}: ${result.reason}`,
+				name: 'UnavailableShortcut',
+				message: `${keyBindingToLabel(next, os.isApple)}: ${reason}`,
 			},
 		});
 		return false;

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/GlobalKeyboardShortcutRecorder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/GlobalKeyboardShortcutRecorder.svelte
@@ -66,11 +66,9 @@
 
 	// Reject reserved or unsafe gestures before saving. Returns true when the
 	// binding is allowed; otherwise reports why and leaves the current binding
-	// untouched. Cancel is the one gesture allowed to be a bare Escape.
+	// untouched.
 	function validateAndReport(next: KeyBinding): boolean {
-		const result = validateGlobalBinding(next, {
-			isCancel: command.id === 'cancelManualRecording',
-		});
+		const result = validateGlobalBinding(next);
 		if (result.ok) return true;
 		report.error({
 			title: 'That shortcut is not available',

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/GlobalKeyboardShortcutRecorder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/GlobalKeyboardShortcutRecorder.svelte
@@ -11,6 +11,7 @@
 		keyBindingToLabel,
 		parseManualBinding,
 	} from '$lib/utils/key-binding';
+	import { validateGlobalBinding } from '$lib/utils/reserved-shortcuts';
 	import RecorderShell from './RecorderShell.svelte';
 
 	// `tauri` is passed non-null from the Tauri-gated global settings page; the
@@ -63,12 +64,32 @@
 		await tauri.globalShortcuts.setCapturing(false);
 	}
 
+	// Reject reserved or unsafe gestures before saving. Returns true when the
+	// binding is allowed; otherwise reports why and leaves the current binding
+	// untouched. Cancel is the one gesture allowed to be a bare Escape.
+	function isAllowed(next: KeyBinding): boolean {
+		const result = validateGlobalBinding(next, {
+			isCancel: command.id === 'cancelManualRecording',
+		});
+		if (result.ok) return true;
+		report.error({
+			title: 'That shortcut is not available',
+			description: result.reason,
+			cause: {
+				name: 'ReservedShortcut',
+				message: `${keyBindingToLabel(next, os.isApple)}: ${result.reason}`,
+			},
+		});
+		return false;
+	}
+
 	async function commitCapture() {
 		const next: KeyBinding = {
 			modifiers: [...capturedModifiers],
 			keys: [...capturedKeys],
 		};
 		await stopCapture();
+		if (!isAllowed(next)) return;
 		await persist(next);
 		open = false;
 	}
@@ -98,7 +119,7 @@
 			report.error({
 				title: 'Invalid shortcut',
 				description:
-					'Try e.g. cmd+shift+d, fn+space, or a modifier-only hold like cmd.',
+					'Try e.g. fn+space, ctrl+meta, or a modifier-only hold like fn.',
 				cause: {
 					name: 'InvalidManualShortcut',
 					message: `"${raw}" is not a valid combination.`,
@@ -106,6 +127,7 @@
 			});
 			return false;
 		}
+		if (!isAllowed(next)) return false;
 		void persist(next).then(() => {
 			open = false;
 		});
@@ -135,9 +157,9 @@
 	{recorder}
 	copy={{
 		placeholder,
-		recordHelp: 'Press a combination. Fn and modifier-only holds work here.',
-		manualHelp: 'Type a combination (e.g. cmd+shift+d, fn+space)',
-		manualPlaceholder: 'e.g. cmd+shift+d',
+		recordHelp: 'Press a gesture. Fn and modifier-only holds work here.',
+		manualHelp: 'Type a gesture (e.g. fn+space, ctrl+meta)',
+		manualPlaceholder: 'e.g. fn+space',
 		manualButtonLabel: 'Type manually',
 		listeningHint: 'Release to set, Esc to cancel',
 	}}

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/GlobalKeyboardShortcutRecorder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/GlobalKeyboardShortcutRecorder.svelte
@@ -67,7 +67,7 @@
 	// Reject reserved or unsafe gestures before saving. Returns true when the
 	// binding is allowed; otherwise reports why and leaves the current binding
 	// untouched. Cancel is the one gesture allowed to be a bare Escape.
-	function isAllowed(next: KeyBinding): boolean {
+	function validateAndReport(next: KeyBinding): boolean {
 		const result = validateGlobalBinding(next, {
 			isCancel: command.id === 'cancelManualRecording',
 		});
@@ -89,7 +89,7 @@
 			keys: [...capturedKeys],
 		};
 		await stopCapture();
-		if (!isAllowed(next)) return;
+		if (!validateAndReport(next)) return;
 		await persist(next);
 		open = false;
 	}
@@ -127,7 +127,7 @@
 			});
 			return false;
 		}
-		if (!isAllowed(next)) return false;
+		if (!validateAndReport(next)) return false;
 		void persist(next).then(() => {
 			open = false;
 		});

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
@@ -30,22 +30,29 @@
 		`control+${CommandOrAlt.toLowerCase()}+delete`,
 	];
 
-	// Global (desktop, rdev) binds in physical-key space with an Fn modifier and
-	// two shapes the old plugin could not express. Labels render through the same
-	// helper the recorder uses, so the guide always matches what gets stored.
+	// Global (desktop, rdev) binds in physical-key space as a held gesture. Labels
+	// render through the same helper the recorder uses, so the guide always
+	// matches what gets stored. Examples mirror the shipped defaults.
 	const GLOBAL_MODIFIERS: Modifier[] = ['ctrl', 'alt', 'shift', 'meta', 'fn'];
 	const modifierLabel = (modifier: Modifier) =>
 		keyBindingToLabel({ modifiers: [modifier], keys: [] }, os.isApple);
 	const GLOBAL_SHAPES = [
 		{
-			binding: { modifiers: ['meta', 'shift'], keys: ['keyD'] },
-			desc: 'a modifier + key combo',
+			binding: os.isApple
+				? { modifiers: ['fn'], keys: [] }
+				: { modifiers: ['ctrl', 'meta'], keys: [] },
+			desc: 'a modifier held on its own (the push-to-talk default)',
 		},
 		{
-			binding: { modifiers: ['fn'], keys: [] },
-			desc: 'a modifier held on its own (great for push-to-talk)',
+			binding: os.isApple
+				? { modifiers: ['fn'], keys: ['space'] }
+				: { modifiers: ['ctrl', 'meta'], keys: ['space'] },
+			desc: 'a modifier + key gesture (the toggle default)',
 		},
-		{ binding: { modifiers: [], keys: ['space'] }, desc: 'a single key' },
+		{
+			binding: { modifiers: [], keys: ['escape'] },
+			desc: 'a bare Escape, allowed only for cancel',
+		},
 	] satisfies { binding: { modifiers: Modifier[]; keys: string[] }; desc: string }[];
 </script>
 
@@ -160,9 +167,11 @@
 				<!-- Global (rdev) summary -->
 				<div class="rounded-lg bg-muted p-4">
 					<p class="text-sm">
-						Global shortcuts match physical keys system-wide, so they fire from
-						any app and can use keys the old shortcuts could not: the Fn key, a
-						modifier held on its own, or a single key.
+						Global shortcuts are held gestures that fire system-wide, so they
+						work from any app and can use keys the old shortcuts could not: the
+						Fn key or a modifier held on its own. Give every gesture a modifier
+						or Fn so it cannot fire on an ordinary keypress. Bare Escape is
+						reserved for canceling.
 					</p>
 				</div>
 
@@ -194,9 +203,9 @@
 
 				<p class="text-xs text-muted-foreground">
 					Keys match by physical position, so on a non-US layout the label may
-					differ from the printed character. Record a shortcut by pressing it, or
-					type one like <code class="font-mono text-xs">cmd+shift+d</code> or
-					<code class="font-mono text-xs">fn+space</code>.
+					differ from the printed character. Record a gesture by pressing it, or
+					type one like <code class="font-mono text-xs">fn+space</code> or
+					<code class="font-mono text-xs">ctrl+meta</code>.
 				</p>
 			{/if}
 		</div>

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
@@ -49,10 +49,6 @@
 				: { modifiers: ['ctrl', 'meta'], keys: ['space'] },
 			desc: 'a modifier + key gesture (the toggle default)',
 		},
-		{
-			binding: { modifiers: [], keys: ['escape'] },
-			desc: 'a bare Escape, allowed only for cancel',
-		},
 	] satisfies { binding: { modifiers: Modifier[]; keys: string[] }; desc: string }[];
 </script>
 
@@ -170,8 +166,7 @@
 						Global shortcuts are held gestures that fire system-wide, so they
 						work from any app and can use keys the old shortcuts could not: the
 						Fn key or a modifier held on its own. Give every gesture a modifier
-						or Fn so it cannot fire on an ordinary keypress. Bare Escape is
-						reserved for canceling.
+						or Fn so it cannot fire on an ordinary keypress.
 					</p>
 				</div>
 
@@ -190,7 +185,7 @@
 
 				<!-- The three shapes -->
 				<div>
-					<h4 class="text-sm font-semibold mb-1">Three kinds of shortcut</h4>
+					<h4 class="text-sm font-semibold mb-1">Two kinds of shortcut</h4>
 					<div class="space-y-2">
 						{#each GLOBAL_SHAPES as shape}
 							<div class="flex items-center gap-2">

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
@@ -45,9 +45,9 @@
 		},
 		{
 			binding: os.isApple
-				? { modifiers: ['fn'], keys: ['space'] }
-				: { modifiers: ['ctrl', 'meta'], keys: ['space'] },
-			desc: 'a modifier + key gesture (the toggle default)',
+				? { modifiers: ['meta', 'shift'], keys: ['space'] }
+				: { modifiers: ['ctrl', 'shift'], keys: ['space'] },
+			desc: 'a modifier chord plus a key (the toggle default)',
 		},
 	] satisfies { binding: { modifiers: Modifier[]; keys: string[] }; desc: string }[];
 </script>
@@ -166,7 +166,9 @@
 						Global shortcuts are held gestures that fire system-wide, so they
 						work from any app and can use keys the old shortcuts could not: the
 						Fn key or a modifier held on its own. Give every gesture a modifier
-						or Fn so it cannot fire on an ordinary keypress.
+						or Fn so it cannot fire on an ordinary keypress, and give each one its
+						own keys: a key bound to one gesture (like push-to-talk's Fn) cannot
+						be part of another.
 					</p>
 				</div>
 

--- a/apps/whispering/src/routes/(app)/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/+layout.svelte
@@ -12,7 +12,7 @@
 		PROVIDERS,
 	} from '$lib/services/transcription/providers';
 	import {
-		cancelManualRecording,
+		cancelRecording,
 		stopManualRecording,
 		stopVadRecording,
 	} from '$lib/operations/recording';
@@ -128,7 +128,7 @@
 			(event) => {
 				if (!overlayStatus) return;
 				if (overlayStatus.mode === 'manual') {
-					if (event.payload === 'cancel') void cancelManualRecording();
+					if (event.payload === 'cancel') void cancelRecording();
 					else void stopManualRecording();
 					return;
 				}

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -299,7 +299,7 @@
 			{#if manualRecorder.state === 'RECORDING'}
 				<Button
 					tooltip="Cancel recording and discard audio"
-					onclick={() => commandCallbacks.cancelManualRecording()}
+					onclick={() => commandCallbacks.cancelRecording()}
 					variant="ghost-destructive"
 					size="sm"
 					style="view-transition-name: {viewTransition.global.cancel};"

--- a/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
+++ b/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
@@ -22,6 +22,7 @@
 	import { syncWindowAlwaysOnTopWithRecorderState } from '../_layout-utils/alwaysOnTop.svelte';
 	import { checkForUpdates } from '../_layout-utils/check-for-updates';
 	import {
+		isSessionActive,
 		resetGlobalShortcutsToDefaultIfDuplicates,
 		resetLocalShortcutsToDefaultIfDuplicates,
 		syncGlobalShortcutsWithSettings,
@@ -96,6 +97,17 @@
 	if (tauri) {
 		syncWindowAlwaysOnTopWithRecorderState(tauri);
 		syncIconWithRecorderState(tauri);
+
+		// Re-push global bindings when session activity flips so the cancel
+		// gesture (a bare Escape) is registered only while a recording or VAD
+		// session is live. Depending on the derived boolean (not the raw recorder
+		// states) means we only re-push on the two transitions that change which
+		// bindings get sent, not on every intermediate sub-state.
+		const isSessionLive = $derived(isSessionActive());
+		$effect(() => {
+			isSessionLive;
+			void syncGlobalShortcutsWithSettings();
+		});
 	}
 
 	$effect(() => {

--- a/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
+++ b/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
@@ -22,7 +22,6 @@
 	import { syncWindowAlwaysOnTopWithRecorderState } from '../_layout-utils/alwaysOnTop.svelte';
 	import { checkForUpdates } from '../_layout-utils/check-for-updates';
 	import {
-		isSessionActive,
 		resetGlobalShortcutsToDefaultIfDuplicates,
 		resetLocalShortcutsToDefaultIfDuplicates,
 		syncGlobalShortcutsWithSettings,
@@ -97,17 +96,6 @@
 	if (tauri) {
 		syncWindowAlwaysOnTopWithRecorderState(tauri);
 		syncIconWithRecorderState(tauri);
-
-		// Re-push global bindings when session activity flips so the cancel
-		// gesture (a bare Escape) is registered only while a recording or VAD
-		// session is live. Depending on the derived boolean (not the raw recorder
-		// states) means we only re-push on the two transitions that change which
-		// bindings get sent, not on every intermediate sub-state.
-		const isSessionLive = $derived(isSessionActive());
-		$effect(() => {
-			isSessionLive;
-			void syncGlobalShortcutsWithSettings();
-		});
 	}
 
 	$effect(() => {

--- a/apps/whispering/src/routes/(app)/_layout-utils/register-commands.ts
+++ b/apps/whispering/src/routes/(app)/_layout-utils/register-commands.ts
@@ -13,8 +13,24 @@ import {
 	DEFAULT_GLOBAL_BINDINGS,
 	deviceConfig,
 } from '$lib/state/device-config.svelte';
+import { manualRecorder } from '$lib/state/manual-recorder.svelte';
 import { settings } from '$lib/state/settings.svelte';
+import { vadRecorder } from '$lib/state/vad-recorder.svelte';
 import type { CommandBinding, KeyBinding } from '$lib/tauri/commands';
+
+/**
+ * Whether a recording or capture session is live. The cancel gesture (a bare
+ * Escape by default) is only registered while this holds, so Escape stays the
+ * system's own key everywhere else instead of firing a "nothing to cancel"
+ * no-op on every press.
+ */
+export function isSessionActive(): boolean {
+	return (
+		manualRecorder.state === 'RECORDING' ||
+		vadRecorder.state === 'LISTENING' ||
+		vadRecorder.state === 'SPEECH_DETECTED'
+	);
+}
 
 /** Default values for in-app (local) shortcuts. Keyed by command id string. */
 const DEFAULT_LOCAL_SHORTCUTS = {
@@ -92,10 +108,15 @@ export async function syncGlobalShortcutsWithSettings() {
 	if (!tauri) return;
 	const { globalShortcuts } = tauri;
 
+	const sessionActive = isSessionActive();
 	const bindings: CommandBinding[] = [];
 	for (const command of commands) {
 		const binding = deviceConfig.get(getGlobalShortcutKey(command.id));
 		if (!binding) continue;
+		// Cancel is active only while a session is live (see `isSessionActive`).
+		// Outside a session it is left unregistered so its bare Escape default
+		// never traps the key globally.
+		if (command.id === 'cancelManualRecording' && !sessionActive) continue;
 		// Storage validates keys as plain strings; Rust validates them by name on
 		// register. The cast bridges the stored `string[]` to the IPC `Key[]`.
 		bindings.push({ commandId: command.id, binding: binding as KeyBinding });

--- a/apps/whispering/src/routes/(app)/_layout-utils/register-commands.ts
+++ b/apps/whispering/src/routes/(app)/_layout-utils/register-commands.ts
@@ -20,7 +20,7 @@ import type { CommandBinding, KeyBinding } from '$lib/tauri/commands';
 const DEFAULT_LOCAL_SHORTCUTS = {
 	pushToTalk: 'p',
 	toggleManualRecording: ' ',
-	cancelManualRecording: 'c',
+	cancelRecording: 'c',
 	toggleVadRecording: 'v',
 	openTransformationPicker: 't',
 	runTransformationOnClipboard: 'r',

--- a/apps/whispering/src/routes/(app)/_layout-utils/register-commands.ts
+++ b/apps/whispering/src/routes/(app)/_layout-utils/register-commands.ts
@@ -13,24 +13,8 @@ import {
 	DEFAULT_GLOBAL_BINDINGS,
 	deviceConfig,
 } from '$lib/state/device-config.svelte';
-import { manualRecorder } from '$lib/state/manual-recorder.svelte';
 import { settings } from '$lib/state/settings.svelte';
-import { vadRecorder } from '$lib/state/vad-recorder.svelte';
 import type { CommandBinding, KeyBinding } from '$lib/tauri/commands';
-
-/**
- * Whether a recording or capture session is live. The cancel gesture (a bare
- * Escape by default) is only registered while this holds, so Escape stays the
- * system's own key everywhere else instead of firing a "nothing to cancel"
- * no-op on every press.
- */
-export function isSessionActive(): boolean {
-	return (
-		manualRecorder.state === 'RECORDING' ||
-		vadRecorder.state === 'LISTENING' ||
-		vadRecorder.state === 'SPEECH_DETECTED'
-	);
-}
 
 /** Default values for in-app (local) shortcuts. Keyed by command id string. */
 const DEFAULT_LOCAL_SHORTCUTS = {
@@ -108,15 +92,10 @@ export async function syncGlobalShortcutsWithSettings() {
 	if (!tauri) return;
 	const { globalShortcuts } = tauri;
 
-	const sessionActive = isSessionActive();
 	const bindings: CommandBinding[] = [];
 	for (const command of commands) {
 		const binding = deviceConfig.get(getGlobalShortcutKey(command.id));
 		if (!binding) continue;
-		// Cancel is active only while a session is live (see `isSessionActive`).
-		// Outside a session it is left unregistered so its bare Escape default
-		// never traps the key globally.
-		if (command.id === 'cancelManualRecording' && !sessionActive) continue;
 		// Storage validates keys as plain strings; Rust validates them by name on
 		// register. The cast bridges the stored `string[]` to the IPC `Key[]`.
 		bindings.push({ commandId: command.id, binding: binding as KeyBinding });


### PR DESCRIPTION
Whispering's old global shortcuts were ordinary app hotkeys registered at system scope. That made the defaults collide with browser, editor, and OS shortcuts, and it also made push-to-talk sensitive to press and release timing.

This moves the global shortcut layer toward held gestures instead. The new defaults use a low-conflict push-to-talk hold, a related toggle gesture, and a platform cancel gesture. Transformation shortcuts are no longer pre-bound globally; users can opt into those instead of having Whispering claim common chords like reload or extension picker. The settings UI now rejects reserved global gestures before saving, including common reload, clipboard, undo, app switch, screenshot, and system-search combinations.

The backend matcher now understands gesture prefixes and pending windows, so a short hold can fire without preventing a longer related gesture from completing. The capture flow also reports the live held gesture instead of trying to infer command triggers while recording a shortcut.

Cancel now means "abort the live capture" rather than "cancel only manual recording." Manual recording cancellation still discards the in-flight manual capture. If VAD is live, cancel tears down the VAD session by stopping it. If nothing is live, the global cancel chord stays silent.

Because Whispering is still pre-release, the cancel command id changes from `cancelManualRecording` to `cancelRecording` without a migration. Existing custom cancel bindings reset to the new default.

Addresses #1263 and #1671.
Partially addresses #1264.

## Changelog

- Add lower-conflict global recording gestures for Whispering
- Prevent common system and app shortcuts from being saved as global recording gestures
- Make cancel abort the active recording session, including live VAD sessions

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784059276&installation_id=128463665&pr_number=1988&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1988&signature=66989794dca22a0eaa1a087a09a29030c9590d1148a70f392b52cf390c6d092a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->