### PR TITLE
docs: clarify writing instruction boundaries

### DIFF
--- a/.agents/skills/agent-instruction-hygiene/SKILL.md
+++ b/.agents/skills/agent-instruction-hygiene/SKILL.md
@@ -91,5 +91,5 @@ When edits land:
 
 1. Run `bun x --package skills skills add /Users/braden/Code/epicenter/.agents/skills --skill <skill-name> --list` for changed or added skills.
 2. Run `git diff --check` on touched instruction files.
-3. Scan touched prose for em and en dashes.
+3. Check touched prose against the `writing-voice` punctuation rubric.
 4. Stage specific files only when the user asks.

--- a/.agents/skills/skill-creator/SKILL.md
+++ b/.agents/skills/skill-creator/SKILL.md
@@ -233,5 +233,5 @@ Use sharper review questions when the design still feels soft:
   them.
 - The skill avoids time-sensitive facts unless sourced and necessary.
 - No orphan `CLAUDE.md` files are created; sibling shims only import `@AGENTS.md`.
-- No em dash or en dash characters are present.
+- Punctuation follows `writing-voice`: no en dash characters, and em dash characters only when they earn the emphasis.
 - Validation passed with the Vercel `skills` CLI.

--- a/.agents/skills/technical-articles/SKILL.md
+++ b/.agents/skills/technical-articles/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # Technical Articles
 
-All articles must follow [writing-voice](../writing-voice/SKILL.md) rules.
+All articles must follow [writing-voice](../writing-voice/SKILL.md) rules. This skill owns article shape; `writing-voice` owns house voice and punctuation.
 
 ## When to Apply This Skill
 
@@ -86,7 +86,7 @@ For articles about ownership, routing, auth, billing, sync, tenancy, API shape, 
 
 1. Use [notebook-explanation](../notebook-explanation/SKILL.md) to build the private model: ownership, boundaries, flow, good/bad examples, and durable rules.
 2. Use this skill to turn that model into a public argument: title, opening, section claims, rhythm, code, diagrams, and closing.
-3. Use [writing-voice](../writing-voice/SKILL.md) as the final pass.
+3. Use [writing-voice](../writing-voice/SKILL.md) throughout as the house voice and final punctuation pass.
 
 Do not publish the notebook scaffold unchanged unless the article is intentionally notebook-style. The notebook is the thinking format; the article is the reader format.
 
@@ -200,7 +200,7 @@ Section headings: use sparingly. Not every paragraph needs a heading. Let conten
 
 Bold text: avoid in body content. Use sparingly if needed for emphasis.
 
-No space-dash-space. No em dashes or en dashes. Use periods, colons, semicolons, commas, or parentheses per writing-voice.
+No space-hyphen-space. Follow [writing-voice](../writing-voice/SKILL.md) for punctuation: no en dash characters, and em dash characters only when they earn the emphasis. In articles, still default to periods, colons, semicolons, commas, or parentheses.
 
 No rigid template: structure should fit the content, not the other way around. Some articles need a "Problem/Solution" flow; others just show code and explain. Don't force sections.
 

--- a/.agents/skills/writing-voice/SKILL.md
+++ b/.agents/skills/writing-voice/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-voice
-description: 'Voice/tone rules for prose, UI text, tooltips, error messages. Use when: "fix the tone", "rewrite this", "sounds like AI", "sounds corporate", or writing user-facing text and docs.'
+description: 'Voice, tone, and punctuation rules for prose, UI text, tooltips, error messages, comments, JSDoc, markdown, commit messages, and docs. Use when: "fix the tone", "rewrite this", "sounds like AI", "sounds corporate", or deciding whether punctuation earns its emphasis.'
 metadata:
   author: epicenter
   version: '1.0'
@@ -20,6 +20,7 @@ Use this pattern when you need to:
 
 - Write user-facing text like UI copy, tooltips, error messages, or prose.
 - Rewrite text that sounds corporate, stilted, or AI-generated.
+- Decide punctuation style in prose, comments, JSDoc, markdown, or commit messages.
 - Explain technical concepts with concrete mechanisms instead of abstract claims.
 - Match the user's tone and pacing in responses.
 - Draft product/open-source writing with honest trade-offs and specifics.
@@ -51,15 +52,19 @@ Patterns that scream "AI wrote this":
 
 ## Punctuation
 
-No em dashes. No en dashes. This is a project-wide rule from `AGENTS.md` and it applies to prose, UI text, comments, error strings, and commit messages. If you reach for one, you are reaching for the wrong tool. Pick from this list instead.
+Punctuation should clarify the sentence, not decorate it. The house default is still to avoid em dash characters (`U+2014`), and `AGENTS.md` bans en dash characters (`U+2013`). If you reach for an em dash, prove that it earns the extra emphasis.
 
-| Prefer        | When                                                           |
-| ------------- | -------------------------------------------------------------- |
-| Period (.)    | Default choice. Two sentences are often clearer than one.      |
-| Colon (:)     | Introducing explanation: "Here's the thing: it doesn't work"   |
-| Semicolon (;) | Related independent clauses: "The code works; the tests pass"  |
-| Parens ( )    | Aside that the sentence could survive without                  |
-| Comma (,)     | Short qualifier inside a sentence                              |
+Prefer these first:
+
+| Prefer        | When                                                          |
+| ------------- | ------------------------------------------------------------- |
+| Period (.)    | Default choice. Two sentences are often clearer than one.     |
+| Colon (:)     | Introducing explanation: "Here's the thing: it doesn't work"  |
+| Semicolon (;) | Related independent clauses: "The code works; tests pass"     |
+| Parens ( )    | Aside that the sentence could survive without                 |
+| Comma (,)     | Short qualifier inside a sentence                             |
+
+An em dash earns itself only when it marks a real appositive, interruption, or parenthetical aside with more emphasis than commas or parentheses would carry. Do not use it as a fancy comma, a vague pause, or glue between two independent thoughts. In UI strings, tooltips, error messages, headings, docs tables, commit messages, comments, and JSDoc, default to a colon, period, comma, semicolon, or parentheses unless the dash is deliberately part of the voice.
 
 When in doubt, use a period. Two clear sentences beat one clever one.
 

--- a/.agents/skills/writing-voice/SKILL.md
+++ b/.agents/skills/writing-voice/SKILL.md
@@ -10,9 +10,22 @@ metadata:
 
 **Core principle**: Write for the ear, not just the eyes. Prose should be suitable to read out loud.
 
-For technical explanations where the user is trying to understand a system, combine this voice with [notebook-explanation](../notebook-explanation/SKILL.md): short working notes, code blocks, tiny definitions, ASCII diagrams, and durable rules.
+## Composition Rule
 
-For PR and commit text, combine this voice with [pull-request](../pull-request/SKILL.md): the voice rules here still apply, but the product and personal-voice sections further down (landing-page framing, "end with an invitation", first-person story openers) are for marketing and community writing, not for a reviewer-facing PR.
+This skill owns house voice, punctuation, anti-AI prose, and Braden's public voice. Other writing skills should own artifact shape, not a competing voice.
+
+Use the narrow artifact skill when the user asks for that artifact:
+
+| Skill | Owns |
+| --- | --- |
+| [notebook-explanation](../notebook-explanation/SKILL.md) | Private or semi-polished technical explanation shape: tiny definitions, flows, ownership maps, concrete rules. |
+| [technical-articles](../technical-articles/SKILL.md) | Public article shape: title as argument, opening, rhythm between prose and code, section claims, closing. |
+| [pull-request](../pull-request/SKILL.md) | PR title, PR body, changelog, issue links, merge strategy, durable reviewer context. |
+| [documentation](../documentation/SKILL.md) | Folder READMEs, JSDoc, and comments that explain why rather than restating code. |
+| [github-issues](../github-issues/SKILL.md) | Public issue and PR-thread replies with maintainer context. |
+| [discord-voice](../discord-voice/SKILL.md) | Casual team chat and Discord messages. |
+
+For PR and commit text, the voice rules here still apply, but the product and personal-voice sections further down (landing-page framing, "end with an invitation", first-person story openers) are for marketing and community writing, not for reviewer-facing PRs or commits.
 
 ## When to Apply This Skill
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,6 @@ Script suffix convention: `:local` suffix scripts work on a fresh clone without 
 
 Library logging: Do not use direct `console.*` in library code. Use `wellcrafted/logger`, except in CLIs, tests, and benchmarks.
 
-Writing conventions: Load `writing-voice` skill for any user-facing text (UI strings, tooltips, error messages, docs). Do not use em dash characters (`U+2014`) or en dash characters (`U+2013`) anywhere, including prose, comments, JSDoc, and error strings. Use a colon, comma, semicolon, parenthesis, or sentence break instead. This applies to source files, markdown, and commit messages.
+Writing conventions: Load `writing-voice` skill for any user-facing text or punctuation-sensitive prose (UI strings, tooltips, error messages, docs, comments, JSDoc, markdown, and commit messages). Default to colon, comma, semicolon, parenthesis, or sentence break over em dash characters (`U+2014`), especially in UI strings. Do not use en dash characters (`U+2013`).
 
 Review gates: For substantial implementations, public API changes, refactors, multi-file changes, or user requests to grill, simplify, or clean up the result, load `post-implementation-review` before final handoff or staging. Load `collapse-pass` directly for continuous indirection-reduction work. During review, escalate to `cohesive-clean-breaks` for ownership, lifecycle, API, package-boundary, or asymmetric-win decisions, and to `greenfield-clean-breaks` when compatibility is not load-bearing or the user asks for the ideal shape. Keep procedures in skills; keep `AGENTS.md` to routing.


### PR DESCRIPTION
This PR turns the writing instructions into a clearer house-rule system. `writing-voice` now owns voice, punctuation, and anti-AI prose, while artifact skills such as `technical-articles` keep ownership of concrete output shape.

It also changes the em dash rule from a blanket ban into a default-against rubric: agents should prefer periods, colons, commas, semicolons, or parentheses, but a rare em dash can stay when it marks a real aside or interruption. En dash characters remain banned.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784059301&installation_id=128463665&pr_number=1990&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1990&signature=ab8a6977473bd73cdb685e2f06a9252b5096d789aa780c9dff21063b3d258be7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->