### PR TITLE
ci: fold cloudflare builds into per-app deploy blocks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -30,7 +30,7 @@ Web apps (Cloudflare Workers) deploy **together in one workflow** because deploy
 
 | File | Trigger | What it does |
 |---|---|---|
-| `deploy.cloudflare.yml` | Push to `main`, manual | Builds Whispering, Landing, and the API dashboard, then deploys Whispering + Landing + API to Cloudflare Workers. Posts Discord notification. |
+| `deploy.cloudflare.yml` | Push to `main`, manual | Builds and deploys Whispering, Landing, and API to Cloudflare Workers. Each app builds itself immediately before its own deploy, so a deploy can never ship stale assets. Posts Discord notification. |
 | `deploy.cloudflare-preview.yml` | Pull requests touching `apps/whispering/**`, `apps/landing/**`, `packages/**` | Uploads preview versions via `wrangler versions upload --preview-alias`. Posts PR comment with preview URLs. No cleanup needed (aliases auto-expire at 1000). |
 
 ### CI

--- a/.github/workflows/deploy.cloudflare.yml
+++ b/.github/workflows/deploy.cloudflare.yml
@@ -32,39 +32,48 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Build deploy targets
-        run: bun run --filter @epicenter/whispering --filter @epicenter/landing --filter @epicenter/api-ui build
-        env:
-          NODE_ENV: production
-
-      - name: Deploy Whispering
+      # Each deploy builds the app it publishes, then deploys it. Build and
+      # deploy stay coupled inside one block so a deploy can never ship stale
+      # assets, and the set of deployed targets lives in exactly one place.
+      # NODE_ENV is scoped to the step (not the job) so `bun install` above
+      # still resolves devDependencies.
+      - name: Build & Deploy Whispering
         id: whispering
         uses: cloudflare/wrangler-action@v3
+        env:
+          NODE_ENV: production
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/whispering
           packageManager: bun
+          preCommands: bun run build
           command: deploy
 
-      - name: Deploy Landing
+      - name: Build & Deploy Landing
         id: landing
         uses: cloudflare/wrangler-action@v3
+        env:
+          NODE_ENV: production
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/landing
           packageManager: bun
+          preCommands: bun run build
           command: deploy
 
-      - name: Deploy API
+      - name: Build & Deploy API
         id: api
         uses: cloudflare/wrangler-action@v3
+        env:
+          NODE_ENV: production
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/api
           packageManager: bun
+          preCommands: bun run --cwd ui build
           command: deploy
 
       - name: Deployment summary


### PR DESCRIPTION
Follow-up to #1991. That PR fixed the Node runtime and narrowed the build to the three published targets, but it kept a standalone build step listing `{whispering, landing, api-ui}` separate from the three deploy steps listing `{whispering, landing, api}`.

Two lists had to stay in sync, the `api-ui` to `api` mapping was implicit, and each deploy ran `wrangler deploy` with no build of its own, trusting a decoupled pre-build to have produced fresh output. That is the same shape that let a failed build leave stale assets in production.

This couples build to deploy. Each app now builds itself via the `wrangler-action` `preCommands` hook immediately before its own deploy, so:

- The set of deployed targets lives in exactly one place (the three deploy blocks).
- A deploy can never ship stale assets, because the build that feeds it is co-located with it.
- The implicit `api-ui` to `api` naming gap is gone.

`NODE_ENV=production` is scoped to each deploy step rather than the job, so the job-level `bun install` still resolves devDependencies (vite, astro). `preCommands` runs in each step's `workingDirectory` and inherits step-level env, confirmed against the wrangler-action source.

Note: this workflow only runs on push to `main` / manual dispatch, not on PRs, so the real exercise of this change is the first post-merge deploy. Verified statically here: YAML parses, each `preCommands` build output dir matches that app's wrangler `assets.directory`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784061667&installation_id=128463665&pr_number=1994&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1994&signature=4496792d8f0ef99a81df50d19fe30ab2f618e16600db69feadb0bed949cbb395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->