### PR TITLE
refactor: inject baseURL into app mounts, drop @epicenter/constants from block closures

### DIFF
--- a/apps/fuji/src/lib/workspace/project.ts
+++ b/apps/fuji/src/lib/workspace/project.ts
@@ -20,7 +20,6 @@
  */
 
 import { join } from 'node:path';
-import { EPICENTER_API_URL } from '@epicenter/constants/apps';
 import {
 	defineActions,
 	defineWorkspace,
@@ -44,6 +43,11 @@ import { createFuji, type Entry, entryContentDocGuid } from './index.js';
 export type FujiMountOptions = {
 	/** Enable per-materializer Git autosave for markdown output. */
 	git?: GitAutosaveConfig;
+	/**
+	 * Base URL of the Epicenter cloud API used for entry-body reads and sync.
+	 * Defaults to `process.env.EPICENTER_API_URL`, falling back to the hosted API.
+	 */
+	baseURL?: string;
 };
 
 export function fuji(opts: FujiMountOptions = {}) {
@@ -51,6 +55,10 @@ export function fuji(opts: FujiMountOptions = {}) {
 		name: 'fuji',
 		open(ctx) {
 			const { epicenterRoot, mount, session } = ctx;
+			const baseURL =
+				opts.baseURL ||
+				process.env.EPICENTER_API_URL ||
+				'https://api.epicenter.so';
 
 			const workspace = createFuji({ keyring: session.keyring });
 
@@ -73,7 +81,7 @@ export function fuji(opts: FujiMountOptions = {}) {
 			const readEntryBody = (entry: Entry): Promise<string> =>
 				readRoomOverHttp({
 					fetch: session.fetch,
-					baseURL: EPICENTER_API_URL,
+					baseURL,
 					ownerId: session.ownerId,
 					guid: entryContentDocGuid(entry.id),
 					read: (ydoc) => serializeEntryBody(ydoc.getXmlFragment('content')),
@@ -111,7 +119,7 @@ export function fuji(opts: FujiMountOptions = {}) {
 			});
 
 			const infrastructure = attachMountInfrastructure(workspace.ydoc, ctx, {
-				baseURL: EPICENTER_API_URL,
+				baseURL,
 				actions,
 				materializers: [sqlite, markdown],
 			});

--- a/apps/honeycrisp/project.ts
+++ b/apps/honeycrisp/project.ts
@@ -9,7 +9,6 @@
  */
 
 import { join } from 'node:path';
-import { EPICENTER_API_URL } from '@epicenter/constants/apps';
 import { defineActions, defineWorkspace } from '@epicenter/workspace';
 import { defineSessionMount } from '@epicenter/workspace/daemon';
 import {
@@ -27,6 +26,11 @@ import { createHoneycrisp } from './honeycrisp.js';
 
 export type HoneycrispMountOptions = {
 	git?: GitAutosaveConfig;
+	/**
+	 * Base URL of the Epicenter cloud API used for sync.
+	 * Defaults to `process.env.EPICENTER_API_URL`, falling back to the hosted API.
+	 */
+	baseURL?: string;
 };
 
 export function honeycrisp(opts: HoneycrispMountOptions = {}) {
@@ -34,6 +38,10 @@ export function honeycrisp(opts: HoneycrispMountOptions = {}) {
 		name: 'honeycrisp',
 		open(ctx) {
 			const { epicenterRoot, mount } = ctx;
+			const baseURL =
+				opts.baseURL ||
+				process.env.EPICENTER_API_URL ||
+				'https://api.epicenter.so';
 
 			const workspace = createHoneycrisp({ keyring: ctx.session.keyring });
 
@@ -61,7 +69,7 @@ export function honeycrisp(opts: HoneycrispMountOptions = {}) {
 			});
 
 			const infrastructure = attachMountInfrastructure(workspace.ydoc, ctx, {
-				baseURL: EPICENTER_API_URL,
+				baseURL,
 				actions,
 				materializers: [sqlite, markdown],
 			});

--- a/apps/tab-manager/project.ts
+++ b/apps/tab-manager/project.ts
@@ -7,7 +7,6 @@
  */
 
 import { join } from 'node:path';
-import { EPICENTER_API_URL } from '@epicenter/constants/apps';
 import { defineActions, defineWorkspace } from '@epicenter/workspace';
 import { defineSessionMount } from '@epicenter/workspace/daemon';
 import {
@@ -26,6 +25,11 @@ import { createTabManager } from './src/lib/workspace/definition.js';
 export type TabManagerMountOptions = {
 	/** Enable per-materializer Git autosave for markdown output. */
 	git?: GitAutosaveConfig;
+	/**
+	 * Base URL of the Epicenter cloud API used for sync.
+	 * Defaults to `process.env.EPICENTER_API_URL`, falling back to the hosted API.
+	 */
+	baseURL?: string;
 };
 
 export function tabManager(opts: TabManagerMountOptions = {}) {
@@ -33,6 +37,10 @@ export function tabManager(opts: TabManagerMountOptions = {}) {
 		name: 'tab-manager',
 		open(ctx) {
 			const { epicenterRoot, mount } = ctx;
+			const baseURL =
+				opts.baseURL ||
+				process.env.EPICENTER_API_URL ||
+				'https://api.epicenter.so';
 
 			const workspace = createTabManager({ keyring: ctx.session.keyring });
 
@@ -68,7 +76,7 @@ export function tabManager(opts: TabManagerMountOptions = {}) {
 			});
 
 			const infrastructure = attachMountInfrastructure(workspace.ydoc, ctx, {
-				baseURL: EPICENTER_API_URL,
+				baseURL,
 				actions,
 				materializers: [sqlite, markdown],
 			});


### PR DESCRIPTION
The fuji/honeycrisp/tab-manager mount factories read `EPICENTER_API_URL` from `@epicenter/constants`, which couples the part of each app that becomes a vendored jsrepo block (the workspace mount source) to Epicenter product config. A block installed into someone else's repo should not drag in our hosted-API constants.

Each `*MountOptions` now takes an optional `baseURL`, defaulting to the same env-or-literal value the constant resolved to:

```ts
// before: import { EPICENTER_API_URL } from '@epicenter/constants/apps';
//         baseURL: EPICENTER_API_URL,

export function fuji(opts: FujiMountOptions = {}) {
  // ...
  const baseURL =
    opts.baseURL ||
    process.env.EPICENTER_API_URL ||
    'https://api.epicenter.so';
}
```

Behavior is unchanged for the in-repo apps (same default). Only the app-shell code (vite, oauth, auth) still imports `@epicenter/constants`; the workspace mount closure is now constants-free, which is the prerequisite for distributing it as a jsrepo block whose npm closure is just the framework.

Prep refactor 2 of the Phase 0 publish work (spec `20260614T120000`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784062128&installation_id=128463665&pr_number=1995&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1995&signature=1b9e8e3f176a0bbbab8b985a67a825986da80351a769994d7ef61fbad19fbea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->