### PR TITLE
ci: move cloudflare builds into wrangler build.command

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,7 +15,7 @@ All workflows live flat in `.github/workflows/` (GitHub Actions requirement). We
 
 Tauri desktop apps get **separate per-app workflows** because builds run a 3-platform matrix (macOS Apple Silicon, Ubuntu, Windows) taking 20+ minutes. A PR touching only Whispering shouldn't trigger an Epicenter build.
 
-Web apps (Cloudflare Workers) deploy **together in one workflow** because deploys are fast (~2 min on a single runner) and share the same runtime setup. The deploy workflow builds only the targets it publishes; repo-wide lint, typecheck, and unrelated package builds belong to CI.
+Web apps (Cloudflare Workers) deploy **together in one workflow** because deploys are fast (~2 min on a single runner) and share the same runtime setup. Each worker's build lives in its own `wrangler.jsonc` `build.command`, which Wrangler runs for both `deploy` and `versions upload`, so production, previews, and local `wrangler deploy` build through one definition. Repo-wide lint, typecheck, and unrelated package builds belong to CI.
 
 ## Workflows
 
@@ -30,7 +30,7 @@ Web apps (Cloudflare Workers) deploy **together in one workflow** because deploy
 
 | File | Trigger | What it does |
 |---|---|---|
-| `deploy.cloudflare.yml` | Push to `main`, manual | Builds and deploys Whispering, Landing, and API to Cloudflare Workers. Each app builds itself immediately before its own deploy, so a deploy can never ship stale assets. Posts Discord notification. |
+| `deploy.cloudflare.yml` | Push to `main`, manual | Deploys Whispering, Landing, and API to Cloudflare Workers. Each `wrangler deploy` runs that worker's `build.command` first, so a deploy can never ship stale assets. Posts Discord notification. |
 | `deploy.cloudflare-preview.yml` | Pull requests touching `apps/whispering/**`, `apps/landing/**`, `packages/**` | Uploads preview versions via `wrangler versions upload --preview-alias`. Posts PR comment with preview URLs. No cleanup needed (aliases auto-expire at 1000). |
 
 ### CI

--- a/.github/workflows/deploy.cloudflare-preview.yml
+++ b/.github/workflows/deploy.cloudflare-preview.yml
@@ -37,11 +37,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Build previews
-        run: bun run --filter @epicenter/whispering --filter @epicenter/landing build
-        env:
-          NODE_ENV: production
-
+      # `versions upload` runs each worker's `wrangler.jsonc` build.command, so
+      # previews build through the same definition as production deploys. No
+      # separate build step needed.
       - name: Upload Whispering preview
         id: whispering
         uses: cloudflare/wrangler-action@v3

--- a/.github/workflows/deploy.cloudflare.yml
+++ b/.github/workflows/deploy.cloudflare.yml
@@ -32,48 +32,38 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # Each deploy builds the app it publishes, then deploys it. Build and
-      # deploy stay coupled inside one block so a deploy can never ship stale
-      # assets, and the set of deployed targets lives in exactly one place.
-      # NODE_ENV is scoped to the step (not the job) so `bun install` above
-      # still resolves devDependencies.
-      - name: Build & Deploy Whispering
+      # Each `deploy` runs the worker's own `wrangler.jsonc` build.command first,
+      # so build stays coupled to deploy (no stale assets) without a separate
+      # build step here. The same build runs on local `wrangler deploy` and in
+      # the preview workflow's `versions upload`, so there is one build path.
+      - name: Deploy Whispering
         id: whispering
         uses: cloudflare/wrangler-action@v3
-        env:
-          NODE_ENV: production
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/whispering
           packageManager: bun
-          preCommands: bun run build
           command: deploy
 
-      - name: Build & Deploy Landing
+      - name: Deploy Landing
         id: landing
         uses: cloudflare/wrangler-action@v3
-        env:
-          NODE_ENV: production
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/landing
           packageManager: bun
-          preCommands: bun run build
           command: deploy
 
-      - name: Build & Deploy API
+      - name: Deploy API
         id: api
         uses: cloudflare/wrangler-action@v3
-        env:
-          NODE_ENV: production
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/api
           packageManager: bun
-          preCommands: bun run --cwd ui build
           command: deploy
 
       - name: Deployment summary

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,7 @@
 		"typecheck": "tsc --noEmit",
 		"dev": "bun scripts/dev.ts",
 		"dev:dashboard": "bun run --cwd ui build && bun scripts/dev.ts",
-		"deploy": "bun run --cwd ui build && wrangler deploy",
+		"deploy": "wrangler deploy",
 		"typegen": "wrangler types",
 		"auth:generate": "infisical run --env=prod --path=/ops --path=/api -- bun x @better-auth/cli generate --yes --config ./better-auth.config.ts --output ../../packages/server/src/db/schema/auth.ts",
 		"db:generate": "drizzle-kit generate",

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -5,8 +5,15 @@
 	"compatibility_date": "2026-03-06",
 	"compatibility_flags": ["nodejs_compat", "enable_request_signal"],
 	"send_metrics": false,
+	// Build the dashboard SPA before publishing. Wrangler runs build.command for
+	// `deploy` and `versions upload`, so local, CI prod, and CI preview build
+	// through one definition. Skip it for `dev`/`types`: the local `wrangler dev`
+	// loop (scripts/dev.ts) intentionally serves an unbuilt dashboard so the
+	// edit loop stays fast.
+	"build": {
+		"command": "case \"$WRANGLER_COMMAND\" in dev|types) ;; *) bun run --cwd ui build ;; esac"
+	},
 	// --- Static assets: Dashboard SPA (built by SvelteKit adapter-static) ---
-	// Build first: bun run --cwd apps/api/ui build
 	// SvelteKit writes output to ui/build/dashboard/ (paths.base = '/dashboard');
 	// the directory below is the PARENT so /dashboard/* URLs map correctly.
 	// Hono handles SPA fallback for /dashboard/*.

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -10,7 +10,7 @@
 		"build": "astro build",
 		"preview": "astro preview",
 		"astro": "astro",
-		"deploy": "bun run build && wrangler deploy",
+		"deploy": "wrangler deploy",
 		"typecheck": "astro check && svelte-check --tsconfig ./tsconfig.json"
 	},
 	"dependencies": {

--- a/apps/landing/wrangler.jsonc
+++ b/apps/landing/wrangler.jsonc
@@ -2,6 +2,12 @@
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "landing",
 	"compatibility_date": "2025-07-29",
+	// Build the site before publishing. Wrangler runs build.command for both
+	// `deploy` and `versions upload`, so local, CI prod, and CI preview build
+	// through one definition. (This app never uses `wrangler dev`.)
+	"build": {
+		"command": "bun run build"
+	},
 	"assets": {
 		"directory": "dist",
 		"not_found_handling": "404-page"

--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -72,7 +72,7 @@
 		"typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"typecheck:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"tauri": "tauri",
-		"deploy": "bun run build && wrangler deploy"
+		"deploy": "wrangler deploy"
 	},
 	"license": "AGPL-3.0-or-later",
 	"devDependencies": {

--- a/apps/whispering/wrangler.jsonc
+++ b/apps/whispering/wrangler.jsonc
@@ -2,6 +2,12 @@
 	"$schema": "../../node_modules/wrangler/config-schema.json",
 	"name": "whispering",
 	"compatibility_date": "2025-11-04",
+	// Build the SPA before publishing. Wrangler runs build.command for both
+	// `deploy` and `versions upload`, so local, CI prod, and CI preview build
+	// through one definition. (This app never uses `wrangler dev`.)
+	"build": {
+		"command": "bun run build"
+	},
 	// --- Custom domain: whispering.epicenter.so (auto-creates DNS record on deploy) ---
 	"routes": [
 		{


### PR DESCRIPTION
Greenfield follow-up to #1991 and #1994. Those fixed the Node runtime and coupled build to deploy via the workflow's `preCommands` hook. This finishes the unification by moving the build to where it belongs: the worker's own config.

The problem this addresses is:

After #1994, "how to build a worker" was defined twice: in each app's `package.json` `deploy` script (`bun run build && wrangler deploy`) and in the CI workflow (`preCommands`). The two could drift. The preview workflow couldn't reuse either and kept its own separate build step. Three places, one fact.

## Change

Each worker's build now lives in its `wrangler.jsonc` `build.command`. Wrangler runs it automatically for **both** `wrangler deploy` and `wrangler versions upload`, including for assets-only workers, so production, previews, and local `wrangler deploy` all build through one definition co-located with the worker:

- `build.command` added to `wrangler.jsonc` for whispering, landing, api.
- `deploy` scripts collapse to `wrangler deploy` (local == CI).
- Prod workflow drops `preCommands` and per-step `NODE_ENV` (app build scripts set it).
- Preview workflow drops its standalone build step.

The api `build.command` is guarded on `WRANGLER_COMMAND` so it skips `dev` and `types`: `apps/api/scripts/dev.ts` runs `wrangler dev` and intentionally serves an unbuilt dashboard to keep the edit loop fast.

For verification:

- `wrangler deploy --dry-run` on landing ran the custom build (astro), wrote `dist/`, read 35 assets, then exited without uploading: confirms `build.command` fires on the deploy path.
- Guard logic unit-checked: `deploy`/`versions upload` build, `dev`/`types` skip.
- All three `wrangler.jsonc` parse; both workflows parse.
- `build.command` for `versions upload` and the assets-only case confirmed against Cloudflare docs (DeepWiki).

The scope is intentionally bounded:

- Targets stay whispering + landing + api. opensidian, zhongwen, posthog-reverse-proxy have deploy scripts but no CI; self-host is community-operated and intentionally excluded.
- The api **preview** gap (api isn't in `deploy.cloudflare-preview.yml`) is left as a separate decision: previewing a stateful auth/billing worker is a different risk class than static-asset previews.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784062489&installation_id=128463665&pr_number=1998&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1998&signature=23b522a99bce5f6b51d458a74adbf6d3f91e1fe8db91bef8b4108c440adbd687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->