### PR TITLE
ci: uniform wrangler deploy treatment for static apps

### DIFF
--- a/apps/fuji/package.json
+++ b/apps/fuji/package.json
@@ -23,6 +23,7 @@
 		"dev:local": "vite dev",
 		"build": "NODE_ENV=production vite build",
 		"preview": "vite preview",
+		"deploy": "wrangler deploy",
 		"prepare": "svelte-kit sync || echo ''",
 		"tauri": "tauri",
 		"test": "bun test",

--- a/apps/fuji/wrangler.jsonc
+++ b/apps/fuji/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
 	"$schema": "../../node_modules/wrangler/config-schema.json",
-	"name": "opensidian",
+	"name": "fuji",
 	"compatibility_date": "2025-11-04",
 	// Build the SPA before publishing. Wrangler runs build.command for both
 	// `deploy` and `versions upload`, so local, CI, and previews share one
@@ -8,14 +8,11 @@
 	"build": {
 		"command": "bun run build"
 	},
-	// --- Custom domains: opensidian.com + opensidian.epicenter.so (auto-creates DNS records on deploy) ---
+	// --- Custom domain: fuji.epicenter.so (auto-creates DNS record on deploy) ---
+	// Domain is owned by APPS.FUJI in packages/constants/src/apps.ts; keep in sync.
 	"routes": [
 		{
-			"pattern": "opensidian.com",
-			"custom_domain": true
-		},
-		{
-			"pattern": "opensidian.epicenter.so",
+			"pattern": "fuji.epicenter.so",
 			"custom_domain": true
 		}
 	],

--- a/apps/honeycrisp/package.json
+++ b/apps/honeycrisp/package.json
@@ -13,6 +13,7 @@
 		"dev:local": "vite dev",
 		"build": "NODE_ENV=production vite build",
 		"preview": "vite preview",
+		"deploy": "wrangler deploy",
 		"prepare": "svelte-kit sync || echo ''",
 		"test": "bun test",
 		"typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"

--- a/apps/honeycrisp/wrangler.jsonc
+++ b/apps/honeycrisp/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
 	"$schema": "../../node_modules/wrangler/config-schema.json",
-	"name": "opensidian",
+	"name": "honeycrisp",
 	"compatibility_date": "2025-11-04",
 	// Build the SPA before publishing. Wrangler runs build.command for both
 	// `deploy` and `versions upload`, so local, CI, and previews share one
@@ -8,14 +8,11 @@
 	"build": {
 		"command": "bun run build"
 	},
-	// --- Custom domains: opensidian.com + opensidian.epicenter.so (auto-creates DNS records on deploy) ---
+	// --- Custom domain: honeycrisp.epicenter.so (auto-creates DNS record on deploy) ---
+	// Domain is owned by APPS.HONEYCRISP in packages/constants/src/apps.ts; keep in sync.
 	"routes": [
 		{
-			"pattern": "opensidian.com",
-			"custom_domain": true
-		},
-		{
-			"pattern": "opensidian.epicenter.so",
+			"pattern": "honeycrisp.epicenter.so",
 			"custom_domain": true
 		}
 	],

--- a/apps/opensidian/package.json
+++ b/apps/opensidian/package.json
@@ -13,7 +13,7 @@
 		"dev": "bun run dev:local",
 		"dev:local": "vite dev",
 		"build": "vite build",
-		"deploy": "bun run build && wrangler deploy",
+		"deploy": "wrangler deploy",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"test": "if find src -name '*.test.ts' -o -name '*.test.tsx' -o -name '*.spec.ts' | grep -q .; then bun test; fi",

--- a/apps/zhongwen/package.json
+++ b/apps/zhongwen/package.json
@@ -17,7 +17,7 @@
 		"prepare": "svelte-kit sync || echo ''",
 		"test": "if find src -name '*.test.ts' -o -name '*.test.tsx' -o -name '*.spec.ts' | grep -q .; then bun test; fi",
 		"typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"deploy": "bun run build && wrangler deploy"
+		"deploy": "wrangler deploy"
 	},
 	"dependencies": {
 		"@epicenter/auth": "workspace:*",

--- a/apps/zhongwen/wrangler.jsonc
+++ b/apps/zhongwen/wrangler.jsonc
@@ -2,6 +2,12 @@
 	"$schema": "../../node_modules/wrangler/config-schema.json",
 	"name": "zhongwen",
 	"compatibility_date": "2025-11-04",
+	// Build the SPA before publishing. Wrangler runs build.command for both
+	// `deploy` and `versions upload`, so local, CI, and previews share one
+	// build path. (This app never uses `wrangler dev`.)
+	"build": {
+		"command": "bun run build"
+	},
 	// --- Custom domain: zhongwen.epicenter.so (auto-creates DNS record on deploy) ---
 	"routes": [
 		{


### PR DESCRIPTION
Extends the deploy unification (#1991 → #1994 → #1998) to every static app, so they are all treated as equals.

## Insight

`packages/constants/src/apps.ts` already declares itself the single source of truth for app URLs (`fuji.epicenter.so`, `honeycrisp.epicenter.so`, etc. are pre-declared). And every public app here is the same architecture: a SvelteKit `adapter-static` SPA that serves its `build/` output. So "how a static app deploys" should be one uniform shape, not per-app bespoke config.

## Change

- **fuji, honeycrisp**: add a `wrangler.jsonc` (identical 12-line shape to whispering/zhongwen) + a `deploy` script, with custom domains read from `APPS.FUJI` / `APPS.HONEYCRISP`. They were already Workers in everything but config.
- **opensidian, zhongwen**: add `build.command` and collapse `deploy` to `wrangler deploy`, matching #1998.

After this, all six static Workers (whispering, landing-by-analogy, opensidian, zhongwen, fuji, honeycrisp) deploy through one definition co-located in each worker's `wrangler.jsonc`. Adding the next deployable app becomes: write the 12-line config (domain already in `APPS`) + a one-line `deploy` script.

For verification:

`wrangler deploy --dry-run` on **fuji** and **honeycrisp**: the custom build ran (SvelteKit adapter-static → wrote `build/`), wrangler read the assets and validated the config, then exited without uploading. All four `wrangler.jsonc` parse.

The scope is intentionally bounded:

- **No CI changes.** Production CI still deploys only whispering + landing + api. The four apps here are deployable by hand (`bun run --filter @epicenter/<app> deploy`). Auto-deploying them on push to `main` is a separate, deliberate decision (are they production-ready at their domains?) and would come with the workflow's matrix refactor.
- posthog-reverse-proxy and self-host need no change (no frontend build; already bare `wrangler deploy`).
- Not touched: matter (no `APPS` domain), skills (adapter-auto), and the non-Worker apps.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784063440&installation_id=128463665&pr_number=1999&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1999&signature=8bee24fe68065731ac76aa29841ac561ee8f8928b7e9fc9358aae48be4a78fb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->