### PR TITLE
refactor(whispering): flatten isInstalled around the symlink case

### DIFF
--- a/apps/whispering/src/lib/services/transcription/local-model-folder.ts
+++ b/apps/whispering/src/lib/services/transcription/local-model-folder.ts
@@ -301,59 +301,51 @@ export function createModelStorage(model: LocalModelConfig) {
 
 	return {
 		/**
-		 * Whether a valid install exists in the folder. Every expected file
-		 * must exist with a plausible size (at least 90% of the catalog size),
-		 * so interrupted downloads read as not installed. Never rejects; any
-		 * filesystem or path error reads as not installed.
+		 * Whether a valid install exists in the folder. Two paths to true:
+		 *
+		 * 1. A listed symlink entry with this model's name *is* the install.
+		 *    The user manages the link, and its target may live outside appdata
+		 *    where the webview fs scope cannot stat it, so it is trusted as-is —
+		 *    never size-validated.
+		 * 2. Otherwise a real install: every expected file present at a plausible
+		 *    size (at least 90% of the catalog size), so an interrupted download
+		 *    reads as not installed.
+		 *
+		 * Never rejects; any filesystem or path error reads as not installed.
 		 */
 		async isInstalled(): Promise<boolean> {
-			const { data: installedPath } = await tryAsync({
-				try: async (): Promise<string | null> => {
-					const path = await getPath();
-					const { data: pathExists } = await tryAsync({
-						try: () => exists(path),
-						catch: () => Ok(false),
-					});
-					if (!pathExists) return (await hasListedSymlinkEntry()) ? path : null;
+			if (await hasListedSymlinkEntry()) return true;
 
+			// The symlink case is handled above, so any error here just means the
+			// real install is absent or unreadable: not installed.
+			const { data: valid } = await tryAsync({
+				try: async (): Promise<boolean> => {
+					const path = await getPath();
+					if (!(await exists(path))) return false;
 					switch (model.engine) {
 						case 'whispercpp': {
-							const { data: stats } = await tryAsync({
-								try: () => stat(path),
-								catch: () => Ok(null),
-							});
-							if (!stats) {
-								return (await hasListedSymlinkEntry()) ? path : null;
-							}
-							return isModelFileSizeValid(stats.size, model.sizeBytes)
-								? path
-								: null;
+							const stats = await stat(path);
+							return isModelFileSizeValid(stats.size, model.sizeBytes);
 						}
 						case 'parakeet':
 						case 'moonshine': {
-							const { data: dirStats } = await tryAsync({
-								try: () => stat(path),
-								catch: () => Ok(null),
-							});
-							if (!dirStats) {
-								return (await hasListedSymlinkEntry()) ? path : null;
-							}
-							if (!dirStats.isDirectory) return null;
+							const dirStats = await stat(path);
+							if (!dirStats.isDirectory) return false;
 							for (const file of model.files) {
 								const filePath = await join(path, file.filename);
-								if (!(await exists(filePath))) return null;
+								if (!(await exists(filePath))) return false;
 								const fileStats = await stat(filePath);
 								if (!isModelFileSizeValid(fileStats.size, file.sizeBytes)) {
-									return null;
+									return false;
 								}
 							}
-							return path;
+							return true;
 						}
 					}
 				},
-				catch: () => Ok(null),
+				catch: () => Ok(false),
 			});
-			return installedPath != null;
+			return valid ?? false;
 		},
 
 		/**


### PR DESCRIPTION
Follow-up to #1997. A pure-readability collapse of `createModelStorage().isInstalled()` in `local-model-folder.ts`, plus one deliberate behavior change.

## The collapse

`isInstalled` checked the canonical path first and treated a listed symlink entry as a *fallback* whenever a stat failed. That repeated the symlink branch three times and forced every disk read to carry its own nested `tryAsync` just to route failures back to that fallback.

A listed symlink entry with the model's name **is** the install — the user manages the link, and its target may live outside appdata where the webview fs scope can't stat it. Check that once, up front, trust it, and the rest falls out:

- The three repeated `hasListedSymlinkEntry()` fallbacks become one early return.
- With the symlink case gone, the real-install branch needs no per-read error routing — a single outer `tryAsync` maps any fs/path error to "not installed", so the nested `stat`/`exists` wrappers collapse to plain calls.

Net: -35 / +27, and the nesting drops a level.

## Deliberate behavior change

An **in-scope** symlink is no longer size-validated — any correctly-named link is trusted. This is consistent with `deleteModelEntry`, which already refuses to touch a link's target: a user-placed link is trusted, not policed. Out-of-scope links (the common case) behaved this way already.

Intentionally out of scope:

Checked the Rust side (`model_manager.rs`) for the same single-vs-multi-file split — it isn't there. `model_path_for` is a uniform name→path resolve, and the `match engine` is genuine engine dispatch (different params/FFI/loaders), not a cardinality branch. Nothing to collapse there.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784063829&installation_id=128463665&pr_number=2000&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2000&signature=19b8c59da27ee48c5bf45e87c0d310ded6ed960fa49e01af5434cd2cf67629e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->