### PR TITLE
refactor(workspace): brand content-doc guids and own child-doc construction

### DIFF
--- a/apps/fuji/src/lib/workspace/browser.ts
+++ b/apps/fuji/src/lib/workspace/browser.ts
@@ -21,6 +21,7 @@ import {
 	type ActionRegistry,
 	attachLocalStorage,
 	attachRichText,
+	createContentDoc,
 	createDisposableCache,
 	DateTimeString,
 	type DeviceId,
@@ -30,7 +31,7 @@ import {
 	roomWsUrl,
 	wipeLocalStorage,
 } from '@epicenter/workspace';
-import * as Y from 'yjs';
+import type * as Y from 'yjs';
 import { createFuji, type EntryId, entryContentDocGuid } from './index';
 
 export function openFujiBrowser({
@@ -78,7 +79,7 @@ export function openFujiBrowser({
 	});
 
 	const entryBodies = createDisposableCache((id: EntryId) => {
-		const ydoc = new Y.Doc({ guid: entryContentDocGuid(id), gc: true });
+		const ydoc = createContentDoc(entryContentDocGuid(id));
 		// Sync is opened for its side effect; the collaboration handle is
 		// orphaned on purpose, teardown cascades from `ydoc.destroy()` below.
 		const { idb: bodyIdb } = wire(ydoc, { actions: {} });

--- a/apps/fuji/src/lib/workspace/index.ts
+++ b/apps/fuji/src/lib/workspace/index.ts
@@ -32,6 +32,7 @@ import { field } from '@epicenter/field';
 import {
 	createWorkspace,
 	DateTimeString,
+	type DocGuid,
 	defineActions,
 	defineMutation,
 	defineQuery,
@@ -349,7 +350,7 @@ export type FujiWorkspace = ReturnType<typeof createFuji>;
  * Browser editors, daemon materializers, and wipe paths reach this same
  * function so every layer points at the same Y.Doc identity.
  */
-export function entryContentDocGuid(entryId: EntryId): string {
+export function entryContentDocGuid(entryId: EntryId): DocGuid {
 	return docGuid({
 		workspaceId: FUJI_ID,
 		collection: 'entries',

--- a/apps/honeycrisp/honeycrisp.ts
+++ b/apps/honeycrisp/honeycrisp.ts
@@ -17,9 +17,11 @@
 import { field } from '@epicenter/field';
 import {
 	attachRichText,
+	createContentDoc,
 	createDisposableCache,
 	createWorkspace,
 	DateTimeString,
+	type DocGuid,
 	defineActions,
 	defineMutation,
 	defineTable,
@@ -33,7 +35,6 @@ import {
 } from '@epicenter/workspace';
 import Type from 'typebox';
 import type { Brand } from 'wellcrafted/brand';
-import * as Y from 'yjs';
 
 export const HONEYCRISP_ID = 'epicenter-honeycrisp';
 
@@ -134,10 +135,7 @@ export function createHoneycrisp(opts: { keyring: () => Keyring }) {
 	});
 	const { tables } = workspace;
 	const noteBodyDocs = createDisposableCache((noteId: NoteId) => {
-		const childYdoc = new Y.Doc({
-			guid: noteBodyDocGuid(noteId),
-			gc: true,
-		});
+		const childYdoc = createContentDoc(noteBodyDocGuid(noteId));
 		const body = attachRichText(childYdoc);
 
 		onLocalUpdate(childYdoc, () => {
@@ -195,7 +193,7 @@ export type HoneycrispWorkspace = ReturnType<typeof createHoneycrisp>;
  * Browser editors, daemon materializers, and wipe paths reach this same
  * function so every layer points at the same Y.Doc identity.
  */
-export function noteBodyDocGuid(noteId: NoteId): string {
+export function noteBodyDocGuid(noteId: NoteId): DocGuid {
 	return docGuid({
 		workspaceId: HONEYCRISP_ID,
 		collection: 'notes',

--- a/apps/opensidian/opensidian.ts
+++ b/apps/opensidian/opensidian.ts
@@ -22,8 +22,10 @@ import {
 } from '@epicenter/filesystem';
 import {
 	attachTimeline,
+	createContentDoc,
 	createDisposableCache,
 	createWorkspace,
+	type DocGuid,
 	defineActions,
 	defineTable,
 	defineWorkspace,
@@ -36,7 +38,6 @@ import {
 } from '@epicenter/workspace';
 import { Type } from 'typebox';
 import type { Brand } from 'wellcrafted/brand';
-import * as Y from 'yjs';
 
 export const OPENSIDIAN_ID = 'epicenter-opensidian';
 
@@ -165,10 +166,7 @@ export function createOpensidian(opts: { keyring: () => Keyring }) {
 		kv: {},
 	});
 	const fileContentDocs = createDisposableCache((fileId: FileId) => {
-		const childYdoc = new Y.Doc({
-			guid: opensidianFileContentDocGuid(fileId),
-			gc: true,
-		});
+		const childYdoc = createContentDoc(opensidianFileContentDocGuid(fileId));
 
 		onLocalUpdate(childYdoc, () =>
 			workspace.tables.files.update(fileId, { updatedAt: Date.now() }),
@@ -202,7 +200,7 @@ export type OpensidianWorkspace = ReturnType<typeof createOpensidian>;
  * function so every layer points at the same Y.Doc identity. Thin wrapper
  * around {@link fileContentDocGuid} that pins the workspace id.
  */
-export function opensidianFileContentDocGuid(fileId: FileId): string {
+export function opensidianFileContentDocGuid(fileId: FileId): DocGuid {
 	return fileContentDocGuid({
 		workspaceId: OPENSIDIAN_ID,
 		fileId,

--- a/apps/opensidian/src/lib/state/skill-state.svelte.ts
+++ b/apps/opensidian/src/lib/state/skill-state.svelte.ts
@@ -8,12 +8,12 @@ import {
 	attachBroadcastChannel,
 	attachIndexedDb,
 	attachPlainText,
+	createContentDoc,
 	createDisposableCache,
 	onLocalUpdate,
 } from '@epicenter/workspace';
 import type { OpensidianBrowser } from 'opensidian/browser';
 import { Ok, tryAsync } from 'wellcrafted/result';
-import * as Y from 'yjs';
 
 /** A global skill loaded from the @epicenter/skills workspace. */
 type GlobalSkill = { name: string; instructions: string };
@@ -161,13 +161,12 @@ function openGlobalSkills() {
 	attachBroadcastChannel(doc.ydoc);
 
 	const instructionsDocs = createDisposableCache((skillId: string) => {
-		const ydoc = new Y.Doc({
-			guid: skillInstructionsDocGuid({
+		const ydoc = createContentDoc(
+			skillInstructionsDocGuid({
 				workspaceId: doc.ydoc.guid,
 				skillId,
 			}),
-			gc: true,
-		});
+		);
 		onLocalUpdate(ydoc, () =>
 			doc.tables.skills.update(skillId, { updatedAt: Date.now() }),
 		);
@@ -183,13 +182,12 @@ function openGlobalSkills() {
 	});
 
 	const referenceDocs = createDisposableCache((referenceId: string) => {
-		const ydoc = new Y.Doc({
-			guid: referenceContentDocGuid({
+		const ydoc = createContentDoc(
+			referenceContentDocGuid({
 				workspaceId: doc.ydoc.guid,
 				referenceId,
 			}),
-			gc: true,
-		});
+		);
 		onLocalUpdate(ydoc, () =>
 			doc.tables.references.update(referenceId, { updatedAt: Date.now() }),
 		);

--- a/apps/skills/src/lib/skills/browser.ts
+++ b/apps/skills/src/lib/skills/browser.ts
@@ -7,11 +7,11 @@ import {
 	attachBroadcastChannel,
 	attachIndexedDb,
 	attachPlainText,
+	createContentDoc,
 	createDisposableCache,
 	onLocalUpdate,
 } from '@epicenter/workspace';
 import { clearDocument } from 'y-indexeddb';
-import * as Y from 'yjs';
 import { createSkills } from './index.js';
 
 export function openSkillsBrowser() {
@@ -20,13 +20,12 @@ export function openSkillsBrowser() {
 	attachBroadcastChannel(doc.ydoc);
 
 	const instructionsDocs = createDisposableCache((skillId: string) => {
-		const ydoc = new Y.Doc({
-			guid: skillInstructionsDocGuid({
+		const ydoc = createContentDoc(
+			skillInstructionsDocGuid({
 				workspaceId: doc.ydoc.guid,
 				skillId,
 			}),
-			gc: true,
-		});
+		);
 		onLocalUpdate(ydoc, () =>
 			doc.tables.skills.update(skillId, { updatedAt: Date.now() }),
 		);
@@ -46,13 +45,12 @@ export function openSkillsBrowser() {
 		};
 	});
 	const referenceDocs = createDisposableCache((referenceId: string) => {
-		const ydoc = new Y.Doc({
-			guid: referenceContentDocGuid({
+		const ydoc = createContentDoc(
+			referenceContentDocGuid({
 				workspaceId: doc.ydoc.guid,
 				referenceId,
 			}),
-			gc: true,
-		});
+		);
 		onLocalUpdate(ydoc, () =>
 			doc.tables.references.update(referenceId, { updatedAt: Date.now() }),
 		);

--- a/apps/zhongwen/zhongwen.browser.ts
+++ b/apps/zhongwen/zhongwen.browser.ts
@@ -17,6 +17,7 @@
 import type { SignedIn } from '@epicenter/svelte/auth';
 import {
 	attachLocalStorage,
+	createContentDoc,
 	createDisposableCache,
 	type DeviceId,
 	defineWorkspace,
@@ -24,7 +25,6 @@ import {
 	roomWsUrl,
 	wipeLocalStorage,
 } from '@epicenter/workspace';
-import * as Y from 'yjs';
 import {
 	type ConversationId,
 	createZhongwen,
@@ -64,10 +64,9 @@ export function openZhongwenBrowser({
 
 	const conversationDocs = createDisposableCache(
 		(conversationId: ConversationId) => {
-			const ydoc = new Y.Doc({
-				guid: zhongwenConversationDocGuid(conversationId),
-				gc: true,
-			});
+			const ydoc = createContentDoc(
+				zhongwenConversationDocGuid(conversationId),
+			);
 			const childIdb = attachLocalStorage(ydoc, {
 				server: signedIn.server,
 				ownerId: signedIn.ownerId,

--- a/packages/filesystem/src/file-content-docs.ts
+++ b/packages/filesystem/src/file-content-docs.ts
@@ -1,4 +1,4 @@
-import { docGuid } from '@epicenter/workspace';
+import { type DocGuid, docGuid } from '@epicenter/workspace';
 import type { FileId } from './ids.js';
 
 export function fileContentDocGuid({
@@ -7,7 +7,7 @@ export function fileContentDocGuid({
 }: {
 	workspaceId: string;
 	fileId: FileId;
-}): string {
+}): DocGuid {
 	return docGuid({
 		workspaceId,
 		collection: 'files',

--- a/packages/filesystem/src/file-system.test.ts
+++ b/packages/filesystem/src/file-system.test.ts
@@ -12,12 +12,12 @@
 import { describe, expect, test } from 'bun:test';
 import {
 	attachTimeline,
+	createContentDoc,
 	createDisposableCache,
 	createWorkspace,
 	onLocalUpdate,
 } from '@epicenter/workspace';
 import { Bash } from 'just-bash';
-import * as Y from 'yjs';
 import { fileContentDocGuid } from './file-content-docs.js';
 import { attachYjsFileSystem, type YjsFileSystem } from './file-system.js';
 import { type FileId, generateFileId } from './ids.js';
@@ -36,10 +36,9 @@ function setup() {
 	};
 	const contentDocs = createDisposableCache(
 		(fileId: FileId) => {
-			const contentYdoc = new Y.Doc({
-				guid: fileContentDocGuid({ workspaceId: ws.id, fileId }),
-				gc: true,
-			});
+			const contentYdoc = createContentDoc(
+				fileContentDocGuid({ workspaceId: ws.id, fileId }),
+			);
 			onLocalUpdate(contentYdoc, () =>
 				ws.tables.files.update(fileId, { updatedAt: Date.now() }),
 			);

--- a/packages/server/src/routes/ai.ts
+++ b/packages/server/src/routes/ai.ts
@@ -44,6 +44,7 @@ import {
 	type ServableModel,
 } from '@epicenter/constants/ai-providers';
 import { API_ROUTES } from '@epicenter/constants/api-routes';
+import { isDocGuid } from '@epicenter/workspace';
 import { sValidator } from '@hono/standard-validator';
 import {
 	type AnyTextAdapter,
@@ -88,18 +89,15 @@ const aiChatBody = type({
 	'apiKey?': 'string | undefined',
 });
 
-/**
- * Canonical content-doc guid grammar: four dot-separated safe segments
- * (`workspaceId.collection.rowId.field`, see `docGuid` in
- * `@epicenter/workspace`). Ownership scoping happens upstream via
- * `doName(ownerId, guid)`; this only rejects strings that could never name
- * a content doc.
- */
-const DOC_GUID_REGEX =
-	/^[a-z0-9]+(?:-[a-z0-9]+)*(?:\.[a-z0-9]+(?:-[a-z0-9]+)*){3}$/;
-
 const aiChatDocBody = type({
-	guid: type('string').narrow((s) => DOC_GUID_REGEX.test(s)),
+	/**
+	 * Canonical content-doc guid (`workspaceId.collection.rowId.field`).
+	 * Validated with `isDocGuid` from `@epicenter/workspace` so this boundary
+	 * shares the one grammar `docGuid` mints with, rather than re-deriving it.
+	 * Ownership scoping happens upstream via `doName(ownerId, guid)`; this only
+	 * rejects strings that could never name a content doc.
+	 */
+	guid: type('string').narrow((s) => isDocGuid(s)),
 	/** Client-minted; doubles as the assistant message id for idempotency. */
 	generationId: 'string > 0',
 	// Same options as the SSE route minus `tools` (doc-as-wire chat is

--- a/packages/skills/src/node.ts
+++ b/packages/skills/src/node.ts
@@ -25,6 +25,7 @@ import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
 	attachPlainText,
+	createContentDoc,
 	defineActions,
 	defineMutation,
 	generateId,
@@ -37,7 +38,6 @@ import {
 	type InferErrors,
 } from 'wellcrafted/error';
 import { Ok, tryAsync } from 'wellcrafted/result';
-import * as Y from 'yjs';
 import { parseSkillMd } from './parse.js';
 import { referenceContentDocGuid } from './reference-content-docs.js';
 import { serializeSkillMd } from './serialize.js';
@@ -79,10 +79,9 @@ export function openSkillsNode({ workspaceId }: { workspaceId: string }) {
 	const { tables } = doc;
 
 	function openInstructionsDoc(skillId: string) {
-		const ydoc = new Y.Doc({
-			guid: skillInstructionsDocGuid({ workspaceId, skillId }),
-			gc: true,
-		});
+		const ydoc = createContentDoc(
+			skillInstructionsDocGuid({ workspaceId, skillId }),
+		);
 		onLocalUpdate(ydoc, () =>
 			tables.skills.update(skillId, { updatedAt: Date.now() }),
 		);
@@ -97,10 +96,9 @@ export function openSkillsNode({ workspaceId }: { workspaceId: string }) {
 	}
 
 	function openReferenceDoc(referenceId: string) {
-		const ydoc = new Y.Doc({
-			guid: referenceContentDocGuid({ workspaceId, referenceId }),
-			gc: true,
-		});
+		const ydoc = createContentDoc(
+			referenceContentDocGuid({ workspaceId, referenceId }),
+		);
 		onLocalUpdate(ydoc, () =>
 			tables.references.update(referenceId, { updatedAt: Date.now() }),
 		);

--- a/packages/skills/src/reference-content-docs.ts
+++ b/packages/skills/src/reference-content-docs.ts
@@ -1,4 +1,4 @@
-import { docGuid } from '@epicenter/workspace';
+import { type DocGuid, docGuid } from '@epicenter/workspace';
 
 export function referenceContentDocGuid({
 	workspaceId,
@@ -6,7 +6,7 @@ export function referenceContentDocGuid({
 }: {
 	workspaceId: string;
 	referenceId: string;
-}): string {
+}): DocGuid {
 	return docGuid({
 		workspaceId,
 		collection: 'references',

--- a/packages/skills/src/skill-instructions-docs.ts
+++ b/packages/skills/src/skill-instructions-docs.ts
@@ -1,4 +1,4 @@
-import { docGuid } from '@epicenter/workspace';
+import { type DocGuid, docGuid } from '@epicenter/workspace';
 
 export function skillInstructionsDocGuid({
 	workspaceId,
@@ -6,7 +6,7 @@ export function skillInstructionsDocGuid({
 }: {
 	workspaceId: string;
 	skillId: string;
-}): string {
+}): DocGuid {
 	return docGuid({
 		workspaceId,
 		collection: 'skills',

--- a/packages/workspace/src/document/content-doc.test.ts
+++ b/packages/workspace/src/document/content-doc.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Tests for `createContentDoc`: it stamps the composed guid onto the doc and
+ * enables gc, and (at the type level) it refuses anything but a `DocGuid`.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { createContentDoc } from './content-doc.js';
+import { docGuid } from './doc-guid.js';
+
+const guid = docGuid({
+	workspaceId: 'epicenter-honeycrisp',
+	collection: 'notes',
+	rowId: 'k7x9m2p4q8',
+	field: 'body',
+});
+
+describe('createContentDoc', () => {
+	test('stamps the composed guid onto the doc', () => {
+		const ydoc = createContentDoc(guid);
+		expect(ydoc.guid).toBe(guid);
+		ydoc.destroy();
+	});
+
+	test('enables gc (deleted content garbage-collects like any CRDT)', () => {
+		const ydoc = createContentDoc(guid);
+		expect(ydoc.gc).toBe(true);
+		ydoc.destroy();
+	});
+
+	test('refuses a bare string: only a DocGuid composes a content doc', () => {
+		// @ts-expect-error a raw string (or a row id) is not a DocGuid; the brand
+		// is the whole point, turning "forgot to compose the guid" into a compile
+		// error rather than a silent collision.
+		createContentDoc('notes.k7x9m2p4q8');
+	});
+});

--- a/packages/workspace/src/document/content-doc.ts
+++ b/packages/workspace/src/document/content-doc.ts
@@ -1,0 +1,23 @@
+import * as Y from 'yjs';
+import type { DocGuid } from './doc-guid.js';
+
+/**
+ * Construct a content-doc `Y.Doc` from a composed {@link DocGuid}.
+ *
+ * This is the one place a child content document is allocated, and requiring a
+ * `DocGuid` (not a bare string) is the point. `new Y.Doc({ guid })` accepts any
+ * string, so a raw row id or a random `Guid` would construct silently against
+ * the wrong identity, with no error until two docs collided. Threading the
+ * composed-guid brand to the constructor turns that mistake into a compile
+ * error: the only way to get a `DocGuid` is to mint one with `docGuid` (or a
+ * wrapper around it).
+ *
+ * Owns the one construction policy every content doc shares: `gc: true`. Row
+ * metadata lives in the root workspace doc; a content doc holds only the
+ * collaborative body, which garbage-collects deleted content like any CRDT.
+ * Runtime concerns (persistence, sync, codecs, caching, one-shot reads) are
+ * deliberately not here: they diverge per runtime and stay at the call site.
+ */
+export function createContentDoc(guid: DocGuid): Y.Doc {
+	return new Y.Doc({ guid, gc: true });
+}

--- a/packages/workspace/src/document/doc-guid.test.ts
+++ b/packages/workspace/src/document/doc-guid.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for the content-doc guid grammar: collision-freedom (injectivity),
+ * parsing unambiguity (exactly four recoverable segments), the segment
+ * alphabet contract, and the `isDocGuid` boundary validator staying in lockstep
+ * with what `docGuid` mints.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { generateId } from '../shared/id.js';
+import { DOC_GUID_SEGMENTS, docGuid, isDocGuid } from './doc-guid.js';
+
+const tuple = {
+	workspaceId: 'epicenter-honeycrisp',
+	collection: 'notes',
+	rowId: 'k7x9m2p4q8',
+	field: 'body',
+};
+
+describe('docGuid', () => {
+	test('composes the canonical four-part dotted form', () => {
+		// Widen to `string` for the byte-exact check: the `DocGuid` brand makes
+		// `toBe` reject a raw string literal, which is the brand doing its job.
+		expect(String(docGuid(tuple))).toBe(
+			'epicenter-honeycrisp.notes.k7x9m2p4q8.body',
+		);
+	});
+
+	test('is deterministic: same tuple -> same guid', () => {
+		expect(docGuid(tuple)).toBe(docGuid(tuple));
+	});
+
+	test('emits exactly DOC_GUID_SEGMENTS segments (parsing is unambiguous)', () => {
+		// Hyphens live inside segments; only dots separate them. So a guid built
+		// from hyphen-bearing segments still splits into exactly four parts.
+		expect(docGuid(tuple).split('.')).toHaveLength(DOC_GUID_SEGMENTS);
+	});
+});
+
+describe('docGuid injectivity (no two tuples collide)', () => {
+	test('distinct tuples produce distinct guids', () => {
+		const guids = [
+			docGuid(tuple),
+			docGuid({ ...tuple, collection: 'folders' }),
+			docGuid({ ...tuple, rowId: 'aaaaaaaaaa' }),
+			docGuid({ ...tuple, workspaceId: 'epicenter-fuji' }),
+			// `field` is the segment that lets one row own two sibling child docs:
+			// same workspace/collection/row, different field -> distinct guids.
+			docGuid({ ...tuple, field: 'preview' }),
+		];
+		expect(new Set(guids).size).toBe(guids.length);
+	});
+
+	test('two child docs on the same row stay distinct via field', () => {
+		const body = docGuid({ ...tuple, field: 'body' });
+		const preview = docGuid({ ...tuple, field: 'preview' });
+		expect(body).not.toBe(preview);
+	});
+
+	test('a hyphen boundary cannot masquerade as a segment boundary', () => {
+		// `a-b . c` and `a . b-c` differ only in where the hyphen vs dot falls.
+		// Because hyphen is never the separator, these stay distinct guids and
+		// each still parses back to its own tuple.
+		const left = docGuid({ ...tuple, workspaceId: 'a-b', collection: 'c' });
+		const right = docGuid({ ...tuple, workspaceId: 'a', collection: 'b-c' });
+		expect(left).not.toBe(right);
+		expect(left.split('.')).toHaveLength(DOC_GUID_SEGMENTS);
+		expect(right.split('.')).toHaveLength(DOC_GUID_SEGMENTS);
+	});
+
+	test('property: every generated rowId yields a four-segment guid', () => {
+		for (let i = 0; i < 1000; i++) {
+			const guid = docGuid({ ...tuple, rowId: generateId() });
+			expect(guid.split('.')).toHaveLength(DOC_GUID_SEGMENTS);
+			expect(isDocGuid(guid)).toBe(true);
+		}
+	});
+});
+
+describe('docGuid rejects unsafe segments (the delimiter invariant)', () => {
+	test.each([
+		['dot in a segment', { collection: 'no.tes' }],
+		['slash in a segment', { rowId: 'a/b' }],
+		['colon in a segment', { rowId: 'a:b' }],
+		['uppercase', { collection: 'Notes' }],
+		['leading hyphen', { collection: '-notes' }],
+		['trailing hyphen', { collection: 'notes-' }],
+		['double hyphen', { collection: 'no--tes' }],
+		['empty segment', { rowId: '' }],
+		['dot in the field segment', { field: 'bo.dy' }],
+		['windows reserved name', { collection: 'con' }],
+	])('throws on %s', (_label, override) => {
+		expect(() => docGuid({ ...tuple, ...override })).toThrow();
+	});
+});
+
+describe('isDocGuid (boundary validator)', () => {
+	test('accepts exactly what docGuid mints', () => {
+		expect(isDocGuid(docGuid(tuple))).toBe(true);
+	});
+
+	test.each([
+		['three segments', 'epicenter-honeycrisp.notes.k7x9m2p4q8'],
+		['five segments', 'epicenter-honeycrisp.notes.k7x9m2p4q8.body.extra'],
+		['empty string', ''],
+		['trailing dot (empty final segment)', 'a.b.c.'],
+		['uppercase segment', 'epicenter-honeycrisp.Notes.k7x9m2p4q8.body'],
+		['slash in a segment', 'a.b.c/d.e'],
+		['windows reserved segment', 'a.con.c.d'],
+	])('rejects %s', (_label, value) => {
+		expect(isDocGuid(value)).toBe(false);
+	});
+});

--- a/packages/workspace/src/document/doc-guid.ts
+++ b/packages/workspace/src/document/doc-guid.ts
@@ -1,5 +1,21 @@
-import type { Guid } from '../shared/id.js';
-import { assertSafeSegment } from '../shared/safe-segment.js';
+import type { Brand } from 'wellcrafted/brand';
+import { assertSafeSegment, isSafeSegment } from '../shared/safe-segment.js';
+
+/**
+ * A composed content-doc guid: the dotted string returned by {@link docGuid}
+ * (`workspaceId.collection.rowId.field`).
+ *
+ * A distinct brand from `Guid`. A `Guid` is a single random token (one safe
+ * segment, e.g. `generateGuid()`); a `DocGuid` is a deterministic four-segment
+ * composition. They obey different grammars, so they are not interchangeable
+ * even though both end up as `ydoc.guid`. Keeping the brands apart stops a
+ * random `Guid` being passed where a composed `DocGuid` is required, and the
+ * reverse.
+ */
+export type DocGuid = string & Brand<'DocGuid'>;
+
+/** Number of dot-separated segments in every {@link DocGuid}. */
+export const DOC_GUID_SEGMENTS = 4;
 
 /**
  * Compose a content-doc `Y.Doc` guid in the canonical 4-part dotted form:
@@ -12,6 +28,15 @@ import { assertSafeSegment } from '../shared/safe-segment.js';
  * | `collection`  | package/app | `entries`, `files` |
  * | `rowId`       | caller      | `k7x9m2p4q8`     |
  * | `field`       | package/app | `content`, `body` |
+ *
+ * The `field` segment names which child document of the row this guid points
+ * at. Most collections own exactly one child doc today (`notes -> body`,
+ * `files -> content`), so `field` looks redundant there. It is kept anyway: it
+ * is the segment that lets a single row own more than one sibling child doc
+ * (e.g. an article with a `code` doc and a `preview` doc) without the two guids
+ * colliding. Dropping it would make injectivity rest on the unenforced
+ * convention "one child doc per row", and a second child doc would then merge
+ * silently into the first. One cheap segment buys a structural guarantee.
  *
  * Every part is validated against {@link assertSafeSegment}, so each is a
  * single dot-free safe segment. That is what makes this composition injective:
@@ -34,10 +59,25 @@ export const docGuid = ({
 	collection: string;
 	rowId: string;
 	field: string;
-}): Guid => {
+}): DocGuid => {
 	assertSafeSegment(workspaceId, 'workspaceId');
 	assertSafeSegment(collection, 'collection');
 	assertSafeSegment(rowId, 'rowId');
 	assertSafeSegment(field, 'field');
-	return `${workspaceId}.${collection}.${rowId}.${field}` as Guid;
+	return `${workspaceId}.${collection}.${rowId}.${field}` as DocGuid;
 };
+
+/**
+ * True when `value` is a well-formed {@link DocGuid}: exactly
+ * {@link DOC_GUID_SEGMENTS} dot-separated safe segments.
+ *
+ * Derives from the same segment grammar `docGuid` mints with, so a validator
+ * and a minter can never disagree. Use at trust boundaries (e.g. a server
+ * reading a guid off the wire) where the structured tuple is not in hand to
+ * re-mint from. Everywhere else, build the guid with {@link docGuid} rather
+ * than validating a string.
+ */
+export function isDocGuid(value: string): value is DocGuid {
+	const segments = value.split('.');
+	return segments.length === DOC_GUID_SEGMENTS && segments.every(isSafeSegment);
+}

--- a/packages/workspace/src/document/http-room-sync.test.ts
+++ b/packages/workspace/src/document/http-room-sync.test.ts
@@ -10,11 +10,17 @@ import { describe, expect, test } from 'bun:test';
 import { asOwnerId } from '@epicenter/identity';
 import * as Y from 'yjs';
 import type { AuthedFetch } from '../shared/types.js';
+import { docGuid } from './doc-guid.js';
 import { readRoomOverHttp } from './http-room-sync.js';
 
 const baseURL = 'https://api.test';
 const ownerId = asOwnerId('owner-1');
-const guid = 'content-doc-1';
+const guid = docGuid({
+	workspaceId: 'epicenter-test',
+	collection: 'entries',
+	rowId: 'content-doc-1',
+	field: 'content',
+});
 
 /** A fake relay: serves `snapshot` on GET, records POSTs. */
 function fakeRelay({

--- a/packages/workspace/src/document/http-room-sync.ts
+++ b/packages/workspace/src/document/http-room-sync.ts
@@ -2,6 +2,8 @@ import type { OwnerId } from '@epicenter/identity';
 import { ROOM_ROUTE } from '@epicenter/sync';
 import * as Y from 'yjs';
 import type { AuthedFetch } from '../shared/types.js';
+import { createContentDoc } from './content-doc.js';
+import type { DocGuid } from './doc-guid.js';
 
 /**
  * Bound for a one-shot room HTTP request. A hung relay must not stall the caller
@@ -15,7 +17,7 @@ type RoomHttpTarget = {
 	fetch: AuthedFetch;
 	baseURL: string;
 	ownerId: OwnerId;
-	guid: string;
+	guid: DocGuid;
 };
 
 /**
@@ -41,7 +43,7 @@ async function getRoomDoc({
 		);
 	}
 	const snapshot = new Uint8Array(await snapshotResponse.arrayBuffer());
-	const ydoc = new Y.Doc({ guid, gc: true });
+	const ydoc = createContentDoc(guid);
 	if (snapshot.byteLength > 0) Y.applyUpdateV2(ydoc, snapshot);
 	return ydoc;
 }

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -13,6 +13,7 @@
  * import {
  *   attachIndexedDb,
  *   attachRichText,
+ *   createContentDoc,
  *   createDeviceId,
  *   createDisposableCache,
  *   createWorkspace,
@@ -24,7 +25,6 @@
  * import { field } from '@epicenter/field';
  * import type { AuthClient } from '@epicenter/auth';
  * import type { OwnerId } from '@epicenter/identity';
- * import * as Y from 'yjs';
  *
  * const posts = defineTable({
  *   id: field.string(),
@@ -56,19 +56,19 @@
  *   actions: {},
  * });
  *
- * // Content docs are per-row child Y.Docs constructed inline. Sub-doc
- * // primitives (attachRichText, etc.) take a raw Y.Doc, not a workspace.
+ * // Content docs are per-row child Y.Docs built with `createContentDoc` from a
+ * // composed `docGuid`. Sub-doc primitives (attachRichText, etc.) take a raw
+ * // Y.Doc, not a workspace.
  * const noteBodyDocs = createDisposableCache(
  *   (noteId: string) => {
- *     const bodyYdoc = new Y.Doc({
- *       guid: docGuid({
+ *     const bodyYdoc = createContentDoc(
+ *       docGuid({
  *         workspaceId: workspace.ydoc.guid,
  *         collection: 'posts',
  *         rowId: noteId,
  *         field: 'body',
  *       }),
- *       gc: true,
- *     });
+ *     );
  *     const bodyIdb = attachIndexedDb(bodyYdoc);
  *     const bodySync = openCollaboration(bodyYdoc, {
  *       url: roomWsUrl({
@@ -171,6 +171,7 @@ export { attachLocalStorage } from './document/attach-local-storage.js';
 export { attachPlainText } from './document/attach-plain-text.js';
 export { attachRichText } from './document/attach-rich-text.js';
 export { attachTimeline } from './document/attach-timeline/index.js';
+export { createContentDoc } from './document/content-doc.js';
 export { defineKv } from './document/define-kv.js';
 export { defineTable } from './document/define-table.js';
 export {

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -177,7 +177,7 @@ export {
 	DispatchError,
 	type DispatchRequest,
 } from './document/dispatch.js';
-export { docGuid } from './document/doc-guid.js';
+export { type DocGuid, docGuid, isDocGuid } from './document/doc-guid.js';
 // One-shot HTTP read of a hosted room: GET the snapshot into a throwaway doc.
 // The atomic snapshot lets a relay-only doc be read without a live
 // `openCollaboration` session.

--- a/packages/workspace/src/shared/safe-segment.ts
+++ b/packages/workspace/src/shared/safe-segment.ts
@@ -55,6 +55,19 @@ const WINDOWS_RESERVED = new Set([
 ]);
 
 /**
+ * True when `value` is a single safe guid segment: lowercase `a-z`/`0-9` with
+ * single internal hyphens, no dots, and not a Windows reserved device name.
+ *
+ * This is the one grammar predicate. {@link assertSafeSegment} (minting) and
+ * `isDocGuid` (boundary validation) both derive from it, so the segment
+ * contract can never drift between the path that builds a guid and the path
+ * that checks one.
+ */
+export function isSafeSegment(value: string): boolean {
+	return SAFE_SEGMENT.test(value) && !WINDOWS_RESERVED.has(value);
+}
+
+/**
  * Assert that `value` is a single safe guid segment. Throws on anything that
  * would break a URL, a filename, or the injectivity of a composed guid. This
  * is the one chokepoint: every guid-minting path runs it, so a malformed id
@@ -64,7 +77,7 @@ const WINDOWS_RESERVED = new Set([
  * @param label what it is, for the error message (e.g. `'workspace id'`)
  */
 export function assertSafeSegment(value: string, label: string): void {
-	if (!SAFE_SEGMENT.test(value) || WINDOWS_RESERVED.has(value)) {
+	if (!isSafeSegment(value)) {
 		throw new Error(
 			`Invalid ${label}: ${JSON.stringify(value)}. A guid segment must be lowercase a-z and 0-9 with single internal hyphens (matching ${SAFE_SEGMENT}), contain no dots, and not be a reserved device name.`,
 		);


### PR DESCRIPTION
Two commits, each reviewable on its own. The guid string is unchanged from main (4-part `workspaceId.collection.rowId.field`), so no stored data moves.

## 1. Brand the guid and unify its validator (`25dd2be`)

- **`DocGuid` brand.** `docGuid` returned `Guid`, the same brand as `generateGuid()` (a random token). A composed dotted guid and a random token obey different grammars, so they now carry distinct brands.
- **One grammar, one validator.** The server hand-copied the segment grammar as a local regex (`DOC_GUID_REGEX`). That is now `isDocGuid`, derived from the same `isSafeSegment` predicate `docGuid` mints with, so a validator and a minter cannot drift.
- **`field` kept.** An earlier pass dropped it to a 3-part guid on the theory that every row owns one child doc. It is what lets a row own more than one sibling child doc (e.g. an article with a `code` doc and a `preview` doc, see `docs/articles/updated-at-sentinel-for-external-yjs-docs.md`) without the two colliding. Dropping it would rest injectivity on an unenforced convention, and a second child doc would merge silently into the first.

## 2. Make the brand load-bearing via `createContentDoc` (`b56d5fa`)

After commit 1 the brand was produce-only: `new Y.Doc({ guid })` takes a plain `string`, so nothing required a `DocGuid` and the per-app wrappers widened it back to `string`. A brand no consumer demands is decorative.

- **`createContentDoc(guid: DocGuid): Y.Doc`** is now the one place a child content document is allocated. Requiring a `DocGuid` turns "passed a raw row id / random guid to child-doc construction" into a compile error instead of a silent collision into the wrong doc. It also owns the one shared construction policy (`gc: true`); runtime concerns (persistence, sync, codecs, caching) stay at call sites.
- **Threaded through every content-doc site** (all were a uniform `new Y.Doc({ guid, gc: true })`): fuji, honeycrisp, opensidian, zhongwen, the skills package (browser + node), opensidian skill-state, the filesystem test, and the one-shot `readRoomOverHttp`. The six wrappers now return `DocGuid`, so the brand survives end to end to the constructor.

## Surface

- `packages/workspace`: `DocGuid` brand, `isDocGuid`, `isSafeSegment`, `createContentDoc`; `docGuid` returns `DocGuid`; `readRoomOverHttp` takes a `DocGuid`.
- `packages/filesystem`, `packages/skills`: content-doc wrappers return `DocGuid`; openers use `createContentDoc`.
- `packages/server`: doc-as-wire guid validated with `isDocGuid` instead of `DOC_GUID_REGEX`.
- `apps/*` (fuji, honeycrisp, opensidian, zhongwen, skills): construct content docs with `createContentDoc`.