### PR TITLE
docs(skills): add cross-file duplication and clean-HEAD verification to post-implementation-review

### DIFF
--- a/.agents/skills/post-implementation-review/SKILL.md
+++ b/.agents/skills/post-implementation-review/SKILL.md
@@ -77,7 +77,9 @@ yjs                      CRDT documents, shared types, transactions, conflict be
 5. Run the ownership and collapse check.
 6. Run the smell and invariant checks.
 7. Review API shape, naming, and file organization.
-8. Run diagnostics and tests appropriate to the changed lane.
+8. Run diagnostics and tests appropriate to the changed lane. Reproduce any
+   failure on clean HEAD before blaming the change; separate pre-existing red
+   from regressions you introduced.
 9. Report findings before making cleanup edits unless the issue is a direct
    compile or test failure.
 
@@ -148,7 +150,14 @@ fallback parsers for old shapes
 callbacks that mirror internal implementation steps
 decision callbacks that could be caller-owned composition
 single-file directories and pointless barrels
+near-identical sibling files or types
 ```
+
+Duplication is not automatically a defect. When two sibling files or types are
+byte-identical or nearly so, judge it: cheap independence between modules that
+should stay decoupled, or latent coupling that wants one source of truth? Name
+the call either way, and check that any stated rationale matches the code (a
+"these subsets genuinely differ" comment over two identical files is a tell).
 
 If a smell is repo-recurring, use `code-audit` for the relevant grep pattern. If
 the smell came from the refactor itself, use `refactoring` for the straggler
@@ -236,7 +245,8 @@ Would leave alone
 [Indirection or duplication that earns its keep]
 
 Verification
-[Commands run and result, or why not run]
+[Commands run and result, or why not run. For any failure, note whether it
+ reproduces on clean HEAD so pre-existing red is not misread as a regression.]
 ```
 
 For an implementation pass, make the cleanup edits after reporting the issue in

--- a/.agents/skills/post-implementation-review/SKILL.md
+++ b/.agents/skills/post-implementation-review/SKILL.md
@@ -150,14 +150,8 @@ fallback parsers for old shapes
 callbacks that mirror internal implementation steps
 decision callbacks that could be caller-owned composition
 single-file directories and pointless barrels
-near-identical sibling files or types
+near-identical sibling files or types (judge: cheap independence or latent coupling)
 ```
-
-Duplication is not automatically a defect. When two sibling files or types are
-byte-identical or nearly so, judge it: cheap independence between modules that
-should stay decoupled, or latent coupling that wants one source of truth? Name
-the call either way, and check that any stated rationale matches the code (a
-"these subsets genuinely differ" comment over two identical files is a tell).
 
 If a smell is repo-recurring, use `code-audit` for the relevant grep pattern. If
 the smell came from the refactor itself, use `refactoring` for the straggler


### PR DESCRIPTION
The post-implementation-review skill is the hub for the second-read pass after an implementation. This PR adds two reusable prompts that belong in that review loop.

First, the review order now tells agents to reproduce a failure on clean HEAD before blaming the current diff. That keeps pre-existing red from being reported as a regression, and the output template asks for the same distinction so it survives into the final handoff.

Second, the smell checklist now calls out near-identical sibling files or types. The point is deliberately narrow: judge whether the duplication is cheap independence between modules that should stay decoupled or latent coupling that wants one source of truth.

The duplication guidance stays as one line. The earlier, longer paragraph was too tied to one review anecdote, so the final version keeps the general lens without turning a one-off tell into skill doctrine.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784082883&installation_id=128463665&pr_number=2010&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2010&signature=b7ffe7d6e6f1bc9b2a861326c2f3a9f695df6032baf47c704a552ebc33884fe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
