### PR TITLE
refactor(settings): share typed settings controls

### DIFF
--- a/apps/whispering/src/lib/components/settings/SettingSelect.svelte
+++ b/apps/whispering/src/lib/components/settings/SettingSelect.svelte
@@ -1,6 +1,11 @@
 <script lang="ts" generics="K extends SelectSettingKey">
 	import * as Field from '@epicenter/ui/field';
 	import * as Select from '@epicenter/ui/select';
+	// Bound to the synced workspace `settings` store by design. Device-local
+	// selects (bitrate, sample rate on the recording page) stay bespoke on
+	// purpose: `deviceConfig` is a separate store with its own value map, and
+	// generalizing this component over both stores costs far more in generic
+	// machinery than the handful of duplicated `<Select.Root>` blocks it saves.
 	import {
 		type SelectSettingKey,
 		type SettingValue,

--- a/apps/whispering/src/lib/components/settings/SettingSelect.svelte
+++ b/apps/whispering/src/lib/components/settings/SettingSelect.svelte
@@ -1,0 +1,58 @@
+<script lang="ts" generics="K extends SelectSettingKey">
+	import * as Field from '@epicenter/ui/field';
+	import * as Select from '@epicenter/ui/select';
+	import {
+		type SelectSettingKey,
+		type SettingValue,
+		settings,
+	} from '$lib/state/settings.svelte';
+
+	let {
+		key,
+		label,
+		items,
+		description,
+		placeholder = 'Select an option',
+	}: {
+		key: K;
+		label: string;
+		items: readonly { value: SettingValue<K>; label: string }[];
+		description?: string;
+		placeholder?: string;
+	} = $props();
+
+	// Opaque, generated id wired into both `for` and the trigger from one source.
+	const id = $props.id();
+
+	const selectedLabel = $derived(
+		items.find((item) => item.value === settings.get(key))?.label,
+	);
+</script>
+
+<Field.Field>
+	<Field.Label for={id}>{label}</Field.Label>
+	<Select.Root
+		type="single"
+		bind:value={
+			() => String(settings.get(key)),
+			(value) => {
+				// bits-ui Select is string-valued; the items list is the source of
+				// truth for mapping the string form back to the typed setting value.
+				const match = items.find((item) => String(item.value) === value);
+				if (match) settings.set(key, match.value);
+			}
+		}
+	>
+		<Select.Trigger {id} class="w-full">
+			{selectedLabel ?? placeholder}
+		</Select.Trigger>
+		<Select.Content>
+			{#each items as item}
+				<Select.Item value={String(item.value)} label={item.label} />
+			{/each}
+		</Select.Content>
+	</Select.Root>
+	{#if description}
+		<Field.Description>{description}</Field.Description>
+	{/if}
+</Field.Field>

--- a/apps/whispering/src/lib/components/settings/SettingSelect.svelte
+++ b/apps/whispering/src/lib/components/settings/SettingSelect.svelte
@@ -12,13 +12,11 @@
 		label,
 		items,
 		description,
-		placeholder = 'Select an option',
 	}: {
 		key: K;
 		label: string;
 		items: readonly { value: SettingValue<K>; label: string }[];
 		description?: string;
-		placeholder?: string;
 	} = $props();
 
 	// Opaque, generated id wired into both `for` and the trigger from one source.
@@ -44,7 +42,7 @@
 		}
 	>
 		<Select.Trigger {id} class="w-full">
-			{selectedLabel ?? placeholder}
+			{selectedLabel ?? 'Select an option'}
 		</Select.Trigger>
 		<Select.Content>
 			{#each items as item}

--- a/apps/whispering/src/lib/components/settings/SettingSwitch.svelte
+++ b/apps/whispering/src/lib/components/settings/SettingSwitch.svelte
@@ -1,0 +1,23 @@
+<script lang="ts" generics="K extends BooleanSettingKey">
+	import * as Field from '@epicenter/ui/field';
+	import { Switch } from '@epicenter/ui/switch';
+	import {
+		type BooleanSettingKey,
+		settings,
+	} from '$lib/state/settings.svelte';
+
+	let { key, label }: { key: K; label: string } = $props();
+
+	// Opaque, generated id wired into both `for` and `id` from one source. The
+	// id has no external consumer, so it carries no meaning by design: there is
+	// nothing to keep in sync with the setting key, and nothing to drift.
+	const id = $props.id();
+</script>
+
+<Field.Field orientation="horizontal">
+	<Field.Label for={id}>{label}</Field.Label>
+	<Switch
+		{id}
+		bind:checked={() => settings.get(key), (checked) => settings.set(key, checked)}
+	/>
+</Field.Field>

--- a/apps/whispering/src/lib/components/settings/SettingSwitch.svelte
+++ b/apps/whispering/src/lib/components/settings/SettingSwitch.svelte
@@ -6,7 +6,18 @@
 		settings,
 	} from '$lib/state/settings.svelte';
 
-	let { key, label }: { key: K; label: string } = $props();
+	let {
+		key,
+		label,
+		description,
+		onCheckedChange,
+	}: {
+		key: K;
+		label: string;
+		description?: string;
+		/** Runs after the setting is written, e.g. to log the change. */
+		onCheckedChange?: (checked: boolean) => void;
+	} = $props();
 
 	// Opaque, generated id wired into both `for` and `id` from one source. The
 	// id has no external consumer, so it carries no meaning by design: there is
@@ -15,9 +26,20 @@
 </script>
 
 <Field.Field orientation="horizontal">
-	<Field.Label for={id}>{label}</Field.Label>
+	<Field.Content>
+		<Field.Label for={id}>{label}</Field.Label>
+		{#if description}
+			<Field.Description>{description}</Field.Description>
+		{/if}
+	</Field.Content>
 	<Switch
 		{id}
-		bind:checked={() => settings.get(key), (checked) => settings.set(key, checked)}
+		bind:checked={
+			() => settings.get(key),
+			(checked) => {
+				settings.set(key, checked);
+				onCheckedChange?.(checked);
+			}
+		}
 	/>
 </Field.Field>

--- a/apps/whispering/src/lib/components/settings/index.ts
+++ b/apps/whispering/src/lib/components/settings/index.ts
@@ -5,6 +5,7 @@ export {
 	type ProviderConfigId,
 } from './ProviderConfigFields.svelte';
 // Shared components
+export { default as SettingSwitch } from './SettingSwitch.svelte';
 export { default as ManualDeviceSelector } from './selectors/ManualDeviceSelector.svelte';
 // Selector components
 export { default as RecordingModeSelector } from './selectors/RecordingModeSelector.svelte';

--- a/apps/whispering/src/lib/components/settings/index.ts
+++ b/apps/whispering/src/lib/components/settings/index.ts
@@ -5,6 +5,7 @@ export {
 	type ProviderConfigId,
 } from './ProviderConfigFields.svelte';
 // Shared components
+export { default as SettingSelect } from './SettingSelect.svelte';
 export { default as SettingSwitch } from './SettingSwitch.svelte';
 export { default as ManualDeviceSelector } from './selectors/ManualDeviceSelector.svelte';
 // Selector components

--- a/apps/whispering/src/lib/state/settings.svelte.ts
+++ b/apps/whispering/src/lib/state/settings.svelte.ts
@@ -3,6 +3,21 @@ import { whispering } from '#platform/whispering';
 
 type Kv = typeof whispering.kv;
 
+/** Every setting's value type, keyed by setting key. */
+type SettingsValues = ReturnType<Kv['getAll']>;
+
+/**
+ * Setting keys whose stored value is a boolean.
+ *
+ * The `<SettingSwitch>` component constrains its `key` prop to these, so the
+ * generic flows through `settings.get`/`settings.set` and a non-boolean key
+ * (a number like `retention.maxCount`, an enum like `ui.alwaysOnTop`) is a
+ * compile error instead of a silently-broken toggle.
+ */
+export type BooleanSettingKey = {
+	[K in keyof SettingsValues]: SettingsValues[K] extends boolean ? K : never;
+}[keyof SettingsValues];
+
 function createSettings() {
 	const map = new SvelteMap<string, unknown>();
 

--- a/apps/whispering/src/lib/state/settings.svelte.ts
+++ b/apps/whispering/src/lib/state/settings.svelte.ts
@@ -18,6 +18,20 @@ export type BooleanSettingKey = {
 	[K in keyof SettingsValues]: SettingsValues[K] extends boolean ? K : never;
 }[keyof SettingsValues];
 
+/** The stored value type for a given setting key. */
+export type SettingValue<K extends keyof SettingsValues> = SettingsValues[K];
+
+/**
+ * Setting keys whose stored value is a string or number: the keys a
+ * `<SettingSelect>` can drive from a list of options. Boolean keys use
+ * `<SettingSwitch>`; nullable and object-valued keys are not plain dropdowns.
+ */
+export type SelectSettingKey = {
+	[K in keyof SettingsValues]: SettingsValues[K] extends string | number
+		? K
+		: never;
+}[keyof SettingsValues];
+
 function createSettings() {
 	const map = new SvelteMap<string, unknown>();
 

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -231,7 +231,7 @@ const ui = {
  */
 const dataRetention = {
 	'retention.strategy': defineKv(
-		field.select(['keep-forever', 'limit-count']),
+		field.select(['keep-forever', 'limit-count', 'delete-all']),
 		() => 'keep-forever' as const,
 	),
 	'retention.maxCount': defineKv(field.integer({ minimum: 1 }), () => 100),

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -225,13 +225,16 @@ const ui = {
 } as const;
 
 /**
- * Recording retention policy. `maxCount` is stored as an integer: the old
- * settings schema used `string.digits` for localStorage; the workspace uses
- * the semantically correct numeric type.
+ * Recording retention policy. `retention.strategy` is the source of truth for
+ * how many recordings to keep: `keep-forever` (all), `limit-count` (the newest
+ * `maxCount`), or `keep-none` (zero). `maxCount` only applies under
+ * `limit-count`; it stays `>= 1` so the original "0 means never save" overload
+ * can never be persisted again. "Keep zero" lives in the strategy enum, not in
+ * a sentinel count: `keep-none` maps to a runtime count of 0 without storing 0.
  */
 const dataRetention = {
 	'retention.strategy': defineKv(
-		field.select(['keep-forever', 'limit-count', 'delete-all']),
+		field.select(['keep-forever', 'limit-count', 'keep-none']),
 		() => 'keep-forever' as const,
 	),
 	'retention.maxCount': defineKv(field.integer({ minimum: 1 }), () => 100),

--- a/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
@@ -15,14 +15,19 @@
 		{ value: 'keep-none', label: "Don't Keep Recordings" },
 	] as const;
 
-	// `keep-none` deletes existing recordings the moment it is enabled, not just
-	// future ones, so the description has to say so. Other strategies are
-	// self-explanatory from their label.
-	const retentionDescription = $derived(
-		settings.get('retention.strategy') === 'keep-none'
-			? 'Recordings are deleted right after transcription. Turning this on also deletes recordings you already have.'
-			: undefined,
-	);
+	// Both pruning strategies act retroactively: they delete recordings you
+	// already have, not just future ones. The label alone reads as forward-only,
+	// so the description has to say otherwise.
+	const retentionDescription = $derived.by(() => {
+		switch (settings.get('retention.strategy')) {
+			case 'keep-none':
+				return 'Recordings are deleted right after transcription. Turning this on also deletes recordings you already have.';
+			case 'limit-count':
+				return 'Older recordings beyond your limit are deleted automatically, including ones you already have.';
+			case 'keep-forever':
+				return undefined;
+		}
+	});
 
 	const maxRecordingItems = [
 		{ value: 5, label: '5 Recordings' },

--- a/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import * as Field from '@epicenter/ui/field';
-	import * as Select from '@epicenter/ui/select';
 	import { Switch } from '@epicenter/ui/switch';
 	import { createMutation, createQuery } from '@tanstack/svelte-query';
-	import { SettingSwitch } from '$lib/components/settings';
+	import { SettingSelect, SettingSwitch } from '$lib/components/settings';
 	import { ALWAYS_ON_TOP_MODE_OPTIONS } from '$lib/constants/always-on-top';
 	import { report } from '$lib/report';
 	import { autostartKeys } from '$lib/tauri/autostart-keys';
@@ -13,7 +12,7 @@
 	const retentionItems = [
 		{ value: 'keep-forever', label: 'Keep All Recordings' },
 		{ value: 'limit-count', label: 'Keep Limited Number' },
-	];
+	] as const;
 
 	const maxRecordingItems = [
 		{ value: 0, label: '0 Recordings (Never Save)' },
@@ -22,24 +21,7 @@
 		{ value: 25, label: '25 Recordings' },
 		{ value: 50, label: '50 Recordings' },
 		{ value: 100, label: '100 Recordings' },
-	];
-
-	const retentionLabel = $derived(
-		retentionItems.find((i) => i.value === settings.get('retention.strategy'))
-			?.label,
-	);
-
-	const maxRecordingLabel = $derived(
-		maxRecordingItems.find(
-			(i) => i.value === settings.get('retention.maxCount'),
-		)?.label,
-	);
-
-	const alwaysOnTopLabel = $derived(
-		ALWAYS_ON_TOP_MODE_OPTIONS.find(
-			(i) => i.value === settings.get('ui.alwaysOnTop'),
-		)?.label,
-	);
+	] as const;
 
 	// Autostart is Tauri-only; on web `tauri` is null and the query stays
 	// disabled (default value `false`).
@@ -134,44 +116,18 @@
 
 		<Field.Separator />
 
-		<Field.Field>
-			<Field.Label for="recording-retention-strategy"
-				>Auto Delete Recordings</Field.Label
-			>
-			<Select.Root
-				type="single"
-				bind:value={() => settings.get('retention.strategy'),
-					(v) => settings.set('retention.strategy', v)}
-			>
-				<Select.Trigger id="recording-retention-strategy" class="w-full">
-					{retentionLabel ?? 'Select retention strategy'}
-				</Select.Trigger>
-				<Select.Content>
-					{#each retentionItems as item}
-						<Select.Item value={item.value} label={item.label} />
-					{/each}
-				</Select.Content>
-			</Select.Root>
-		</Field.Field>
+		<SettingSelect
+			key="retention.strategy"
+			label="Auto Delete Recordings"
+			items={retentionItems}
+		/>
 
 		{#if settings.get('retention.strategy') === 'limit-count'}
-			<Field.Field>
-				<Field.Label for="max-recording-count">Maximum Recordings</Field.Label>
-				<Select.Root
-					type="single"
-					bind:value={() => String(settings.get('retention.maxCount')),
-						(v) => settings.set('retention.maxCount', Number(v))}
-				>
-					<Select.Trigger id="max-recording-count" class="w-full">
-						{maxRecordingLabel ?? 'Select maximum recordings'}
-					</Select.Trigger>
-					<Select.Content>
-						{#each maxRecordingItems as item}
-							<Select.Item value={String(item.value)} label={item.label} />
-						{/each}
-					</Select.Content>
-				</Select.Root>
-			</Field.Field>
+			<SettingSelect
+				key="retention.maxCount"
+				label="Maximum Recordings"
+				items={maxRecordingItems}
+			/>
 		{/if}
 
 		{#if tauri}
@@ -201,23 +157,11 @@
 						disableAutostartMutation.isPending}
 				/>
 			</Field.Field>
-			<Field.Field>
-				<Field.Label for="always-on-top">Always On Top</Field.Label>
-				<Select.Root
-					type="single"
-					bind:value={() => settings.get('ui.alwaysOnTop'),
-					(v) => settings.set('ui.alwaysOnTop', v)}
-				>
-					<Select.Trigger id="always-on-top" class="w-full">
-						{alwaysOnTopLabel ?? 'Select always on top mode'}
-					</Select.Trigger>
-					<Select.Content>
-						{#each ALWAYS_ON_TOP_MODE_OPTIONS as item}
-							<Select.Item value={item.value} label={item.label} />
-						{/each}
-					</Select.Content>
-				</Select.Root>
-			</Field.Field>
+			<SettingSelect
+				key="ui.alwaysOnTop"
+				label="Always On Top"
+				items={ALWAYS_ON_TOP_MODE_OPTIONS}
+			/>
 		{/if}
 	</Field.Group>
 </Field.Set>

--- a/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
@@ -12,8 +12,17 @@
 	const retentionItems = [
 		{ value: 'keep-forever', label: 'Keep All Recordings' },
 		{ value: 'limit-count', label: 'Keep Limited Number' },
-		{ value: 'delete-all', label: 'Never Save Recordings' },
+		{ value: 'keep-none', label: "Don't Keep Recordings" },
 	] as const;
+
+	// `keep-none` deletes existing recordings the moment it is enabled, not just
+	// future ones, so the description has to say so. Other strategies are
+	// self-explanatory from their label.
+	const retentionDescription = $derived(
+		settings.get('retention.strategy') === 'keep-none'
+			? 'Recordings are deleted right after transcription. Turning this on also deletes recordings you already have.'
+			: undefined,
+	);
 
 	const maxRecordingItems = [
 		{ value: 5, label: '5 Recordings' },
@@ -120,6 +129,7 @@
 			key="retention.strategy"
 			label="Auto Delete Recordings"
 			items={retentionItems}
+			description={retentionDescription}
 		/>
 
 		{#if settings.get('retention.strategy') === 'limit-count'}

--- a/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import * as Field from '@epicenter/ui/field';
-	import * as RadioGroup from '@epicenter/ui/radio-group';
 	import * as Select from '@epicenter/ui/select';
 	import { Switch } from '@epicenter/ui/switch';
 	import { createMutation, createQuery } from '@tanstack/svelte-query';
+	import { SettingSwitch } from '$lib/components/settings';
 	import { ALWAYS_ON_TOP_MODE_OPTIONS } from '$lib/constants/always-on-top';
 	import { report } from '$lib/report';
 	import { autostartKeys } from '$lib/tauri/autostart-keys';
@@ -86,39 +86,21 @@
 				Applies immediately after an audio transcription finishes.
 			</Field.Description>
 			<Field.Group>
-				<Field.Field orientation="horizontal">
-					<Switch
-						id="transcription.copyToClipboardOnSuccess"
-						bind:checked={() => settings.get('output.transcription.clipboard'),
-							(v) => settings.set('output.transcription.clipboard', v)}
-					/>
-					<Field.Label for="transcription.copyToClipboardOnSuccess">
-						Copy transcript to clipboard
-					</Field.Label>
-				</Field.Field>
+				<SettingSwitch
+					key="output.transcription.clipboard"
+					label="Copy transcript to clipboard"
+				/>
 
-				<Field.Field orientation="horizontal">
-					<Switch
-						id="transcription.writeToCursorOnSuccess"
-						bind:checked={() => settings.get('output.transcription.cursor'),
-							(v) => settings.set('output.transcription.cursor', v)}
-					/>
-					<Field.Label for="transcription.writeToCursorOnSuccess">
-						Paste transcript at cursor
-					</Field.Label>
-				</Field.Field>
+				<SettingSwitch
+					key="output.transcription.cursor"
+					label="Paste transcript at cursor"
+				/>
 
 				{#if tauri && settings.get('output.transcription.cursor')}
-					<Field.Field orientation="horizontal">
-						<Switch
-							id="transcription.simulateEnterAfterOutput"
-							bind:checked={() => settings.get('output.transcription.enter'),
-								(v) => settings.set('output.transcription.enter', v)}
-						/>
-						<Field.Label for="transcription.simulateEnterAfterOutput">
-							Press Enter after pasting transcript
-						</Field.Label>
-					</Field.Field>
+					<SettingSwitch
+						key="output.transcription.enter"
+						label="Press Enter after pasting transcript"
+					/>
 				{/if}
 			</Field.Group>
 		</Field.Set>
@@ -131,39 +113,21 @@
 				Applies after you run a saved transformation on a transcription.
 			</Field.Description>
 			<Field.Group>
-				<Field.Field orientation="horizontal">
-					<Switch
-						id="transformation.copyToClipboardOnSuccess"
-						bind:checked={() => settings.get('output.transformation.clipboard'),
-							(v) => settings.set('output.transformation.clipboard', v)}
-					/>
-					<Field.Label for="transformation.copyToClipboardOnSuccess">
-						Copy transformed text to clipboard
-					</Field.Label>
-				</Field.Field>
+				<SettingSwitch
+					key="output.transformation.clipboard"
+					label="Copy transformed text to clipboard"
+				/>
 
-				<Field.Field orientation="horizontal">
-					<Switch
-						id="transformation.writeToCursorOnSuccess"
-						bind:checked={() => settings.get('output.transformation.cursor'),
-							(v) => settings.set('output.transformation.cursor', v)}
-					/>
-					<Field.Label for="transformation.writeToCursorOnSuccess">
-						Paste transformed text at cursor
-					</Field.Label>
-				</Field.Field>
+				<SettingSwitch
+					key="output.transformation.cursor"
+					label="Paste transformed text at cursor"
+				/>
 
 				{#if tauri && settings.get('output.transformation.cursor')}
-					<Field.Field orientation="horizontal">
-						<Switch
-							id="transformation.simulateEnterAfterOutput"
-							bind:checked={() => settings.get('output.transformation.enter'),
-								(v) => settings.set('output.transformation.enter', v)}
-						/>
-						<Field.Label for="transformation.simulateEnterAfterOutput">
-							Press Enter after pasting transformed text
-						</Field.Label>
-					</Field.Field>
+					<SettingSwitch
+						key="output.transformation.enter"
+						label="Press Enter after pasting transformed text"
+					/>
 				{/if}
 			</Field.Group>
 		</Field.Set>

--- a/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
@@ -12,10 +12,10 @@
 	const retentionItems = [
 		{ value: 'keep-forever', label: 'Keep All Recordings' },
 		{ value: 'limit-count', label: 'Keep Limited Number' },
+		{ value: 'delete-all', label: 'Never Save Recordings' },
 	] as const;
 
 	const maxRecordingItems = [
-		{ value: 0, label: '0 Recordings (Never Save)' },
 		{ value: 5, label: '5 Recordings' },
 		{ value: 10, label: '10 Recordings' },
 		{ value: 25, label: '25 Recordings' },

--- a/apps/whispering/src/routes/(app)/(config)/settings/analytics/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/analytics/+page.svelte
@@ -36,74 +36,48 @@
 		</SectionHeader.Description>
 	</SectionHeader.Root>
 
-	<!-- Main Toggle -->
-	<SettingSwitch
-		key="analytics.enabled"
-		label="Share anonymized events"
-		description={'We log simple events like "recording started" or "transcription completed". No personal data is attached to any of these events.'}
-		onCheckedChange={(checked) => {
-			// Log the change (only actually sends if analytics is now enabled).
-			if (checked) {
-				analytics.logEvent({ type: 'settings_changed', section: 'analytics' });
-			}
-		}}
-	/>
+	<Card.Root>
+		<Card.Content class="py-2">
+			<SettingSwitch
+				key="analytics.enabled"
+				label="Share anonymized events"
+				description='We log simple events like "recording started" or "transcription completed". No personal data is attached to any of these events.'
+				onCheckedChange={(checked) => {
+					// Log the change (only actually sends if analytics is now enabled).
+					if (checked) {
+						analytics.logEvent({
+							type: 'settings_changed',
+							section: 'analytics',
+						});
+					}
+				}}
+			/>
+		</Card.Content>
+	</Card.Root>
 
-	<!-- Data Collection Information -->
-	<div class="grid gap-4 md:grid-cols-2">
-		<Card.Root class="border-green-100 dark:border-green-900/20">
-			<Card.Header>
-				<Card.Title
-					class="text-sm font-medium text-green-700 dark:text-green-400 flex items-center gap-2"
-				>
-					<div class="w-2 h-2 bg-green-500 rounded-full"></div>
-					Events we log
-				</Card.Title>
-			</Card.Header>
-			<Card.Content>
-				<ul class="text-sm text-muted-foreground space-y-1.5 leading-relaxed">
-					<li class="flex items-start gap-2">
-						<span class="text-green-500 mt-1">•</span>
-						<span>Button clicks (which features you use)</span>
-					</li>
-					<li class="flex items-start gap-2">
-						<span class="text-green-500 mt-1">•</span>
-						<span>Completion times (how long things take)</span>
-					</li>
-					<li class="flex items-start gap-2">
-						<span class="text-green-500 mt-1">•</span>
-						<span>Error messages (when something fails)</span>
-					</li>
-				</ul>
-			</Card.Content>
-		</Card.Root>
-
-		<Card.Root class="border-warning dark:border-warning/20">
-			<Card.Header>
-				<Card.Title
-					class="text-sm font-medium text-warning dark:text-warning flex items-center gap-2"
-				>
-					<div class="w-2 h-2 bg-warning rounded-full"></div>
-					Never collected
-				</Card.Title>
-			</Card.Header>
-			<Card.Content>
-				<ul class="text-sm text-muted-foreground space-y-1.5 leading-relaxed">
-					<li class="flex items-start gap-2">
-						<span class="text-warning mt-1">•</span>
-						<span>Your actual transcriptions or recordings</span>
-					</li>
-					<li class="flex items-start gap-2">
-						<span class="text-warning mt-1">•</span>
-						<span>Device IDs or user identifiers</span>
-					</li>
-					<li class="flex items-start gap-2">
-						<span class="text-warning mt-1">•</span>
-						<span>API keys or any personal data</span>
-					</li>
-				</ul>
-			</Card.Content>
-		</Card.Root>
+	<div class="grid gap-x-8 gap-y-6 px-1 sm:grid-cols-2">
+		<div class="space-y-2">
+			<p
+				class="text-xs font-medium uppercase tracking-wide text-green-700 dark:text-green-400"
+			>
+				Events we log
+			</p>
+			<ul class="text-sm text-muted-foreground space-y-1 leading-relaxed">
+				<li>Button clicks (which features you use)</li>
+				<li>Completion times (how long things take)</li>
+				<li>Error messages (when something fails)</li>
+			</ul>
+		</div>
+		<div class="space-y-2">
+			<p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+				Never collected
+			</p>
+			<ul class="text-sm text-muted-foreground space-y-1 leading-relaxed">
+				<li>Your actual transcriptions or recordings</li>
+				<li>Device IDs or user identifiers</li>
+				<li>API keys or any personal data</li>
+			</ul>
+		</div>
 	</div>
 
 	<!-- Transparency Section -->

--- a/apps/whispering/src/routes/(app)/(config)/settings/analytics/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/analytics/+page.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import { Badge } from '@epicenter/ui/badge';
 	import * as Card from '@epicenter/ui/card';
-	import { Label } from '@epicenter/ui/label';
 	import * as SectionHeader from '@epicenter/ui/section-header';
-	import { Switch } from '@epicenter/ui/switch';
+	import { SettingSwitch } from '$lib/components/settings';
 	import { analytics } from '$lib/operations/analytics';
 	import { settings } from '$lib/state/settings.svelte';
 </script>
@@ -37,41 +36,18 @@
 		</SectionHeader.Description>
 	</SectionHeader.Root>
 
-	<!-- Main Toggle Section -->
-	<Card.Root class="transition-colors duration-200">
-		<Card.Content>
-			<div class="flex items-start justify-between gap-4">
-				<div class="space-y-2 flex-1">
-					<Label
-						for="analytics-toggle"
-						class="text-base font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-					>
-						Share anonymized events
-					</Label>
-					<p class="text-sm text-muted-foreground leading-relaxed">
-						We log simple events like "recording started" or "transcription
-						completed". No personal data is attached to any of these events.
-					</p>
-				</div>
-				<Switch
-					id="analytics-toggle"
-					bind:checked={() => settings.get('analytics.enabled'),
-						(checked) => {
-							settings.set('analytics.enabled', checked);
-
-							// Log the change (will only send if analytics is now enabled)
-							if (checked) {
-								analytics.logEvent({
-									type: 'settings_changed',
-									section: 'analytics',
-								});
-							}
-						}}
-					class="shrink-0"
-				/>
-			</div>
-		</Card.Content>
-	</Card.Root>
+	<!-- Main Toggle -->
+	<SettingSwitch
+		key="analytics.enabled"
+		label="Share anonymized events"
+		description={'We log simple events like "recording started" or "transcription completed". No personal data is attached to any of these events.'}
+		onCheckedChange={(checked) => {
+			// Log the change (only actually sends if analytics is now enabled).
+			if (checked) {
+				analytics.logEvent({ type: 'settings_changed', section: 'analytics' });
+			}
+		}}
+	/>
 
 	<!-- Data Collection Information -->
 	<div class="grid gap-4 md:grid-cols-2">

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
@@ -7,6 +7,7 @@
 	import InfoIcon from '@lucide/svelte/icons/info';
 	import { createMutation } from '@tanstack/svelte-query';
 	import { mutationOptions } from 'wellcrafted/query';
+	import { SettingSelect } from '$lib/components/settings';
 	import {
 		BITRATE_OPTIONS,
 		RECORDING_MODE_OPTIONS,
@@ -24,12 +25,6 @@
 	import VadSelectRecordingDevice from './VadSelectRecordingDevice.svelte';
 
 	// Derived labels for select triggers
-	const recordingModeLabel = $derived(
-		RECORDING_MODE_OPTIONS.find(
-			(o) => o.value === settings.get('recording.mode'),
-		)?.label,
-	);
-
 	const sampleRateLabel = $derived(
 		SAMPLE_RATE_OPTIONS.find(
 			(o) => o.value === deviceConfig.get('recording.cpal.sampleRate'),
@@ -59,31 +54,14 @@
 	</Field.Description>
 	<Field.Separator />
 	<Field.Group>
-		<Field.Field>
-			<Field.Label for="recording-mode">Recording Mode</Field.Label>
-			<Select.Root
-				type="single"
-				bind:value={() => settings.get('recording.mode'),
-					(selected) => {
-						if (selected) settings.set('recording.mode', selected);
-					}}
-			>
-				<Select.Trigger id="recording-mode" class="w-full">
-					{recordingModeLabel ?? 'Select a recording mode'}
-				</Select.Trigger>
-				<Select.Content>
-					{#each RECORDING_MODE_OPTIONS as item}
-						<Select.Item value={item.value} label={item.label} />
-					{/each}
-				</Select.Content>
-			</Select.Root>
-			<Field.Description>
-				Choose how you want to activate recording:
-				{RECORDING_MODE_OPTIONS.map(
-					(option) => option.label.toLowerCase(),
-				).join(', ')}
-			</Field.Description>
-		</Field.Field>
+		<SettingSelect
+			key="recording.mode"
+			label="Recording Mode"
+			items={RECORDING_MODE_OPTIONS}
+			description="Choose how you want to activate recording: {RECORDING_MODE_OPTIONS.map(
+				(option) => option.label.toLowerCase(),
+			).join(', ')}"
+		/>
 
 		{#if settings.get('recording.mode') === 'manual'}
 			<ManualSelectRecordingDevice

--- a/apps/whispering/src/routes/(app)/(config)/settings/sound/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/sound/+page.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import * as Field from '@epicenter/ui/field';
-	import { Switch } from '@epicenter/ui/switch';
+	import { SettingSwitch } from '$lib/components/settings';
 	import { os } from '#platform/os';
 	import { tauri } from '#platform/tauri';
-	import { settings } from '$lib/state/settings.svelte';
 </script>
 
 <svelte:head> <title>Sound Settings - Whispering</title> </svelte:head>
@@ -22,16 +21,10 @@
 					Pause Music or Spotify while Whispering records.
 				</Field.Description>
 				<Field.Group>
-					<Field.Field orientation="horizontal">
-						<Switch
-							id="sound.pause-media-during-recording"
-							bind:checked={() => settings.get('sound.pauseMediaDuringRecording'),
-								(v) => settings.set('sound.pauseMediaDuringRecording', v)}
-						/>
-						<Field.Label for="sound.pause-media-during-recording">
-							Pause media while recording
-						</Field.Label>
-					</Field.Field>
+					<SettingSwitch
+						key="sound.pauseMediaDuringRecording"
+						label="Pause media while recording"
+					/>
 				</Field.Group>
 			</Field.Set>
 
@@ -44,38 +37,18 @@
 				Configure sounds for manual recording events.
 			</Field.Description>
 			<Field.Group>
-				<Field.Field orientation="horizontal">
-					<Switch
-						id="sound.playOn.manual-start"
-						bind:checked={() => settings.get('sound.manualStart'),
-							(v) => settings.set('sound.manualStart', v)}
-					/>
-					<Field.Label for="sound.playOn.manual-start">
-						Play sound when starting manual recording
-					</Field.Label>
-				</Field.Field>
-
-				<Field.Field orientation="horizontal">
-					<Switch
-						id="sound.playOn.manual-stop"
-						bind:checked={() => settings.get('sound.manualStop'),
-							(v) => settings.set('sound.manualStop', v)}
-					/>
-					<Field.Label for="sound.playOn.manual-stop">
-						Play sound when stopping manual recording
-					</Field.Label>
-				</Field.Field>
-
-				<Field.Field orientation="horizontal">
-					<Switch
-						id="sound.playOn.manual-cancel"
-						bind:checked={() => settings.get('sound.manualCancel'),
-							(v) => settings.set('sound.manualCancel', v)}
-					/>
-					<Field.Label for="sound.playOn.manual-cancel">
-						Play sound when canceling manual recording
-					</Field.Label>
-				</Field.Field>
+				<SettingSwitch
+					key="sound.manualStart"
+					label="Play sound when starting manual recording"
+				/>
+				<SettingSwitch
+					key="sound.manualStop"
+					label="Play sound when stopping manual recording"
+				/>
+				<SettingSwitch
+					key="sound.manualCancel"
+					label="Play sound when canceling manual recording"
+				/>
 			</Field.Group>
 		</Field.Set>
 
@@ -87,38 +60,18 @@
 				Configure sounds for voice-activated detection events.
 			</Field.Description>
 			<Field.Group>
-				<Field.Field orientation="horizontal">
-					<Switch
-						id="sound.playOn.vad-start"
-						bind:checked={() => settings.get('sound.vadStart'),
-							(v) => settings.set('sound.vadStart', v)}
-					/>
-					<Field.Label for="sound.playOn.vad-start">
-						Play sound when starting VAD recording session
-					</Field.Label>
-				</Field.Field>
-
-				<Field.Field orientation="horizontal">
-					<Switch
-						id="sound.playOn.vad-capture"
-						bind:checked={() => settings.get('sound.vadCapture'),
-							(v) => settings.set('sound.vadCapture', v)}
-					/>
-					<Field.Label for="sound.playOn.vad-capture">
-						Play sound on VAD capture
-					</Field.Label>
-				</Field.Field>
-
-				<Field.Field orientation="horizontal">
-					<Switch
-						id="sound.playOn.vad-stop"
-						bind:checked={() => settings.get('sound.vadStop'),
-							(v) => settings.set('sound.vadStop', v)}
-					/>
-					<Field.Label for="sound.playOn.vad-stop">
-						Play sound when stopping VAD recording session
-					</Field.Label>
-				</Field.Field>
+				<SettingSwitch
+					key="sound.vadStart"
+					label="Play sound when starting VAD recording session"
+				/>
+				<SettingSwitch
+					key="sound.vadCapture"
+					label="Play sound on VAD capture"
+				/>
+				<SettingSwitch
+					key="sound.vadStop"
+					label="Play sound when stopping VAD recording session"
+				/>
 			</Field.Group>
 		</Field.Set>
 
@@ -130,27 +83,14 @@
 				Configure sounds for transcription and transformation completion.
 			</Field.Description>
 			<Field.Group>
-				<Field.Field orientation="horizontal">
-					<Switch
-						id="play-sound-transcription"
-						bind:checked={() => settings.get('sound.transcriptionComplete'),
-							(v) => settings.set('sound.transcriptionComplete', v)}
-					/>
-					<Field.Label for="play-sound-transcription">
-						Play sound after transcription
-					</Field.Label>
-				</Field.Field>
-
-				<Field.Field orientation="horizontal">
-					<Switch
-						id="play-sound-transformation"
-						bind:checked={() => settings.get('sound.transformationComplete'),
-							(v) => settings.set('sound.transformationComplete', v)}
-					/>
-					<Field.Label for="play-sound-transformation">
-						Play sound after transformation
-					</Field.Label>
-				</Field.Field>
+				<SettingSwitch
+					key="sound.transcriptionComplete"
+					label="Play sound after transcription"
+				/>
+				<SettingSwitch
+					key="sound.transformationComplete"
+					label="Play sound after transformation"
+				/>
 			</Field.Group>
 		</Field.Set>
 	</Field.Group>

--- a/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
+++ b/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
@@ -100,9 +100,10 @@
 
 	$effect(() => {
 		const strategy = settings.get('retention.strategy');
-		if (strategy !== 'limit-count') return;
+		if (strategy === 'keep-forever') return;
 
-		const maxCount = settings.get('retention.maxCount');
+		const maxCount =
+			strategy === 'delete-all' ? 0 : settings.get('retention.maxCount');
 		const allRecordingIds = recordings.sorted.map((r) => r.id);
 		if (allRecordingIds.length <= maxCount) return;
 

--- a/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
+++ b/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
@@ -102,12 +102,22 @@
 		const strategy = settings.get('retention.strategy');
 		if (strategy === 'keep-forever') return;
 
+		// `keep-none` keeps zero recordings; it maps to a runtime count of 0
+		// without ever persisting 0 (the schema enforces `maxCount >= 1`).
 		const maxCount =
-			strategy === 'delete-all' ? 0 : settings.get('retention.maxCount');
-		const allRecordingIds = recordings.sorted.map((r) => r.id);
-		if (allRecordingIds.length <= maxCount) return;
+			strategy === 'keep-none' ? 0 : settings.get('retention.maxCount');
 
-		const idsToDelete = allRecordingIds.slice(maxCount);
+		// Only settled recordings are eligible for pruning. A recording still
+		// in the pipeline has `transcription: null`; deleting it would pull the
+		// audio blob out from under transcription, which reads it back by id.
+		// So `keep-none` deletes each recording once its transcription settles,
+		// never before, which is the window the recording needs to be usable.
+		const settledIds = recordings.sorted
+			.filter((recording) => recording.transcription !== null)
+			.map((recording) => recording.id);
+		if (settledIds.length <= maxCount) return;
+
+		const idsToDelete = settledIds.slice(maxCount);
 		// Delete audio blobs from storage
 		services.blobs.audio.delete(idsToDelete);
 		// Delete recording metadata from workspace (single-scan bulk)


### PR DESCRIPTION
Settings had three separate problems hiding in plain sight: every page manually paired ids and labels with KV keys, boolean rows were easy to drift from their store keys, and enum selects duplicated value typing at the call site. This moves the recurring controls into two KV-backed components so settings pages describe intent instead of wiring.

```svelte
<SettingSwitch key="sound.manualStart" label="Play sound when starting manual recording" />

<SettingSelect key="ui.alwaysOnTop" label="Always on top" items={alwaysOnTopItems} />
```

Both components derive their allowed keys and value types from the settings facade. A misspelled key, a boolean key passed to `SettingSelect`, or a select item outside the key value union now fails at typecheck time instead of becoming a quiet form-control mismatch.

The migrated sound, output, recording, and analytics controls now use the shared label-left, control-right row where the setting is a plain KV-backed value. The richer selectors and informational cards stay bespoke because they carry behavior or content beyond a plain setting row.

The analytics page gets one extra hierarchy pass: the opt-in toggle now reads as the primary decision, while the logged and never-collected data lists sit underneath as quieter supporting evidence. The transparency links and active/disabled status footer stay intact.

## Retention fix

Migrating the retention controls surfaced a latent bug. The strategy enum exposed `delete-all`, whose runtime mapped to `maxCount = 0` through a reactive effect that pruned every recording the moment it entered the list, before the pipeline transcribed it. Because transcription reads the audio blob back by id, "never save" raced the pipeline and could delete a recording out from under its own transcription.

The durable value is now `keep-none` (it names the policy, parallel with `keep-forever`), and the retention effect only prunes settled recordings, those carrying a terminal transcription outcome. `keep-none` deletes each recording once its transcription settles, never before, which is the window the recording needs to stay transcribable. The schema keeps `maxCount >= 1`, so the old "0 means never save" overload can never persist again: "keep zero" lives in the strategy enum, not a sentinel count. Both pruning strategies now disclose in their description that they delete recordings you already have, not just future ones.

Scope: 8 commits, 10 files, +304 / -362.