### PR TITLE
fix(ci): stop release re-runs from stranding published assets

### DIFF
--- a/.github/actions/setup-whispering-build/action.yml
+++ b/.github/actions/setup-whispering-build/action.yml
@@ -92,6 +92,13 @@ runs:
         choco install llvm --version=22.1.7 --no-progress -y
         "LIBCLANG_PATH=C:\Program Files\LLVM\bin" >> $env:GITHUB_ENV
 
+    # Tags cut before .nvmrc was added (e.g. v7.11.0) check out a tree without
+    # the file, which would fail setup-node's node-version-file lookup. Fall
+    # back to a default so re-releasing historical tags still builds.
+    - name: Ensure .nvmrc exists
+      shell: bash
+      run: '[ -f .nvmrc ] || echo "24" > .nvmrc'
+
     - name: Setup Node
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/release.whispering.yml
+++ b/.github/workflows/release.whispering.yml
@@ -16,41 +16,11 @@ on:
         type: string
 
 jobs:
-  # Job to clean up existing release assets before building
-  cleanup-release:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    permissions:
-      contents: write
-    steps:
-      - name: Delete existing release assets
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event.inputs.tag || github.ref_name }}
-          REPO: ${{ github.repository }}
-        run: |
-          echo "Cleaning up assets for release: $TAG"
-
-          # Get release ID
-          RELEASE_ID=$(gh api "repos/$REPO/releases/tags/$TAG" --jq '.id' 2>/dev/null || echo "")
-
-          if [ -n "$RELEASE_ID" ]; then
-            echo "Found release ID: $RELEASE_ID"
-
-            # Get all assets and delete them
-            ASSETS=$(gh api "repos/$REPO/releases/$RELEASE_ID/assets" --jq '.[].id' 2>/dev/null || echo "")
-
-            for ASSET_ID in $ASSETS; do
-              echo "Deleting asset: $ASSET_ID"
-              gh api -X DELETE "repos/$REPO/releases/assets/$ASSET_ID" || true
-            done
-
-            echo "Cleanup complete"
-          else
-            echo "No existing release found for $TAG, skipping cleanup"
-          fi
-
+  # tauri-action (below) overwrites same-named assets after each successful
+  # build, so re-running a release replaces its assets in place. We deliberately
+  # do NOT pre-delete assets in a separate job: that would strand the release
+  # with zero downloads if any later build step (e.g. notarization) failed.
   publish-tauri:
-    needs: cleanup-release
     # Required permissions to create releases and upload assets
     permissions:
       contents: write


### PR DESCRIPTION
## Context

While diagnosing a macOS notarization 401 on the Whispering release pipeline, re-dispatching `release.whispering.yml` for an existing tag (v7.11.0) **deleted all of that release's published assets and then failed to rebuild them**, leaving the public "Latest" release with zero downloads.

Two root causes, both fixed here:

### 1. `cleanup-release` deleted assets before the build could replace them
The job ran as a prerequisite to `publish-tauri` and unconditionally deleted every asset on the release **before** any build started. If a later build step failed (here: notarization), nothing got re-uploaded and the release was stranded empty.

This pre-delete is also **redundant**: `tauri-action` already overwrites same-named assets (it deletes-then-uploads each asset *after* a successful build, since v0.3.0, verified via DeepWiki). So removing the job restores safe behavior: a failed re-run now leaves existing assets untouched.

### 2. `.nvmrc` lookup broke re-running older tags
`setup-whispering-build` uses `setup-node` with `node-version-file: .nvmrc`. Tags cut before `.nvmrc` was added (e.g. v7.11.0) check out a tree without it, failing setup before the build. Added a fallback that writes a default `.nvmrc` only when absent, so historical tags re-release cleanly.

A note for review:
This does not touch the notarization credential issue (a separate, invalid app-specific password) — that's resolved out-of-band in Infisical.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784085483&installation_id=128463665&pr_number=2013&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2013&signature=b2e957c84ab04d9857775f707f44e5452dddef0a31b43c8d433a0eac28da824e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->