### PR TITLE
ci(whispering): notarize and staple the macOS release DMG

### DIFF
--- a/.github/actions/notarize-whispering-dmg/action.yml
+++ b/.github/actions/notarize-whispering-dmg/action.yml
@@ -1,0 +1,104 @@
+name: Notarize Whispering macOS DMG
+description: >-
+  Notarize, staple, and verify the built macOS .dmg, then replace the draft
+  release's .dmg asset with the stapled copy. tauri-action notarizes and staples
+  the .app but builds the .dmg around it afterwards and only signs that .dmg, so
+  the file users actually download is "Unnotarized Developer ID" and fails
+  Gatekeeper's open assessment until it is notarized in its own right. macOS-only;
+  call it from a step gated on the macOS runner, after tauri-action has built and
+  uploaded the release.
+
+inputs:
+  apple-id:
+    description: 'Apple ID for notarization (APPLE_ID secret).'
+    required: true
+  apple-password:
+    description: 'App-specific password for notarization (APPLE_PASSWORD secret).'
+    required: true
+  apple-team-id:
+    description: 'Apple Developer team ID (APPLE_TEAM_ID secret).'
+    required: true
+  github-token:
+    description: 'Token for the asset replace API calls (GITHUB_TOKEN secret).'
+    required: true
+  release-id:
+    description: "tauri-action's releaseId output: the draft release to replace the asset on."
+    required: true
+  upload-url:
+    description: "tauri-action's releaseUploadUrl output: where to POST the stapled .dmg."
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Notarize, staple, verify, and replace the DMG
+      shell: bash
+      env:
+        APPLE_ID: ${{ inputs.apple-id }}
+        APPLE_PASSWORD: ${{ inputs.apple-password }}
+        APPLE_TEAM_ID: ${{ inputs.apple-team-id }}
+        GH_TOKEN: ${{ inputs.github-token }}
+        RELEASE_ID: ${{ inputs.release-id }}
+        UPLOAD_URL: ${{ inputs.upload-url }}
+      run: |
+        set -euo pipefail
+
+        DMG=$(find apps/whispering/src-tauri/target -path '*/release/bundle/dmg/*.dmg' -type f | head -n1)
+        test -n "$DMG" || { echo "::error::no .dmg bundle found to notarize"; exit 1; }
+        NAME=$(basename "$DMG")
+        echo "Notarizing DMG: $DMG"
+
+        # Notarize the .dmg itself. tauri-action already notarized and stapled the
+        # .app inside it; this makes the wrapper users download pass Gatekeeper too.
+        xcrun notarytool submit "$DMG" \
+          --apple-id "$APPLE_ID" \
+          --password "$APPLE_PASSWORD" \
+          --team-id "$APPLE_TEAM_ID" \
+          --wait
+
+        xcrun stapler staple "$DMG"
+
+        echo "::group::Validate staple"
+        xcrun stapler validate -v "$DMG"
+        echo "::endgroup::"
+
+        echo "::group::Gatekeeper open assessment (the downloaded DMG)"
+        spctl -a -vvv -t open --context context:primary-signature "$DMG"
+        echo "::endgroup::"
+
+        # Verify the .app inside the DMG by mounting read-only; always detach.
+        echo "::group::Gatekeeper execute assessment (the app inside the DMG)"
+        MOUNT_DIR=$(mktemp -d)
+        cleanup() { hdiutil detach "$MOUNT_DIR" -quiet >/dev/null 2>&1 || true; rm -rf "$MOUNT_DIR" || true; }
+        trap cleanup EXIT
+        hdiutil attach "$DMG" -nobrowse -readonly -mountpoint "$MOUNT_DIR"
+        APP=$(find "$MOUNT_DIR" -maxdepth 1 -name '*.app' -type d | head -n1)
+        test -n "$APP" || { echo "::error::no .app found inside DMG"; exit 1; }
+        spctl -a -vvv -t execute "$APP"
+        echo "::endgroup::"
+
+        # Replace the draft's signed-but-unstapled DMG with the stapled copy.
+        # We address the release by its id and post to its upload URL (both from
+        # tauri-action's outputs) rather than by tag: `gh release upload <tag>`
+        # resolves tags via GET /releases/tags/<tag>, which 404s for drafts, and
+        # its --clobber deletes-then-uploads non-atomically. Deleting the old
+        # asset by id and posting the new one is unambiguous on a draft.
+        #
+        # latest.json references the .app.tar.gz updater bundle, not the .dmg, so
+        # replacing the .dmg leaves updater metadata and signatures untouched.
+        echo "Replacing asset '$NAME' on release $RELEASE_ID"
+        ASSET_ID=$(gh api --paginate "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets" \
+          --jq ".[] | select(.name == \"$NAME\") | .id")
+        if [ -n "$ASSET_ID" ]; then
+          echo "Deleting tauri-action's unstapled asset (id $ASSET_ID)"
+          gh api -X DELETE "repos/$GITHUB_REPOSITORY/releases/assets/$ASSET_ID"
+        fi
+
+        # releaseUploadUrl carries an RFC 6570 template suffix ({?name,label}); strip it.
+        UPLOAD="${UPLOAD_URL%%\{*}"
+        echo "Uploading stapled DMG to $UPLOAD"
+        curl -fSL --retry 3 -X POST "$UPLOAD?name=$NAME" \
+          -H "Authorization: Bearer $GH_TOKEN" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          -H "Content-Type: application/octet-stream" \
+          --data-binary @"$DMG"

--- a/.github/actions/notarize-whispering-dmg/action.yml
+++ b/.github/actions/notarize-whispering-dmg/action.yml
@@ -66,16 +66,11 @@ runs:
         spctl -a -vvv -t open --context context:primary-signature "$DMG"
         echo "::endgroup::"
 
-        # Verify the .app inside the DMG by mounting read-only; always detach.
-        echo "::group::Gatekeeper execute assessment (the app inside the DMG)"
-        MOUNT_DIR=$(mktemp -d)
-        cleanup() { hdiutil detach "$MOUNT_DIR" -quiet >/dev/null 2>&1 || true; rm -rf "$MOUNT_DIR" || true; }
-        trap cleanup EXIT
-        hdiutil attach "$DMG" -nobrowse -readonly -mountpoint "$MOUNT_DIR"
-        APP=$(find "$MOUNT_DIR" -maxdepth 1 -name '*.app' -type d | head -n1)
-        test -n "$APP" || { echo "::error::no .app found inside DMG"; exit 1; }
-        spctl -a -vvv -t execute "$APP"
-        echo "::endgroup::"
+        # We assert only on the .dmg here, the wrapper this action notarizes and
+        # staples. The .app inside it is notarized and stapled by tauri-action
+        # upstream and untouched here, so verifying it would test an invariant we
+        # don't own. The README documents the full manual check (mount + spctl
+        # execute) for a human doing a post-release sanity pass.
 
         # Replace the draft's signed-but-unstapled DMG with the stapled copy.
         # We address the release by its id and post to its upload URL (both from

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -26,6 +26,23 @@ Web apps (Cloudflare Workers) deploy **together in one workflow** because deploy
 | `release.whispering.yml` | `v*` tags, manual | Builds Whispering for 3 platforms, publishes to GitHub Releases as draft. Includes code signing, notarization, and release notes from `docs/release-notes/`. |
 | `pr-preview.whispering.yml` | Pull requests | Builds Whispering for 3 platforms, uploads as PR artifacts. Cancels previous builds via concurrency groups. |
 
+#### macOS release invariant: the `.app` and the `.dmg` must both be notarized
+
+`tauri-action` notarizes and staples the `.app`, then builds the `.dmg` around it and only signs that `.dmg`. So the file users download (the `.dmg`) is "Unnotarized Developer ID" and fails Gatekeeper's open check even though the app inside it passes. The `notarize-whispering-dmg` action closes that gap: after `tauri-action` uploads, it notarizes, staples, and verifies the `.dmg`, then replaces the draft's asset with the stapled copy. It addresses the draft by the `releaseId` and `releaseUploadUrl` that `tauri-action` outputs, not by tag, because `gh release upload <tag>` resolves tags through an endpoint that 404s for drafts. Because the release is a draft, no one can download the unstapled file first, and because `latest.json` references the `.app.tar.gz` updater bundle rather than the `.dmg`, replacing the `.dmg` leaves the updater signature untouched.
+
+Both of these must pass on a release `.dmg` (run against the exact uploaded file, not a local rebuild):
+
+```bash
+xcrun stapler validate -v Whispering_*.dmg
+spctl -a -vvv -t open --context context:primary-signature Whispering_*.dmg   # accepted, Notarized Developer ID
+```
+
+And the app inside it must still pass once the `.dmg` is mounted:
+
+```bash
+spctl -a -vvv -t execute /Volumes/Whispering/Whispering.app                  # accepted, Notarized Developer ID
+```
+
 ### Web Deployment (Cloudflare Workers)
 
 | File | Trigger | What it does |

--- a/.github/workflows/release.whispering.yml
+++ b/.github/workflows/release.whispering.yml
@@ -99,7 +99,8 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       # Main Tauri build and release action
-      - uses: tauri-apps/tauri-action@v0
+      - id: tauri-build
+        uses: tauri-apps/tauri-action@v0
         env:
           # Set CI environment variable to help with DMG bundling
           CI: true
@@ -149,6 +150,25 @@ jobs:
 
           # Platform-specific build arguments (e.g., --target for macOS)
           args: ${{ matrix.tauriArgs }}
+
+      # tauri-action notarizes and staples the .app but only signs the .dmg it
+      # wraps around it afterwards, so the downloaded .dmg is "Unnotarized
+      # Developer ID" and fails Gatekeeper's open assessment. This notarizes,
+      # staples, and verifies the .dmg itself, then replaces the draft's asset
+      # with the stapled copy before anyone can publish or download it. The
+      # release id and upload URL come from the tauri-build step's outputs so the
+      # asset swap addresses the draft directly instead of resolving it by tag.
+      # @main rather than ./ for the same reason as the setup action above.
+      - name: Notarize Whispering DMG (macOS only)
+        if: ${{ matrix.os == 'macos' }}
+        uses: EpicenterHQ/epicenter/.github/actions/notarize-whispering-dmg@main
+        with:
+          apple-id: ${{ secrets.APPLE_ID }}
+          apple-password: ${{ secrets.APPLE_PASSWORD }}
+          apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          release-id: ${{ steps.tauri-build.outputs.releaseId }}
+          upload-url: ${{ steps.tauri-build.outputs.releaseUploadUrl }}
 
       # @main rather than ./ for the same reason as the setup action above.
       - name: Process AppImage (Linux only)


### PR DESCRIPTION
The macOS DMG users download fails Gatekeeper. `tauri-action` notarizes and staples the `.app`, then builds the `.dmg` around it and only signs that DMG. So `Whispering_*_aarch64.dmg` is "Unnotarized Developer ID" and `spctl` rejects it on open, even though the app inside passes once the DMG is mounted. v7.11.0 shipped this way:

```
xcrun stapler validate -v Whispering_7.11.0_aarch64.dmg
# does not have a ticket stapled to it
spctl -a -vvv -t open --context context:primary-signature Whispering_7.11.0_aarch64.dmg
# rejected  source=Unnotarized Developer ID
```

This adds a macOS-only `notarize-whispering-dmg` action that runs after `tauri-action` and notarizes the DMG in its own right: `notarytool submit --wait`, `stapler staple`, then verification (`stapler validate`, `spctl -t open`, and mounting the DMG read-only to `spctl -t execute` the inner app, always detaching). It then replaces the draft's DMG asset with the stapled copy.

The asset swap addresses the draft by `tauri-action`'s `releaseId` and `releaseUploadUrl` outputs, not by tag. `gh release upload <tag>` resolves the tag through `GET /releases/tags/<tag>`, which 404s for draft releases, so the by-id path is the reliable one and also avoids `--clobber`'s non-atomic delete-then-upload.

The reason for this shape is:

The release is a draft, so no one can download the signed-but-unstapled DMG before the swap. `latest.json` references the `.app.tar.gz` updater bundle and its `.sig`, never the `.dmg`, so replacing the DMG leaves the updater signature and metadata untouched. And nothing pre-deletes assets (no `cleanup-release`): `tauri-action` overwrites in place and the by-id replace removes only the one stale DMG, so a failed build never strands a published release.

The action is referenced `@main` like the existing setup and AppImage actions, so re-releasing an older tag resolves the current logic. It lands on `main` before it can run; the first release after merge exercises it against a draft, which a maintainer reviews before publishing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784091335&installation_id=128463665&pr_number=2016&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2016&signature=2fd9be174612500f8ee82be8b9c0b471dc583327b28c4583c552726db14cff27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->