### PR TITLE
refactor(whispering): drive SettingSelect over any typed store

### DIFF
--- a/apps/whispering/src/lib/components/settings/SettingSelect.svelte
+++ b/apps/whispering/src/lib/components/settings/SettingSelect.svelte
@@ -1,26 +1,30 @@
-<script lang="ts" generics="K extends SelectSettingKey">
+<script lang="ts" generics="V extends string | number, K extends string">
 	import * as Field from '@epicenter/ui/field';
 	import * as Select from '@epicenter/ui/select';
-	// Bound to the synced workspace `settings` store by design. Device-local
-	// selects (bitrate, sample rate on the recording page) stay bespoke on
-	// purpose: `deviceConfig` is a separate store with its own value map, and
-	// generalizing this component over both stores costs far more in generic
-	// machinery than the handful of duplicated `<Select.Root>` blocks it saves.
-	import {
-		type SelectSettingKey,
-		type SettingValue,
-		settings,
-	} from '$lib/state/settings.svelte';
 
+	// Drives one typed dropdown over whatever store is passed: the synced
+	// workspace `settings` or the device-local `deviceConfig`. Both expose the
+	// same `get(key)`/`set(key, value)` shape, so one component covers both. The
+	// store is an explicit prop, not a default, so each call site states where
+	// its value lives.
 	let {
+		store,
 		key,
 		label,
 		items,
 		description,
 	}: {
+		// `NoInfer` keeps the store from driving inference: `K` comes from `key`
+		// and `V` from `items`, and the store is only checked against them. Without
+		// it, the store's full key union and value union (which includes `null` and
+		// `boolean` keys) pollute `K`/`V` and the component stops type-checking.
+		store: {
+			get(key: NoInfer<K>): NoInfer<V>;
+			set(key: NoInfer<K>, value: NoInfer<V>): void;
+		};
 		key: K;
 		label: string;
-		items: readonly { value: SettingValue<K>; label: string }[];
+		items: readonly { value: V; label: string }[];
 		description?: string;
 	} = $props();
 
@@ -28,7 +32,7 @@
 	const id = $props.id();
 
 	const selectedLabel = $derived(
-		items.find((item) => item.value === settings.get(key))?.label,
+		items.find((item) => item.value === store.get(key))?.label,
 	);
 </script>
 
@@ -37,12 +41,12 @@
 	<Select.Root
 		type="single"
 		bind:value={
-			() => String(settings.get(key)),
+			() => String(store.get(key)),
 			(value) => {
 				// bits-ui Select is string-valued; the items list is the source of
-				// truth for mapping the string form back to the typed setting value.
+				// truth for mapping the string form back to the typed value.
 				const match = items.find((item) => String(item.value) === value);
-				if (match) settings.set(key, match.value);
+				if (match) store.set(key, match.value);
 			}
 		}
 	>

--- a/apps/whispering/src/lib/state/settings.svelte.ts
+++ b/apps/whispering/src/lib/state/settings.svelte.ts
@@ -18,20 +18,6 @@ export type BooleanSettingKey = {
 	[K in keyof SettingsValues]: SettingsValues[K] extends boolean ? K : never;
 }[keyof SettingsValues];
 
-/** The stored value type for a given setting key. */
-export type SettingValue<K extends keyof SettingsValues> = SettingsValues[K];
-
-/**
- * Setting keys whose stored value is a string or number: the keys a
- * `<SettingSelect>` can drive from a list of options. Boolean keys use
- * `<SettingSwitch>`; nullable and object-valued keys are not plain dropdowns.
- */
-export type SelectSettingKey = {
-	[K in keyof SettingsValues]: SettingsValues[K] extends string | number
-		? K
-		: never;
-}[keyof SettingsValues];
-
 function createSettings() {
 	const map = new SvelteMap<string, unknown>();
 

--- a/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
@@ -29,13 +29,15 @@
 		}
 	});
 
-	const maxRecordingItems = [
+	// Values stay `number` (not literals): `retention.maxCount` is a
+	// `field.integer`, so SettingSelect infers its value type from these options.
+	const maxRecordingItems: { value: number; label: string }[] = [
 		{ value: 5, label: '5 Recordings' },
 		{ value: 10, label: '10 Recordings' },
 		{ value: 25, label: '25 Recordings' },
 		{ value: 50, label: '50 Recordings' },
 		{ value: 100, label: '100 Recordings' },
-	] as const;
+	];
 
 	// Autostart is Tauri-only; on web `tauri` is null and the query stays
 	// disabled (default value `false`).
@@ -131,6 +133,7 @@
 		<Field.Separator />
 
 		<SettingSelect
+			store={settings}
 			key="retention.strategy"
 			label="Auto Delete Recordings"
 			items={retentionItems}
@@ -139,6 +142,7 @@
 
 		{#if settings.get('retention.strategy') === 'limit-count'}
 			<SettingSelect
+				store={settings}
 				key="retention.maxCount"
 				label="Maximum Recordings"
 				items={maxRecordingItems}
@@ -173,6 +177,7 @@
 				/>
 			</Field.Field>
 			<SettingSelect
+				store={settings}
 				key="ui.alwaysOnTop"
 				label="Always On Top"
 				items={ALWAYS_ON_TOP_MODE_OPTIONS}

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
@@ -3,7 +3,6 @@
 	import { Button } from '@epicenter/ui/button';
 	import * as Field from '@epicenter/ui/field';
 	import { Link } from '@epicenter/ui/link';
-	import * as Select from '@epicenter/ui/select';
 	import InfoIcon from '@lucide/svelte/icons/info';
 	import { createMutation } from '@tanstack/svelte-query';
 	import { mutationOptions } from 'wellcrafted/query';
@@ -24,19 +23,6 @@
 	import ManualSelectRecordingDevice from './ManualSelectRecordingDevice.svelte';
 	import VadSelectRecordingDevice from './VadSelectRecordingDevice.svelte';
 
-	// Derived labels for select triggers
-	const sampleRateLabel = $derived(
-		SAMPLE_RATE_OPTIONS.find(
-			(o) => o.value === deviceConfig.get('recording.cpal.sampleRate'),
-		)?.label,
-	);
-
-	const bitrateLabel = $derived(
-		BITRATE_OPTIONS.find(
-			(o) => o.value === deviceConfig.get('recording.navigator.bitrateKbps'),
-		)?.label,
-	);
-
 	const exportMarkdown = createMutation(() =>
 		mutationOptions({
 			mutationKey: ['recordings', 'exportMarkdown'],
@@ -55,6 +41,7 @@
 	<Field.Separator />
 	<Field.Group>
 		<SettingSelect
+			store={settings}
 			key="recording.mode"
 			label="Recording Mode"
 			items={RECORDING_MODE_OPTIONS}
@@ -166,57 +153,21 @@
 
 		{#if settings.get('recording.mode') === 'manual'}
 			{#if !tauri}
-				<Field.Field>
-					<Field.Label for="bit-rate">Bitrate</Field.Label>
-					<Select.Root
-						type="single"
-						bind:value={() => deviceConfig.get('recording.navigator.bitrateKbps'),
-							(selected) => {
-								if (selected)
-									deviceConfig.set(
-										'recording.navigator.bitrateKbps',
-										selected,
-									);
-							}}
-					>
-						<Select.Trigger id="bit-rate" class="w-full">
-							{bitrateLabel ?? 'Select a bitrate'}
-						</Select.Trigger>
-						<Select.Content>
-							{#each BITRATE_OPTIONS as item}
-								<Select.Item value={item.value} label={item.label} />
-							{/each}
-						</Select.Content>
-					</Select.Root>
-					<Field.Description>
-						The bitrate of the recording. Higher values mean better quality but
-						larger file sizes.
-					</Field.Description>
-				</Field.Field>
+				<SettingSelect
+					store={deviceConfig}
+					key="recording.navigator.bitrateKbps"
+					label="Bitrate"
+					items={BITRATE_OPTIONS}
+					description="The bitrate of the recording. Higher values mean better quality but larger file sizes."
+				/>
 			{:else}
-				<Field.Field>
-					<Field.Label for="sample-rate">Sample Rate</Field.Label>
-					<Select.Root
-						type="single"
-						bind:value={() => deviceConfig.get('recording.cpal.sampleRate'),
-							(selected) => {
-								if (selected)
-									deviceConfig.set('recording.cpal.sampleRate', selected);
-							}}
-					>
-						<Select.Trigger id="sample-rate" class="w-full">
-							{sampleRateLabel ?? 'Select sample rate'}
-						</Select.Trigger>
-						<Select.Content>
-							{#each SAMPLE_RATE_OPTIONS as item}
-								<Select.Item value={item.value} label={item.label} />
-							{/each}
-						</Select.Content>
-					</Select.Root>
-					<Field.Description>
-						Higher sample rates provide better quality but create larger files
-					</Field.Description>
-				</Field.Field>
+				<SettingSelect
+					store={deviceConfig}
+					key="recording.cpal.sampleRate"
+					label="Sample Rate"
+					items={SAMPLE_RATE_OPTIONS}
+					description="Higher sample rates provide better quality but create larger files"
+				/>
 			{/if}
 		{/if}
 	</Field.Group>


### PR DESCRIPTION
Recording settings had one remaining split after #2012: synced settings used `SettingSelect`, but device-local bitrate and sample-rate stayed hand-built. That made the recording page repeat the same `Select` markup while giving the local controls weaker typing than the shared component.

This turns `SettingSelect` into a typed adapter over any store with the same `get(key)` / `set(key, value)` shape. Each call site now says where the value lives, while `items` and `key` still infer the value/key pair:

```svelte
<SettingSelect
  store={deviceConfig}
  key="audioBitrate"
  items={audioBitrateItems}
/>
```

`NoInfer` keeps the store from widening that contract. With the store passed explicitly, the synced settings page keeps using `settings`, and the recording page can render bitrate and sample rate through the same component over `deviceConfig`.

One type cleanup came along for the ride: `maxRecordingItems` now widens to `{ value: number }[]` to match the integer field boundary. The old component already treated those item values as numbers, so this is not a behavior change.