### PR TITLE
docs(specs): trusted-relay and collaborative child docs design

### DIFF
--- a/specs/20260614T160000-zero-knowledge-relay-and-collaborative-fields.md
+++ b/specs/20260614T160000-zero-knowledge-relay-and-collaborative-fields.md
@@ -1,0 +1,506 @@
+# Zero-Knowledge Relay and Collaborative Fields
+
+**Date**: 2026-06-14
+**Status**: Draft
+**Owner**: Braden (workspace platform)
+**Branch**: TBD
+**Supersedes**: none (the cell-vs-row storage debate is absorbed and dissolved here, see Design Decisions)
+
+## One Sentence
+
+Every Yjs update is encrypted on the client before it touches disk or the network, the relay becomes a zero-knowledge **permanent append-only log** of opaque blobs (bounded by client-side flush coalescing and an optional non-destructive checkpoint cache, never by client-commanded deletion), and a row's collaborative fields (`field.richText()`, `field.text()`) are declared in the table schema instead of hand-wired per app.
+
+## How to read this spec
+
+```txt
+Read first:
+  One Sentence
+  Motivation (Current State + Problems)
+  Target Shape
+  The trilemma
+  Implementation Plan
+  Success Criteria
+
+Read if changing the architecture:
+  Research Findings
+  Design Decisions
+  The field.* catalog
+  Edge Cases
+
+Skip:
+  nothing is historical yet; this is a fresh design
+```
+
+This is a **clean break**. There is no migration plan and no compatibility path. Existing on-disk and on-relay data is disposable. Do not write dual-read code, versioned envelopes, or fallback branches to preserve old formats.
+
+## Overview
+
+Today body content (rich text) syncs to the cloud relay in plaintext while metadata is encrypted, the relay carries a full server-side Yjs merge brain, and each app hand-wires encryption, persistence, sync, and child-doc lifecycle in its own `.browser.ts`. This spec collapses all of that: one client-side encryption boundary for every update, a dumb relay, and a schema that declares collaborative fields so the workspace owns their entire lifecycle.
+
+## Motivation
+
+### Current State
+
+Three encryption behaviors coexist, and which one a doc gets is an emergent property of how an app bolts primitives together:
+
+| Path | Local IndexedDB | Relay (cloud) |
+| --- | --- | --- |
+| Root/metadata doc | encrypted | **encrypted** (value-level, in-doc ciphertext) |
+| Body child-doc | **encrypted** (`attachEncryptedIndexedDb`) | **PLAINTEXT** |
+
+Metadata encrypts at the value level inside `createEncryptedYkvLww` (`packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts:211`), so the relay receives ciphertext. Body docs are plain `Y.Doc`s holding a `Y.XmlFragment` (`packages/workspace/src/document/attach-rich-text.ts:31`); local disk is encrypted by `attachEncryptedIndexedDb` (`packages/workspace/src/document/attach-encrypted-indexed-db.ts:175`), but `openCollaboration` ships the raw `updateV2` bytes to the relay untouched (`packages/workspace/src/document/internal/sync-supervisor.ts:233`).
+
+The relay is a smart Yjs merge brain: it holds a live `Y.Doc` (`packages/server/src/room/core.ts:175`), replays every update on cold start (`core.ts:199-201`), serves state-vector diffs, and compacts server-side via `Y.encodeStateAsUpdateV2` (`core.ts:738`).
+
+Row deletion is four lines (`packages/workspace/src/document/table.ts:950`) calling `ykv.delete(id)` (`packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.ts:727`). It removes the row from the root CRDT and nothing else.
+
+This creates problems:
+
+1. **Body content is plaintext on the relay.** The actual thing users write is encrypted on their own disk but readable by the server they are told not to trust. This directly contradicts the login-only / server-trusted-encryption product promise.
+2. **The invariant has no owner.** "Is my data safe end to end" is smeared across ~40 lines of per-app `.browser.ts` wiring (`apps/fuji/src/lib/workspace/browser.ts:80`, `apps/honeycrisp/honeycrisp.browser.ts:58`), replicated per app, checked nowhere. Bodies leak because `openCollaboration` will sync anything handed to it.
+3. **Deletion orphans bodies forever.** A hard delete leaves the body child-doc's IndexedDB store on disk and its Durable Object on the relay indefinitely. `packages/server/src/routes/rooms.ts` has no DELETE verb; no sweep exists.
+4. **The materializer relies on a side effect.** A body edit reaches the vault projection only as a side effect of the `updatedAt` bump, an unnamed load-bearing invariant.
+
+### Desired State
+
+```ts
+// A body is a declared FIELD of the row, not a free-floating GUID-joined sibling doc.
+const fuji = defineWorkspace({
+  id: 'epicenter-fuji',
+  tables: {
+    entries: defineTable({
+      title:  field.string(),        // scalar: opaque cell in the row
+      pinned: field.boolean(),       // scalar: opaque cell in the row
+      body:   field.richText(),      // collaborative: own child doc, character merge
+      code:   field.text(),          // collaborative: Y.Text (code.txt / plaintext)
+    }),
+  },
+});
+
+// Keyring required. Plaintext sync is unrepresentable.
+const ws = await openWorkspace(fuji, { auth, transport: relay });
+
+using body = ws.entries.open(id).body;   // lazy, character-merged, encrypted
+body.observe(render);
+
+ws.entries.delete(id);  // cascades: disposes the body doc, clears its IDB, drops the relay room
+```
+
+## The trilemma
+
+For any synced collaborative field you can have at most two of three:
+
+```txt
+        smart relay (server merges + compacts)
+              /                    \
+   character-level merge  ───  encrypted content
+   (real-time collab text)      (relay can't read it)
+```
+
+- smart relay + character merge -> **plaintext content** (today, the bug)
+- smart relay + encrypted content -> **no character merge** (whole-blob LWW; rejected, see below)
+- character merge + encrypted content -> **dumb relay** (this spec)
+
+Key correction that drives the whole design: **character-level merge happens on clients, not the server.** Two devices converge as long as something shuttles their updates. The server being smart is only an optimization (delta sync + server compaction), not a requirement for collaboration. So choosing the dumb-relay corner keeps collaboration fully intact and costs only server-side optimizations, which clients can replace.
+
+## Research Findings
+
+### Yjs merge is structural; values are opaque (grounded in yjs/yjs)
+
+- CRDT merge (`Y.applyUpdate`, `Y.mergeUpdatesV2`) operates on item IDs, clocks, and client IDs. It never interprets stored values. A `Uint8Array` becomes a `ContentBinary` item treated as atomic, so a relay can merge and compact a doc full of encrypted blob values without decrypting. Yjs ships `Y.obfuscateUpdate` (replaces content, keeps merge metadata), proving this is intended.
+- `Y.Text` / `Y.XmlFragment` require the inserted content to be real text/structure for character-level merge. You **cannot** store rich text as one opaque blob and keep character merge.
+
+**Implication**: scalar fields can be opaque encrypted blobs even on a smart relay. Rich text cannot; encrypting it forces a dumb relay (clients hold the live CRDT, the wire/disk carries ciphertext deltas).
+
+### Compaction primitives and the delete-set guarantee (grounded in yjs/yjs)
+
+- `Y.encodeStateAsUpdateV2` preserves the **delete set** (`writeIdSet(encoder, doc.store.ds)`). An offline peer that missed a deletion gets the delete set in the snapshot and re-marks items deleted via `readAndApplyDeleteSet`. Deletions are state-based; dropping old updates and keeping only the snapshot does **not** resurrect deleted content.
+- Updates and snapshots are commutative and idempotent ("apply in any order, multiple times"). Overlapping snapshots from two devices converge; double-apply is filtered via `ss.exclude(knownState)`.
+- `Y.mergeUpdatesV2` merges blobs without a `Y.Doc` (but still must read them, so only a decrypting client can run it).
+
+### Garbage collection hazard (grounded in yjs/yjs)
+
+- With `gc:true`, deleted content becomes lightweight GC markers (id + length, no content). A peer offline **across** a deletion+GC whose old update references GC'd items can hit ambiguous integration. Yjs forbids `createDocFromSnapshot` on gc:true docs for this reason.
+- That forbidden API is the **versioning** path, not our compaction path. Our path (`encodeStateAsUpdate` + `applyUpdate`) is the normal sync path, which y-indexeddb runs on gc:true docs in production. Routine offline windows are safe; only pathological long-offline-across-GC is at risk.
+
+### Client-side compaction is proven; the relay never deletes on a client's word (grounded in yjs/y-indexeddb)
+
+y-indexeddb stores each update as a record and, at `PREFERRED_TRIM_SIZE = 500`, calls `Y.encodeStateAsUpdate`, writes one consolidated record, deletes the old ones (`_dbsize` collapses to 1). This is the client's *local-disk* compaction and it already runs in `attachEncryptedIndexedDb`. We reuse the exact same snapshot computation for the relay, but as a **non-destructive checkpoint cache**: the client uploads `(snapshot, asOfSeq)`, the relay keeps the newest and serves `checkpoint + after(asOfSeq)` on cold start. The raw append log remains ground truth; the checkpoint is a safely-ignorable optimization. The relay never deletes raw blobs because a client told it to (it cannot decrypt to verify the claim); any reclamation is an operator-policy decision (see Architecture).
+
+### Yjs GC is not relay compaction (grounded in yjs/yjs)
+
+`gc:true` shrinks deleted *content inside one doc's struct store* (deleted items become id+length GC markers). It has **no effect on the count of update blobs** the relay stores. The two are orthogonal: relay storage is bounded by flush coalescing + checkpoints + optional operator reclaim, never by `gc`.
+
+### Cost grounding: append-only on Cloudflare SQLite Durable Objects (grounded in Cloudflare docs)
+
+Billing (live Jan 2026), one Durable Object per doc, one row per flushed blob:
+
+| Lever | Rate | Free tier (account-wide, shared across all users) |
+| --- | --- | --- |
+| Rows written | $1.00 / million | first 50M / month |
+| Rows read | $0.001 / million | first 25 billion / month |
+| Stored data | $0.20 / GB-month | first 5 GB-month |
+| Max storage per DO | 10 GB hard cap | per doc/room |
+
+Facts that shape the design:
+
+- **Cost is driven by edit-*event* count, not content size.** Each flushed update is one permanent row; a 1 KB note edited 100k times is 100k rows. The tail concentrates in streamed editing (transcription, AI completions written into a `field.*`), which produces updates 10-50x faster than human typing.
+- **Writes and reads are effectively free at single-user scale and small at fleet scale.** Writes are design-neutral (you pay per live update regardless of compaction); reads stay under the vast free tier until very large scale.
+- **Storage is the only term that compounds.** The free tier is per *account*, not per user, so it divides by user count. At ~5,000 users (blended ~30k updates/user/month) the fleet adds ~20 GB/month and storage runs roughly $300 (year 1) climbing past $1,400 (year 3) and rising every year under pure append-only. Trivial against revenue, but it never stops growing, and streamed editing accelerates it.
+- **The per-doc 10 GB cap is ~40 years of human typing but can shrink to ~2 years on a hot streamed doc.**
+
+Implication: append-only is free-ish for a launch window and never needs *client-commanded* deletion, but at fleet scale or with heavy streaming you eventually want operator-policy reclaim. Flush coalescing attacks the root cause (event count) before any compaction is needed.
+
+### Comparable trust models
+
+| System | Server reads content? | Merge model | Server can forge? | Notes |
+| --- | --- | --- | --- | --- |
+| Bitwarden | no | whole-item replace (no CRDT) | no | comparable for scalar fields |
+| Signal (libsignal) | no | E2E message log | no | comparable for the append-log shape, not doc sync |
+| Jazz | no | E2E CRDTs over a relay | no | directional comparable; verify compaction specifics before leaning on them |
+
+**Key finding**: "E2E content + metadata-leaky + availability-trusting" is a recognized, defensible tier (Bitwarden lives there). We are not inventing a weaker model; we are reaching that tier for the first time.
+
+## Design Decisions
+
+| Decision | Class | Choice | Rationale |
+| --- | --- | --- | --- |
+| Relay topology | 2 coherence | Dumb zero-knowledge append-only log | Encryption forces opaque updates the server cannot merge; collaboration is client-side anyway |
+| Encryption layer | 1 evidence | Encrypt the Yjs update blob at the transport boundary | `attachEncryptedIndexedDb:175` already does this for disk; extend the same wrapper to the relay channel |
+| Encryption scheme | 2 coherence | One scheme (XChaCha20-Poly1305 over the update blob) for all docs | Retire value-level `createEncryptedYkvLww`; relay-compaction was its only advantage and the relay no longer compacts |
+| Flush granularity | 1 evidence | Client debounces + `mergeUpdatesV2` before encrypting/sending | Decouples relay row rate from keystroke/token rate at the source; the primary, zero-trust cost lever, esp. for streamed editing |
+| Storage bounding | 2 coherence | Non-destructive checkpoint cache + optional operator-policy reclaim; never client-commanded deletion | Client uploads `(snapshot, asOfSeq)`; relay keeps newest as a safely-ignorable cache; only the operator deletes raw blobs, on its own retention timer, reusing the snapshot trust local disk already extends |
+| GC mode | 3 taste | `gc:true` on client docs; offline hazard bounded by the always-retained raw log (and an operator retention window where reclaim is enabled) | Matches Yjs default and y-indexeddb; under append-only the raw log itself is the safety net |
+| Collaborative fields | 2 coherence | Declared in schema (`field.richText()`, `field.text()`); workspace owns the child doc | Promotes ~40 lines of per-app wiring into the schema; makes delete-cascade structural |
+| Body merge for rich text | 1 evidence | Character-level CRDT (kept) | User requirement: collaborative editing of a body/code field is load-bearing for Honeycrisp/Opensidian |
+| AAD binding | 2 coherence | AAD = docGuid + key version per blob | Prevents cross-room splicing and replay |
+| Auth vs encryption | 2 coherence | Two layers: relay authenticates access, keyring (never sent) gates readability | Makes the untrusted-relay promise honest |
+| Privacy target | 3 taste | L2 (content + schema hidden); room-name hashing (L3) deferred | Room names still leak collection/rowId; closing it is a cheap rider, not load-bearing now |
+| Rollback resistance | Deferred | Deferred (signed monotonic checkpoint / hash chain) | AEAD already blocks forgery; rollback/withholding is an availability-trust concern acceptable for a notes app initially |
+| Cell-vs-whole-row storage | 2 coherence | Dissolved: it is now a pure client-side Yjs-type choice the relay never sees | With a dumb relay, merge granularity has no server consequence; declare per field in schema |
+
+### What was considered and rejected
+
+| Candidate | Why rejected |
+| --- | --- |
+| Approach P: body as opaque blob in a table cell | Loses character-level merge (whole-blob LWW); user requires collaborative body editing |
+| Keep smart relay, value-encrypt bodies | Value-level encryption fits rich text terribly (leaks edit positions, structure, lengths) and cannot character-merge an opaque value |
+| Two relay modes (smart for metadata, dumb for bodies) | "Two ways to do the same thing" carved into the foundation; once the dumb path exists, unifying on it deletes the server brain |
+| Homomorphic / secure merge on server | Research-grade; infinite build cost for a win client checkpointing already provides |
+| Server-side compaction retained | Server cannot compact ciphertext it cannot read; clients compact instead |
+| Client-commanded destructive compaction ("delete raw updates <= N") | Hands an unverifiable client a delete trigger on data the relay cannot read; replaced by a non-destructive checkpoint cache + operator-policy reclaim |
+| Migration / dual-read | Explicitly out of scope; clean break |
+
+## The field.* catalog
+
+```ts
+// Scalar fields: stored as the row's value (opaque to the relay), structural/LWW merge
+field.string<TBrand?>(s?)     // text
+field.number(s?)              // real
+field.integer(s?)             // integer
+field.boolean()              // 0/1
+field.select([...])          // enumerated text
+field.json<S>(schema)        // JSON-encoded value
+
+// Collaborative fields: own lazy child doc, character-level CRDT merge, encrypted deltas
+field.richText()             // Y.XmlFragment (Tiptap/ProseMirror rich body)
+field.text()                 // Y.Text (plaintext / code.txt)
+```
+
+A collaborative field declares: the field is backed by a child doc whose guid derives from `(workspaceId, collection, rowId, fieldName)`; the workspace owns its creation, encryption, sync, disposal, and delete-cascade.
+
+## Architecture
+
+### Encryption boundary (one place, every update)
+
+```txt
+client edit
+  -> Y.Doc updateV2 (plaintext CRDT delta, in client memory)
+    -> encrypt(blob, keyring, aad = docGuid + keyVersion)     <-- the single boundary
+      -> attachEncryptedIndexedDb (local)   AND   relay channel (network)
+relay: stores opaque blob, assigns monotonic seq, fans out to peers. Never decrypts.
+peer:  receives blob -> decrypt -> applyUpdateV2 -> Yjs merges (char-level for rich text)
+```
+
+The relay never imports Yjs for room storage. It is: append-blob, serve-blobs-after-seq-N, accept-checkpoint, GC-before-checkpoint, DELETE-room.
+
+### Storage bounding: a zero-trust escalation ladder
+
+The raw append log is permanent ground truth. Bound its growth with the cheapest rung that suffices; everything except the last rung has no trust surface.
+
+```txt
+Rung 0  flush coalescing (client, free, no trust)
+  client buffers updates ~500ms, Y.mergeUpdatesV2 -> one blob -> encrypt -> send
+  turns a 2,000-token stream into a few dozen rows instead of 2,000
+
+Rung 1  non-destructive checkpoint cache (client, ~free, no trust)
+  snapshot = Y.encodeStateAsUpdateV2(localDoc)   // delete set included
+  upload (encrypt(snapshot), asOfSeq)
+  relay keeps the NEWEST checkpoint; deletes nothing
+  new device: download checkpoint + after(asOfSeq) -> decrypt -> apply
+  if a checkpoint is wrong, relay falls back to full replay (raw log still there)
+
+Rung 2  operator-policy reclaim (operator, the ONLY deletion, off by default)
+  operator's own timer deletes raw blobs <= newest-checkpoint.asOfSeq
+    older than a retention window
+  not client-commanded; trust == the same encodeStateAsUpdateV2 already
+    trusted for local-disk compaction; retention window is the backstop
+  enable per-deployable only when storage bills enough to care
+```
+
+The relay's surface stays: append-blob, serve-after-seq, accept-checkpoint, DELETE-room, and (operator-only) reclaim-before-checkpoint. It never decrypts and never deletes on a client's instruction.
+
+### Lifecycle ownership
+
+```txt
+row (schema declares its collaborative fields)
+  owns -> body child doc creation (lazy, via createDisposableCache)
+  owns -> encryption on every channel (keyring)
+  owns -> sync (dumb relay)
+  owns -> disposal (refcount + grace)
+  owns -> delete cascade: clearLocal() + relay DELETE room
+```
+
+### Transport and liveness (two channels, two backends)
+
+Liveness and storage cost are different channels with different latency budgets; do not force one stream to serve both.
+
+```txt
+ephemeral broadcast         durable append
+latency budget <100ms       latency budget "before a crash matters"
+every raw update            debounced ~1s, mergeUpdatesV2 -> one blob
+relay fans out, NO store    relay appends one row (the cold-start substrate)
+```
+
+A live peer renders character-by-character from the broadcast channel; an offline peer catches up from the durable log. Coalescing (Rung 0) touches only the durable channel, so it never costs liveness. The window is loss-free: every update is already on the writer's local disk (`attachEncryptedIndexedDb`) and in any peer that received the broadcast, so the relay log is a shared rendezvous allowed to lag, not the only copy. Live cursors/selections ride Yjs **awareness** (ephemeral, never logged); persisting them would row-bomb the log with mouse moves.
+
+Transport by doc state, not one-size-fits-all (both surfaces already exist: WS in `room/core.ts`, HTTP in `http-room-sync.ts`):
+
+- **WebSocket (hibernatable)** for the *actively-edited* doc's live fan-out. `ctx.acceptWebSocket` + `setWebSocketAutoResponse` keep idle sockets open with no compute billing.
+- **HTTP fetch** for cold-start bootstrap (`GET checkpoint` + `GET after-seq`, cacheable) and background flush of docs not being live-edited.
+
+Scaling consequence: you hold roughly **one WebSocket per actively-edited doc (usually one per user)**, not one per doc. Concurrent sockets track active editors, not user count or doc count.
+
+### Wire protocol (relay surface)
+
+The relay is one Durable Object per room (per doc). Single-threaded, so `seq` is a total order with no distributed-counter problem. Per-room storage is two tables:
+
+```sql
+updates    (seq INTEGER PRIMARY KEY AUTOINCREMENT, blob BLOB)  -- append-only, opaque
+checkpoint (blob BLOB, as_of_seq INTEGER)                      -- one row, newest as_of_seq wins
+```
+
+Four content verbs (plus the unchanged WS live-fan-out and the unchanged dispatch/presence text channel):
+
+| Verb | Input | Effect | Output |
+| --- | --- | --- | --- |
+| **append** | encrypted blob | assign next `seq`, insert, fan out to live WS peers | `seq` |
+| **read-after-seq** | cursor `N` (absent = cold start) | rows where `seq > N`; on cold start return `checkpoint` + rows where `seq > checkpoint.as_of_seq` | blobs (+ checkpoint) |
+| **accept-checkpoint** | encrypted snapshot, `asOfSeq` | upsert `checkpoint` if `asOfSeq` newer; **delete nothing** | 204 |
+| **DELETE-room** | (room id) | drop `updates` + `checkpoint` for the cascade | 204 |
+
+The relay never decrypts a blob, never runs Yjs, and never deletes a raw update except via the optional operator-policy reclaim timer (Rung 2). The transport for `append` (WS broadcast-only frame vs HTTP POST) is the deferred two-channel mapping; the *operation* above is transport-independent.
+
+### Cursor semantics
+
+The client persists `lastSeq` per doc in the encrypted-IDB CUSTOM store. On connect/bootstrap it calls read-after-seq with `lastSeq`, applies each blob with `applyUpdateV2` (idempotent), and advances `lastSeq` to the max `seq` received. Delivery is **at-least-once + idempotent apply**, never exactly-once: a crash between applying a blob and persisting the cursor merely re-fetches it next time, and Yjs dedups on `(client, clock)`. No transaction spans apply + cursor-write. Cold start (`lastSeq` absent) applies the checkpoint first, then the tail.
+
+### Yjs doc granularity and non-goals
+
+A Yjs doc is the unit of **concurrent co-editing**, never the unit of **readership** or **storage**. Its fan-out set is "who has this entity open right now," which stays small by construction.
+
+- **Split by entity, never one megadoc.** One root metadata doc plus one independent child doc per collaborative field (guid from `(workspaceId, collection, rowId, fieldName)`). These are **separate top-level docs, not Yjs subdocuments**: subdocs propagate updates *through* the parent, which would defeat independent per-field encryption, lazy loading, and per-room sync (grounded in yjs/yjs). Derived-guid independent docs give each field its own lifecycle, encryption, and room.
+- **Non-goal: a single doc fanned out to many simultaneous editors (a "megaroom").** Thousands of live editors on one doc is a different system (segmented/sharded docs) and is out of scope. Collaboration here is small-fan-out (your devices; a few co-authors of one page).
+- **Readership is a database read, not CRDT sync.** Browsing/searching a corpus is served from a SQLite projection (client-side for personal; server-side for shared-wiki), never by joining a Yjs room. The per-DO 1,000 req/s and 10 GB caps bind only under the excluded megaroom load; flush coalescing keeps a hot doc far under both, and a `SQLITE_FULL` DO still serves reads and deletes so reclaim always recovers it.
+
+### Deployable fork: trust model decides where truth lives
+
+The personal hosted relay (`apps/api`) and the self-hosted shared-wiki relay (`apps/self-host`) have different trust models, so they have different sources of truth. This is not "two relay modes for one deployable" (rejected above); it is two deployables with genuinely different threat models sharing `packages/server` primitives.
+
+| | Personal hosted (this spec) | Self-host shared-wiki (separate spec) |
+| --- | --- | --- |
+| Server may read content | No (ZK) | Yes (members' own server) |
+| Source of truth | Encrypted append log (opaque blobs) | Plaintext SQLite (queryable, FTS) |
+| Query / search | Client-side SQLite materializer | Server-side SQLite |
+| Yjs doc role | The doc *is* the truth, synced encrypted | Ephemeral live co-edit layer over a SQLite row |
+| Yjs lifetime | Long-lived per device | Hydrated on open, materialized + destroyed on quiesce |
+| Encryption | Mandatory update-blob | Optional (server trusted) |
+
+**Phase 4.2's "delete the server merge brain" is scoped to the personal relay.** The shared-wiki relay legitimately keeps a smart but **ephemeral** Y.Doc: hydrate a page's doc from its SQLite row, fan out to the few live editors, materialize back to SQLite on quiesce, destroy the doc (snapshot-hydrate-then-destroy is supported; clientID rotation is harmless because presence keys on `deviceId`). Non-editing readers never join the room; they read the SQLite row over HTTP. The shared-wiki SQLite-as-truth design is its own spec; this spec only fixes the boundary so Phase 4.2 does not delete a brain that deployable wants.
+
+## Call sites: before and after
+
+### Fuji entry body
+
+**Before** (`apps/fuji/src/lib/workspace/browser.ts:80`, abbreviated):
+
+```ts
+const ydoc = new Y.Doc({ guid: entryContentDocGuid(id), gc: true });
+const { idb: bodyIdb } = wire(ydoc, { actions: {} });   // attachLocalStorage + openCollaboration
+const body = attachRichText(ydoc);
+// + onLocalUpdate hook bumping updatedAt
+// + manual disposal in cache build closure
+```
+
+**After**:
+
+```ts
+// declared once in the schema:
+entries: defineTable({ /* ... */, body: field.richText() })
+
+// consumed:
+using body = ws.entries.open(id).body;   // workspace owns guid, encryption, sync, disposal, cascade
+```
+
+**Semantic shift to flag**: the body update path now reaches the relay as ciphertext, not plaintext. The `onLocalUpdate -> updatedAt` bump is no longer the body-changed signal; the materializer observes the field directly. App `.browser.ts` no longer constructs body docs.
+
+### Honeycrisp note body
+
+**Before** (`apps/honeycrisp/honeycrisp.ts:136`, `honeycrisp.browser.ts:58`): identical pattern, plus `openCollaboration` with no keyring (the leak).
+
+**After**: a `body: field.richText()` field; `openWorkspace` requires a keyring, so a keyring-less sync path is unrepresentable.
+
+## Implementation Plan
+
+Clean break uses Build, then Remove. No "prove old path still works" wave because there is no old path to preserve.
+
+### Phase 1: Dumb relay (the architectural collapse)
+
+**Single-channel at launch.** Phase 1 ships one stream: the client sends every update over the WebSocket; the relay appends it (assigns `seq`, stores the blob) **and** fans it out to live peers. The ephemeral-broadcast vs durable-append split (Transport and liveness) is explicitly out of this slice; it is a later prototype, not a Phase 1 task. Build the whole branch through Phase 4 before release, since the plaintext-body bug is only closed once Phase 2 lands (encryption requires the dumb relay, so it cannot precede Phase 1).
+
+- [ ] **1.1** Replace the room core's live `Y.Doc` binary-sync storage (`packages/server/src/room/core.ts`) with an append-only encrypted-blob log keyed by monotonic seq. **Keep the dispatch-correlation and presence text-frame channel unchanged** (it is content-blind; do not delete it).
+- [ ] **1.2** Replace state-vector sync with offset-cursor sync ("send blobs after seq N") in `packages/sync/src/protocol.ts` and `rooms.ts`. The client persists a per-doc relay seq cursor (new bookkeeping, alongside the encrypted update store).
+- [ ] **1.3** Add a DELETE room verb to `packages/server/src/routes/rooms.ts`.
+- [ ] **1.4** Remove `yjs` from `packages/server` room storage; confirm the relay never imports it for rooms.
+
+### Phase 2: Client encryption boundary
+
+- [ ] **2.1** Extract the update-blob encryption from `attachEncryptedIndexedDb` into a shared boundary usable by both disk and relay channels.
+- [ ] **2.2** Make `openCollaboration` require a keyring and encrypt every outbound update / decrypt every inbound update (AAD = docGuid + key version).
+- [ ] **2.3** Retire `createEncryptedYkvLww` value-level encryption; all docs use update-blob encryption.
+- [ ] **2.4** Add flush coalescing: debounce outbound updates (~500ms) and `Y.mergeUpdatesV2` the buffer into one blob before encrypting/sending. Decouples relay row rate from edit-event rate; the primary cost lever.
+
+### Phase 3: Schema-owned collaborative fields
+
+- [ ] **3.1** Add `field.richText()` and `field.text()` to the field catalog; declare child-doc backing.
+- [ ] **3.2** Wire `table.open(id).<field>` to lazily open the backing child doc via `createDisposableCache` and return the live `Y.XmlFragment` / `Y.Text`.
+- [ ] **3.3** Make `table.delete(id)` cascade: dispose the child doc, `clearLocal()` its IDB, call the relay DELETE for each collaborative field.
+- [ ] **3.4** Point the materializer at the collaborative field's observer directly; remove the `updatedAt`-bump-as-signal coupling.
+
+### Phase 4: Remove
+
+- [ ] **4.1** Delete per-app body-doc wiring from `apps/fuji`, `apps/honeycrisp`, `apps/opensidian` `.browser.ts`.
+- [ ] **4.2** Delete the per-room live `Y.Doc`, STEP1/STEP2 state-vector sync, and server-side compaction. Do **not** delete dispatch correlation or presence.
+- [ ] **4.3** Typecheck, run workspace + server tests, smoke each app.
+
+### Phase 5: Storage bounding (deferred until cold-start latency or fleet storage bills enough to matter)
+
+- [ ] **5.1** Non-destructive checkpoint: client uploads `(encrypt(encodeStateAsUpdateV2(doc)), asOfSeq)`; relay keeps the newest and serves `checkpoint + after(asOfSeq)` on cold start. Deletes nothing.
+- [ ] **5.2** (Optional, per-deployable, off by default) Operator-policy reclaim: an operator timer deletes raw blobs <= newest-checkpoint.asOfSeq older than a retention window. Never client-triggered. Personal: enable when fleet storage bills enough. Shared-wiki: leave off (or feed only owner checkpoints); rate-limit row-bombing instead.
+
+## Edge Cases
+
+### Concurrent checkpoints from two devices
+
+1. Device A uploads a checkpoint with asOfSeq 1300; device B uploads one with asOfSeq 1349.
+2. The relay keeps the newest by asOfSeq (1349) as its cache and discards the older checkpoint. Nothing else is deleted.
+3. Outcome: convergent, no data loss. Because checkpoints are non-destructive, a wrong one is at worst ignored in favor of full replay.
+
+### Device offline across a deletion + GC
+
+1. Device offline for months; content it concurrently edited was deleted and GC'd elsewhere.
+2. Its old update references GC'd items.
+3. Under append-only (reclaim off), the raw log is fully retained, so it reconciles against real deltas (zero risk). Where reclaim is enabled, the same holds if offline < retention window; longer than that it gets the checkpoint and is effectively a fresh sync. The always-retained raw log is the default safety net.
+
+### Malicious or compromised relay
+
+1. AEAD blocks tampering and forgery (decryption fails); reorder is harmless (CRDT).
+2. The relay can still withhold updates or serve a stale checkpoint (rollback).
+3. Outcome: confidentiality and forgery-resistance hold; availability/freshness are trusted unless a hash chain is added. See Open Questions.
+
+### New device cold start with 10k rows
+
+1. Root/metadata doc snapshot may be several MB of opaque cells.
+2. Downloaded once; bodies remain lazy per doc.
+3. Outcome: acceptable one-time cost; the lazy split is preserved.
+
+## Open Questions
+
+1. **Shared-wiki reclaim / abuse policy.**
+   - Context: a malicious member could row-bomb one doc toward the 10 GB per-DO cap, or upload a bad checkpoint.
+   - **Recommendation**: keep operator reclaim off for shared-wiki (or feed it only owner checkpoints); bound growth with flush coalescing + rate limits. Do not add server-side content validation to the personal relay. Leave open.
+
+2. **Flush debounce window vs liveness.**
+   - Context: coalescing trades a few hundred ms of remote-echo latency for a large drop in row count.
+   - **Recommendation**: ~500ms default, tunable per field kind (tighter if a live-cursor surface ever needs it; awareness/cursors ride a separate ephemeral channel and are not row-logged regardless). Revisit if collaborative typing feels laggy. Leave open.
+
+3. **Rollback resistance.**
+   - Context: AEAD blocks forgery; a malicious relay can still serve a stale checkpoint or withhold tail blobs.
+   - **Recommendation**: defer. Add a signed monotonic checkpoint counter (clients refuse regressions) only if the threat model rises above "notes app." Leave open.
+
+(Retention-window length, checkpoint-trigger ownership, and `gc:true`-vs-`false` are no longer open: clients never command deletion, so the always-retained raw log is the safety net, and the only retention question is the optional operator reclaim's window, owned per deployable.)
+
+## Adjacent Work
+
+- Room-name hashing (L3 privacy): not required now; brings the relay from "can't read content/schema" to "can't enumerate rows." A cheap rider on Phase 1 if desired.
+- Hash-chain / signed checkpoints (rollback resistance): deferred per Open Question 2.
+
+## Decisions Log
+
+- Keep `gc:true` on client docs: matches Yjs default, y-indexeddb, and existing code; smaller docs.
+  Revisit when: a real long-offline-across-GC corruption is observed in practice.
+- Relay never deletes on a client's word: append-only is permanent ground truth; bounding escalates flush coalescing -> non-destructive checkpoint -> operator-policy reclaim, cheapest rung first.
+  Revisit when: the per-DO 10 GB cap or fleet storage cost forces operator reclaim on by default.
+- Keep the root-doc / body-doc lazy split: it owns the instant-list-render-with-10k-rows invariant.
+  Revisit when: bodies become small enough to inline without a cold-start cost (unlikely).
+
+## User story
+
+> As a Honeycrisp user with a laptop and a phone, when I type into a note's body on my laptop, the words appear on my phone within ~1s, the relay operator can never read what I wrote, and when I delete the note it leaves nothing behind: no IndexedDB store on either device, no live room on the relay.
+
+This one story exercises every load-bearing claim: liveness, character-level merge, encryption, and delete-cascade.
+
+## Test matrix
+
+Most tests are client-side with a fake relay: `createSyncSupervisor` already accepts an injected `openWebSocket`, so two in-memory docs drive a fake relay with no network.
+
+| # | Test | Asserts |
+| --- | --- | --- |
+| 1 | Plaintext-never | every stored relay blob fails `applyUpdateV2`/decode without the keyring; `openCollaboration` throws without a keyring |
+| 2 | Convergence | two docs + fake relay, concurrent edits to one `field.richText()` converge character-for-character |
+| 3 | Cold-start | fresh client bootstraps from `checkpoint + after(asOfSeq)` and deep-equals the writer |
+| 4 | Delete-cascade | `table.delete(id)` clears the IDB store, calls DELETE-room, leaves no live room/socket |
+| 5 | One-cipher | `createEncryptedYkvLww` deleted; all docs use the update-blob path |
+| 6 | Coalescing (Rung 0, when built) | 2,000 streamed updates produce a relay row count far below 2,000 |
+| 7 | Relay-has-no-yjs | `packages/server` room storage does not import `yjs` (import-graph assertion) |
+| 8 | Cursor idempotency | replaying overlapping `read-after-seq` ranges leaves doc state and `lastSeq` unchanged |
+
+One real integration test against a deployed Durable Object covers the four wire verbs (append, read-after-seq, accept-checkpoint, DELETE-room) and hibernation wake/replay, which the in-memory fake cannot. The manual end-to-end is the user story itself: type on one device, watch it land on another within ~1s, inspect the relay rows to confirm they are opaque, delete, confirm both stores and the room are gone.
+
+## Success Criteria
+
+- [ ] No doc reaches the relay in plaintext; `openCollaboration` cannot sync without a keyring.
+- [ ] The relay does not import `yjs` for room storage and never decrypts a blob.
+- [ ] Two devices editing the same `field.richText()` body converge character-by-character through the relay.
+- [ ] Flush coalescing keeps relay row count well below edit-event count under streamed editing.
+- [ ] A non-destructive checkpoint lets a new device cold-start from checkpoint + tail without the relay deleting any raw blob.
+- [ ] `table.delete(id)` leaves no orphaned IndexedDB store and no live relay room for the row's collaborative fields.
+- [ ] One encryption scheme in the codebase; `createEncryptedYkvLww` value-level path deleted.
+- [ ] Per-app body-doc wiring removed from `apps/*/.browser.ts`.
+- [ ] Typecheck passes; workspace + server tests pass; each app smoke-tested.
+
+## References
+
+- `packages/workspace/src/document/internal/sync-supervisor.ts:233` - where raw updates currently reach the relay unencrypted
+- `packages/workspace/src/document/attach-encrypted-indexed-db.ts:175` - the update-blob encryption to lift into a shared boundary
+- `packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts:211` - value-level encryption to retire
+- `packages/workspace/src/document/attach-rich-text.ts:31` - current body `Y.XmlFragment` construction
+- `packages/server/src/room/core.ts:175,199-201,738` - the server Yjs brain to delete
+- `packages/server/src/room/backends/cloudflare/durable-object.ts` - room Durable Object shell
+- `packages/server/src/routes/rooms.ts:135,186` - room routes; needs offset-cursor sync + DELETE verb
+- `packages/sync/src/protocol.ts:78,107` - sync framing to swap to offset cursor
+- `packages/workspace/src/document/table.ts:950` - row delete; needs cascade
+- `packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.ts:727` - underlying delete
+- `packages/workspace/src/cache/disposable-cache.ts` - lazy child-doc lifecycle to reuse
+- `apps/fuji/src/lib/workspace/browser.ts:80`, `apps/honeycrisp/honeycrisp.browser.ts:58` - per-app wiring to remove
+- yjs/yjs, yjs/y-indexeddb (DeepWiki) - merge-is-structural, delete-set preservation, compaction model

--- a/specs/20260615T120000-trusted-relay-and-collaborative-fields.md
+++ b/specs/20260615T120000-trusted-relay-and-collaborative-fields.md
@@ -1,0 +1,295 @@
+# Trusted Relay and Collaborative Child Docs (single path)
+
+**Date**: 2026-06-15
+**Status**: Draft
+**Owner**: Braden (workspace platform)
+**Branch**: TBD
+**Supersedes**: `20260614T160000-zero-knowledge-relay-and-collaborative-fields.md` (the ZK append-log design is withdrawn; see Decision)
+
+## How to read this spec
+
+```txt
+Read first:
+  One Sentence
+  Decision: trusted, not zero-knowledge
+  Target shape: three layers
+  Implementation Plan
+
+Read if changing the architecture:
+  Research Findings
+  Design Decisions
+  Open Questions
+
+Historical / supporting:
+  What collapses / What stays
+```
+
+## One Sentence
+
+There is exactly one trusted relay that runs Yjs, merges, and reads content; a collaborative body is a child Y.Doc addressed by a stable guid, opened through one bound `session.childDocs` runtime (lifecycle), shaped by an `attach*(ydoc)` layout (shape + writer policy), and declared on a row only for identity + delete-cascade; the server-trust encryption layer (keyring, value-level and update-blob encryption) is deleted, and at-rest protection moves to infrastructure.
+
+## Decision: trusted, not zero-knowledge
+
+"Even logged in, we cannot read your data" was evaluated as a **nice-to-have, not a primary differentiator** for Epicenter. It is not a landing-page reason to choose the product, and the roadmap does not commit to "the server never computes over content forever." Therefore:
+
+- The hosted relay **may read content**. The server is a normal trusted peer.
+- The ZK append-log design (`20260614`) is withdrawn. Its dumb-relay rewrite (Wave 1) is reverted.
+- Encryption-at-rest for **server trust** (server-blindness) is removed. Encryption-at-rest for **disk theft** moves to infrastructure (see Encryption matrix), not the CRDT wrapper.
+
+Reversibility note: trusted -> opt-in ZK later is additive (a per-corpus encrypted mode). ZK -> server intelligence later is a promise regression. Choosing trusted keeps the door to server-side content features (AI, materialization, search) open, which is the point.
+
+## Research Findings
+
+### Finding 1: `@epicenter/field` is a closed cell palette; `field.richText()` is a category error
+
+`@epicenter/field` is a closed meta-schema (`packages/field/src/field.ts`). Every kind (a) has an at-rest truth that is a plain JSON Schema, (b) maps to exactly one SQLite storage class (`TEXT`/`INTEGER`/`REAL`), and (c) is mutually exclusive with the others so `recognize()` is unambiguous. The full namespace (`packages/field/src/builders.ts:226`) is:
+
+```txt
+string url number integer boolean date instant datetime select multiSelect tags json
+```
+
+A collaborative body is a separate Y.Doc. It has no JSON-Schema-cell truth and no SQLite storage class. Adding `field.richText()` (returning a live `Y.XmlFragment`) would either be rejected by `recognize()` and degrade to raw, or force a fake storage class. **Conclusion: child docs are a different axis from cells. Declaration belongs at the table/document level, not inside the `field.*` cell palette.**
+
+### Finding 2: the layout-over-doc pattern already exists (the IoC is composition, not invention)
+
+The three layers the design needs are already built; they are just not wired together:
+
+| Concern | Owner | Status |
+| --- | --- | --- |
+| **Lifecycle** (refcount, grace, dedup, dispose) | `createDisposableCache` (`packages/workspace/src/cache/disposable-cache.ts`) | exists |
+| **Shape** (Y.Doc layout) | `attachPlainText(ydoc)` (`attach-plain-text.ts`), `chat-doc.ts` free-functions over a `Y.Doc` | exists (text, conversation) |
+| **Identity** (the guid) | `zhongwenConversationDocGuid` (`apps/zhongwen/zhongwen.ts:109`) | exists, hand-wired per app |
+
+`createDisposableCache(build, { gcTime })` already separates lifecycle (the cache) from shape (the `build` closure): shape is injected, lifecycle is owned. `attachPlainText` is already a layout (`attach*(ydoc) -> handle`). `chat-doc.ts` is the conversation layout, already functions over a doc. The work is naming and composition.
+
+**Caveat from `chat-doc.ts:46`:** a layout encodes *writer policy*, not just shape ("Single writer per map: the creating client for user messages, the server generation actor for assistant messages"). A generic "child doc of any shape" abstraction must not erase this, or it invites two-writer corruption. A layout owns shape AND who-may-write-what; that is why `text` / `richText` / `conversation` are not interchangeable knobs.
+
+### Finding 3: trusted unlocks stored-id child docs (1:N, relocatable, nested)
+
+A blind relay cannot follow a child id stored in a parent doc (it can't read the parent), which is why Zhongwen is forced into a deterministic *derived* guid and a structural 1:1 relationship. A trusted relay can read the parent, so a field may store an arbitrary set of child-doc ids: 1:N, relocatable, and nestable (a child doc's own field stores grandchild ids). The trust decision does not just delete the keyring; it *enables* the more composable identity model.
+
+### Finding 4: the encryption wrapper does not provide transit or CRDT logic
+
+Audit of `createEncryptedYkvLww` (`packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts`): it encrypts cell *values* at the CRDT boundary (`set` encrypts into the Y.Array, `get`/observer decrypts). It does NOT provide transport encryption (that is TLS on the WebSocket, a separate layer) and does NOT provide conflict resolution (that is the inner `YKeyValueLww`, which stays). Deleting the wrapper loses only: at-rest value encryption (server-blindness), the keyring, and the "unreadable cell" failure class. The bare `YKeyValueLww` is already a drop-in (`workspace.ts:193-196`).
+
+### Encryption matrix (what each layer protects, after this change)
+
+| Layer | Provider | Status after change |
+| --- | --- | --- |
+| In transit | TLS (wss:// / HTTPS) | Unchanged, always on |
+| CRDT merge / LWW | inner `YKeyValueLww` | Unchanged |
+| At rest, server | infra (Cloudflare DO/R2 platform encryption or KMS) | Encrypted at rest, server-readable in memory |
+| At rest, client (IndexedDB) | OS full-disk encryption (FileVault/BitLocker) | App-level encryption dropped (see Open Questions) |
+| Server-blindness (ZK) | (removed) | Deleted on purpose |
+
+## Target shape: three layers
+
+```txt
+declare (identity + cascade)        open (lifecycle)            shape (+ writer policy)
+─────────────────────────────       ──────────────────         ────────────────────────
+row field OR derived convention  ->  session.childDocs(guid) ->  attach*(ydoc) layout
+  derives/stores the guid             createDisposableCache       attachPlainText  (text)
+  delete() drops the id ref           refcount + grace + GC       attachRichText   (richText, TODO)
+  NOT a member of field.*             config pre-bound            attachChatTranscript (conversation)
+```
+
+- **Lifecycle** is one runtime: `session.childDocs(build)` over `createDisposableCache`, with server/ownerId/url/openWebSocket/deviceId pre-bound. Same guid -> one shared Y.Doc; N opens require N disposes; grace window survives route/pane swaps.
+- **Shape** is an `attach*(ydoc)` layout that owns the CRDT layout and its writer discipline. `attachPlainText` exists; `attachChatTranscript`/`chat-doc.ts` exists; `attachRichText` (Y.XmlFragment) is the one to add for prose bodies.
+- **Identity** is either a *derived* guid (row + literal field name; stores nothing; 1:1; invisible to SQL) or a *stored id* cell (`field.string()`/`field.json()` holding the child id; 1:N; relocatable; queryable in SQL). This is the one genuine fork (Open Question 2).
+
+This is **not** the deleted `defineDocument` contract: no handle brand, no `DocumentFactory`, no `ActionIndex`. It is a cache, a set of `attach*` layouts, and a thin row-declaration for cascade.
+
+## The row-declaration (replaces `field.richText()` as a field member)
+
+The common single-body case (Fuji, Honeycrisp, Opensidian, Skills) still wants the body declared on the row so the workspace owns guid derivation, lazy open via `session.childDocs`, disposal, and **structural delete-cascade** (a bare id-keyed factory cannot give the cascade). But the declaration is a child-doc axis, distinct from the `field.*` cell palette:
+
+```ts
+// ILLUSTRATIVE — surface is Open Question 1, not settled.
+entries: defineTable(
+  { title: field.string() },                 // cells: materialize to SQLite
+  { body: childDoc(attachRichText),          // child docs: separate axis, cascade on row delete
+    code: childDoc(attachPlainText) },
+)
+
+using body = ws.entries.open(id).body;       // lazily opens via session.childDocs, returns the layout handle
+```
+
+`childDoc(layout)` derives the guid from `(workspaceId, collection, rowId, name)` (derived mode) and binds the cascade. Zhongwen's conversation is the *same* mechanism with a custom layout (`attachChatTranscript`); whether it stays a hand-wired call or becomes a `childDoc(attachChatTranscript)` declaration is Open Question 3.
+
+### Refused
+
+- `field.richText()` / `field.text()` / `field.childDoc()` as members of `@epicenter/field`. Category error (Finding 1). Layouts are `attach*(ydoc)`; the cell palette stays closed.
+- Restoring `defineDocument` as a contract. Custom shapes use the runtime + a layout; they own their reference.
+
+## Child-doc deletion & garbage collection (the cautious path)
+
+Deletion in a distributed CRDT is the hard part (idempotency, the delete-vs-re-add race, real-time cascade). Greenfield decision: **do not solve it in the hot path.** Trust lets us move deletion off the critical path entirely.
+
+- `delete(rowId)` does ONE thing: drop the child-id reference from the parent. It never touches the child doc. The list re-renders without the row immediately, so the user sees it gone at once.
+- The child doc becomes an **orphan**: an unreferenced Y.Doc, invisible to the app (nothing can open it), costing only storage.
+- **Reclamation is offline mark-and-sweep, run by the trusted server** (the win trust unlocks: a blind relay cannot read parents to know what is referenced; a trusted one can). The sweep reads every parent, computes the set of referenced child guids, and deletes the child DOs not in that set. On a consistent server snapshot there are no races and idempotency is trivial. It is the SAME sweep that clears old encrypted data: one offline GC for both.
+
+| Layer | Reclaimed by | When |
+| --- | --- | --- |
+| In-memory handle | `createDisposableCache` refcount | already: disposed when no surface holds it (grace window) |
+| Server doc (DO) | trusted-server mark-and-sweep | manual script now; scheduled later |
+| Client doc (IDB) | accepted dead storage; optional load-time prune | low priority |
+
+This keeps the "two paths delete the child" smell away: the parent table owns the reference; the sweep owns child-doc deletion; they never overlap.
+
+### Accepted downsides (named, per greenfield)
+
+1. **Byte-level deletion is eventually-consistent.** An orphan persists until the next sweep. Acceptable: privacy is explicitly not the moat (see Decision) and the UI shows the row gone immediately.
+2. **Client IDB accumulates orphans** until a prune. Negligible; storage cost is low.
+
+### Trigger to upgrade to real-time GC
+
+A compliance/product promise requiring immediate hard delete, material storage growth, or a need to reflect a remote peer's delete in real time. The upgrade is the observer-driven single-owner cascade: `delete()` still only drops the reference, and one observer in `session.childDocs` reacts to the reference dropping by disposing the handle, clearing IDB, and calling idempotent `DELETE-room`. Documented here so it is a known next step, not a redesign.
+
+## What collapses (the deletions this decision authorizes)
+
+| Deleted | Reason |
+| --- | --- |
+| Update-blob encryption boundary + AAD binding | Server reads plaintext; nothing to encrypt for the relay |
+| `createEncryptedYkvLww` value-level encryption | Only existed so the relay couldn't read cells; bare `YKeyValueLww` is a drop-in |
+| The keyring: `derive-workspace-keyring`, keyring-mandatory `openWorkspace`, `attach-encrypted-indexed-db` | No server-trust key needed; also deletes the key-recovery problem |
+| Wave 1 dumb append-log: offset-cursor sync, checkpoint cache, `append`/`readAfter` room contract | Server runs Yjs again; normal state-vector sync returns |
+| Client-mediated AI relocation, peer-continuation machinery | `doc-generation.ts` server peer stays; build nothing new |
+| Custody fork: Mailbox vs Actor, two-sources-of-truth, deployable trust-mode table | One trusted relay; deployables differ only in who operates them |
+
+The custody fork and the keyring are the two largest subtractions. The keyring deletion ripples into auth (identity + tokens only), local storage (plain, not encrypted), and onboarding (no recovery-code flow). At-rest protection is not lost; it moves to infra (Encryption matrix).
+
+## What stays
+
+- **Smart Yjs relay** (the pre-Wave-1 behavior): live per-room `Y.Doc`, state-vector sync (STEP1/STEP2), server-side compaction. Revert restores this.
+- **Server-side AI** as a Yjs peer: `doc-generation.ts` hydrates a replica, streams tokens into the doc, syncs back. Unchanged.
+- **Root metadata doc + lazy body child docs split**: still owns the instant-list-render-with-10k-rows invariant. Bodies remain separate top-level docs (independent guids), lazy-loaded.
+- **Dispatch correlation + presence channel**: content-blind, untouched.
+- **The `field.*` cell palette**: unchanged and closed; cells continue to materialize to SQLite.
+
+## Design Decisions
+
+| Decision | Class | Choice | Rationale |
+| --- | --- | --- | --- |
+| Trusted vs zero-knowledge | 3 taste | Trusted | ZK is a nice-to-have, not a differentiator; trusted keeps server-content features open and is additively reversible to ZK |
+| `field.richText()` as a field member | 1 evidence | Rejected | `field` is a closed SQLite-cell palette (`builders.ts:226`); a Y.Doc is not a cell |
+| Layout mechanism | 2 coherence | `attach*(ydoc)` | `attachPlainText`/`chat-doc.ts` already are this; one mechanism for simple and custom bodies |
+| Lifecycle runtime | 2 coherence | `session.childDocs` over `createDisposableCache` | Cache already separates lifecycle from injected shape; binds the session connection |
+| Layout owns writer policy | 1 evidence | Yes | `chat-doc.ts:46` single-writer invariant must survive the abstraction |
+| At-rest encryption location | 3 taste | Infra (platform/KMS), not the wrapper | Server-held key makes the wrapper pure cost; infra at-rest is simpler and has no keyring |
+| Identity: derived vs stored id | Deferred | Support both | Derived fits Zhongwen 1:1; stored id (newly possible under trust) fits 1:N/nested; pick per declaration |
+| Child-doc deletion | 3 taste | `delete()` drops the reference; offline server mark-and-sweep reclaims | Real-time CRDT cascade is the hard problem; trust lets the server GC offline (no races). Accept transient orphans (privacy not the moat) |
+
+## Branch action
+
+1. Preserve the stray working tree first: the 9 modified `packages/server/**` files are an uncommitted append-log experiment (matches the dangling `a841628ef`), on no branch. Commit them to `feat/zk-append-log-relay-wip` before anything, so the experiment is not lost.
+2. Clean this branch: `git restore packages/server/...` so `chore/skill-library-composition-audit` is skills-only again.
+3. Build forward from `main` (the smart relay already is main; there is nothing to "revert" as a commit). Re-add **`DELETE-room`** as a targeted patch against the smart-relay contract (the orphan-on-delete bug exists under trusted too).
+
+## Implementation Plan
+
+### Phase 0: Preserve + clean (do first)
+- [ ] **0.1** Commit the 9 working-tree server files to `feat/zk-append-log-relay-wip`.
+- [ ] **0.2** `git restore packages/server/...` on the skills branch.
+- [ ] **0.3** Branch `feat/trusted-relay-collab-docs` off `main`.
+
+### Phase 1: Confirm smart relay + DELETE-room
+- [ ] **1.1** Confirm client and server speak the same Yjs sync frames on `main` (no half-state).
+- [ ] **1.2** Re-add `DELETE-room` as a targeted patch against the smart-relay contract.
+- [ ] **1.3** Smoke each app against the relay.
+
+### Phase 2: Delete the encryption layer
+- [ ] **2.0** Migration (one-off, manual): a server-side admin script clears every existing room DO (`DELETE FROM updates` / `storage.deleteAll()`). Existing encrypted data is intentionally discarded (accepted). **Correctness caveat**: must run before the plaintext code reads those rooms, or the plaintext reader ingests old ciphertext as Yjs updates (corruption). Client local stores wipe by bumping the IndexedDB DB name (old encrypted DBs orphaned; optional one-time delete). This is the same sweep that later reclaims orphaned child docs (see Child-doc deletion).
+- [ ] **2.1** Remove update-blob encryption from the relay channel.
+- [ ] **2.2** Delete `createEncryptedYkvLww`; cells sync plaintext via bare `YKeyValueLww`.
+- [ ] **2.3** Collapse the now-dead contract: with the wrapper gone, `unreadable` has zero producers (`YKeyValueLww.read()` only returns `present`/`absent`). Reduce `ObservableKvStore` from the `KvRead`/`KvStoredRead` tri-state to `get()`/`has()`; `has` re-aligns with `get() !== undefined`; `size` just counts entries.
+- [ ] **2.4** Remove the mandatory keyring from `openWorkspace`; `attachLocalStorage` uses plain IndexedDB; delete `attach-encrypted-indexed-db`, `derive-workspace-keyring`; `attachStore` collapses to `new YKeyValueLww(yarray)` (drop the `workspaceKeyring` param thread).
+- [ ] **2.5** Enable infra at-rest encryption (confirm Cloudflare DO/R2 default at-rest, or KMS-wrap the storage key). Client local-at-rest: OS disk encryption (Open Question 4).
+
+### Phase 3: Bound child-doc runtime
+- [ ] **3.1** Add `session.childDocs(build)` over `createDisposableCache`, config pre-bound (`attachLocalStorage`, `attachCollaboration`, `onLocalUpdate`).
+- [ ] **3.2** Add `attachRichText(ydoc)` (Y.XmlFragment layout) alongside `attachPlainText` and `attachChatTranscript`.
+- [ ] **3.3** Port Zhongwen (the proven case) onto `session.childDocs` + `attachChatTranscript`. Prove the composition before generalizing.
+
+### Phase 4: Row-declared child docs (Build, Prove, Remove)
+- [ ] **4.1** Add the table-level `childDoc(layout)` declaration (surface per Open Question 1): resolve guid, lazy-open via `session.childDocs`. `delete()` drops the child-id reference only (no cascade; GC reclaims, see Child-doc deletion).
+- [ ] **4.2** Port Fuji/Honeycrisp/Opensidian/Skills bodies onto `childDoc(attachRichText)` / `childDoc(attachPlainText)`.
+- [ ] **4.3** Materializer observes the layout's signal directly; remove the `updatedAt`-bump-as-signal coupling.
+- [ ] **4.4** Verify delete UX: `delete()` drops the reference, the row disappears immediately, the in-memory handle disposes via the cache; the orphaned doc is left for the sweep (Phase 5), not the delete path.
+
+### Phase 5: Garbage collection (offline, not hot-path)
+- [ ] **5.1** `DELETE-room` verb on the smart-relay contract, idempotent (deleting an absent room is a no-op).
+- [ ] **5.2** Server mark-and-sweep: read parents, compute referenced child guids, delete unreferenced child DOs. Runnable as the same admin script that clears old encrypted data (2.0).
+- [ ] **5.3** (Optional) client load-time prune of local IDB docs with no parent reference.
+
+## Edge Cases
+
+### Child doc whose row is deleted while open by two surfaces
+1. Two editors open the same body (one shared Y.Doc via the cache).
+2. Row deleted in one surface -> only the child-id reference is dropped; the doc is NOT touched.
+3. Expected: both surfaces re-render without the row; their handles dispose via the cache when navigated away. The orphaned doc lingers until the sweep. No real-time cascade, so no cross-surface race.
+
+### Stored-id child whose id is dangling
+1. A row stores a child id whose doc was never created or already deleted.
+2. `session.childDocs(guid)` opens an empty doc.
+3. Expected: empty layout (not a crash); a separate reconciliation may prune dangling ids. See Open Questions.
+
+### Materialization of child docs
+1. Cells materialize to SQLite; child docs do not (Zhongwen transcript is a Y.Doc, only the list materializes).
+2. A generic `childDoc` abstraction is also deciding "child docs are outside the SQL mirror."
+3. Expected: explicit. Optionally a derived summary cell (e.g. last-message preview) is written back as a normal cell.
+
+## Open Questions
+
+1. **`childDoc(layout)` declaration surface.**
+   - Options: (a) second positional arg to `defineTable` parallel to cells, (b) a `childDocs:` block on the table, (c) no declaration — derived convention + manual open everywhere.
+   - **Recommendation**: (a) or (b) so cascade + lazy open are owned by the table; leave the exact shape to the implementer. Keep it OUT of `field.*`.
+
+2. **Identity: derived guid vs stored id.**
+   - Derived (row + name): 1:1, stores nothing, invisible to SQL. Stored id (`field.string()`/`field.json()`): 1:N, relocatable, nestable, queryable in SQL.
+   - **Recommendation**: support both, chosen per declaration. Zhongwen wants derived-1:1; an Opensidian-style nested workspace wants stored id. Do not pick one globally.
+
+3. **Does Zhongwen's conversation become a declaration or stay manual?**
+   - Options: (a) `childDoc(attachChatTranscript)` declaration like the others, (b) keep the hand-wired `zhongwenConversationDocGuid` + manual open.
+   - **Recommendation**: once `childDoc(layout)` exists and writer policy is preserved, fold Zhongwen in so it stops being a special case. Defer until Phase 3 proves the runtime.
+
+4. **Client local-at-rest encryption.**
+   - Keep an optional device-local encrypted-IDB slice (native only) or rely on OS disk encryption everywhere?
+   - **Recommendation**: drop; rely on OS disk encryption. A browser cannot hold a key safely (it would live in the same storage). Revisit for native (Tauri) if a segment needs it; additive, not load-bearing.
+
+5. **Server-side materialization + SQLite-as-truth** (future deepening).
+   - Server observes docs and writes SQLite, dissolving the client materializer; bodies hydrated on open, materialized + destroyed on quiesce.
+   - **Recommendation**: defer. Real collapse, new architecture; do not bundle with this pass.
+
+## Adjacent Work
+
+- Stored-id reconciliation (prune dangling child ids): folded into the server mark-and-sweep (Phase 5.2); the same pass that reclaims orphans also drops references to docs that never existed.
+- Derived summary cells (last-message preview materialized back to SQL): opportunistic; only if a list view needs it.
+
+## Decisions Log
+
+- Keep both derived and stored-id identity modes: Zhongwen genuinely wants derived-1:1, nested workspaces genuinely want stored-id.
+  Revisit when: one mode goes unused across all apps after Phase 4.
+
+## Success Criteria
+
+- [ ] One relay; client and server speak the same Yjs sync frames; no half-state.
+- [ ] No keyring in `openWorkspace`; `createEncryptedYkvLww`, `attach-encrypted-indexed-db`, `derive-workspace-keyring` deleted; storage is plain.
+- [ ] At-rest encryption confirmed at the infra layer (platform or KMS).
+- [ ] Server-side AI (`doc-generation.ts`) works unchanged against the restored relay.
+- [ ] One `session.childDocs` runtime; per-app cache closures gone.
+- [ ] Bodies are `childDoc(attachRichText)` / `childDoc(attachPlainText)`; delete cascades with no orphaned IDB store or live room.
+- [ ] `field.*` palette unchanged; no `field.richText()` member; no `defineDocument` contract.
+- [ ] Zhongwen transcript runs on the shared runtime (declared or manual) and cascades on conversation delete.
+
+## References
+
+- `packages/field/src/field.ts`, `builders.ts` - closed cell palette (Finding 1)
+- `packages/workspace/src/cache/disposable-cache.ts` - lifecycle primitive
+- `packages/workspace/src/document/attach-plain-text.ts` - existing text layout
+- `packages/workspace/src/ai/chat-doc.ts` - conversation layout + writer policy
+- `apps/zhongwen/zhongwen.ts` - the proven child-doc pattern (derived guid)
+- `packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts` - the wrapper to delete (Finding 4)
+- `packages/workspace/src/document/workspace.ts:186-197` - `attachStore` (plaintext branch already exists)
+</content>
+</invoke>


### PR DESCRIPTION
Lands the design record for the trusted-relay direction on main.

This change:

Two planning docs under \`specs/\`, no code:

- **\`20260615T120000-trusted-relay-and-collaborative-fields.md\`** (live): the trusted-relay design. One trusted relay runs Yjs and may read content; a collaborative body is a child Y.Doc opened through one bound \`session.childDocs\` runtime, shaped by an \`attach*(ydoc)\` layout, and declared on a row only for identity and delete-cascade. The server-trust encryption layer (keyring, value-level and update-blob encryption) is deleted; at-rest protection moves to infrastructure.
- **\`20260614T160000-zero-knowledge-relay-and-collaborative-fields.md\`** (withdrawn): the predecessor zero-knowledge append-log design, kept for the decision record. The live spec supersedes it.

The reason for this shape is:

"Even logged in we cannot read your data" was evaluated as a nice-to-have, not a primary differentiator. Trusted keeps server-side content features (AI, materialization, search) open and is additively reversible to opt-in ZK later; ZK to server-intelligence later would be a promise regression.

Design is settled; this PR only records it. Implementation lands separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784130609&installation_id=128463665&pr_number=2020&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2020&signature=32f9b986a373833a6147650a9c2ad1b92170af1c02289179be8aa1e94bf808d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->