### PR TITLE
docs(specs): resolve childDoc declaration surface, defer DELETE-room

### DIFF
--- a/specs/20260615T120000-trusted-relay-and-collaborative-fields.md
+++ b/specs/20260615T120000-trusted-relay-and-collaborative-fields.md
@@ -104,17 +104,18 @@ This is **not** the deleted `defineDocument` contract: no handle brand, no `Docu
 The common single-body case (Fuji, Honeycrisp, Opensidian, Skills) still wants the body declared on the row so the workspace owns guid derivation, lazy open via `session.childDocs`, disposal, and **structural delete-cascade** (a bare id-keyed factory cannot give the cascade). But the declaration is a child-doc axis, distinct from the `field.*` cell palette:
 
 ```ts
-// ILLUSTRATIVE — surface is Open Question 1, not settled.
-entries: defineTable(
-  { title: field.string() },                 // cells: materialize to SQLite
-  { body: childDoc(attachRichText),          // child docs: separate axis, cascade on row delete
-    code: childDoc(attachPlainText) },
-)
+// Resolved (Open Question 1): a `.childDocs({ name: layout })` builder method,
+// chained after the columns (and after `.migrate()` for a multi-version table).
+entries: defineTable({ title: field.string() })   // cells: materialize to SQLite
+  .childDocs({
+    body: attachRichText,                          // child docs: separate axis, derived guid
+    code: attachPlainText,                         // orphaned on row delete, reclaimed by the sweep
+  })
 
 using body = ws.entries.open(id).body;       // lazily opens via session.childDocs, returns the layout handle
 ```
 
-`childDoc(layout)` derives the guid from `(workspaceId, collection, rowId, name)` (derived mode) and binds the cascade. Zhongwen's conversation is the *same* mechanism with a custom layout (`attachChatTranscript`); whether it stays a hand-wired call or becomes a `childDoc(attachChatTranscript)` declaration is Open Question 3.
+`.childDocs({ name: layout })` derives each child guid from `(workspaceId, collection, rowId, name)` (derived mode); because the guid is a pure function of the row, deleting the row orphans the child with no bookkeeping and the offline sweep reclaims it. Zhongwen's conversation is the *same* mechanism with a custom layout (`attachChatTranscript`); whether it stays a hand-wired call or becomes a `.childDocs({ messages: attachChatTranscript })` declaration is Open Question 3.
 
 ### Refused
 
@@ -177,14 +178,14 @@ The custody fork and the keyring are the two largest subtractions. The keyring d
 | Lifecycle runtime | 2 coherence | `session.childDocs` over `createDisposableCache` | Cache already separates lifecycle from injected shape; binds the session connection |
 | Layout owns writer policy | 1 evidence | Yes | `chat-doc.ts:46` single-writer invariant must survive the abstraction |
 | At-rest encryption location | 3 taste | Infra (platform/KMS), not the wrapper | Server-held key makes the wrapper pure cost; infra at-rest is simpler and has no keyring |
-| Identity: derived vs stored id | Deferred | Support both | Derived fits Zhongwen 1:1; stored id (newly possible under trust) fits 1:N/nested; pick per declaration |
+| Identity: derived vs stored id | Resolved | Derived-only for now | Derived 1:1 makes the trusted sweep safe (row exists iff child referenced); stored-id 1:N deferred until a real case forces it |
 | Child-doc deletion | 3 taste | `delete()` drops the reference; offline server mark-and-sweep reclaims | Real-time CRDT cascade is the hard problem; trust lets the server GC offline (no races). Accept transient orphans (privacy not the moat) |
 
 ## Branch action
 
 1. Preserve the stray working tree first: the 9 modified `packages/server/**` files are an uncommitted append-log experiment (matches the dangling `a841628ef`), on no branch. Commit them to `feat/zk-append-log-relay-wip` before anything, so the experiment is not lost.
 2. Clean this branch: `git restore packages/server/...` so `chore/skill-library-composition-audit` is skills-only again.
-3. Build forward from `main` (the smart relay already is main; there is nothing to "revert" as a commit). Re-add **`DELETE-room`** as a targeted patch against the smart-relay contract (the orphan-on-delete bug exists under trusted too).
+3. Build forward from `main` (the smart relay already is `main`; there is nothing to "revert" as a commit). `DELETE-room` lands in Phase 5 alongside the mark-and-sweep that consumes it, not as a standalone Phase 1 patch.
 
 ## Implementation Plan
 
@@ -193,10 +194,10 @@ The custody fork and the keyring are the two largest subtractions. The keyring d
 - [ ] **0.2** `git restore packages/server/...` on the skills branch.
 - [ ] **0.3** Branch `feat/trusted-relay-collab-docs` off `main`.
 
-### Phase 1: Confirm smart relay + DELETE-room
-- [ ] **1.1** Confirm client and server speak the same Yjs sync frames on `main` (no half-state).
-- [ ] **1.2** Re-add `DELETE-room` as a targeted patch against the smart-relay contract.
-- [ ] **1.3** Smoke each app against the relay.
+### Phase 1: Confirm smart relay
+- [x] **1.1** Confirm client and server speak the same Yjs sync frames on `main` (no half-state). VERIFIED 2026-06-15: the room contract on `main` is `sync` / `getDoc` / `handleUpgrade` (state-vector smart relay, `packages/server/src/room/contracts.ts`); the withdrawn append-log rewrite is not on `main`. No code needed.
+- [ ] **1.2** Smoke each app against the relay.
+- Note: `DELETE-room` moved to Phase 5. Its only consumer is the mark-and-sweep, so adding it here would ship a verb with no caller through Phases 2 to 4. Its value is as the sweep's deletion primitive, not a storage-cost win (orphan storage is negligible).
 
 ### Phase 2: Delete the encryption layer
 - [ ] **2.0** Migration (one-off, manual): a server-side admin script clears every existing room DO (`DELETE FROM updates` / `storage.deleteAll()`). Existing encrypted data is intentionally discarded (accepted). **Correctness caveat**: must run before the plaintext code reads those rooms, or the plaintext reader ingests old ciphertext as Yjs updates (corruption). Client local stores wipe by bumping the IndexedDB DB name (old encrypted DBs orphaned; optional one-time delete). This is the same sweep that later reclaims orphaned child docs (see Child-doc deletion).
@@ -241,13 +242,15 @@ The custody fork and the keyring are the two largest subtractions. The keyring d
 
 ## Open Questions
 
-1. **`childDoc(layout)` declaration surface.**
-   - Options: (a) second positional arg to `defineTable` parallel to cells, (b) a `childDocs:` block on the table, (c) no declaration — derived convention + manual open everywhere.
-   - **Recommendation**: (a) or (b) so cascade + lazy open are owned by the table; leave the exact shape to the implementer. Keep it OUT of `field.*`.
+1. **`childDoc(layout)` declaration surface. RESOLVED (2026-06-15).**
+   - Resolution: a `.childDocs({ name: layout })` builder method on `TableDefinition`, chained after `.migrate()`. Coupled to the table (the workspace supplies the collection key structurally, so no collection string is hand-typed), derived-only, never versioned. A flat `name -> layout` map of the current shape.
+   - Why not a positional arg (option a): `defineTable`'s positional slots are already the version tuple (`defineTable(v1, v2)` means v1 + v2 columns), so a second positional arg is indistinguishable from declaring a v2 column set. The illustrative `defineTable({cells}, {childDocs})` shown earlier in this spec is therefore unbuildable as written.
+   - Why outside the version tuple: `.migrate(fn)` operates on the row value (cells that materialize to SQLite) and structurally cannot rewrite a separate child Y.Doc. So a version bump never migrates child docs: add a child in a later version and old rows open it empty, remove one and the orphan is swept. Incompatible layout changes are migrate-on-read inside the layout, not a row migration.
+   - Refused: option (a) positional; option (b) as a separate `childDocs:` block was folded into the builder method. The stored-id 1:N mode and any top-level child-doc abstraction are also refused for now (see Question 2).
 
-2. **Identity: derived guid vs stored id.**
-   - Derived (row + name): 1:1, stores nothing, invisible to SQL. Stored id (`field.string()`/`field.json()`): 1:N, relocatable, nestable, queryable in SQL.
-   - **Recommendation**: support both, chosen per declaration. Zhongwen wants derived-1:1; an Opensidian-style nested workspace wants stored id. Do not pick one globally.
+2. **Identity: derived guid vs stored id. RESOLVED (2026-06-15): derived-only for now.**
+   - Ship derived-1:1 only: the guid is `docGuid({ workspaceId, collection, rowId, name })`, storing nothing. Derived is what makes the trusted offline sweep safe: the invariant "row exists if and only if its child is referenced" holds by construction, so `delete(id)` (drop the row) orphans the child with zero reference bookkeeping, and the sweep recomputes the referenced set and deletes the rest.
+   - Stored-id 1:N is deferred: there is no real or near-term consumer (the Opensidian-nesting case is hypothetical). It slots in additively when a real 1:N case forces it, via the top-level abstraction that derived-1:1 does not need.
 
 3. **Does Zhongwen's conversation become a declaration or stay manual?**
    - Options: (a) `childDoc(attachChatTranscript)` declaration like the others, (b) keep the hand-wired `zhongwenConversationDocGuid` + manual open.
@@ -268,8 +271,9 @@ The custody fork and the keyring are the two largest subtractions. The keyring d
 
 ## Decisions Log
 
-- Keep both derived and stored-id identity modes: Zhongwen genuinely wants derived-1:1, nested workspaces genuinely want stored-id.
-  Revisit when: one mode goes unused across all apps after Phase 4.
+- `.childDocs()` declaration surface (Open Question 1): coupled, derived-only builder method chained after `.migrate()`, table-scoped, never versioned. Positional arg rejected (collides with the version tuple); stored-id and any top-level abstraction deferred until a real 1:N case.
+  Revisit when: a real 1:N, nested, or relocatable child-doc case appears.
+- DELETE-room: deferred from Phase 1 to Phase 5. It is the sweep's deletion primitive, not a standalone storage-cost win, so it ships with its only consumer.
 
 ## Success Criteria
 


### PR DESCRIPTION
Follow-up to #2020 (which merged the design record). Records the decisions reached while grilling Open Question 1.

- **Open Question 1 (declaration surface): resolved** to a coupled, derived-only `.childDocs({ name: layout })` builder method chained after `.migrate()`. The positional-arg option is rejected on evidence: `defineTable`'s positional slots are already the version tuple, so `defineTable({cells}, {childDocs})` is indistinguishable from a two-version table. Child docs sit outside the version tuple because `.migrate` operates on row values and cannot rewrite a child Y.Doc; layout evolution is migrate-on-read inside the layout.
- **Open Question 2 (identity): resolved** to derived-only for now. Derived 1:1 is what makes the trusted offline sweep safe (row exists iff child referenced). Stored-id 1:N is deferred until a real case forces it.
- **DELETE-room moved from Phase 1 to Phase 5.** Its only consumer is the mark-and-sweep, so it ships with the sweep rather than as a no-caller verb. Its value is as the sweep's deletion primitive, not a storage-cost win. Phase 1 is confirmed done by inspection: main is the smart relay.

Also fixes the now-stale illustrative code block, Design Decisions table row, and Decisions Log entry that still said "support both".

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784132198&installation_id=128463665&pr_number=2022&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2022&signature=be1f356d8c2e055c3d56c9de817fb3db4250a9c51397a8ed54c5a697eb18300c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->