### PR TITLE
feat(workspace): bound child-doc runtime (trusted relay, Phase 3)

### DIFF
--- a/apps/zhongwen/src/routes/(signed-in)/components/ConversationView.svelte
+++ b/apps/zhongwen/src/routes/(signed-in)/components/ConversationView.svelte
@@ -24,13 +24,14 @@
 	import * as Chat from '@epicenter/ui/chat';
 	import { generateId } from '@epicenter/workspace';
 	import {
-		appendUserMessage,
 		findActiveChatDocGeneration,
 		type ChatDocMessage,
-		observeChatDocMessages,
-		readChatDocMessages,
 	} from '@epicenter/workspace/ai';
-	import { type ConversationId, ZHONGWEN_MODEL } from '@epicenter/zhongwen';
+	import {
+		type ConversationId,
+		ZHONGWEN_MODEL,
+		zhongwenConversationDocGuid,
+	} from '@epicenter/zhongwen';
 	import { onDestroy } from 'svelte';
 	import { extractErrorMessage } from 'wellcrafted/error';
 	import { requireZhongwen } from '$lib/session';
@@ -62,9 +63,11 @@
 	// back-and-forth switching. conversationId is the keyed identity and never
 	// changes within one instance, so a one-time read is intentional.
 	// svelte-ignore state_referenced_locally
-	const docHandle = zhongwen.conversationDocs.open(conversationId);
+	const docHandle = zhongwen.conversationDocs.open(
+		zhongwenConversationDocGuid(conversationId),
+	);
 
-	const initialMessages = readChatDocMessages(docHandle.ydoc);
+	const initialMessages = docHandle.read();
 	const mountedAt = Date.now();
 	const initialActiveGeneration = findActiveChatDocGeneration(
 		initialMessages,
@@ -72,8 +75,8 @@
 	);
 	let messages = $state.raw<ChatDocMessage[]>(initialMessages);
 	let lastDocChangeAt = $state(initialActiveGeneration ? mountedAt : 0);
-	const unobserve = observeChatDocMessages(docHandle.ydoc, () => {
-		messages = readChatDocMessages(docHandle.ydoc);
+	const unobserve = docHandle.observe(() => {
+		messages = docHandle.read();
 		lastDocChangeAt = Date.now();
 	});
 
@@ -156,7 +159,7 @@
 				method: 'POST',
 				headers: { 'content-type': 'application/json' },
 				body: JSON.stringify({
-					guid: docHandle.ydoc.guid,
+					guid: docHandle.guid,
 					generationId: generateId(),
 					data: {
 						model: ZHONGWEN_MODEL,
@@ -166,9 +169,9 @@
 				signal: controller.signal,
 			});
 			// The kickoff resolving (200) IS the finish signal for the requester.
-			// The relay only syncs the conversations table; it never writes it,
-			// and a completed reply only lands while this requester is alive, so
-			// the requester owns the list-recency bump on completion.
+			// The server generation actor only writes the transcript child doc, not
+			// the conversations list table, and a completed reply only lands while
+			// this requester is alive, so the requester owns the list-recency bump.
 			zhongwen.tables.conversations.update(conversationId, {
 				updatedAt: Date.now(),
 			});
@@ -188,7 +191,7 @@
 	function sendMessage(content: string) {
 		const text = content.trim();
 		if (!text || isGenerating) return;
-		appendUserMessage(docHandle.ydoc, {
+		docHandle.appendUser({
 			id: generateId(),
 			content: text,
 			createdAt: Date.now(),

--- a/apps/zhongwen/zhongwen.browser.ts
+++ b/apps/zhongwen/zhongwen.browser.ts
@@ -17,19 +17,15 @@
 import type { SignedIn } from '@epicenter/svelte/auth';
 import {
 	attachLocalStorage,
-	createDisposableCache,
+	createChildDocs,
 	type DeviceId,
 	defineWorkspace,
 	openCollaboration,
 	roomWsUrl,
 	wipeLocalStorage,
 } from '@epicenter/workspace';
-import * as Y from 'yjs';
-import {
-	type ConversationId,
-	createZhongwen,
-	zhongwenConversationDocGuid,
-} from './zhongwen';
+import { attachChatTranscript } from '@epicenter/workspace/ai';
+import { createZhongwen } from './zhongwen';
 
 /**
  * Open Zhongwen in the browser with local storage, cloud sync, and the
@@ -61,45 +57,14 @@ export function openZhongwenBrowser({
 		actions: workspace.actions,
 	});
 
-	const conversationDocs = createDisposableCache(
-		(conversationId: ConversationId) => {
-			const ydoc = new Y.Doc({
-				guid: zhongwenConversationDocGuid(conversationId),
-				gc: true,
-			});
-			const childIdb = attachLocalStorage(ydoc, {
-				server: signedIn.server,
-				ownerId: signedIn.ownerId,
-			});
-			// Transcripts sync through Cloud: that is what lets the server
-			// generation actor stream assistant tokens into the doc and lets
-			// every signed-in device watch them live.
-			const childSync = openCollaboration(ydoc, {
-				url: roomWsUrl({
-					baseURL: signedIn.baseURL,
-					ownerId: signedIn.ownerId,
-					guid: ydoc.guid,
-					deviceId,
-				}),
-				openWebSocket: signedIn.openWebSocket,
-				onReconnectSignal: signedIn.onReconnectSignal,
-				waitFor: childIdb.whenLoaded,
-				actions: {},
-			});
-			return {
-				ydoc,
-				idb: childIdb,
-				sync: childSync,
-				/**
-				 * Child disposer rejections do not propagate; bundle.wipe() relies on
-				 * IDB's deleteDatabase native blocking as belt-and-suspenders for
-				 * storage deletion.
-				 */
-				[Symbol.dispose]() {
-					ydoc.destroy();
-				},
-			};
-		},
+	// Per-conversation transcript child docs: the bound runtime owns lifecycle
+	// (refcount + grace) and connection (local storage + cloud sync, the latter
+	// being what lets the server generation actor stream assistant tokens into
+	// the doc and every signed-in device watch them live). `attachChatTranscript`
+	// owns the transcript shape and the client writer policy. Keyed by guid; the
+	// consumer derives it from the conversation id via `zhongwenConversationDocGuid`.
+	const conversationDocs = createChildDocs({ ...signedIn, deviceId })(
+		attachChatTranscript,
 	);
 
 	let docsTornDown = false;

--- a/packages/workspace/src/ai/chat-doc.test.ts
+++ b/packages/workspace/src/ai/chat-doc.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for `attachChatTranscript`: the client-facing transcript layout handle.
+ *
+ * The free functions (`appendUserMessage`, `appendAssistantMessage`, ...) are
+ * the implementation and the server's entry point; this suite covers the
+ * boundary-respecting handle a UI binds to, and that it reads writes from the
+ * server-side assistant writer (the two-writer contract holding through one doc).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import * as Y from 'yjs';
+import { appendAssistantMessage, attachChatTranscript } from './chat-doc.js';
+
+describe('attachChatTranscript', () => {
+	test('appendUser then read returns the message in transcript order', () => {
+		const doc = new Y.Doc({ guid: 'chat-test' });
+		const transcript = attachChatTranscript(doc);
+
+		transcript.appendUser({ id: 'm1', content: 'hello', createdAt: 1 });
+		transcript.appendUser({ id: 'm2', content: 'world', createdAt: 2 });
+
+		const messages = transcript.read();
+		expect(
+			messages.map((m) => ({ id: m.id, role: m.role, text: m.text })),
+		).toEqual([
+			{ id: 'm1', role: 'user', text: 'hello' },
+			{ id: 'm2', role: 'user', text: 'world' },
+		]);
+		doc.destroy();
+	});
+
+	test('observe fires on a write and re-read reflects it', () => {
+		const doc = new Y.Doc({ guid: 'chat-observe' });
+		const transcript = attachChatTranscript(doc);
+
+		let fired = 0;
+		const unobserve = transcript.observe(() => {
+			fired++;
+		});
+		transcript.appendUser({ id: 'm1', content: 'hi', createdAt: 1 });
+
+		expect(fired).toBeGreaterThan(0);
+		expect(transcript.read()).toHaveLength(1);
+
+		unobserve();
+		transcript.appendUser({ id: 'm2', content: 'bye', createdAt: 2 });
+		// No further callbacks after unobserve, but the write still lands.
+		expect(fired).toBe(1);
+		expect(transcript.read()).toHaveLength(2);
+		doc.destroy();
+	});
+
+	test('reads assistant messages written by the server-side writer', () => {
+		const doc = new Y.Doc({ guid: 'chat-assistant' });
+		const transcript = attachChatTranscript(doc);
+
+		transcript.appendUser({ id: 'u1', content: 'ask', createdAt: 1 });
+		// The server generation actor writes assistant messages via the free
+		// function; the client handle reads them through the same doc.
+		const writer = appendAssistantMessage(doc, { id: 'a1', createdAt: 2 });
+		writer.appendText('answer');
+		writer.finish({ kind: 'completed' });
+
+		const messages = transcript.read();
+		expect(messages.map((m) => m.role)).toEqual(['user', 'assistant']);
+		expect(messages[1]?.text).toBe('answer');
+		expect(messages[1]?.finish).toEqual({ kind: 'completed' });
+		doc.destroy();
+	});
+});

--- a/packages/workspace/src/ai/chat-doc.ts
+++ b/packages/workspace/src/ai/chat-doc.ts
@@ -192,3 +192,45 @@ export function observeChatDocMessages(
 	target.observeDeep(observer);
 	return () => target.unobserveDeep(observer);
 }
+
+/**
+ * `attachChatTranscript(ydoc)`: the conversation layout as a handle (shape +
+ * client writer policy), for use with `createChildDocs`.
+ *
+ * This is the client surface of the transcript: read the messages, observe
+ * changes, and append a user message (the one write a browser client owns). The
+ * assistant-message writer is the server generation actor, which imports
+ * {@link appendAssistantMessage} directly; that writer policy is exactly why
+ * this handle exposes `appendUser` and not an assistant writer.
+ *
+ * The free functions above remain the implementation and the server's entry
+ * point; this handle is the boundary-respecting view a UI binds to (no raw
+ * `ydoc` reach). `findActiveChatDocGeneration` stays a free function: it is pure
+ * over a message snapshot and never touches the doc.
+ */
+export function attachChatTranscript(doc: Y.Doc) {
+	return {
+		/** Snapshot every message in transcript order. */
+		read(): ChatDocMessage[] {
+			return readChatDocMessages(doc);
+		},
+		/**
+		 * Observe transcript changes (new messages, token appends, finish writes).
+		 * Fires once per transaction; re-read with {@link read}. Returns unobserve.
+		 */
+		observe(callback: () => void): () => void {
+			return observeChatDocMessages(doc, callback);
+		},
+		/**
+		 * Append one user message. Single writer: the creating client mints the id
+		 * and never writes to the message again.
+		 */
+		appendUser(message: {
+			id: string;
+			content: string;
+			createdAt: number;
+		}): void {
+			appendUserMessage(doc, message);
+		},
+	};
+}

--- a/packages/workspace/src/ai/index.ts
+++ b/packages/workspace/src/ai/index.ts
@@ -1,6 +1,7 @@
 export {
 	appendAssistantMessage,
 	appendUserMessage,
+	attachChatTranscript,
 	CHAT_DOC_ACTIVE_GENERATION_WINDOW_MS,
 	type ChatDocFinish,
 	type ChatDocMessage,

--- a/packages/workspace/src/document/create-child-docs.test.ts
+++ b/packages/workspace/src/document/create-child-docs.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for `createChildDocs`: the bound child-doc runtime.
+ *
+ * Verifies the three layers compose correctly: the injected `attach*` layout is
+ * applied to each doc (shape), the cache dedups by guid and refcounts opens
+ * (lifecycle), and the connection fields are pre-bound (so `open(guid)` needs
+ * only the guid). Local storage uses `fake-indexeddb`; the fake `openWebSocket`
+ * parks the sync supervisor in CONNECTING and unparks on `ydoc.destroy()`, so
+ * the runtime is exercised without a real relay.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { asOwnerId } from '@epicenter/identity';
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb';
+import type { Guid } from '../shared/id.js';
+import { attachPlainText } from './attach-plain-text.js';
+import {
+	type ChildDocConnection,
+	createChildDocs,
+} from './create-child-docs.js';
+import { asDeviceId } from './device-id.js';
+
+Object.assign(globalThis, { indexedDB, IDBKeyRange });
+
+/**
+ * Minimal fake WebSocket: stays in CONNECTING (readyState 0) until `close()`,
+ * then transitions to CLOSED and fires `onclose`. `ydoc.destroy()` triggers
+ * the close, which unparks the supervisor so the test process exits cleanly.
+ */
+function fakeWebSocket(): Promise<WebSocket> {
+	const ws = {
+		readyState: 0,
+		onclose: null as ((e: CloseEvent) => void) | null,
+		close() {
+			if (ws.readyState === 3) return;
+			ws.readyState = 3;
+			ws.onclose?.({ code: 1000, reason: '' } as CloseEvent);
+		},
+	};
+	return Promise.resolve(ws as unknown as WebSocket);
+}
+
+const connection: ChildDocConnection = {
+	server: 'api.test.invalid',
+	baseURL: 'https://api.test.invalid',
+	ownerId: asOwnerId('owner-1'),
+	openWebSocket: fakeWebSocket,
+	onReconnectSignal: () => () => {},
+	deviceId: asDeviceId('device-1'),
+};
+
+const GUID = 'epicenter-test.entries.row-1.content' as Guid;
+
+describe('createChildDocs', () => {
+	test('applies the injected layout and exposes lifecycle fields', async () => {
+		const bodies = createChildDocs(connection)(attachPlainText, { gcTime: 0 });
+		const handle = bodies.open(GUID);
+		try {
+			// Layout surface is present (attachPlainText -> { binding, read, write }).
+			handle.write('hello');
+			expect(handle.read()).toBe('hello');
+			// Lifecycle fields the runtime adds.
+			expect(handle.guid).toBe(GUID);
+			// `whenLoaded` resolves once local IDB state has replayed (opaque value).
+			await handle.whenLoaded;
+		} finally {
+			handle[Symbol.dispose]();
+		}
+	});
+
+	test('dedups by guid: same guid shares one underlying Y.Doc', () => {
+		const bodies = createChildDocs(connection)(attachPlainText, { gcTime: 0 });
+		const a = bodies.open(GUID);
+		const b = bodies.open(GUID);
+		try {
+			// Distinct handles...
+			expect(a).not.toBe(b);
+			// ...over one shared doc: a write through `a` is visible through `b`.
+			a.write('shared');
+			expect(b.read()).toBe('shared');
+		} finally {
+			a[Symbol.dispose]();
+			b[Symbol.dispose]();
+		}
+	});
+
+	test('refcounts: N opens require N disposes before teardown', () => {
+		const bodies = createChildDocs(connection)(attachPlainText, { gcTime: 0 });
+		const a = bodies.open(GUID);
+		a.write('persisted');
+		const b = bodies.open(GUID);
+
+		// First dispose drops refcount to 1; the doc stays alive.
+		a[Symbol.dispose]();
+		expect(b.read()).toBe('persisted');
+
+		// Last dispose tears the entry down; the next open rebuilds fresh (empty).
+		b[Symbol.dispose]();
+		const c = bodies.open(GUID);
+		try {
+			expect(c.read()).toBe('');
+		} finally {
+			c[Symbol.dispose]();
+		}
+	});
+
+	test('different guids are independent docs', () => {
+		const bodies = createChildDocs(connection)(attachPlainText, { gcTime: 0 });
+		const one = bodies.open(GUID);
+		const two = bodies.open('epicenter-test.entries.row-2.content' as Guid);
+		try {
+			one.write('first');
+			expect(two.read()).toBe('');
+			expect(one.guid).not.toBe(two.guid);
+		} finally {
+			one[Symbol.dispose]();
+			two[Symbol.dispose]();
+		}
+	});
+});

--- a/packages/workspace/src/document/create-child-docs.ts
+++ b/packages/workspace/src/document/create-child-docs.ts
@@ -1,0 +1,133 @@
+/**
+ * `createChildDocs`: the bound child-doc runtime (lifecycle layer).
+ *
+ * A collaborative body (a chat transcript, a prose note, a code snippet) is its
+ * own synced `Y.Doc`, addressed by a stable {@link Guid}. Three concerns recur
+ * every time an app opens one:
+ *
+ *  - **lifecycle**: same guid -> one shared `Y.Doc`; N opens require N disposes;
+ *    a grace window survives route/pane swaps. ({@link createDisposableCache})
+ *  - **connection**: local IndexedDB persistence + cloud sync, both partitioned
+ *    by `(server, ownerId)` and pointed at the room for this guid.
+ *  - **shape**: the CRDT layout and its writer policy, owned by an
+ *    `attach*(ydoc)` function ({@link attachPlainText}, {@link attachRichText},
+ *    `attachChatTranscript`).
+ *
+ * Before this runtime, every app hand-wired all three inline (Zhongwen's
+ * `conversationDocs`, Fuji's `entryBodies`, Honeycrisp's `noteBodyDocs`). This
+ * factory binds the connection once and lets each app declare only the shape:
+ *
+ * ```ts
+ * // once, in the app's signed-in composition:
+ * const childDocs = createChildDocs({ ...signedIn, deviceId });
+ *
+ * // once per layout (connection pre-bound, shape injected):
+ * const conversations = childDocs(attachChatTranscript);
+ *
+ * // per open (lazy; same guid shares one Y.Doc):
+ * using convo = conversations.open(conversationDocGuid(id));
+ * convo.appendUser({ id, content, createdAt });
+ * ```
+ *
+ * Each `childDocs(layout)` call is one {@link createDisposableCache} keyed by
+ * guid. A guid encodes its `field` segment (see {@link docGuid}), so distinct
+ * fields never collide and the "one guid, one layout" invariant holds by
+ * construction: opening the same guid through two different layouts is a
+ * programmer error the guid grammar makes hard to reach.
+ *
+ * Sync is opened for its side effect; the `openCollaboration` handle is
+ * intentionally orphaned, exactly as the hand-wired caches did. Teardown
+ * cascades from `ydoc.destroy()` when the cache evicts the entry.
+ *
+ * @module
+ */
+
+import type { OwnerId } from '@epicenter/identity';
+import * as Y from 'yjs';
+import { createDisposableCache } from '../cache/disposable-cache.js';
+import type { Guid } from '../shared/id.js';
+import { attachLocalStorage } from './attach-local-storage.js';
+import type { DeviceId } from './device-id.js';
+import {
+	type OnReconnectSignal,
+	type OpenWebSocketFn,
+	openCollaboration,
+} from './open-collaboration.js';
+import { roomWsUrl } from './transport.js';
+
+/**
+ * Everything `createChildDocs` needs to connect a child doc to local storage
+ * and cloud sync. Structurally a superset of the auth `SignedIn` payload plus
+ * the per-client `deviceId`; typed against workspace-native types so the
+ * runtime never imports from the auth/Svelte layer.
+ *
+ * Pass `{ ...signedIn, deviceId }` at the call site.
+ */
+export type ChildDocConnection = {
+	/** API origin host (e.g. `api.epicenter.so`); partitions local storage. */
+	server: string;
+	/** Full API origin URL (e.g. `https://api.epicenter.so`); scheme upgrades to `wss://`. */
+	baseURL: string;
+	ownerId: OwnerId;
+	/** Bearer-attached WebSocket opener (`auth.openWebSocket`). */
+	openWebSocket: OpenWebSocketFn;
+	/** Auth state-change publication; sync reconnects after token refreshes. */
+	onReconnectSignal: OnReconnectSignal;
+	deviceId: DeviceId;
+};
+
+/**
+ * Bind the connection once and return a `childDocs(layout)` factory.
+ *
+ * @param connection - `(server, baseURL, ownerId, openWebSocket,
+ *                       onReconnectSignal, deviceId)`, pre-bound into every
+ *                      child doc this runtime opens.
+ */
+export function createChildDocs(connection: ChildDocConnection) {
+	/**
+	 * Create a guid-keyed cache of child docs shaped by `layout`. The connection
+	 * is already bound; the cache lazily opens each doc on first `open(guid)` and
+	 * tears it down a grace window after the last dispose.
+	 *
+	 * @param layout  - `attach*(ydoc)` function owning the CRDT shape and writer
+	 *                  policy. Its returned handle is spread onto the open handle.
+	 * @param options - `gcTime` forwarded to the underlying cache (default 5s).
+	 */
+	return function childDocs<TLayout extends object>(
+		layout: (ydoc: Y.Doc) => TLayout,
+		options: { gcTime?: number } = {},
+	) {
+		return createDisposableCache((guid: Guid) => {
+			const ydoc = new Y.Doc({ guid, gc: true });
+			const idb = attachLocalStorage(ydoc, {
+				server: connection.server,
+				ownerId: connection.ownerId,
+			});
+			// Sync is opened for its side effect: it lets the server generation
+			// actor stream into the doc and every signed-in device watch live. The
+			// handle is orphaned on purpose; teardown cascades from `ydoc.destroy()`.
+			openCollaboration(ydoc, {
+				url: roomWsUrl({
+					baseURL: connection.baseURL,
+					ownerId: connection.ownerId,
+					guid,
+					deviceId: connection.deviceId,
+				}),
+				openWebSocket: connection.openWebSocket,
+				onReconnectSignal: connection.onReconnectSignal,
+				waitFor: idb.whenLoaded,
+				actions: {},
+			});
+			return {
+				...layout(ydoc),
+				/** The doc's guid (the cache key); callers needing the room id read it here, not the raw `ydoc`. */
+				guid,
+				/** Resolves when local IndexedDB state has replayed into the doc. */
+				whenLoaded: idb.whenLoaded,
+				[Symbol.dispose]() {
+					ydoc.destroy();
+				},
+			};
+		}, options);
+	};
+}

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -170,6 +170,10 @@ export { attachLocalStorage } from './document/attach-local-storage.js';
 export { attachPlainText } from './document/attach-plain-text.js';
 export { attachRichText } from './document/attach-rich-text.js';
 export { attachTimeline } from './document/attach-timeline/index.js';
+export {
+	type ChildDocConnection,
+	createChildDocs,
+} from './document/create-child-docs.js';
 export { defineKv } from './document/define-kv.js';
 export { defineTable } from './document/define-table.js';
 export {


### PR DESCRIPTION
This adds the shared child-doc runtime that row-declared collaborative fields will build on.

Child docs now have one reusable lifecycle and connection layer:

```ts
const childDocs = createChildDocs({ ...signedIn, deviceId });
const conversations = childDocs(attachChatTranscript);

using transcript = conversations.open(zhongwenConversationDocGuid(conversationId));
transcript.appendUser({ id, content, createdAt });
```

`createChildDocs(connection)` binds local storage, sync, reconnect behavior, device identity, and refcounted disposal once. Each layout still owns its own CRDT shape and writer policy. `attachChatTranscript(ydoc)` is the first layout handle: UI code can read, observe, and append user messages without touching the raw `Y.Doc`, while the server generation actor keeps using the lower-level assistant writer.

Zhongwen moves its conversation transcript cache onto this runtime as the proof case. The behavior is meant to stay the same, but the composition boundary changes: browser app code opens a transcript by guid and consumes a typed handle, not a hand-wired `{ ydoc, idb, sync }` bundle.

This deliberately leaves row-level `.childDocs({ name: layout })` declaration for the next phase. This PR gives that phase the runtime it needs: derived guids can point at the same `createChildDocs` path instead of each app rebuilding storage and sync wiring by hand.
