### PR TITLE
refactor(apps): finish single-mount cleanup

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -22,22 +22,22 @@ satisfiesWorkspace()
 
 ```
 apps/<app>/
-├── project.ts       optional `<app>()` daemon mount factory
+├── mount.ts         optional `<app>()` daemon mount factory
 ├── workspace.ts     shared schema, branded IDs, workspace definition, actions
 ├── src/             SvelteKit app
-└── package.json     "exports": { ".": "./workspace.ts", "./project": "./project.ts" }
+└── package.json     "exports": { ".": "./workspace.ts", "./mount": "./mount.ts" }
 ```
 
 Some apps keep the shared workspace contract under `src/lib/workspace.ts`
 instead of the package root. Follow the existing package shape. The important
 boundary is the same: shared model in the workspace file, runtime wiring in
-`browser.ts`, `project.ts`, or `tauri.ts`.
+`browser.ts`, `mount.ts`, or `tauri.ts`.
 
 ## Boundaries
 
 `workspace.ts` is the sync contract. It defines table shapes, KV schemas, branded IDs, actions, child-doc layouts, and the app's `defineWorkspace(...)` value. Forking that file means forking sync compatibility.
 
-`project.ts` is the reusable mount factory. It opens the shared workspace with Node-only attachments: Yjs persistence, collaboration, SQLite and Markdown materializers, and daemon-exposed actions.
+`mount.ts` is the reusable mount factory. It opens the shared workspace with Node-only attachments: Yjs persistence, collaboration, SQLite and Markdown materializers, and daemon-exposed actions.
 
 Browser and desktop code open the same definition with runtime-specific composition. Scripts usually skip Yjs entirely: they read materialized files or SQLite and call daemon actions through `connectDaemonActions`.
 
@@ -46,6 +46,6 @@ Browser and desktop code open the same definition with runtime-specific composit
 1. Add `apps/<app>/workspace.ts` or `apps/<app>/src/lib/workspace.ts`, following the package's existing layout.
 2. Point `package.json` `exports["."]` at the workspace contract file.
 3. Add an exported `defineWorkspace({ id, tables, kv, actions })` value. Declare row child docs with `table.docs(...)`.
-4. Add `apps/<app>/project.ts` exporting `<app>(opts?)`, a factory that returns `defineSessionMount({ name, open })` (or `defineMount` for a mount that can run signed out).
-5. Point `package.json` `exports["./project"]` at `./project.ts`.
+4. Add `apps/<app>/mount.ts` exporting `<app>(opts?)`, a factory that returns `defineSessionMount({ name, open })` (or `defineMount` for a mount that can run signed out).
+5. Point `package.json` `exports["./mount"]` at `./mount.ts`.
 6. Run `epicenter daemon up -C <epicenter-root>` and confirm the mount appears in `epicenter list`.

--- a/apps/fuji/README.md
+++ b/apps/fuji/README.md
@@ -104,7 +104,7 @@ This starts the app dev server on port 5174. Auth and sync expect the local API 
 Fuji's mount is registered from the Epicenter root (the folder that holds `epicenter.config.ts`). It is not discovered from `.epicenter/` or any source folder. A folder that wants the Fuji mount needs an `epicenter.config.ts` like this:
 
 ```ts
-import { fuji } from "@epicenter/fuji/project";
+import { fuji } from "@epicenter/fuji/mount";
 
 export default fuji();
 ```

--- a/apps/fuji/mount.ts
+++ b/apps/fuji/mount.ts
@@ -1,0 +1,8 @@
+/**
+ * Fuji mount entry point.
+ *
+ * Keep this file at the app root so an `epicenter.config.ts` can import
+ * `@epicenter/fuji/mount`, matching the other app packages.
+ */
+
+export { fuji } from './src/lib/workspace/mount.js';

--- a/apps/fuji/package.json
+++ b/apps/fuji/package.json
@@ -6,7 +6,7 @@
 	"type": "module",
 	"exports": {
 		".": "./src/lib/workspace/index.ts",
-		"./project": "./project.ts"
+		"./mount": "./mount.ts"
 	},
 	"imports": {
 		"#platform/auth": {

--- a/apps/fuji/project.ts
+++ b/apps/fuji/project.ts
@@ -1,8 +1,0 @@
-/**
- * Fuji project mount entry point.
- *
- * Keep this file at the app root so local project configs can import
- * `../epicenter/apps/fuji/project.ts`, matching the other app packages.
- */
-
-export { fuji } from './src/lib/workspace/project.js';

--- a/apps/fuji/src/lib/workspace/index.ts
+++ b/apps/fuji/src/lib/workspace/index.ts
@@ -20,8 +20,8 @@
  *
  * Composition lives elsewhere:
  *  - `src/lib/workspace/browser.ts` → `openFujiBrowser({ signedIn, deviceId })`
- *  - `src/lib/workspace/project.ts` → `fuji(opts?)` mount factory
- *  - `examples/fuji/epicenter.config.ts` → canonical project layout composition
+ *  - `src/lib/workspace/mount.ts` → `fuji(opts?)` mount factory
+ *  - `examples/fuji/epicenter.config.ts` → canonical Epicenter folder composition
  *
  * The workspace factory returns actions under `workspace.actions`; runtime
  * openers pass that registry to collaboration and can layer runtime-specific

--- a/apps/fuji/src/lib/workspace/mount.ts
+++ b/apps/fuji/src/lib/workspace/mount.ts
@@ -1,5 +1,5 @@
 /**
- * Fuji project mount.
+ * Fuji mount.
  *
  * `fuji(opts?)` returns the `Mount` that an `epicenter.config.ts`
  * default-exports. Disk paths follow the Epicenter-root layout: the

--- a/apps/honeycrisp/README.md
+++ b/apps/honeycrisp/README.md
@@ -23,7 +23,7 @@ honeycrispWorkspace
 openHoneycrispBrowser()
   browser runtime: local storage, sync, child-doc storage and sync
 
-honeycrisp() (project mount)
+honeycrisp() (mount)
   daemon runtime: Yjs log, sync, SQLite mirror, markdown materializer
 ```
 

--- a/apps/honeycrisp/honeycrisp.ts
+++ b/apps/honeycrisp/honeycrisp.ts
@@ -11,7 +11,7 @@
  *
  * Composition lives elsewhere:
  *  - `apps/honeycrisp/honeycrisp.browser.ts`  -> `openHoneycrispBrowser({ signedIn, deviceId })`
- *  - `apps/honeycrisp/project.ts`  -> `honeycrisp(opts?)` mount factory
+ *  - `apps/honeycrisp/mount.ts`  -> `honeycrisp(opts?)` mount factory
  */
 
 import { field } from '@epicenter/field';

--- a/apps/honeycrisp/mount.ts
+++ b/apps/honeycrisp/mount.ts
@@ -1,9 +1,11 @@
 /**
- * Tab Manager project mount.
+ * Honeycrisp mount.
  *
- * `tabManager(opts?)` returns the Mount used by `epicenter.config.ts`.
- * It projects saved tabs, bookmarks, and devices into markdown while keeping
- * the Y.Doc update log and SQLite mirror under `.epicenter/`.
+ * `honeycrisp(opts?)` returns the `Mount` that an
+ * `epicenter.config.ts` default-exports. Disk paths follow the
+ * Epicenter-root layout: the SQLite mirror at `.epicenter/sqlite/<id>.db`
+ * (hidden) and the read-only markdown projection under table-named folders in
+ * the app root.
  */
 
 import { join } from 'node:path';
@@ -20,10 +22,9 @@ import {
 	sqlitePath,
 } from '@epicenter/workspace/node';
 import { createLogger } from 'wellcrafted/logger';
-import { createTabManager } from './src/lib/workspace/definition.js';
+import { honeycrispWorkspace } from './honeycrisp.js';
 
-export type TabManagerMountOptions = {
-	/** Enable per-materializer Git autosave for markdown output. */
+export type HoneycrispMountOptions = {
 	git?: GitAutosaveConfig;
 	/**
 	 * Base URL of the Epicenter cloud API used for sync.
@@ -32,9 +33,9 @@ export type TabManagerMountOptions = {
 	baseURL?: string;
 };
 
-export function tabManager(opts: TabManagerMountOptions = {}) {
+export function honeycrisp(opts: HoneycrispMountOptions = {}) {
 	return defineSessionMount({
-		name: 'tab-manager',
+		name: 'honeycrisp',
 		open(ctx) {
 			const { epicenterRoot, mount } = ctx;
 			const baseURL =
@@ -42,35 +43,27 @@ export function tabManager(opts: TabManagerMountOptions = {}) {
 				process.env.EPICENTER_API_URL ||
 				'https://api.epicenter.so';
 
-			const workspace = createTabManager();
+			const workspace = honeycrispWorkspace.create();
 
 			const sqlite = attachBunSqliteMaterializer(workspace, {
 				filePath: sqlitePath(epicenterRoot, workspace.ydoc.guid),
-				fts: {
-					bookmarks: ['title', 'url'],
-					savedTabs: ['title', 'url'],
-				},
 				log: createLogger(`${mount}-sqlite`),
 			});
+
 			const markdown = attachMarkdownExport(workspace, {
 				dir: epicenterRoot,
-				tables: {
-					bookmarks: {},
-					devices: {},
-					savedTabs: {},
-				},
+				tables: { notes: {} },
 			});
 			if (opts.git) {
-				for (const tableDir of ['bookmarks', 'devices', 'savedTabs']) {
-					attachGitAutosave({
-						ydoc: workspace.ydoc,
-						dir: join(epicenterRoot, tableDir),
-						config: opts.git,
-					});
-				}
+				attachGitAutosave({
+					ydoc: workspace.ydoc,
+					dir: join(epicenterRoot, 'notes'),
+					config: opts.git,
+				});
 			}
 
 			const actions = defineActions({
+				...workspace.actions,
 				...sqlite.actions,
 				...markdown.actions,
 			});

--- a/apps/honeycrisp/package.json
+++ b/apps/honeycrisp/package.json
@@ -6,7 +6,7 @@
 	"type": "module",
 	"exports": {
 		".": "./honeycrisp.ts",
-		"./project": "./project.ts"
+		"./mount": "./mount.ts"
 	},
 	"scripts": {
 		"dev": "bun run dev:local",

--- a/apps/opensidian/mount.ts
+++ b/apps/opensidian/mount.ts
@@ -1,18 +1,20 @@
 /**
- * Zhongwen project mount.
+ * Opensidian mount.
  *
- * `zhongwen()` returns the `Mount` that a project's `epicenter.config.ts`
- * default-exports. Zhongwen has no daemon actions and no materializers today;
- * the daemon's only job is to host the Y.Doc on disk and bridge
- * sync.
+ * `opensidian()` returns the `Mount` that an `epicenter.config.ts`
+ * default-exports.
+ *
+ * The shared workspace currently exposes no daemon actions. Opensidian's file
+ * and shell actions need browser services (Yjs filesystem, in-browser SQLite,
+ * just-bash) and are added only by the browser runtime.
  */
 
 import { satisfiesWorkspace } from '@epicenter/workspace';
 import { defineSessionMount } from '@epicenter/workspace/daemon';
 import { attachMountInfrastructure } from '@epicenter/workspace/node';
-import { zhongwenWorkspace } from './zhongwen.js';
+import { opensidianWorkspace } from './opensidian.js';
 
-export type ZhongwenMountOptions = {
+export type OpensidianMountOptions = {
 	/**
 	 * Base URL of the Epicenter cloud API used for sync.
 	 * Defaults to `process.env.EPICENTER_API_URL`, falling back to the hosted API.
@@ -20,22 +22,16 @@ export type ZhongwenMountOptions = {
 	baseURL?: string;
 };
 
-/**
- * Mount Zhongwen in an Epicenter project daemon.
- *
- * The daemon hosts the root Y.Doc and sync bridge. Transcript child docs are
- * opened on demand by browser UI or server generation actors.
- */
-export function zhongwen(opts: ZhongwenMountOptions = {}) {
+export function opensidian(opts: OpensidianMountOptions = {}) {
 	return defineSessionMount({
-		name: 'zhongwen',
+		name: 'opensidian',
 		open(ctx) {
 			const baseURL =
 				opts.baseURL ||
 				process.env.EPICENTER_API_URL ||
 				'https://api.epicenter.so';
 
-			const workspace = zhongwenWorkspace.create();
+			const workspace = opensidianWorkspace.create();
 
 			const infrastructure = attachMountInfrastructure(workspace.ydoc, ctx, {
 				baseURL,

--- a/apps/opensidian/opensidian.ts
+++ b/apps/opensidian/opensidian.ts
@@ -11,7 +11,7 @@
  *
  * Composition lives elsewhere:
  *  - `apps/opensidian/opensidian.browser.ts` -> `openOpensidianBrowser({ signedIn, deviceId })`
- *  - `apps/opensidian/project.ts`                    -> `opensidian()` mount factory
+ *  - `apps/opensidian/mount.ts`                      -> `opensidian()` mount factory
  */
 
 import { field, jsonValue } from '@epicenter/field';

--- a/apps/opensidian/package.json
+++ b/apps/opensidian/package.json
@@ -7,7 +7,7 @@
 	"exports": {
 		".": "./opensidian.ts",
 		"./browser": "./opensidian.browser.ts",
-		"./project": "./project.ts"
+		"./mount": "./mount.ts"
 	},
 	"scripts": {
 		"dev": "bun run dev:local",

--- a/apps/tab-manager/mount.ts
+++ b/apps/tab-manager/mount.ts
@@ -1,11 +1,9 @@
 /**
- * Honeycrisp project mount.
+ * Tab Manager mount.
  *
- * `honeycrisp(opts?)` returns the `Mount` that an
- * `epicenter.config.ts` default-exports. Disk paths follow the
- * Epicenter-root layout: the SQLite mirror at `.epicenter/sqlite/<id>.db`
- * (hidden) and the read-only markdown projection under table-named folders in
- * the app root.
+ * `tabManager(opts?)` returns the Mount used by `epicenter.config.ts`.
+ * It projects saved tabs, bookmarks, and devices into markdown while keeping
+ * the Y.Doc update log and SQLite mirror under `.epicenter/`.
  */
 
 import { join } from 'node:path';
@@ -22,9 +20,10 @@ import {
 	sqlitePath,
 } from '@epicenter/workspace/node';
 import { createLogger } from 'wellcrafted/logger';
-import { honeycrispWorkspace } from './honeycrisp.js';
+import { createTabManager } from './src/lib/workspace/definition.js';
 
-export type HoneycrispMountOptions = {
+export type TabManagerMountOptions = {
+	/** Enable per-materializer Git autosave for markdown output. */
 	git?: GitAutosaveConfig;
 	/**
 	 * Base URL of the Epicenter cloud API used for sync.
@@ -33,9 +32,9 @@ export type HoneycrispMountOptions = {
 	baseURL?: string;
 };
 
-export function honeycrisp(opts: HoneycrispMountOptions = {}) {
+export function tabManager(opts: TabManagerMountOptions = {}) {
 	return defineSessionMount({
-		name: 'honeycrisp',
+		name: 'tab-manager',
 		open(ctx) {
 			const { epicenterRoot, mount } = ctx;
 			const baseURL =
@@ -43,27 +42,35 @@ export function honeycrisp(opts: HoneycrispMountOptions = {}) {
 				process.env.EPICENTER_API_URL ||
 				'https://api.epicenter.so';
 
-			const workspace = honeycrispWorkspace.create();
+			const workspace = createTabManager();
 
 			const sqlite = attachBunSqliteMaterializer(workspace, {
 				filePath: sqlitePath(epicenterRoot, workspace.ydoc.guid),
+				fts: {
+					bookmarks: ['title', 'url'],
+					savedTabs: ['title', 'url'],
+				},
 				log: createLogger(`${mount}-sqlite`),
 			});
-
 			const markdown = attachMarkdownExport(workspace, {
 				dir: epicenterRoot,
-				tables: { notes: {} },
+				tables: {
+					bookmarks: {},
+					devices: {},
+					savedTabs: {},
+				},
 			});
 			if (opts.git) {
-				attachGitAutosave({
-					ydoc: workspace.ydoc,
-					dir: join(epicenterRoot, 'notes'),
-					config: opts.git,
-				});
+				for (const tableDir of ['bookmarks', 'devices', 'savedTabs']) {
+					attachGitAutosave({
+						ydoc: workspace.ydoc,
+						dir: join(epicenterRoot, tableDir),
+						config: opts.git,
+					});
+				}
 			}
 
 			const actions = defineActions({
-				...workspace.actions,
 				...sqlite.actions,
 				...markdown.actions,
 			});

--- a/apps/tab-manager/package.json
+++ b/apps/tab-manager/package.json
@@ -6,7 +6,7 @@
 	"private": true,
 	"exports": {
 		".": "./src/lib/workspace/index.ts",
-		"./project": "./project.ts"
+		"./mount": "./mount.ts"
 	},
 	"scripts": {
 		"dev": "bun run dev:local",

--- a/apps/zhongwen/mount.ts
+++ b/apps/zhongwen/mount.ts
@@ -1,20 +1,18 @@
 /**
- * Opensidian project mount.
+ * Zhongwen mount.
  *
- * `opensidian()` returns the `Mount` that a project's `epicenter.config.ts`
- * default-exports.
- *
- * The shared workspace currently exposes no daemon actions. Opensidian's file
- * and shell actions need browser services (Yjs filesystem, in-browser SQLite,
- * just-bash) and are added only by the browser runtime.
+ * `zhongwen()` returns the `Mount` that an `epicenter.config.ts`
+ * default-exports. Zhongwen has no daemon actions and no materializers today;
+ * the daemon's only job is to host the Y.Doc on disk and bridge
+ * sync.
  */
 
 import { satisfiesWorkspace } from '@epicenter/workspace';
 import { defineSessionMount } from '@epicenter/workspace/daemon';
 import { attachMountInfrastructure } from '@epicenter/workspace/node';
-import { opensidianWorkspace } from './opensidian.js';
+import { zhongwenWorkspace } from './zhongwen.js';
 
-export type OpensidianMountOptions = {
+export type ZhongwenMountOptions = {
 	/**
 	 * Base URL of the Epicenter cloud API used for sync.
 	 * Defaults to `process.env.EPICENTER_API_URL`, falling back to the hosted API.
@@ -22,16 +20,22 @@ export type OpensidianMountOptions = {
 	baseURL?: string;
 };
 
-export function opensidian(opts: OpensidianMountOptions = {}) {
+/**
+ * Mount Zhongwen in an Epicenter daemon.
+ *
+ * The daemon hosts the root Y.Doc and sync bridge. Transcript child docs are
+ * opened on demand by browser UI or server generation actors.
+ */
+export function zhongwen(opts: ZhongwenMountOptions = {}) {
 	return defineSessionMount({
-		name: 'opensidian',
+		name: 'zhongwen',
 		open(ctx) {
 			const baseURL =
 				opts.baseURL ||
 				process.env.EPICENTER_API_URL ||
 				'https://api.epicenter.so';
 
-			const workspace = opensidianWorkspace.create();
+			const workspace = zhongwenWorkspace.create();
 
 			const infrastructure = attachMountInfrastructure(workspace.ydoc, ctx, {
 				baseURL,

--- a/apps/zhongwen/package.json
+++ b/apps/zhongwen/package.json
@@ -7,7 +7,7 @@
 	"exports": {
 		".": "./zhongwen.ts",
 		"./browser": "./zhongwen.browser.ts",
-		"./project": "./project.ts"
+		"./mount": "./mount.ts"
 	},
 	"scripts": {
 		"dev": "bun run dev:local",

--- a/apps/zhongwen/zhongwen.ts
+++ b/apps/zhongwen/zhongwen.ts
@@ -13,7 +13,7 @@
  * Composition lives elsewhere:
  *  - `apps/zhongwen/zhongwen.browser.ts`
  *      → `openZhongwenBrowser({ signedIn, deviceId })`
- *  - `apps/zhongwen/project.ts` → `zhongwen()` mount factory
+ *  - `apps/zhongwen/mount.ts` → `zhongwen()` mount factory
  */
 
 import type { ServableModel } from '@epicenter/constants/ai-providers';

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,7 +89,7 @@ Apps wrap `createWorkspace` in a per-app factory. That is where the app id, tabl
 createWorkspace()
   -> createFuji()
     -> openFujiBrowser()
-    -> fuji() (project mount)
+    -> fuji() (mount)
 ```
 
 Use `defineWorkspace()` when returning the composed object so TypeScript keeps the exact inferred bundle shape after spreads.

--- a/docs/articles/satisfies-lets-go-to-definition-follow-the-value.md
+++ b/docs/articles/satisfies-lets-go-to-definition-follow-the-value.md
@@ -184,7 +184,7 @@ TWorkspace extends Workspace<TTables, TKv, TActions>
 
 Writing that at every call site would make the implementation harder to read. The helper exists to keep the object literal readable while preserving the exact inferred return type.
 
-A concrete Epicenter example is a project mount: the small object a project config gives the daemon. Every mount receives one `MountContext` with a nullable `session`:
+A concrete Epicenter example is a mount: the small object `epicenter.config.ts` gives the daemon. Every mount receives one `MountContext` with a nullable `session`:
 
 ```typescript
 type Mount = {

--- a/examples/fuji/.gitignore
+++ b/examples/fuji/.gitignore
@@ -1,10 +1,7 @@
-# Epicenter: machine state and generated mount projections.
-# Everything here is regenerable from the Yjs persistence under .epicenter/.
+# Epicenter machine state, regenerable from the Yjs persistence under it.
+# The Markdown projection (entries/) is tracked on purpose: it is the file
+# output you keep and version.
 .epicenter/
-
-# Generated mount projections are direct children of the Epicenter root,
-# keyed by mount name. Ignore them while keeping epicenter.config.ts tracked.
-/fuji/
 
 # Bun / Node
 node_modules/

--- a/examples/fuji/README.md
+++ b/examples/fuji/README.md
@@ -5,9 +5,9 @@ The canonical Epicenter folder layout demonstrated against `@epicenter/fuji`.
 ## What this shows
 
 One Epicenter folder, one Fuji mount, declared in `epicenter.config.ts`. The
-mount projects its markdown to `fuji/` (a direct child of the Epicenter root,
-keyed by the mount name) and the daemon keeps machine state under `.epicenter/`.
-Both are gitignored; `epicenter.config.ts` is the tracked boundary marker.
+mount projects its markdown to `entries/` (a direct child of the Epicenter root,
+one folder per table) and the daemon keeps machine state under `.epicenter/`.
+The projection is tracked in git; only `.epicenter/` is gitignored.
 
 This example is the reference implementation of the layout spec at
 `specs/20260612T000201-epicenter-namespace-root-layout.md`. If the spec changes,
@@ -23,12 +23,11 @@ The Epicenter root is the folder that holds `epicenter.config.ts`. Here that is
 examples/fuji/
 ├── package.json           dependencies (this file)
 ├── tsconfig.json          extends the repo base
-├── epicenter.config.ts    REQUIRED. Marker + mount list.
-├── .gitignore             tracks the config, ignores .epicenter/ and fuji/
-├── entries/               sample seed markdown (committed)
-│   ├── welcome.md
+├── epicenter.config.ts    REQUIRED. Marker + mount.
+├── .gitignore             tracks the config and entries/, ignores .epicenter/
+├── entries/               markdown projection for the entries table (tracked)
+│   ├── welcome.md         committed seed; the daemon rewrites it on each run
 │   └── hello-fuji.md
-├── fuji/                  markdown projection for the `fuji` mount (generated)
 └── .epicenter/            machine state; created on first daemon run
     ├── yjs/
     │   └── <id>.db        Yjs persistence, keyed by ydoc.guid
@@ -46,7 +45,7 @@ bun x epicenter daemon up -C examples/fuji
 On first run the daemon creates `.epicenter/` and writes the guid-keyed SQLite
 mirror plus the Yjs persistence file used by `attachMountInfrastructure`. The
 mount materializes the live Y.Doc out to SQLite and writes markdown as a
-projection under `fuji/`: root row frontmatter plus entry body text read from
+projection under `entries/`: root row frontmatter plus entry body text read from
 the app-owned body Y.Doc. Importing markdown back into Fuji body Y.Docs is
 follow-up work.
 
@@ -68,7 +67,7 @@ The SQLite mirror is regenerable from the Yjs persistence file, so deleting
 
 Today, edit through mount actions or a connected Fuji runtime and watch the
 markdown and SQLite projections update. The reverse direction, editing
-`fuji/*.md` and having the daemon ingest body text back into entry body Y.Docs,
+`entries/*.md` and having the daemon ingest body text back into entry body Y.Docs,
 is planned follow-up work.
 
 You can also drive changes through the daemon's RPC actions. Use the CLI:
@@ -95,8 +94,6 @@ the root row and body text into the entry body Y.Doc.
 
 - Auth and sync. The example is local-only; no `epicenter auth login` step.
 - Browser or Tauri frontend. The example is daemon-hosted only.
-- Multiple mounts. This example keeps the mount list small so the layout stays
-  easy to inspect.
 
 ## See also
 

--- a/examples/fuji/entries/welcome.md
+++ b/examples/fuji/entries/welcome.md
@@ -26,7 +26,7 @@ SQLite projections update.
 
 This fixture is a committed markdown projection for a Fuji mount:
 
-- `epicenter.config.ts` is the Epicenter root marker and default-exports the mount list.
+- `epicenter.config.ts` is the Epicenter root marker and default-exports the mount.
 - `entries/` (this directory) holds the markdown projection.
 - `.epicenter/` is the runtime cache (gitignored).
 

--- a/examples/fuji/entries/welcome.md
+++ b/examples/fuji/entries/welcome.md
@@ -36,5 +36,6 @@ This fixture is a committed markdown projection for a Fuji mount:
     bun x epicenter daemon up
 
 The daemon materializes `.epicenter/yjs/epicenter-fuji.db` and
-`.epicenter/sqlite.db` on first run. Inspect the SQLite mirror with
-`sqlite3 .epicenter/sqlite.db` for queryable access to the same data.
+`.epicenter/sqlite/epicenter-fuji.db` on first run. Inspect the SQLite mirror
+with `sqlite3 .epicenter/sqlite/epicenter-fuji.db` for queryable access to the
+same data.

--- a/examples/fuji/epicenter.config.ts
+++ b/examples/fuji/epicenter.config.ts
@@ -14,6 +14,6 @@
  * table), and the SQLite mirror is guid-keyed under `.epicenter/sqlite/<id>.db`.
  */
 
-import { fuji } from '@epicenter/fuji/project';
+import { fuji } from '@epicenter/fuji/mount';
 
 export default fuji();

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -36,7 +36,7 @@ The same env var and scripts apply to every command that talks to the API, inclu
 
 ## Commands
 
-`epicenter daemon up` opens every mount listed in the Epicenter root's `epicenter.config.ts`. `list`, `run`, and `peers` dispatch to that local daemon over its Unix socket.
+`epicenter daemon up` opens the mount the Epicenter root's `epicenter.config.ts` declares. `list`, `run`, and `peers` dispatch to that local daemon over its Unix socket.
 
 ```bash
 epicenter auth login
@@ -55,7 +55,7 @@ epicenter run fuji.entries_update '{"id":"entry_1","tags":["triaged"]}' --peer u
 epicenter peers -C ~/workspace
 ```
 
-`-C` is a start directory for Epicenter-root discovery. Discovery walks upward until it finds `epicenter.config.ts`, then the daemon starts every mount in that config. Discovery is upward-only and never scans down, so run from inside your Epicenter folder (or any directory under it) or pass `-C <epicenter-root>`. From a repo whose Epicenter folder lives at `repo/apps`, that is `epicenter daemon up -C apps`.
+`-C` is a start directory for Epicenter-root discovery. Discovery walks upward until it finds `epicenter.config.ts`, then the daemon opens the mount that config declares. Discovery is upward-only and never scans down, so run from inside your Epicenter folder (or any directory under it) or pass `-C <epicenter-root>`. From a repo whose Epicenter folder lives at `repo/apps`, that is `epicenter daemon up -C apps`.
 
 ## Exit codes
 
@@ -91,7 +91,7 @@ repo/                      unreserved repo root
 └── fuji/                  Epicenter root (folder name is your choice)
     ├── epicenter.config.ts   tracked, marks the Epicenter root
     ├── .epicenter/           ignored, machine state for this root
-    └── fuji/                 ignored, generated projection
+    └── entries/              generated Markdown projection (one folder per table)
 ```
 
 Put `epicenter.config.ts` in a folder dedicated to one app. The marker is the config file, not the folder name. Run several apps by giving each its own folder, each its own root.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -77,7 +77,7 @@ Error text goes to stderr; machine-readable output (`--format json|jsonl`, table
 `epicenter.config.ts` marks the Epicenter root and declares its mount. One folder is one app is one mount: the default export is a single `Mount`. App packages ship mount factories that return `Mount` values; `Mount.name` owns the CLI prefix. The folder that holds `epicenter.config.ts` is your Epicenter folder: Epicenter owns its direct children, so the mount's visible markdown projection is a direct child folder.
 
 ```ts
-import { fuji } from "@epicenter/fuji/project";
+import { fuji } from "@epicenter/fuji/mount";
 
 export default fuji();
 ```

--- a/packages/cli/test/e2e-up-cross-peer.test.ts
+++ b/packages/cli/test/e2e-up-cross-peer.test.ts
@@ -7,7 +7,7 @@
  * § "Acceptance criteria". Each line below cites the criterion and the test
  * that exercises it (or the infra gap that blocks coverage).
  *
- *   [ok] `daemon up` prints "online (mounts=[...])" on stderr,
+ *   [ok] `daemon up` prints "online (mount=...)" on stderr,
  *        followed by the initial peers snapshot.
  *        Covered by `daemon up lifecycle: online banner + peers snapshot + clean exit`.
  *   [ok] Ctrl-C / SIGTERM exits cleanly with no orphan socket / metadata.

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -527,7 +527,7 @@ same row and share one underlying Y.Doc safely; the workspace-owned cache handle
 construction, refcounting, and `gcTime`-delayed teardown.
 
 Reference implementations: `apps/opensidian/opensidian.browser.ts`,
-`apps/fuji/src/lib/workspace/browser.ts`, `apps/fuji/src/lib/workspace/project.ts`,
+`apps/fuji/src/lib/workspace/browser.ts`, `apps/fuji/src/lib/workspace/mount.ts`,
 and `apps/honeycrisp/honeycrisp.browser.ts`.
 
 ## Schema definition

--- a/packages/workspace/src/client/connect-daemon-actions.ts
+++ b/packages/workspace/src/client/connect-daemon-actions.ts
@@ -20,10 +20,10 @@
  * await fuji.entries_update({ id, tags: ['untagged'] });
  * ```
  *
- * Daemon-scope calls (peers, list across mounts) live on `DaemonClient`
- * directly: construct one with `daemonClient(socketPathFor(epicenterRoot))` and
- * call `.peers()` / `.list()` against the same socket. They are not
- * reachable through this workspace handle.
+ * Daemon-scope calls (`peers`, `list`) live on `DaemonClient` directly:
+ * construct one with `daemonClient(socketPathFor(epicenterRoot))` and call
+ * `.peers()` / `.list()` against the same socket. They are not reachable
+ * through this workspace handle.
  */
 
 import { getDaemon } from '../daemon/client.js';

--- a/packages/workspace/src/config/epicenter-config-source.ts
+++ b/packages/workspace/src/config/epicenter-config-source.ts
@@ -3,7 +3,7 @@ export const EPICENTER_CONFIG_FILENAME = 'epicenter.config.ts';
 export const DEFAULT_EPICENTER_CONFIG_SOURCE = `// One folder is one app is one mount. Default-export the mount your app
 // factory returns to bring this Epicenter folder online. For example:
 //
-//   import { fuji } from '@epicenter/fuji/project';
+//   import { fuji } from '@epicenter/fuji/mount';
 //
 //   export default fuji();
 //

--- a/packages/workspace/src/config/load-epicenter-config.test.ts
+++ b/packages/workspace/src/config/load-epicenter-config.test.ts
@@ -101,14 +101,6 @@ describe('loadEpicenterConfig', () => {
 		});
 	}
 
-	test('accepts a mount with just name and open (no kind needed)', async () => {
-		writeConfig("export default { name: 'demo', open() {} };\n");
-
-		const { data, error } = await loadEpicenterConfig(epicenterRoot);
-		if (error !== null) throw new Error(error.message);
-		expect(data.name).toBe('demo');
-	});
-
 	test('rejects a config with no default export', async () => {
 		writeConfig('export const config = {};\n');
 

--- a/packages/workspace/src/document/README.md
+++ b/packages/workspace/src/document/README.md
@@ -100,7 +100,7 @@ those guids. Browser runtimes use `tables.notes.docs.body.open(noteId)` when a
 surface needs the content doc. Daemon projections can derive the same guid,
 read one doc for one row, and destroy it.
 See `apps/fuji/src/lib/workspace/browser.ts` and
-`apps/fuji/src/lib/workspace/project.ts` for the Fuji pattern.
+`apps/fuji/src/lib/workspace/mount.ts` for the Fuji pattern.
 
 ## Design Decisions
 
@@ -126,6 +126,6 @@ Tests live in `*.test.ts` next to the implementation. Use `createWorkspace({ id:
 
 - `apps/whispering/src/lib/whispering/whispering.tauri.ts`: IndexedDB + BroadcastChannel + recording markdown export
 - `apps/fuji/src/lib/workspace/browser.ts`: IndexedDB + sync + server-owned presence
-- `apps/fuji/src/lib/workspace/project.ts`: daemon materializers and per-row body doc reads
+- `apps/fuji/src/lib/workspace/mount.ts`: daemon materializers and per-row body doc reads
 - `packages/workspace/README.md`: quick start
 - `packages/workspace/SYNC_ARCHITECTURE.md`: multi-device sync design


### PR DESCRIPTION
This finishes the post-#2029 cleanup around the single-mount model: one Epicenter folder has one `epicenter.config.ts`, and that config default-exports one `Mount`.

The public app mount subpath now says the same thing as the runtime contract:

```ts
// Before
import { fuji } from '@epicenter/fuji/project';

// After
import { fuji } from '@epicenter/fuji/mount';
```

That rename applies across the app packages, the init scaffold, the Fuji example, and the app convention docs. It is a breaking subpath change for callers importing `@epicenter/<app>/project`; they should import `@epicenter/<app>/mount` instead.

The rest of the PR removes stale language that survived the daemon collapse: plural mount phrasing in CLI docs and JSDoc, the fictional `fuji/` markdown projection in the Fuji example, an obsolete `kind`-removal test, and a stale daemon banner comment. The Fuji example now points at the real tracked `entries/` projection and the guid-keyed SQLite mirror under `.epicenter/sqlite/`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784187705&installation_id=128463665&pr_number=2030&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2030&signature=f4d0ebb53f784d31de4a389f843343b824e109ae4b85ed93a42928451c7c6618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->