### PR TITLE
fix(whispering): stop the app from positioning the Svelte inspector

### DIFF
--- a/apps/whispering/docs/recording-overlay.md
+++ b/apps/whispering/docs/recording-overlay.md
@@ -52,12 +52,20 @@ introduced: the overlay only reflects and triggers the existing operations.
 ## Dev environment note
 
 The TanStack Query devtools were removed from the root layout entirely (the
-dependency too): it blocked the view in dev and was not pulling its weight. With
-it gone, the root layout's custom CSS that offset the Svelte inspector toggle to
-bottom-center (only there to dodge the devtools) was removed as well, so the
-inspector returns to its default position. The overlay route still hides
-`#svelte-inspector-host` in its own webview with one co-located CSS rule, since
-the inspector would otherwise sit on the pill. All of this is dev-only.
+dependency too): it blocked the view in dev and was not pulling its weight.
+
+The app does not position the Svelte inspector. `svelte.config.js` owns only
+its behavior (hold mode, always-visible toggle, `alt-x`); the toggle inherits
+the plugin default `top-right`, the corner left free by the current chrome (the
+sidebar on the left, the full-width BottomNav at the bottom). Do not reintroduce
+CSS that offsets `#svelte-inspector-host`: earlier overrides keyed to nav
+z-index broke twice when the nav changed. To move or disable it per-machine, set
+an env var instead, for example
+`SVELTE_INSPECTOR_OPTIONS='{"toggleButtonPos":"top-left"}'`.
+
+The overlay route still hides `#svelte-inspector-host` in its own webview with
+one co-located CSS rule, since the inspector would otherwise sit on the pill.
+That is suppression, not positioning, and it stays. All of this is dev-only.
 
 ## Deliberately deferred
 

--- a/apps/whispering/svelte.config.js
+++ b/apps/whispering/svelte.config.js
@@ -22,12 +22,16 @@ const config = {
 
 	vitePlugin: {
 		inspector: {
+			// This block owns dev-tooling behavior, not geometry. The toggle
+			// inherits the plugin default 'top-right', the corner left free by
+			// the current chrome (sidebar on the left, full-width BottomNav at
+			// the bottom). The app must never reposition #svelte-inspector-host:
+			// earlier CSS overrides keyed to nav z-index broke twice when the nav
+			// changed. To move or disable it per-machine, set an env var instead
+			// (the plugin gives it top precedence), e.g.
+			// SVELTE_INSPECTOR_OPTIONS='{"toggleButtonPos":"top-left"}'
 			holdMode: true,
 			showToggleButton: 'always',
-			// Using 'bottom-left' as base position, but CSS overrides in
-			// src/routes/+layout.svelte move it to bottom-center to avoid
-			// conflicts with devtools (bottom-left) and toasts (bottom-right)
-			toggleButtonPos: 'bottom-left',
 			toggleKeyCombo: 'alt-x',
 		},
 	},


### PR DESCRIPTION
Closes #2036.

The Svelte inspector toggle disappeared behind the Whispering chrome in dev mode. The committed config pinned it to `bottom-left`, and the old root-layout CSS that lifted it above the nav was removed with the TanStack Query devtools cleanup. Once that override was gone, the toggle sat under the desktop sidebar and the mobile BottomNav.

This fix stops the app from owning the inspector position. `svelte.config.js` now keeps only behavior: hold mode, always-visible toggle, and `alt-x`. Without `toggleButtonPos`, the plugin uses its `top-right` default, which is the corner the current app chrome leaves open.

The one remaining `#svelte-inspector-host` rule is the overlay route hiding the inspector in its own webview. That is suppression for a non-dev surface, not app-level positioning. Per-machine moves or disabling should use `SVELTE_INSPECTOR_OPTIONS` / `SVELTE_INSPECTOR_TOGGLE`, which the plugin already lets override committed config.

## Changelog

- Fixes the Svelte inspector toggle placement in Whispering dev mode so it stays visible above the app chrome.