### PR TITLE
fix(whispering): remove broken minimized window mode

### DIFF
--- a/apps/whispering/src-tauri/tauri.conf.json
+++ b/apps/whispering/src-tauri/tauri.conf.json
@@ -66,8 +66,8 @@
 				"title": "Whispering",
 				"width": 1080,
 				"height": 800,
-				"minHeight": 84,
-				"minWidth": 72
+				"minHeight": 500,
+				"minWidth": 360
 			}
 		],
 		"security": {

--- a/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
+++ b/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
@@ -9,16 +9,10 @@
 	import { os } from '#platform/os';
 	import MoreDetailsDialog from '$lib/components/MoreDetailsDialog.svelte';
 	import UpdateDialog from '$lib/components/UpdateDialog.svelte';
-	import {
-		RECORDER_STATE_TO_ICON,
-		VAD_STATE_TO_ICON,
-	} from '$lib/constants/audio';
 	import { services } from '$lib/services';
 	import { tauri } from '#platform/tauri';
-	import { manualRecorder } from '$lib/state/manual-recorder.svelte';
 	import { recordings } from '$lib/state/recordings.svelte';
 	import { settings } from '$lib/state/settings.svelte';
-	import { vadRecorder } from '$lib/state/vad-recorder.svelte';
 	import { syncWindowAlwaysOnTopWithRecorderState } from '../_layout-utils/alwaysOnTop.svelte';
 	import { checkForUpdates } from '../_layout-utils/check-for-updates';
 	import {
@@ -127,33 +121,7 @@
 	let { children } = $props();
 </script>
 
-{#if settings.get('recording.mode') === 'vad'}
-	<button
-		class="xxs:hidden hover:bg-accent hover:text-accent-foreground h-screen w-screen transform duration-300 ease-in-out"
-		onclick={() => commandCallbacks.toggleVadRecording()}
-	>
-		<span
-			style="filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.5));"
-			class="text-[48px] leading-none"
-		>
-			{VAD_STATE_TO_ICON[vadRecorder.state]}
-		</span>
-	</button>
-{:else}
-	<button
-		class="xxs:hidden hover:bg-accent hover:text-accent-foreground h-screen w-screen transform duration-300 ease-in-out"
-		onclick={() => commandCallbacks.toggleManualRecording()}
-	>
-		<span
-			style="filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.5));"
-			class="text-[48px] leading-none"
-		>
-			{RECORDER_STATE_TO_ICON[manualRecorder.state]}
-		</span>
-	</button>
-{/if}
-
-<div class="hidden flex-1 flex-col gap-2 xxs:flex min-w-0 w-full">
+<div class="flex flex-1 flex-col gap-2 min-w-0 w-full">
 	{@render children()}
 </div>
 

--- a/apps/whispering/src/routes/(app)/_components/VerticalNav.svelte
+++ b/apps/whispering/src/routes/(app)/_components/VerticalNav.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
 	import * as Sidebar from '@epicenter/ui/sidebar';
 	import { useSidebar } from '@epicenter/ui/sidebar';
-	import Minimize2Icon from '@lucide/svelte/icons/minimize-2';
 	import MoonIcon from '@lucide/svelte/icons/moon';
 	import SunIcon from '@lucide/svelte/icons/sun';
 	import { toggleMode } from 'mode-watcher';
 	import { page } from '$app/state';
 	import { GithubIcon } from '$lib/components/icons';
 	import { NAV_ITEMS } from './nav-items';
-	import { tauri } from '#platform/tauri';
 
 	const sidebar = useSidebar();
 </script>
@@ -102,26 +100,6 @@
 					{/snippet}
 				</Sidebar.MenuButton>
 			</Sidebar.MenuItem>
-
-			<!-- Minimize (desktop only) -->
-			{#if tauri}
-				<Sidebar.MenuItem>
-					<Sidebar.MenuButton>
-						{#snippet child({ props })}
-							<button
-								onclick={async () => {
-								const { getCurrentWindow, LogicalSize } = await import('@tauri-apps/api/window');
-								getCurrentWindow().setSize(new LogicalSize(72, 84));
-							}}
-								{...props}
-							>
-								<Minimize2Icon />
-								<span>Minimize</span>
-							</button>
-						{/snippet}
-					</Sidebar.MenuButton>
-				</Sidebar.MenuItem>
-			{/if}
 		</Sidebar.Menu>
 	</Sidebar.Footer>
 


### PR DESCRIPTION
Closes #2032.

Whispering minimized window mode shrank the main window to 72x84 and swapped the page for a full-window emoji record button at the `xxs` breakpoint. At that size, the mobile BottomNav covered the button, so minimized mode could leave the record control visible but unusable.

This removes the mode instead of moving pieces around inside a window too small to be useful. Compact recording is already handled by the tray icon, recording overlay, and global shortcut; keeping a fourth path meant maintaining a special layout state that only existed around app chrome.

The main app content now always renders, the desktop Minimize nav action is gone, and the Tauri minimum window size is back to 360x500 so users cannot drag the main window into the broken state. The `xxs` breakpoint stays for ordinary responsive behavior, including hiding the recording preview on ultra-narrow widths.

## Changelog

- Removes Whispering broken minimized window mode and restores a usable minimum window size.