### PR TITLE
fix(whispering): remove dead ultra-narrow responsive tier (xxs/xs)

### DIFF
--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -242,7 +242,7 @@
 <div
 	class="flex flex-1 flex-col items-center justify-start gap-4 w-full max-w-lg mx-auto px-4 pt-6 pb-24 sm:justify-center sm:py-0"
 >
-	<SectionHeader.Root class="xs:flex hidden flex-col items-center gap-4">
+	<SectionHeader.Root class="flex flex-col items-center gap-4">
 		<SectionHeader.Title
 			level={1}
 			class="scroll-m-20 text-4xl tracking-tight lg:text-5xl"
@@ -345,7 +345,7 @@
 	{/if}
 
 	{#if latestRecording}
-		<div class="xxs:flex hidden w-full flex-col gap-2">
+		<div class="flex w-full flex-col gap-2">
 			<TranscriptDialog
 				recordingId={latestRecording.id}
 				transcript={latestRecording.transcript}
@@ -381,7 +381,7 @@
 		</div>
 	{/if}
 
-	<div class="xs:flex hidden flex-col items-center gap-3">
+	<div class="flex flex-col items-center gap-3">
 		{#if settings.get('recording.mode') === 'manual'}
 			<p class="text-foreground/75 text-center text-sm">
 				Click the microphone or press

--- a/apps/whispering/src/routes/+layout.svelte
+++ b/apps/whispering/src/routes/+layout.svelte
@@ -30,7 +30,7 @@
 
 <Toaster
 	offset={16}
-	class="xs:block hidden"
+	class="block"
 	duration={5000}
 	visibleToasts={5}
 	closeButton

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -155,9 +155,6 @@
 	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-ring: var(--sidebar-ring);
-	/* Custom breakpoints */
-	--breakpoint-xxs: 196px;
-	--breakpoint-xs: 320px;
 }
 
 @layer base {


### PR DESCRIPTION
After #2039 removed minimized window mode and raised the Whispering window floor to 360x500, there is no longer a real 72px-wide state for `xxs` or `xs` to protect. The remaining consumers were all hidden by default and revealed only at 196px or 320px, which means they now always render on desktop and do not represent a useful web target either.

This collapses those consumers to their always-shown form: the home header, latest-recording transcript block, helper text, and root toaster. It also deletes `--breakpoint-xxs` and `--breakpoint-xs` from `packages/ui`, where they had no consumers outside Whispering.

The 768px narrow-layout switch stays. That breakpoint still chooses between BottomNav and VerticalNav for usable window sizes; this only removes the tiny tier that existed for the deleted button-window mode.

## Changelog

- Removes the dead Whispering `xxs`/`xs` responsive tier after minimized window mode removal.