### PR TITLE
refactor(whispering): remove unearned Manage billing link

### DIFF
--- a/apps/whispering/src/routes/(app)/(config)/settings/SidebarNav.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/SidebarNav.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
-	import { APP_URLS } from '@epicenter/constants/vite';
 	import { Button } from '@epicenter/ui/button';
 	import { cn } from '@epicenter/ui/utils';
-	import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
 	import { cubicInOut } from 'svelte/easing';
 	import { crossfade } from 'svelte/transition';
 	import { page } from '$app/state';
@@ -66,16 +64,4 @@
 			<span class="relative z-10"> {item.title} </span>
 		</Button>
 	{/each}
-
-	<Button
-		href="{APP_URLS.API}/dashboard"
-		target="_blank"
-		variant="ghost"
-		class="relative justify-start text-left font-normal text-sidebar-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground"
-	>
-		<span class="relative z-10 flex items-center gap-2">
-			Manage billing
-			<ExternalLinkIcon class="size-3 text-muted-foreground" />
-		</span>
-	</Button>
 </nav>


### PR DESCRIPTION
Whispering is local-first and direct-provider, so the settings sidebar should not point users to the hosted Epicenter API dashboard for billing. That link did not control anything the app currently consumes; it was inherited product surface rather than app behavior.

This removes the `Manage billing` button from the Whispering settings sidebar and drops the unused `APP_URLS` and external-link icon imports. Provider API key settings stay in place, including their real OpenAI and Deepgram account links, because those still map to accounts users configure directly.

If Whispering later adds an Epicenter-operated paid path, the billing surface should come back attached to that actual capability: provider choice, credit or usage gate, and the hosted account page it affects. This deletion keeps today's UI honest without making that future path harder.