### PR TITLE
refactor(whispering): gate transformation picker behind a #platform seam

### DIFF
--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -8,6 +8,10 @@
 		"./workspace": "./src/lib/workspace/index.ts"
 	},
 	"imports": {
+		"#platform/commands": {
+			"tauri": "./src/lib/commands.tauri.ts",
+			"default": "./src/lib/commands.browser.ts"
+		},
 		"#platform/analytics": {
 			"tauri": "./src/lib/services/analytics/index.tauri.ts",
 			"default": "./src/lib/services/analytics/index.browser.ts"

--- a/apps/whispering/src/lib/commands.browser.ts
+++ b/apps/whispering/src/lib/commands.browser.ts
@@ -1,0 +1,10 @@
+import type { SatisfiedCommand } from '$lib/commands';
+
+/**
+ * Browser builds contribute no extra commands. The transformation picker is
+ * desktop-only: it captures the selection in another app via a simulated system
+ * copy and opens a separate Tauri window, neither of which a browser tab can do.
+ * The cross-platform `Run transformation on clipboard` command covers the web
+ * transformation path. See `commands.tauri.ts` for the desktop addition.
+ */
+export const platformCommands = [] as const satisfies SatisfiedCommand[];

--- a/apps/whispering/src/lib/commands.tauri.ts
+++ b/apps/whispering/src/lib/commands.tauri.ts
@@ -1,0 +1,26 @@
+import type { SatisfiedCommand, ShortcutEventState } from '$lib/commands';
+import { openTransformationPicker } from '$lib/operations/transformation-picker';
+
+/**
+ * Desktop-only commands, spread into the registry by the `#platform/commands`
+ * seam on Tauri builds. Keeping the picker here (rather than in the shared
+ * `commands.ts`) is what stops a browser build from importing the Tauri-only
+ * picker window and from offering a shortcut that can only error on the web.
+ */
+export const platformCommands = [
+	{
+		id: 'openTransformationPicker',
+		title: 'Open transformation picker',
+		// Fire on release, not press: the global accelerator carries a Cmd/Ctrl+Shift
+		// chord, and capturing on press synthesizes Cmd/Ctrl+C while that chord is
+		// still held, so the foreground app sees Cmd+Shift+C instead of a clean copy.
+		// Register both states (not Released-only) because the local shortcut manager
+		// only arms a command on keydown when `on` includes 'Pressed'; without it the
+		// in-app shortcut would never fire. The callback guard runs once, on release.
+		on: ['Pressed', 'Released'],
+		callback: (state?: ShortcutEventState) => {
+			if (state === 'Released' || state === undefined)
+				openTransformationPicker();
+		},
+	},
+] as const satisfies SatisfiedCommand[];

--- a/apps/whispering/src/lib/commands.ts
+++ b/apps/whispering/src/lib/commands.ts
@@ -1,3 +1,4 @@
+import { platformCommands } from '#platform/commands';
 import {
 	cancelRecording,
 	startManualRecording,
@@ -6,7 +7,6 @@ import {
 	toggleVadRecording,
 } from '$lib/operations/recording';
 import { runTransformationOnClipboard } from '$lib/operations/transformation-clipboard';
-import { platformCommands } from '#platform/commands';
 
 /**
  * Registry of available commands in the application.

--- a/apps/whispering/src/lib/commands.ts
+++ b/apps/whispering/src/lib/commands.ts
@@ -6,7 +6,7 @@ import {
 	toggleVadRecording,
 } from '$lib/operations/recording';
 import { runTransformationOnClipboard } from '$lib/operations/transformation-clipboard';
-import { openTransformationPicker } from '$lib/operations/transformation-picker';
+import { platformCommands } from '#platform/commands';
 
 /**
  * Registry of available commands in the application.
@@ -16,6 +16,11 @@ import { openTransformationPicker } from '$lib/operations/transformation-picker'
  * The actual command implementations live in $lib/operations/* as plain async
  * functions that can be invoked from anywhere in the UI, not just through this
  * command registry.
+ *
+ * Platform split: `sharedCommands` exist in every build. Desktop-only commands
+ * (the transformation picker, which captures a selection from another app and
+ * opens a Tauri window) come from the `#platform/commands` seam, so a browser
+ * build never imports their Tauri-only code and never offers them as shortcuts.
  */
 
 /**
@@ -27,7 +32,7 @@ import { openTransformationPicker } from '$lib/operations/transformation-picker'
  */
 export type ShortcutEventState = 'Pressed' | 'Released';
 
-type SatisfiedCommand = {
+export type SatisfiedCommand = {
 	id: string;
 	title: string;
 	/**
@@ -40,7 +45,8 @@ type SatisfiedCommand = {
 	callback: (state?: ShortcutEventState) => void;
 };
 
-export const commands = [
+/** Commands available in every build (browser and desktop). */
+const sharedCommands = [
 	{
 		id: 'pushToTalk',
 		title: 'Push to talk',
@@ -72,21 +78,6 @@ export const commands = [
 		callback: () => toggleVadRecording(),
 	},
 	{
-		id: 'openTransformationPicker',
-		title: 'Open transformation picker',
-		// Fire on release, not press: the global accelerator carries a Cmd/Ctrl+Shift
-		// chord, and capturing on press synthesizes Cmd/Ctrl+C while that chord is
-		// still held, so the foreground app sees Cmd+Shift+C instead of a clean copy.
-		// Register both states (not Released-only) because the local shortcut manager
-		// only arms a command on keydown when `on` includes 'Pressed'; without it the
-		// in-app shortcut would never fire. The callback guard runs once, on release.
-		on: ['Pressed', 'Released'],
-		callback: (state?: ShortcutEventState) => {
-			if (state === 'Released' || state === undefined)
-				openTransformationPicker();
-		},
-	},
-	{
 		id: 'runTransformationOnClipboard',
 		title: 'Run transformation on clipboard',
 		on: ['Pressed'],
@@ -94,9 +85,14 @@ export const commands = [
 	},
 ] as const satisfies SatisfiedCommand[];
 
+export const commands = [
+	...sharedCommands,
+	...platformCommands,
+] as const satisfies SatisfiedCommand[];
+
 export type Command = (typeof commands)[number];
 
-type CommandCallbacks = Record<Command['id'], Command['callback']>;
+export type CommandCallbacks = Record<Command['id'], Command['callback']>;
 
 export const commandCallbacks = commands.reduce<CommandCallbacks>(
 	(acc, command) => {

--- a/apps/whispering/src/lib/operations/shortcuts.ts
+++ b/apps/whispering/src/lib/operations/shortcuts.ts
@@ -40,7 +40,13 @@ export const localShortcuts = {
 		services.localShortcutManager.unregister(commandId),
 };
 
-/** Default values for in-app (local) shortcuts. Keyed by command id string. */
+/**
+ * Default values for in-app (local) shortcuts, keyed by command id string. A
+ * superset of the current build's commands: `openTransformationPicker` is
+ * desktop-only, so on web it sits here unused (the reset loops iterate the
+ * platform `commands`). Mirrors `DEFAULT_GLOBAL_BINDINGS`, which is keyed the
+ * same way.
+ */
 const DEFAULT_LOCAL_SHORTCUTS = {
 	pushToTalk: 'p',
 	toggleManualRecording: ' ',
@@ -48,7 +54,7 @@ const DEFAULT_LOCAL_SHORTCUTS = {
 	toggleVadRecording: 'v',
 	openTransformationPicker: 't',
 	runTransformationOnClipboard: 'r',
-} as const satisfies Record<Command['id'], string | null>;
+} as const satisfies Record<string, string | null>;
 
 /** Canonical string for a binding, so structurally-equal bindings dedupe. */
 function bindingKey(binding: {


### PR DESCRIPTION
Whispering has two transformation shortcuts, and they are not redundant: `runTransformationOnClipboard` (clipboard input, runs your default transform, cross-platform) and `openTransformationPicker` (captures the selection in another app via a simulated system copy, opens a Tauri window to pick a transform). The picker is desktop-only by nature: a browser tab cannot do a cross-app selection copy or open a native window.

The problem was that the picker lived in the shared command registry (`$lib/commands`). So a web build both bundled the Tauri picker window into the shared graph and surfaced an "Open transformation picker" shortcut, bound to `t` and listed in settings, that could only ever fail with a "could not capture your selection" toast. The shared registry also imported a `.tauri`-suffixed module directly, against the repo's `#platform/*` convention.

## Old shape

```
$lib/commands.ts
  └─ imports openTransformationPicker (→ transformationPickerWindow.tauri)
  └─ commands = [ ...5 shared, pickerCommand ]   // every build, even web
```

Every consumer (registrar, settings table, reset defaults) then had to live with a command that does not work on the platform it is running on.

## New shape

```
$lib/commands.ts        commands = [ ...shared, ...platformCommands ]
#platform/commands  ┐
  commands.tauri.ts   →  platformCommands = [ pickerCommand ]
  commands.browser.ts →  platformCommands = [ ]
```

Platform availability becomes structural: it is decided by which file defines the command, resolved once at the seam, instead of a `desktopOnly` flag that every consumer must remember to filter on. On web the picker is simply absent from `commands`, so it drops out of the registry, the shortcuts settings table, and the default-binding reset automatically, and the Tauri picker window is no longer pulled into the shared app graph.

`runTransformationOnClipboard` is untouched and stays the cross-platform path (and web's only transformation shortcut). The synced shortcut schema keeps every key as a platform-agnostic superset, so a desktop user's picker binding still syncs; web just has no command to honor it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784218317&installation_id=128463665&pr_number=2048&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2048&signature=60f97d04d0c1bc60fbabb2813449df942023e86a4abfff3e899dcb5dcbe383fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->