### PR TITLE
refactor(whispering): single-source shortcut defaults and key construction

### DIFF
--- a/apps/whispering/src/lib/operations/shortcuts.ts
+++ b/apps/whispering/src/lib/operations/shortcuts.ts
@@ -51,11 +51,15 @@ function bindingKey(binding: {
 type LocalShortcutKey = `shortcut.${Command['id']}`;
 type GlobalShortcutKey = `shortcuts.global.${Command['id']}`;
 
-function getLocalShortcutKey(commandId: Command['id']): LocalShortcutKey {
+export function getLocalShortcutKey(
+	commandId: Command['id'],
+): LocalShortcutKey {
 	return `shortcut.${commandId}`;
 }
 
-function getGlobalShortcutKey(commandId: Command['id']): GlobalShortcutKey {
+export function getGlobalShortcutKey(
+	commandId: Command['id'],
+): GlobalShortcutKey {
 	return `shortcuts.global.${commandId}`;
 }
 

--- a/apps/whispering/src/lib/operations/shortcuts.ts
+++ b/apps/whispering/src/lib/operations/shortcuts.ts
@@ -10,10 +10,7 @@ import {
 	type CommandId,
 	shortcutStringToArray,
 } from '$lib/services/local-shortcut-manager';
-import {
-	DEFAULT_GLOBAL_BINDINGS,
-	deviceConfig,
-} from '$lib/state/device-config.svelte';
+import { deviceConfig } from '$lib/state/device-config.svelte';
 import { settings } from '$lib/state/settings.svelte';
 import type { CommandBinding, KeyBinding } from '$lib/tauri/commands';
 
@@ -39,22 +36,6 @@ export const localShortcuts = {
 	unregisterCommand: async ({ commandId }: { commandId: CommandId }) =>
 		services.localShortcutManager.unregister(commandId),
 };
-
-/**
- * Default values for in-app (local) shortcuts, keyed by command id string. A
- * superset of the current build's commands: `openTransformationPicker` is
- * desktop-only, so on web it sits here unused (the reset loops iterate the
- * platform `commands`). Mirrors `DEFAULT_GLOBAL_BINDINGS`, which is keyed the
- * same way.
- */
-const DEFAULT_LOCAL_SHORTCUTS = {
-	pushToTalk: 'p',
-	toggleManualRecording: ' ',
-	cancelRecording: 'c',
-	toggleVadRecording: 'v',
-	openTransformationPicker: 't',
-	runTransformationOnClipboard: 'r',
-} as const satisfies Record<string, string | null>;
 
 /** Canonical string for a binding, so structurally-equal bindings dedupe. */
 function bindingKey(binding: {
@@ -212,27 +193,27 @@ export function resetGlobalShortcutsToDefaultIfDuplicates(): boolean {
 }
 
 /**
- * Reset all local shortcuts to their default values and re-sync.
+ * Reset all local shortcuts to their schema defaults and re-sync. Defaults come
+ * from the synced workspace definition (`settings.getDefault`), the same source
+ * the settings UI shows, so there is no parallel defaults map to drift.
  */
 export function resetLocalShortcuts() {
 	for (const command of commands) {
-		settings.set(
-			getLocalShortcutKey(command.id),
-			DEFAULT_LOCAL_SHORTCUTS[command.id] ?? null,
-		);
+		const key = getLocalShortcutKey(command.id);
+		settings.set(key, settings.getDefault(key));
 	}
 	void syncLocalShortcutsWithSettings();
 }
 
 /**
- * Reset all global shortcuts to their default values and re-sync.
+ * Reset all global shortcuts to their schema defaults and re-sync. Defaults come
+ * from the device-config definition (`deviceConfig.getDefault`), the same source
+ * the settings UI shows.
  */
 export function resetGlobalShortcuts() {
 	for (const command of commands) {
-		deviceConfig.set(
-			getGlobalShortcutKey(command.id),
-			DEFAULT_GLOBAL_BINDINGS[command.id] ?? null,
-		);
+		const key = getGlobalShortcutKey(command.id);
+		deviceConfig.set(key, deviceConfig.getDefault(key));
 	}
 	void syncGlobalShortcutsWithSettings();
 }

--- a/apps/whispering/src/lib/state/device-config.svelte.ts
+++ b/apps/whispering/src/lib/state/device-config.svelte.ts
@@ -37,7 +37,8 @@ const globalBinding = type({
 // cancel gesture since classic Mac OS; Ctrl + Shift + . elsewhere); it carries a
 // modifier so it is safe to hold globally and registers like any other gesture
 // with no session gating. Transformation gestures ship unbound: opt-in only.
-// Exported so the reset path in register-commands shares this one source of truth.
+// This map is the single source for the per-key schema defaults below; the reset
+// path reads them back through `deviceConfig.getDefault`, not this map directly.
 const PUSH_TO_TALK_MODIFIERS: KeyBinding['modifiers'] = os.isApple
 	? ['fn']
 	: ['ctrl', 'meta'];
@@ -50,7 +51,7 @@ const CANCEL_MODIFIERS: KeyBinding['modifiers'] = os.isApple
 	? ['meta']
 	: ['ctrl', 'shift'];
 
-export const DEFAULT_GLOBAL_BINDINGS = {
+const DEFAULT_GLOBAL_BINDINGS = {
 	pushToTalk: { modifiers: PUSH_TO_TALK_MODIFIERS, keys: [] },
 	toggleManualRecording: { modifiers: TOGGLE_MODIFIERS, keys: ['space'] },
 	cancelRecording: { modifiers: CANCEL_MODIFIERS, keys: ['dot'] },

--- a/apps/whispering/src/lib/state/settings.svelte.ts
+++ b/apps/whispering/src/lib/state/settings.svelte.ts
@@ -56,6 +56,13 @@ function createSettings() {
 		set: whispering.kv.set,
 
 		/**
+		 * The schema default for a setting key (the `defineKv` factory value).
+		 * The single source for resets and default-display, so a setting's
+		 * default lives only in the workspace definition, never in a parallel map.
+		 */
+		getDefault: whispering.settings.getDefault,
+
+		/**
 		 * Reset all workspace settings to their default values in a single
 		 * Yjs transaction.
 		 */

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/+page.svelte
@@ -7,14 +7,14 @@
 	import { os } from '#platform/os';
 	import { tauri } from '#platform/tauri';
 	import { whispering } from '#platform/whispering';
-	import {
-		type DeviceConfigKey,
-		deviceConfig,
-	} from '$lib/state/device-config.svelte';
+	import type { Command } from '$lib/commands';
+	import { deviceConfig } from '$lib/state/device-config.svelte';
 	import type { KeyBinding } from '$lib/tauri/commands';
 	import { createPressedKeys } from '$lib/utils/createPressedKeys.svelte';
 	import { keyBindingToLabel } from '$lib/utils/key-binding';
 	import {
+		getGlobalShortcutKey,
+		getLocalShortcutKey,
 		resetGlobalShortcuts,
 		resetLocalShortcuts,
 	} from '$lib/operations/shortcuts';
@@ -43,17 +43,16 @@
 			});
 
 	/** The definition default for a local shortcut, formatted for display. */
-	function localDefault(commandId: string): string | null {
-		const getDefault = whispering.settings.getDefault as (
-			key: string,
-		) => unknown;
-		return (getDefault(`shortcut.${commandId}`) as string | null) ?? null;
+	function localDefault(commandId: Command['id']): string | null {
+		return whispering.settings.getDefault(getLocalShortcutKey(commandId)) ?? null;
 	}
 
 	/** The definition default for a global shortcut, formatted for display. */
-	function globalDefault(commandId: string): string | null {
+	function globalDefault(commandId: Command['id']): string | null {
+		// Stored bindings are validated as plain strings; the IPC `KeyBinding` types
+		// `keys` as the Rust `Key` vocabulary, so the cast bridges that boundary.
 		const binding = deviceConfig.getDefault(
-			`shortcuts.global.${commandId}` as DeviceConfigKey,
+			getGlobalShortcutKey(commandId),
 		) as KeyBinding | null;
 		return binding ? keyBindingToLabel(binding, os.isApple) : null;
 	}


### PR DESCRIPTION
Resetting an in-app shortcut to its default read from `DEFAULT_LOCAL_SHORTCUTS`, a hand-maintained map in `operations/shortcuts.ts`, even though every one of those defaults already lived in the synced workspace schema (`definition.ts`, via `defineKv`). Two copies of the same `p`/`space`/`c`/`v`/`t`/`r` table, kept in sync by hand. The global reset had the same shape against `DEFAULT_GLOBAL_BINDINGS`, and the shortcuts settings page rebuilt the same key strings inline with casts.

This also repays an invariant that #2048 spent. Gating the transformation picker behind the `#platform/commands` seam made `Command['id']` platform-varying (the picker is absent from `commands` on web), which forced `DEFAULT_LOCAL_SHORTCUTS` to loosen from `Record<Command['id'], …>` to `Record<string, …>` and drop its "every command has a default" check. Sourcing from the schema removes the map entirely, and the check is not lost: it relocates to the type system, which now enforces that every command has a matching `shortcut.*` / `shortcuts.global.*` schema entry (the key builders return branded keys constrained to `SettingKey` / `DeviceConfigKey`).

## Reset defaults: old shape

```
operations/shortcuts.ts
  DEFAULT_LOCAL_SHORTCUTS = { pushToTalk: 'p', … }   // parallel copy of the schema
  resetLocalShortcuts:  settings.set(key, DEFAULT_LOCAL_SHORTCUTS[id] ?? null)
  resetGlobalShortcuts: deviceConfig.set(key, DEFAULT_GLOBAL_BINDINGS[id] ?? null)
```

## Reset defaults: new shape

```
resetLocalShortcuts:  settings.set(key, settings.getDefault(key))        // synced schema
resetGlobalShortcuts: deviceConfig.set(key, deviceConfig.getDefault(key)) // device-config schema
```

A shortcut's default now lives in exactly one place per surface. Locals resolve through `settings.getDefault` (the synced workspace definition, the same source the settings UI already shows); globals resolve through `deviceConfig.getDefault` (the device-config definition). The local/global asymmetry is preserved on purpose: globals are device-local and must not come from the synced schema, so each reset routes through its own definition rather than a shared map.

`DEFAULT_GLOBAL_BINDINGS` stays, now private, in its narrowed role of seeding the `defineEntry` defaults; it is no longer exported (its only external consumer, the old `register-commands`, is gone) and no longer read by the reset path. The `?? null` fallbacks are dropped because `getDefault` always returns a value for a valid key.

## Default display: typed key builders

The settings page's `localDefault` / `globalDefault` helpers rebuilt the `shortcut.${id}` / `shortcuts.global.${id}` keys inline, widening the command id to `string` and casting twice (`whispering.settings.getDefault as (key: string) => unknown`, `… as DeviceConfigKey`). Those keys are exactly what `shortcuts.ts` already constructs type-safely via `getLocalShortcutKey` / `getGlobalShortcutKey`. Exporting the builders and reusing them puts the key format in one place and removes both casts. The remaining `as KeyBinding | null` stays: it bridges the stored-string shape to the IPC `KeyBinding` (whose `keys` is the Rust `Key` vocabulary), a real boundary, not a workaround.
