### PR TITLE
fix(whispering): serve VAD assets from node_modules at build time

### DIFF
--- a/apps/whispering/.gitignore
+++ b/apps/whispering/.gitignore
@@ -22,3 +22,6 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# VAD runtime assets are copied from node_modules at build time (vite.config.ts)
+/static/vad/

--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -92,6 +92,7 @@
 		"typescript": "catalog:",
 		"vite": "catalog:",
 		"vite-plugin-devtools-json": "^1.0.0",
+		"vite-plugin-static-copy": "^4.1.1",
 		"wrangler": "catalog:"
 	},
 	"type": "module",

--- a/apps/whispering/src/lib/state/vad-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/vad-recorder.svelte.ts
@@ -44,6 +44,8 @@ const vadKeys = defineKeys({
 	devices: ['vad', 'devices'],
 });
 
+const VAD_ASSET_PATH = '/vad/';
+
 /**
  * Creates a Voice Activity Detection (VAD) recorder with reactive state.
  *
@@ -189,6 +191,14 @@ function createVadRecorder() {
 								if (onLevel) onLevel(computeFrameRms(frame));
 							},
 							model: 'v5',
+							baseAssetPath: VAD_ASSET_PATH,
+							// vad-web sets `ort.env.wasm.wasmPaths` to this base path before
+							// calling ortConfig, so the default onnxruntime-web build resolves
+							// /vad/ort-wasm-simd-threaded.{mjs,wasm} on its own.
+							onnxWASMBasePath: VAD_ASSET_PATH,
+							ortConfig: (ort) => {
+								ort.env.logLevel = 'error';
+							},
 						}),
 					catch: (error) => VadRecorderError.InitializeFailed({ cause: error }),
 				});

--- a/apps/whispering/vite.config.ts
+++ b/apps/whispering/vite.config.ts
@@ -1,14 +1,66 @@
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
 import { APPS } from '@epicenter/constants/apps';
 import { workspaceAppViteConfig } from '@epicenter/vite-config';
 import { defaultClientConditions, defineConfig, mergeConfig } from 'vite';
 import devtoolsJson from 'vite-plugin-devtools-json';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
 
 const host = process.env.TAURI_DEV_HOST;
 const isTauri = process.env.TAURI_ENV_PLATFORM !== undefined;
 
+// VAD runtime assets (Silero model, audio worklet, ONNX Runtime WASM glue) are
+// fetched at runtime from `/vad/*`, not imported through the bundler. Rather
+// than commit frozen copies, derive them from the installed packages on every
+// build so the served files always match the lockfile-pinned versions. Both
+// packages ship their entry inside `dist/` alongside these assets, so resolving
+// the entry and taking its directory yields the asset dir; resolving the entry
+// (rather than a `package.json` subpath, which onnxruntime-web blocks via
+// `exports`) is also hoist-agnostic (root vs app node_modules).
+const require = createRequire(import.meta.url);
+const distOf = (pkg: string) => dirname(require.resolve(pkg));
+const vadDist = distOf('@ricky0123/vad-web');
+const ortDist = distOf('onnxruntime-web');
+
 export default defineConfig(
 	mergeConfig(workspaceAppViteConfig(APPS.WHISPERING), {
-		plugins: [devtoolsJson()],
+		plugins: [
+			devtoolsJson(),
+			viteStaticCopy({
+				// `stripBase` drops the source's directory segments so each file
+				// lands directly at /vad/<name> (the plugin otherwise mirrors the
+				// full absolute source path under dest).
+				targets: [
+					{
+						src: join(vadDist, 'vad.worklet.bundle.min.js'),
+						dest: 'vad',
+						rename: { stripBase: true },
+					},
+					{
+						src: join(vadDist, 'silero_vad_v5.onnx'),
+						dest: 'vad',
+						rename: { stripBase: true },
+					},
+					{
+						src: join(ortDist, 'ort-wasm-simd-threaded.mjs'),
+						dest: 'vad',
+						rename: { stripBase: true },
+					},
+					{
+						src: join(ortDist, 'ort-wasm-simd-threaded.wasm'),
+						dest: 'vad',
+						rename: { stripBase: true },
+					},
+				],
+			}),
+		],
+		// onnxruntime-web (pulled in by @ricky0123/vad-web) ships a WASM glue
+		// .mjs that Vite's dep optimizer can't pre-bundle (it 404s on
+		// .vite/deps/ort-wasm-simd-threaded.mjs). Exclude both so they load
+		// natively; their runtime assets are served from /vad/ (see above).
+		optimizeDeps: {
+			exclude: ['onnxruntime-web', '@ricky0123/vad-web'],
+		},
 		resolve: {
 			// Build-time platform DI. Each `#platform/*` subpath (package.json
 			// "imports") has a browser impl and a Tauri impl; the Tauri build

--- a/apps/whispering/vite.config.ts
+++ b/apps/whispering/vite.config.ts
@@ -21,6 +21,12 @@ const require = createRequire(import.meta.url);
 const distOf = (pkg: string) => dirname(require.resolve(pkg));
 const vadDist = distOf('@ricky0123/vad-web');
 const ortDist = distOf('onnxruntime-web');
+const vadAssetSources = [
+	join(vadDist, 'vad.worklet.bundle.min.js'),
+	join(vadDist, 'silero_vad_v5.onnx'),
+	join(ortDist, 'ort-wasm-simd-threaded.mjs'),
+	join(ortDist, 'ort-wasm-simd-threaded.wasm'),
+];
 
 export default defineConfig(
 	mergeConfig(workspaceAppViteConfig(APPS.WHISPERING), {
@@ -30,28 +36,11 @@ export default defineConfig(
 				// `stripBase` drops the source's directory segments so each file
 				// lands directly at /vad/<name> (the plugin otherwise mirrors the
 				// full absolute source path under dest).
-				targets: [
-					{
-						src: join(vadDist, 'vad.worklet.bundle.min.js'),
-						dest: 'vad',
-						rename: { stripBase: true },
-					},
-					{
-						src: join(vadDist, 'silero_vad_v5.onnx'),
-						dest: 'vad',
-						rename: { stripBase: true },
-					},
-					{
-						src: join(ortDist, 'ort-wasm-simd-threaded.mjs'),
-						dest: 'vad',
-						rename: { stripBase: true },
-					},
-					{
-						src: join(ortDist, 'ort-wasm-simd-threaded.wasm'),
-						dest: 'vad',
-						rename: { stripBase: true },
-					},
-				],
+				targets: vadAssetSources.map((src) => ({
+					src,
+					dest: 'vad',
+					rename: { stripBase: true },
+				})),
 			}),
 		],
 		// onnxruntime-web (pulled in by @ricky0123/vad-web) ships a WASM glue

--- a/bun.lock
+++ b/bun.lock
@@ -531,6 +531,7 @@
         "typescript": "catalog:",
         "vite": "catalog:",
         "vite-plugin-devtools-json": "^1.0.0",
+        "vite-plugin-static-copy": "^4.1.1",
         "wrangler": "catalog:",
       },
     },
@@ -2600,7 +2601,7 @@
 
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
-    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
 
@@ -3212,7 +3213,7 @@
 
     "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
-    "p-map": ["p-map@2.1.0", "", {}, "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="],
+    "p-map": ["p-map@7.0.4", "", {}, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
 
     "p-queue": ["p-queue@9.1.1", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^7.0.0" } }, "sha512-yQS1vV2V7Q14MQrgD8jMNY5owPuGgVHVdSK8NqmKpOVajnjbaeMa6uLOzTALPtvJ7Vo4bw0BGsw7qfUT8z24Ig=="],
 
@@ -3848,6 +3849,8 @@
 
     "vite-plugin-node-polyfills": ["vite-plugin-node-polyfills@0.26.0", "", { "dependencies": { "@rollup/plugin-inject": "^5.0.5", "node-stdlib-browser": "^1.3.1" }, "peerDependencies": { "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-BAe5YzJf368XGev02hDvioidx4uVH8dqEJlG73bjQSxM26/AQnGcKFomq9n3vGq5yqpSHKN4h1XQNxx9l98mBg=="],
 
+    "vite-plugin-static-copy": ["vite-plugin-static-copy@4.1.1", "", { "dependencies": { "chokidar": "^3.6.0", "p-map": "^7.0.4", "picocolors": "^1.1.1", "tinyglobby": "^0.2.17" }, "peerDependencies": { "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-GrlA8YklrAfSyxJ4M3fdQLOo9oNkp56IM9FYgX/WtEgeIFkPwhu4wzpufBCIuNKCa6Fn77FkRdYxkHqV0FwjAw=="],
+
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
     "vm-browserify": ["vm-browserify@1.1.2", "", {}, "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="],
@@ -4184,8 +4187,6 @@
 
     "execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
-    "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
     "fetch-blob/web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
     "firefox-profile/fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
@@ -4263,6 +4264,8 @@
     "node-stdlib-browser/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "node-stdlib-browser/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "p-filter/p-map": ["p-map@2.1.0", "", {}, "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="],
 
     "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
@@ -4370,6 +4373,10 @@
 
     "vite-node/cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
+    "vite-plugin-static-copy/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
+    "vite-plugin-static-copy/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
     "widest-line/string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
@@ -4427,6 +4434,8 @@
     "@inquirer/core/wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@layerstack/tailwind/tailwindcss/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
+    "@layerstack/tailwind/tailwindcss/glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "@layerstack/tailwind/tailwindcss/jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
 
@@ -4522,6 +4531,8 @@
 
     "svelte-check/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
+    "vite-plugin-static-copy/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
     "widest-line/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
@@ -4577,6 +4588,8 @@
     "ripemd160/hash-base/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "ripemd160/hash-base/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "vite-plugin-static-copy/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "widest-line/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 


### PR DESCRIPTION
Voice-activated recording failed before it could start because the VAD runtime assets were not being served as runtime files. The Silero model 404'd, and Vite's dependency optimizer also tried to prebundle ONNX Runtime's WASM glue, producing a missing `.vite/deps/ort-wasm-simd-threaded.mjs` failure.

`@ricky0123/vad-web` fetches the model, worklet, and ONNX Runtime glue from URLs at runtime; they are not ordinary bundler imports. This PR serves them from `/vad/` by copying the resolved package files at build time with `vite-plugin-static-copy`, rather than committing frozen binaries.

The served assets now track the lockfile. Bumping `@ricky0123/vad-web` or `onnxruntime-web` updates the derived output on the next build, and the package directories are resolved from their installed entries so the copy step does not depend on hoisting. Vite also excludes `onnxruntime-web` and `@ricky0123/vad-web` from `optimizeDeps`, which keeps the WASM glue out of prebundling.

The redundant `ort.env.wasm.wasmPaths` override is gone because `vad-web` already sets the base path before applying `ortConfig`. Only the plain `ort-wasm-simd-threaded` glue and WASM files are needed for the import path `vad-web` uses.

## Changelog

- Fixes Whispering voice-activated recording startup by serving the VAD model, worklet, and ONNX Runtime WASM assets from the built app.