### PR TITLE
fix(ui): compose Button tooltip props with mergeProps

### DIFF
--- a/packages/ui/src/button/button.svelte
+++ b/packages/ui/src/button/button.svelte
@@ -56,6 +56,7 @@
 </script>
 
 <script lang="ts">
+	import { mergeProps } from 'bits-ui';
 	import * as Tooltip from '../tooltip/index.js';
 
 	let {
@@ -73,6 +74,16 @@
 </script>
 
 {#snippet buttonContent(tooltipProps?: Record<string, unknown>)}
+	<!--
+		When this button is itself the child of another trigger (e.g. a
+		Popover.Trigger passes its props in via restProps), both sets of trigger
+		props land on one element. Spreading them sequentially clobbers colliding
+		event handlers, ids, and ref callbacks, which silently breaks the tooltip
+		anchor. mergeProps composes them instead. See bits-ui's merge-props util.
+	-->
+	{@const mergedProps = tooltipProps
+		? mergeProps(restProps, tooltipProps)
+		: restProps}
 	{#if href}
 		<!-- biome-ignore lint/a11y/useValidAriaRole: conditional role is valid -->
 		<a
@@ -83,8 +94,7 @@
 			aria-disabled={disabled}
 			role={disabled ? 'link' : undefined}
 			tabindex={disabled ? -1 : undefined}
-			{...tooltipProps}
-			{...restProps}
+			{...mergedProps}
 		>
 			{@render children?.()}
 		</a>
@@ -95,8 +105,7 @@
 			class={cn(buttonVariants({ variant, size }), className)}
 			{type}
 			{disabled}
-			{...tooltipProps}
-			{...restProps}
+			{...mergedProps}
 		>
 			{@render children?.()}
 		</button>


### PR DESCRIPTION
When a `Button` carried a tooltip and was also used as another component's trigger child (e.g. a `Popover.Trigger` passing its props through), both sets of trigger props landed on the same element. They were spread sequentially, so colliding event handlers, ids, and ref callbacks clobbered each other and the tooltip lost its anchor, silently never rendering.

Compose the two prop sets with bits-ui `mergeProps` instead, matching the existing `sidebar-menu-button` pattern. This fixes tooltips for every Button-used-as-a-trigger across the app.

## Changelog

- Tooltips on buttons that double as a popover or dropdown trigger now render correctly instead of silently disappearing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784219904&installation_id=128463665&pr_number=2054&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2054&signature=4d05dbf67a1674ce641b7941c7d50f8dacaf001beb8a791d62ffa85ef5cfd7d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->