### PR TITLE
feat(whispering): surface the transcription model in the capture row

### DIFF
--- a/apps/whispering/src/lib/components/settings/selectors/ManualDeviceSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/ManualDeviceSelector.svelte
@@ -45,7 +45,7 @@
 				{...props}
 				tooltip={manualRecorderConfig.deviceId
 					? 'Change microphone'
-					: 'Select microphone'}
+					: 'Choose microphone'}
 				role="combobox"
 				aria-expanded={combobox.open}
 				variant="ghost"

--- a/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
@@ -6,6 +6,7 @@
 	import { cn } from '@epicenter/ui/utils';
 	import CaptionsIcon from '@lucide/svelte/icons/captions';
 	import CheckIcon from '@lucide/svelte/icons/check';
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
 	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
 	import MicIcon from '@lucide/svelte/icons/mic';
 	import SettingsIcon from '@lucide/svelte/icons/settings';
@@ -49,6 +50,29 @@
 			? !isSelectedServiceReady
 			: !!selectedService && !isSelectedServiceReady,
 	);
+
+	// The pipeline trigger surfaces the active model as text, so it reads at a
+	// glance instead of relying on a hover tooltip. Falls back to a prompt when
+	// nothing usable is configured.
+	const pipelineLabel = $derived(
+		selectedService ? selectedService.label : 'Choose model',
+	);
+
+	// The pipeline pill already shows the model name, so its tooltip describes the
+	// action (parallel with the mic and transformation triggers) rather than
+	// echoing the visible value. The standalone switcher keeps the value, since
+	// there it is the brand icon, not text, that is on screen.
+	const triggerTooltip = $derived.by(() => {
+		if (triggerVariant === 'pipeline') {
+			return selectedService
+				? 'Change transcription model'
+				: 'Choose transcription model';
+		}
+		if (!selectedService) return 'Select transcription service';
+		return selectedService.location === 'cloud'
+			? `${selectedService.label} - ${getSelectedModelNameOrUrl(selectedService)}`
+			: selectedService.label;
+	});
 
 	function getSelectedServiceId() {
 		return settings.get('transcription.service');
@@ -126,25 +150,33 @@
 		{#snippet child({ props })}
 			<Button
 				{...props}
-				class={cn('relative', className)}
-				tooltip={selectedService
-					? `${selectedService.label}${
-							selectedService.location === 'cloud'
-								? ` - ${getSelectedModelNameOrUrl(selectedService)}`
-								: ''
-						}`
-					: 'Select transcription service'}
+				class={cn(
+					'relative',
+					triggerVariant === 'pipeline' && 'min-w-0 flex-1 justify-start',
+					className,
+				)}
+				tooltip={triggerTooltip}
 				role="combobox"
 				aria-expanded={combobox.open}
 				variant="ghost"
-				size="icon"
+				size={triggerVariant === 'pipeline' ? 'default' : 'icon'}
 			>
 				{#if triggerVariant === 'pipeline'}
-					<CaptionsIcon
+					{#if selectedService}
+						{@render renderServiceIcon(selectedService)}
+					{:else}
+						<CaptionsIcon class="size-4 shrink-0 text-warning" />
+					{/if}
+					<span
 						class={cn(
-							'size-5',
-							isSelectedServiceReady ? 'text-green-500' : 'text-warning',
+							'truncate text-sm font-medium',
+							!isSelectedServiceReady && 'text-warning',
 						)}
+					>
+						{pipelineLabel}
+					</span>
+					<ChevronDownIcon
+						class="ml-auto size-3.5 shrink-0 text-muted-foreground/70"
 					/>
 				{:else if selectedService}
 					<div
@@ -160,7 +192,7 @@
 				{:else}
 					<MicIcon class="size-4 text-muted-foreground" />
 				{/if}
-				{#if showConfigurationWarning}
+				{#if showConfigurationWarning && triggerVariant === 'standalone'}
 					<span
 						class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-warning before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-warning/50 before:animate-ping"
 					></span>

--- a/apps/whispering/src/lib/components/settings/selectors/TransformationSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TransformationSelector.svelte
@@ -49,8 +49,8 @@
 				{...props}
 				class={cn('relative', className)}
 				tooltip={selectedTransformation
-					? 'Change post-processing transformation to run after your text is transcribed'
-					: 'Select a post-processing transformation to run after your text is transcribed'}
+					? 'Change transformation'
+					: 'Add a transformation'}
 				role="combobox"
 				aria-expanded={combobox.open}
 				variant="ghost"

--- a/apps/whispering/src/lib/components/settings/selectors/VadDeviceSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/VadDeviceSelector.svelte
@@ -38,8 +38,8 @@
 			<Button
 				{...props}
 				tooltip={selectedDeviceId
-					? 'Change VAD recording device'
-					: 'Select a VAD recording device'}
+					? 'Change recording device'
+					: 'Choose recording device'}
 				role="combobox"
 				aria-expanded={combobox.open}
 				variant="ghost"

--- a/apps/whispering/src/routes/(app)/_components/CapturePipeline.svelte
+++ b/apps/whispering/src/routes/(app)/_components/CapturePipeline.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import * as ButtonGroup from '@epicenter/ui/button-group';
 	import type { Snippet } from 'svelte';
 
 	let {
@@ -9,12 +8,16 @@
 	} = $props();
 </script>
 
-<div class="flex w-full items-center justify-between gap-3">
-	<span class="text-xs font-medium text-muted-foreground/75">Pipeline</span>
-	<ButtonGroup.Root
-		aria-label="Capture pipeline"
-		class="rounded-md bg-muted/25 p-0.5"
-	>
-		{@render children()}
-	</ButtonGroup.Root>
+<!--
+	The capture controls: input device, transcription model, post-processing.
+	The model is the one setting people hunt for, so its selector renders as a
+	labeled pill that stretches between the two icon bookends; the device and
+	transformation stay compact icons (their labels live in hover tooltips).
+-->
+<div
+	class="flex w-full items-center gap-1.5"
+	role="group"
+	aria-label="Capture pipeline"
+>
+	{@render children()}
 </div>


### PR DESCRIPTION
The capture footer showed three unlabeled icon buttons under a generic "Pipeline" label, so the setting people change most, which model transcribes their voice, was hidden behind a captions glyph discoverable only by hovering for a tooltip.

This promotes the model to a labeled pill that stretches between the mic and transformation icons, showing the provider's brand icon and name, and signals "needs setup" with an amber label that matches the popover. The "Pipeline" jargon label is gone. The selector tooltips are now verb-led and parallel ("Change" / "Choose") instead of echoing the current value or over-explaining.

## Changelog

- The active transcription model now shows by name in the recording bar, instead of a generic captions icon you had to hover to identify.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784219905&installation_id=128463665&pr_number=2055&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2055&signature=ada810c785afe5ce4358ecbb7769d97ae12b446d2c6b0da8e5e678da35022cad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->