### PR TITLE
refactor(cli)!: address daemon actions by bare key, drop the redundant mount prefix

### DIFF
--- a/.agents/skills/workspace-api/references/action-return-shapes.md
+++ b/.agents/skills/workspace-api/references/action-return-shapes.md
@@ -12,7 +12,7 @@ result is always a `Result<T, DispatchError>`.
    Same process, direct function call, no wrapping.
 
 2. ADAPTER
-   epicenter run app.tabs_close
+   epicenter run tabs_close
    LLM calls tabs_close tool
    In process, adapter formats the handler result for its surface.
 

--- a/apps/fuji/README.md
+++ b/apps/fuji/README.md
@@ -109,7 +109,7 @@ import { fuji } from "@epicenter/fuji/mount";
 export default fuji();
 ```
 
-`fuji()` returns a `Mount` whose `name` is `fuji`; `Mount.name` is the CLI prefix. `epicenter.config.ts` default-exports one mount. Disk paths follow the app-folder layout: the read-only markdown projection lands in table-named generated folders such as `<epicenterRoot>/entries/`, while the guid-keyed SQLite mirror stays under `.epicenter/sqlite/<id>.db` (hidden). The materialized `.md` is read-only; mutate entries through actions (`epicenter run fuji.<action>`), never by editing the files.
+`fuji()` returns a `Mount` whose `name` is `fuji`; `Mount.name` is the header `epicenter list` prints. `epicenter.config.ts` default-exports one mount. Disk paths follow the app-folder layout: the read-only markdown projection lands in table-named generated folders such as `<epicenterRoot>/entries/`, while the guid-keyed SQLite mirror stays under `.epicenter/sqlite/<id>.db` (hidden). The materialized `.md` is read-only; mutate entries through actions (`epicenter run <action>`), never by editing the files.
 
 `epicenter daemon up -C <epicenter-root>` starts the mount declared in `epicenter.config.ts`. It creates `.epicenter/` for generated machine state when it is missing, but sockets and daemon logs live in platform user paths instead of inside the root.
 

--- a/docs/articles/20260602T220000-keep-yjs-for-the-callback-not-the-conflict.md
+++ b/docs/articles/20260602T220000-keep-yjs-for-the-callback-not-the-conflict.md
@@ -64,7 +64,7 @@ So the entire wiring, both for my own edits and for a sync coming in from my pho
 doc.on('update', () => materialize(workspace));
 ```
 
-The materializer hangs off that and re-renders the files for whatever changed. It does not care if the change came from `epicenter run fuji.update` on this machine or from the relay catching me up after a flight. Same callback, same code path.
+The materializer hangs off that and re-renders the files for whatever changed. It does not care if the change came from `epicenter run entries_update` on this machine or from the relay catching me up after a flight. Same callback, same code path.
 
 SQLite has no `doc.on('update')`. To get the same behavior you build a change feed, and you end up with two code paths: the local write path, and the "a sync update arrived, apply it to the rows, now also fire the materializer" path. You keep them consistent by hand. The DO can emit on its own writes, since it is the choke point, but the moment a second device's write lands you are rebuilding the notify-and-rematerialize half yourself. Yjs collapses both halves into one observable.
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -34,7 +34,7 @@ container is convention, not a rule, and nothing reserves the name. Your own
 folders (`journal/`, `ideas/`, `publish/`) sit beside them as plain files you
 keep forever.
 
-You speak a thought into Whispering and it lands in your Whispering app folder as Markdown. You save tabs, draft entries, capture whatever, each through a purpose-built app, and every capture becomes a file you can grep. An agent reads the same files, queries the SQLite mirrors with plain SQL, and when it needs to change app state it goes through the same gate you do: `epicenter run <mount>.<action>`, validated against the app's schema. Nothing mutates by editing generated files; the projection is one-way on purpose.
+You speak a thought into Whispering and it lands in your Whispering app folder as Markdown. You save tabs, draft entries, capture whatever, each through a purpose-built app, and every capture becomes a file you can grep. An agent reads the same files, queries the SQLite mirrors with plain SQL, and when it needs to change app state it goes through the same gate you do: `epicenter run <action>`, validated against the app's schema. Nothing mutates by editing generated files; the projection is one-way on purpose.
 
 The loop is capture, curate, keep. App output is a disposable inbox, regenerable from the CRDT at any time. What matters graduates into folders you own: ordinary Markdown, tracked in git, still yours after every app in this repo is gone.
 

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -2,7 +2,7 @@
 
 A script is a Bun file that reads the local SQLite materializer and writes through `connectDaemonActions`. There is no `script.ts` recipe to copy. The daemon is the single writer; the script is a short-lived reader plus an IPC client.
 
-The Epicenter root is the folder that holds `epicenter.config.ts`. That config default-exports one `Mount`; one foreground daemon serves that mount over the root's Unix socket. The mount name is still the public action prefix for CLI display (`fuji.entries_update`), but scripts that already connect to a root call actions by their bare keys through `connectDaemonActions`.
+The Epicenter root is the folder that holds `epicenter.config.ts`. That config default-exports one `Mount`; one foreground daemon serves that mount over the root's Unix socket. The CLI addresses actions by their bare key (`epicenter run entries_update`): the daemon serves one mount, so the key alone is unambiguous, and the mount name is just the header `epicenter list` prints. Scripts likewise call actions by their bare keys through `connectDaemonActions`.
 
 ## The whole shape
 
@@ -60,7 +60,7 @@ npm package).
 
 `connectDaemonActions<TActions>({ epicenterRoot })` returns a typed proxy. The proxy translates `fuji.entries_update({ ... })` into a `POST /run` over the daemon's Unix socket in the OS runtime directory. The daemon validates the input against the action's declared schema (invalid input comes back as a usage error), invokes the action in-process against the live Y.Doc, and returns a JSON `Result<T>`.
 
-The mount name comes from the single `Mount.name` default-exported by `epicenter.config.ts`. App factories like `fuji()` return a mount whose name is `fuji`; the CLI uses that label when it renders or accepts `<mount>.<action>` paths.
+The mount name comes from the single `Mount.name` default-exported by `epicenter.config.ts`. App factories like `fuji()` return a mount whose name is `fuji`; the CLI prints that label as the header for `epicenter list`.
 
 Two consequences fall out:
 

--- a/examples/fuji/README.md
+++ b/examples/fuji/README.md
@@ -72,7 +72,7 @@ is planned follow-up work.
 You can also drive changes through the daemon's RPC actions. Use the CLI:
 
 ```sh
-bun x epicenter run fuji.entries_get '{"id":"01HM0000000000000000000000"}' -C examples/fuji
+bun x epicenter run entries_get '{"id":"01HM0000000000000000000000"}' -C examples/fuji
 ```
 
 The action set is defined by `@epicenter/fuji` and re-exposed through this

--- a/examples/notes-cross-peer/README.md
+++ b/examples/notes-cross-peer/README.md
@@ -28,7 +28,7 @@ bun x epicenter daemon up -C examples/notes-cross-peer/peer-a
 ```bash
 bun x epicenter daemon up -C examples/notes-cross-peer/peer-b &
 bun x epicenter peers -C examples/notes-cross-peer/peer-b
-bun x epicenter run notes.notes.add --peer notes-repro-peer-a '{"body":"from peer-b"}' -C examples/notes-cross-peer/peer-b
+bun x epicenter run add --peer notes-repro-peer-a '{"body":"from peer-b"}' -C examples/notes-cross-peer/peer-b
 ```
 
 To inspect peer-a's full action manifest from peer-b, write a script

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -47,10 +47,10 @@ epicenter daemon logs -C ~/workspace
 epicenter daemon down -C ~/workspace
 
 epicenter list -C ~/workspace
-epicenter list fuji.entries_update -C ~/workspace
+epicenter list entries_update -C ~/workspace
 
-epicenter run fuji.entries_update '{"id":"entry_1","tags":["triaged"]}' -C ~/workspace
-epicenter run fuji.entries_update '{"id":"entry_1","tags":["triaged"]}' --peer user-1 -C ~/workspace
+epicenter run entries_update '{"id":"entry_1","tags":["triaged"]}' -C ~/workspace
+epicenter run entries_update '{"id":"entry_1","tags":["triaged"]}' --peer user-1 -C ~/workspace
 
 epicenter peers -C ~/workspace
 ```
@@ -64,7 +64,7 @@ epicenter peers -C ~/workspace
 | Code | `run` | `list`, `peers` |
 | --- | --- | --- |
 | `0` | success | success |
-| `1` | usage error (unknown mount or action, action input that fails the action's schema, bad `--peer` input) or no daemon running | any failure (no daemon, bad arguments) |
+| `1` | usage error (unknown action, action input that fails the action's schema, bad `--peer` input) or no daemon running | any failure (no daemon, bad arguments) |
 | `2` | runtime error: the local action returned `Err`, or the remote RPC failed | (not used) |
 | `3` | peer not found: `--peer <target>` did not resolve within `--wait` | (not used) |
 
@@ -74,7 +74,7 @@ Error text goes to stderr; machine-readable output (`--format json|jsonl`, table
 
 ## Epicenter Roots And Mounts
 
-`epicenter.config.ts` marks the Epicenter root and declares its mount. One folder is one app is one mount: the default export is a single `Mount`. App packages ship mount factories that return `Mount` values; `Mount.name` owns the CLI prefix. The folder that holds `epicenter.config.ts` is your Epicenter folder: Epicenter owns its direct children, so the mount's visible markdown projection is a direct child folder.
+`epicenter.config.ts` marks the Epicenter root and declares its mount. One folder is one app is one mount: the default export is a single `Mount`. App packages ship mount factories that return `Mount` values; `Mount.name` is the display label `epicenter list` prints as its header. The folder that holds `epicenter.config.ts` is your Epicenter folder: Epicenter owns its direct children, so the mount's visible markdown projection is a direct child folder.
 
 ```ts
 import { fuji } from "@epicenter/fuji/mount";
@@ -82,7 +82,7 @@ import { fuji } from "@epicenter/fuji/mount";
 export default fuji();
 ```
 
-The returned `Mount.name` is `fuji`, so the CLI addresses actions as `fuji.<action_key>` regardless of the Epicenter folder name.
+The returned `Mount.name` is `fuji`, so `epicenter list` prints `fuji` as its header regardless of the Epicenter folder name. Actions are addressed by their bare key (`epicenter run entries_update`): the daemon serves one mount, so the key alone is unambiguous.
 
 The folder that holds `epicenter.config.ts` is your Epicenter folder. `.epicenter/` and the generated projection are direct children:
 
@@ -111,7 +111,7 @@ export default defineMount({
 });
 ```
 
-`Mount.name` is the CLI prefix.
+`Mount.name` is the header `epicenter list` prints; actions are addressed by their bare key.
 
 `.epicenter/` holds the Epicenter root's generated machine state such as SQLite materializers, Yjs update logs, markdown materializers, and its generated `.gitignore`. It is not a registry. Runtime files live outside the Epicenter root: sockets and daemon metadata use the OS runtime directory, while daemon logs use the platform log directory from `env-paths`.
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -15,12 +15,12 @@ import { runCommand } from './commands/run.js';
  *   - `auth`:  manage the local machine auth session (pre-workspace)
  *   - `init`:  scaffold epicenter.config.ts (explicit root creation)
  *   - `daemon`: operate daemon lifecycle commands
- *   - `list`:  runnable actions grouped by mount (local schema is authoritative)
- *   - `run`:   invoke one by mount-prefixed action path; `--peer` dispatches over RPC
+ *   - `list`:  runnable actions for the mounted runtime (local schema is authoritative)
+ *   - `run`:   invoke one by action key; `--peer` dispatches over RPC
  *   - `peers`: enumerate other clients currently online via the workspace presence row
  *
  * Every mount action is invoked through `run`, e.g.
- * `epicenter run fuji.markdown_rebuild '{}'` to re-materialize the read-only
+ * `epicenter run markdown_rebuild '{}'` to re-materialize the read-only
  * markdown projection; results come back as JSON on stdout. Materialized `.md`
  * is read-only: mutate app data through actions, never by editing the files.
  *

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -1,9 +1,10 @@
 /**
- * `epicenter list [mount.action_key]`: render actions exposed by this root.
+ * `epicenter list [action_key]`: render actions exposed by this root.
  *
- * The daemon returns a mount label plus bare action keys. The CLI is the
- * public-addressing edge: it prefixes those keys as `<mount>.<action>` before
- * filtering and rendering.
+ * The daemon serves one mount and returns its label plus bare action keys.
+ * Under one-mount-per-root the key alone addresses the action, so the CLI
+ * renders and filters by the bare key; the mount label is a display header
+ * only.
  *
  * Per-peer schema introspection is a script concern. The CLI lists the local
  * daemon's mounted action surface only.
@@ -14,7 +15,11 @@
  */
 
 import type { ActionManifest } from '@epicenter/workspace';
-import { type DaemonError, getDaemon } from '@epicenter/workspace/node';
+import {
+	type DaemonError,
+	type DaemonListSnapshot,
+	getDaemon,
+} from '@epicenter/workspace/node';
 import Type, { type TSchema } from 'typebox';
 import type { Result } from 'wellcrafted/result';
 
@@ -28,18 +33,18 @@ import {
 } from '../util/format-output.js';
 
 export const listCommand = cmd({
-	command: 'list [path]',
-	describe: 'List exposed queries and mutations on this node, by mount',
+	command: 'list [action]',
+	describe: 'List exposed queries and mutations on this node',
 	builder: (yargs) =>
 		yargs
-			.positional('path', {
+			.positional('action', {
 				type: 'string',
-				describe: 'Optional mount-prefixed path to narrow the view',
+				describe: 'Optional action key to show its detail',
 			})
 			.option('C', epicenterRootOption)
 			.options(formatOptions),
 	handler: async (argv) => {
-		const path = argv.path ?? '';
+		const action = argv.action ?? '';
 
 		const { data: daemon, error: daemonErr } = await getDaemon(argv.C);
 		if (daemonErr) {
@@ -47,13 +52,13 @@ export const listCommand = cmd({
 			return;
 		}
 		const result = await daemon.list();
-		renderResult(result, path, argv.format);
+		renderResult(result, action, argv.format);
 	},
 });
 
 function renderResult(
-	result: Result<{ mount: string; actions: ActionManifest }, DaemonError>,
-	path: string,
+	result: Result<DaemonListSnapshot, DaemonError>,
+	action: string,
 	format: OutputFormat | undefined,
 ): void {
 	if (result.error !== null) {
@@ -69,79 +74,55 @@ function renderResult(
 				return;
 		}
 	}
+	const { mount, actions } = result.data;
 	if (format) {
-		renderJson(toPrefixedManifest(result.data), path, format);
+		renderJson(actions, action, format);
 		return;
 	}
-	renderText(toPrefixedManifest(result.data), path);
-}
-
-function toPrefixedManifest({
-	mount,
-	actions,
-}: {
-	mount: string;
-	actions: ActionManifest;
-}): ActionManifest {
-	const manifest: ActionManifest = {};
-	for (const [path, meta] of Object.entries(actions)) {
-		manifest[`${mount}.${path}`] = meta;
-	}
-	return manifest;
+	renderText(mount, actions, action);
 }
 
 function renderJson(
-	entries: ActionManifest,
-	path: string,
+	actions: ActionManifest,
+	action: string,
 	format: OutputFormat,
 ): void {
-	const action = path ? entries[path] : undefined;
 	if (action) {
-		output(toActionDescriptor(action, path), { format });
+		const meta = actions[action];
+		if (!meta) {
+			fail(`"${action}" is not defined.`);
+			return;
+		}
+		output(toActionDescriptor(meta, action), { format });
 		return;
 	}
 
-	const subset = filterByPath(entries, path);
-	const rows = Object.entries(subset).map(([p, meta]) =>
-		toActionDescriptor(meta, p),
+	const rows = Object.entries(actions).map(([key, meta]) =>
+		toActionDescriptor(meta, key),
 	);
-	if (path && rows.length === 0) {
-		fail(`"${path}" is not defined.`);
-		return;
-	}
 	output(rows, { format });
 }
 
-function renderText(entries: ActionManifest, path: string): void {
-	const subset = filterByPath(entries, path);
-	const matches = Object.keys(subset).length;
-
-	if (path && matches === 0) {
-		fail(`"${path}" is not defined.`);
+function renderText(
+	mount: string,
+	actions: ActionManifest,
+	action: string,
+): void {
+	if (action) {
+		const meta = actions[action];
+		if (!meta) {
+			fail(`"${action}" is not defined.`);
+			return;
+		}
+		printActionDetail(action, meta);
 		return;
 	}
 
-	if (matches === 0) {
+	if (Object.keys(actions).length === 0) {
 		console.error('(no actions exposed)');
 		return;
 	}
-
-	const leaf = path ? entries[path] : undefined;
-	if (leaf && matches === 1) {
-		printActionDetail(path, leaf);
-		return;
-	}
-	printGroupedByMount(subset);
-}
-
-function filterByPath(entries: ActionManifest, path: string): ActionManifest {
-	if (!path) return entries;
-	const pfx = `${path}.`;
-	const out: ActionManifest = {};
-	for (const [p, meta] of Object.entries(entries)) {
-		if (p === path || p.startsWith(pfx)) out[p] = meta;
-	}
-	return out;
+	printActions(mount, actions);
 }
 
 type ActionDescriptor = {
@@ -162,30 +143,14 @@ function toActionDescriptor(
 }
 
 /**
- * Action paths are exactly `mount.action_key` (mount names reject dots, action
- * keys are snake_case), so the manifest is two levels deep by construction.
- * Render one mount header per group with its actions indented underneath.
+ * The daemon serves one mount, so render its label as a single header with the
+ * bare action keys (snake_case) listed underneath.
  */
-function printGroupedByMount(entries: ActionManifest): void {
-	const byMount = new Map<string, [string, ActionManifest[string]][]>();
-	for (const [path, action] of Object.entries(entries)) {
-		const dot = path.indexOf('.');
-		const mount = dot === -1 ? path : path.slice(0, dot);
-		const key = dot === -1 ? '' : path.slice(dot + 1);
-		const group = byMount.get(mount);
-		if (group) group.push([key, action]);
-		else byMount.set(mount, [[key, action]]);
-	}
-
-	let first = true;
-	for (const [mount, group] of byMount) {
-		if (!first) console.log('');
-		first = false;
-		console.log(mount);
-		for (const [key, action] of group) {
-			const desc = action.description ? `  ${action.description}` : '';
-			console.log(`  ${key}  (${action.type})${desc}`);
-		}
+function printActions(mount: string, actions: ActionManifest): void {
+	console.log(mount);
+	for (const [key, action] of Object.entries(actions)) {
+		const desc = action.description ? `  ${action.description}` : '';
+		console.log(`  ${key}  (${action.type})${desc}`);
 	}
 }
 

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,22 +1,22 @@
 /**
- * `epicenter run <mount.action_key> [input]`: invoke a `defineQuery` or
- * `defineMutation` by mount-prefixed CLI path through the local
+ * `epicenter run <action_key> [input]`: invoke a `defineQuery` or
+ * `defineMutation` by its bare action key through the local
  * `epicenter daemon up` daemon.
  *
  * `input` is JSON: inline positional, `@file.json` (curl convention), or stdin.
- * The CLI owns the `<mount>.` prefix for public addressing, then sends the
- * daemon the bare action key. With `--peer <target>`, the daemon dispatches
- * the run over its RPC channel to a remote peer instead of running locally;
- * both shapes are one `/run` request (the optional `peer` object selects the
- * target and carries the wait budget).
+ * The daemon serves one mount, so the action key alone addresses the action;
+ * the CLI forwards it to the daemon verbatim. With `--peer <target>`, the
+ * daemon dispatches the run over its RPC channel to a remote peer instead of
+ * running locally; both shapes are one `/run` request (the optional `peer`
+ * object selects the target and carries the wait budget).
  *
  * `epicenter run` requires a running daemon for the discovered Epicenter root.
  * Without `daemon up`, the handler errors with a hint pointing at
  * `epicenter daemon up`.
  *
  * Exit codes:
- *   1: usage error (unknown mount, unknown action, action input that fails the
- *      action's schema, invalid input for `--peer`), or no daemon (`Required`,
+ *   1: usage error (unknown action, action input that fails the action's
+ *      schema, invalid input for `--peer`), or no daemon (`Required`,
  *      transport error)
  *   2: runtime error (local action returned Err, or remote RPC failed)
  *   3: peer not found (`--peer <target>` did not resolve within `--wait`)
@@ -51,7 +51,7 @@ export const runCommand = cmd({
 			.positional('action', {
 				type: 'string',
 				demandOption: true,
-				describe: 'Mount-prefixed action path, e.g. notes.notes_add',
+				describe: 'Action key, e.g. notes_add',
 			})
 			.positional('input', {
 				type: 'string',
@@ -85,24 +85,14 @@ export const runCommand = cmd({
 			return;
 		}
 
-		const { data: list, error: listError } = await daemon.list();
-		if (listError) {
-			fail(listError.message);
-			return;
-		}
-		const { data: actionPath, error: actionPathError } = resolveDaemonRunPath(
-			list.mount,
-			argv.action,
-		);
-		if (actionPathError) {
-			fail(actionPathError.message, { details: actionPathError.suggestions });
-			return;
-		}
-
+		// One mount per root, so the bare action key is the address. An unknown
+		// key surfaces from the daemon's `runLocal` as a `UsageError` with
+		// sibling suggestions, rendered below.
+		//
 		// A `peer` key with an `undefined` value drops out of the JSON wire
 		// body, so a local run sends no peer fields at all.
 		const result = await daemon.run({
-			actionPath,
+			actionPath: argv.action,
 			input: actionInput,
 			peer:
 				argv.peer === undefined
@@ -112,35 +102,6 @@ export const runCommand = cmd({
 		renderRunResult(result, argv.format);
 	},
 });
-
-function resolveDaemonRunPath(
-	mount: string,
-	cliAction: string,
-): Result<string, { message: string; suggestions?: string[] }> {
-	const prefix = `${mount}.`;
-	if (cliAction.startsWith(prefix)) {
-		const localPath = cliAction.slice(prefix.length);
-		if (localPath.length > 0) return { data: localPath, error: null };
-		return {
-			data: null,
-			error: {
-				message: `"${cliAction}" is not a runnable action.`,
-				suggestions: [`  ${mount}.<action_key>`],
-			},
-		};
-	}
-
-	const requestedMount = cliAction.includes('.')
-		? cliAction.slice(0, cliAction.indexOf('.'))
-		: cliAction;
-	return {
-		data: null,
-		error: {
-			message: `No mount "${requestedMount}". Available: ${mount}`,
-			suggestions: [`  ${mount}`],
-		},
-	};
-}
 
 function renderRunResult(
 	result: Result<unknown, RunError | DaemonError>,

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -22,7 +22,7 @@ Write path:
     -> SQLite mirror and Markdown export refresh
 ```
 
-Agents can still edit ordinary project files. They should not patch generated `.md` files to mutate app data. Give them actions instead: browser chat uses `actionsToAiTools`, scripts use `connectDaemonActions`, and humans or automation can call `epicenter run <mount>.<action>`. The action writes the Yjs datastore; the materializers write the files back out.
+Agents can still edit ordinary project files. They should not patch generated `.md` files to mutate app data. Give them actions instead: browser chat uses `actionsToAiTools`, scripts use `connectDaemonActions`, and humans or automation can call `epicenter run <action>`. The action writes the Yjs datastore; the materializers write the files back out.
 
 The current center is small:
 
@@ -362,7 +362,7 @@ Writes:
   UI component
   TanStack AI tool
   Bun script
-  epicenter run <mount>.<action>
+  epicenter run <action>
     -> defineMutation action
       -> Y.Doc tables, KV, or child content docs
         -> sync peers
@@ -961,7 +961,7 @@ Ordering is just lexical: `collaboration` reads `idb.whenLoaded` as `waitFor` be
 
 Markdown comes from one seam, `attachMarkdownExport` (in `@epicenter/workspace/document/materializer/markdown`): a continuous, one-way Yjs to disk projection with free serialization (custom `filename`, `toMarkdown`, per-table `dir`). It exposes a single `markdown_rebuild` mutation for a destructive full re-export (orphan cleanup after a filename or layout change); there is no import path.
 
-The projection is read-only on purpose. The materialized `.md` is never read back into Yjs, so it carries no round-trip obligation and can shape the output however a human-readable export or a published site wants. App data mutates through validated actions (`epicenter run <mount>.<action>`, `connectDaemonActions`, or TanStack AI tools created by `actionsToAiTools`), never by editing the materialized files. If an app needs Markdown as the authoring format, that parser/editor belongs in an app action or UI surface that writes Yjs. This export is not that path. The SQLite materializer is the read-only sibling for a relational projection.
+The projection is read-only on purpose. The materialized `.md` is never read back into Yjs, so it carries no round-trip obligation and can shape the output however a human-readable export or a published site wants. App data mutates through validated actions (`epicenter run <action>`, `connectDaemonActions`, or TanStack AI tools created by `actionsToAiTools`), never by editing the materialized files. If an app needs Markdown as the authoring format, that parser/editor belongs in an app action or UI surface that writes Yjs. This export is not that path. The SQLite materializer is the read-only sibling for a relational projection.
 
 ```typescript
 import { field } from '@epicenter/field';

--- a/packages/workspace/docs/architecture/action-dispatch.md
+++ b/packages/workspace/docs/architecture/action-dispatch.md
@@ -108,7 +108,7 @@ There is no stale-request hazard to design around: dispatch is live, so a node t
 ## Where This Runs
 
 - **In an app (browser, extension, Tauri):** `openCollaboration(...)` returns the `collaboration` handle with `peers` and `dispatch` above.
-- **On the CLI daemon:** the same handle is surfaced as two commands. `epicenter peers` prints `collaboration.peers.list()`; `epicenter run <mount>.<action> --peer <nodeId>` calls `collaboration.dispatch(...)`. A peer that is not reachable surfaces as `PeerNotFound` (the daemon's name for `RecipientOffline`).
+- **On the CLI daemon:** the same handle is surfaced as two commands. `epicenter peers` prints `collaboration.peers.list()`; `epicenter run <action> --peer <nodeId>` calls `collaboration.dispatch(...)`. A peer that is not reachable surfaces as `PeerNotFound` (the daemon's name for `RecipientOffline`).
 
 ## Related Documentation
 

--- a/packages/workspace/src/daemon/app.ts
+++ b/packages/workspace/src/daemon/app.ts
@@ -78,8 +78,8 @@ export type DaemonListSnapshot = {
  * the app through the daemon server factory.
  *
  * The daemon serves one mounted runtime. Its socket is the route; the mount
- * name is a label for CLI display and client-side `<mount>.<action>` parsing,
- * never an internal dispatch key.
+ * name is a label for CLI display, never an internal dispatch key. Actions are
+ * addressed by their bare key on the wire and in the CLI alike.
  */
 export function buildDaemonApp(mount: DaemonServedMount) {
 	return new Hono()

--- a/packages/workspace/src/daemon/define-mount.ts
+++ b/packages/workspace/src/daemon/define-mount.ts
@@ -2,8 +2,8 @@
  * `defineMount`: the entry contract for an app mount inside the daemon.
  *
  * `epicenter.config.ts` default-exports one `Mount`. The mount carries its own
- * canonical `name`, which becomes the CLI action prefix (`<name>.<action_key>`)
- * and is propagated into the mount context so handlers can use it for logging.
+ * canonical `name`, which `epicenter list` prints as the header label and which
+ * is propagated into the mount context so handlers can use it for logging.
  *
  * The host calls `open(ctx)` once on `epicenter daemon up`. A mount can do one
  * of two things:

--- a/packages/workspace/src/daemon/list-mount.test.ts
+++ b/packages/workspace/src/daemon/list-mount.test.ts
@@ -2,8 +2,8 @@
  * Coverage for the `/list` manifest projection.
  *
  * `/list` describes the one hosted mount with a mount label and bare action
- * keys. Mount-prefixed public addressing belongs to clients such as the CLI,
- * not to the daemon wire.
+ * keys. The mount label is a display header for clients such as the CLI;
+ * actions are addressed by their bare key on the wire and in the CLI alike.
  */
 
 import { describe, expect, test } from 'bun:test';


### PR DESCRIPTION
Daemon actions are addressed by bare key because an Epicenter root serves one mount. The mount name still labels `epicenter list`, but it no longer disambiguates `epicenter run`.

## Breaking

```sh
# Before
epicenter run fuji.entries_update '{"id":"entry_1"}'

# After
epicenter run entries_update '{"id":"entry_1"}'
```

The same applies to peer dispatch:

```sh
# Before
epicenter run notes.notes.add --peer notes-repro-peer-a '{"body":"from peer-b"}'

# After
epicenter run add --peer notes-repro-peer-a '{"body":"from peer-b"}'
```

`epicenter run` now sends the action key straight to the daemon. Unknown keys surface from `runLocal` as a usage error with sibling suggestions, so the CLI no longer pre-fetches the manifest just to resolve a path.

`epicenter list [action]` filters by bare key and renders actions under one mount-label header. `DaemonListSnapshot { mount, actions }` stays because the mount name still earns display space; `resolveDaemonRunPath`, `toPrefixedManifest`, `filterByPath`, and `printGroupedByMount` are gone because the qualified action path is no longer a contract.
