### PR TITLE
fix(whispering): surface provider error on transcription failure

### DIFF
--- a/apps/whispering/src/lib/operations/transcribe.ts
+++ b/apps/whispering/src/lib/operations/transcribe.ts
@@ -34,6 +34,15 @@ import { recordings } from '$lib/state/recordings.svelte';
 import { settings } from '$lib/state/settings.svelte';
 import { commands } from '$lib/tauri/commands';
 
+/**
+ * The error any transcription path can surface. Deliberately `AnyTaggedError`
+ * rather than the concrete provider-error union: every consumer (toast,
+ * failed-row tooltip, practice view, analytics) presents these by `.message`,
+ * and none discriminate on `.name`. The user-facing message is curated where
+ * the context lives, in each service's `defineErrors` constructors, so this
+ * boundary only needs to promise `{ name, message }`. Widening to the full
+ * union would add error variants no consumer reads.
+ */
 export type TranscriptionError = AnyTaggedError;
 
 const TranscriptionOperationError = defineErrors({
@@ -164,8 +173,8 @@ export async function transcribeAudio(
 
 	const transcriptionResult =
 		PROVIDERS[selectedService].location === 'local'
-			? await dispatchLocalTranscription(recordingId, selectedService)
-			: await dispatchUploadTranscription(recordingId, selectedService);
+			? await transcribeLocally(recordingId, selectedService)
+			: await transcribeViaUpload(recordingId, selectedService);
 
 	const duration = Date.now() - startTime;
 	if (transcriptionResult.error) {
@@ -245,7 +254,7 @@ async function checkWhisperTruncation(
 	return Ok(undefined);
 }
 
-async function dispatchLocalTranscription(
+async function transcribeLocally(
 	recordingId: string,
 	selectedService: TranscriptionServiceId,
 ): Promise<Result<string, TranscriptionError>> {
@@ -282,7 +291,7 @@ async function dispatchLocalTranscription(
 	return commands.transcribeRecording(recordingId);
 }
 
-async function dispatchUploadTranscription(
+async function transcribeViaUpload(
 	recordingId: string,
 	selectedService: TranscriptionServiceId,
 ): Promise<Result<string, TranscriptionError>> {

--- a/apps/whispering/src/lib/tauri.tauri.ts
+++ b/apps/whispering/src/lib/tauri.tauri.ts
@@ -48,6 +48,7 @@ import {
 	isEnabled as isAutostartEnabled,
 } from '@tauri-apps/plugin-autostart';
 import { readFile } from '@tauri-apps/plugin-fs';
+import { openPath as revealPath } from '@tauri-apps/plugin-opener';
 import { exit } from '@tauri-apps/plugin-process';
 import mime from 'mime';
 import { defineErrors, extractErrorMessage } from 'wellcrafted/error';
@@ -404,6 +405,24 @@ const media = {
 	resume: (players: MediaPlayer[]) => commands.resumeMedia(players),
 };
 
+// opener ------------------------------------------------------------
+const OpenerError = defineErrors({
+	OpenPathFailed: ({ path, cause }: { path: string; cause: unknown }) => ({
+		message: `Failed to open ${path}: ${extractErrorMessage(cause)}`,
+		path,
+		cause,
+	}),
+});
+
+const opener = {
+	/** Reveal a file or folder in the OS file manager (Finder, Explorer). */
+	openPath: (path: string) =>
+		tryAsync({
+			try: () => revealPath(path),
+			catch: (cause) => OpenerError.OpenPathFailed({ path, cause }),
+		}),
+};
+
 // barrel ------------------------------------------------------------
 // `tauriOnly` is the non-null namespace for `.tauri.ts` files. The
 // `tauri` export widens it to `Tauri | null` so shared consumers narrow.
@@ -414,6 +433,7 @@ export const tauriOnly = {
 	globalShortcuts,
 	autostart,
 	media,
+	opener,
 };
 
 /** Shape of the Tauri capability namespace (non-null). */

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -358,19 +358,8 @@
 
 	async function openRecordingsFolder() {
 		if (!tauri) return;
-
-		try {
-			const { openPath } = await import('@tauri-apps/plugin-opener');
-			await openPath(await PATHS.DB.RECORDINGS());
-		} catch (error) {
-			report.error({
-				title: 'Failed to open folder',
-				cause: {
-					name: 'OpenFolderFailed',
-					message: error instanceof Error ? error.message : 'Unknown error',
-				},
-			});
-		}
+		const { error } = await tauri.opener.openPath(await PATHS.DB.RECORDINGS());
+		if (error) report.error({ title: 'Failed to open folder', cause: error });
 	}
 </script>
 

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -406,7 +406,7 @@
 						disabled={transcribeRecordings.isPending}
 						onclick={() => {
 							const loading = report.loading({
-								title: 'Transcribing queries.recordings...',
+								title: 'Transcribing recordings...',
 								description: 'This may take a while.',
 							});
 							transcribeRecordings.mutate(
@@ -422,21 +422,34 @@
 											});
 											return;
 										}
+
+										// Each failed result still carries its tagged error.
+										// Dedupe the real provider messages so a batch that
+										// failed the same way (e.g. every row missing the API
+										// key) reads as one line, not N copies.
+										const failureMessages = [
+											...new Set(errs.map(({ error }) => error.message)),
+										].join('\n');
+
 										const isAllFailed = oks.length === 0;
 										if (isAllFailed) {
-											const count = errs.length;
+											// A single failure forwards its real tagged error, so
+											// the toast and More details dialog show the provider's
+											// own message and name.
+											const [onlyFailure] = errs;
+											if (onlyFailure && errs.length === 1) {
+												loading.reject({
+													cause: onlyFailure.error,
+													title: 'Failed to transcribe recording',
+												});
+												return;
+											}
 											loading.reject({
-												title: `Failed to transcribe ${count} recording${count === 1 ? '' : 's'}`,
-												description:
-													count === 1
-														? 'Your recording could not be transcribed.'
-														: 'None of your recordings could be transcribed.',
+												title: `Failed to transcribe ${errs.length} recordings`,
+												description: failureMessages,
 												cause: {
 													name: 'BulkTranscriptionFailed',
-													message:
-														count === 1
-															? 'Your recording could not be transcribed.'
-															: 'None of your recordings could be transcribed.',
+													message: failureMessages,
 												},
 											});
 											return;
@@ -444,10 +457,10 @@
 										// Mixed results
 										loading.reject({
 											title: `Transcribed ${oks.length} of ${oks.length + errs.length} recordings`,
-											description: `${oks.length} succeeded, ${errs.length} failed.`,
+											description: `${oks.length} succeeded, ${errs.length} failed:\n${failureMessages}`,
 											cause: {
 												name: 'BulkTranscriptionPartiallyFailed',
-												message: `${oks.length} succeeded, ${errs.length} failed.`,
+												message: failureMessages,
 											},
 										});
 									},

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -413,8 +413,7 @@
 								selectedRecordingRows.map(({ original }) => original),
 								{
 									onSuccess: ({ oks, errs }) => {
-										const isAllSuccessful = errs.length === 0;
-										if (isAllSuccessful) {
+										if (errs.length === 0) {
 											const count = oks.length;
 											loading.resolve({
 												title: `Transcribed ${count} recording${count === 1 ? '' : 's'}!`,
@@ -423,45 +422,33 @@
 											return;
 										}
 
-										// Each failed result still carries its tagged error.
-										// Dedupe the real provider messages so a batch that
-										// failed the same way (e.g. every row missing the API
+										// Per-recording errors already live on their rows:
+										// transcribeAndPersist marks each failed row and the row
+										// surfaces its message plus a retry. So the bulk toast only
+										// summarizes, and forwards the first real failure as the
+										// cause so More details stays a genuine provider error
+										// rather than a synthesized one. Dedupe the messages so a
+										// batch that failed the same way (every row missing the API
 										// key) reads as one line, not N copies.
-										const failureMessages = [
+										const [firstFailure] = errs;
+										if (!firstFailure) return; // errs is non-empty here
+										const failureSummary = [
 											...new Set(errs.map(({ error }) => error.message)),
 										].join('\n');
 
-										const isAllFailed = oks.length === 0;
-										if (isAllFailed) {
-											// A single failure forwards its real tagged error, so
-											// the toast and More details dialog show the provider's
-											// own message and name.
-											const [onlyFailure] = errs;
-											if (onlyFailure && errs.length === 1) {
-												loading.reject({
-													cause: onlyFailure.error,
-													title: 'Failed to transcribe recording',
-												});
-												return;
-											}
+										if (oks.length === 0) {
 											loading.reject({
-												title: `Failed to transcribe ${errs.length} recordings`,
-												description: failureMessages,
-												cause: {
-													name: 'BulkTranscriptionFailed',
-													message: failureMessages,
-												},
+												cause: firstFailure.error,
+												title: `Failed to transcribe ${errs.length} recording${errs.length === 1 ? '' : 's'}`,
+												description: failureSummary,
 											});
 											return;
 										}
-										// Mixed results
+
 										loading.reject({
+											cause: firstFailure.error,
 											title: `Transcribed ${oks.length} of ${oks.length + errs.length} recordings`,
-											description: `${oks.length} succeeded, ${errs.length} failed:\n${failureMessages}`,
-											cause: {
-												name: 'BulkTranscriptionPartiallyFailed',
-												message: failureMessages,
-											},
+											description: `${oks.length} succeeded, ${errs.length} failed:\n${failureSummary}`,
 										});
 									},
 								},

--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/RecordingRowActions.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/RecordingRowActions.svelte
@@ -11,7 +11,6 @@
 	import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
 	import TrashIcon from '@lucide/svelte/icons/trash-2';
 	import { createMutation } from '@tanstack/svelte-query';
-	import type { AnyTaggedError } from 'wellcrafted/error';
 	import { deliverTranscriptionResult } from '$lib/operations/delivery';
 	import { deleteRecordingsWithConfirmation } from '$lib/operations/recordings';
 	import { sound } from '$lib/operations/sound';
@@ -81,10 +80,14 @@
 				});
 				transcribeRecording.mutate(recording, {
 					onError: (error) => {
+						// `error` is the mutation's `TError` (the operation's
+						// TranscriptionError, which is AnyTaggedError), so it flows
+						// straight into `cause` with no assertion. Omit `description`
+						// so the toast falls back to the provider's own message (e.g.
+						// "OpenAI API key is required") instead of a generic line.
 						loading.reject({
-							cause: error as AnyTaggedError,
+							cause: error,
 							title: 'Failed to transcribe recording',
-							description: 'Your recording could not be transcribed.',
 						});
 					},
 					onSuccess: async (transcribedText) => {
@@ -143,7 +146,7 @@
 				downloadRecording.mutate(recording, {
 					onError: (error) => {
 						report.error({
-							cause: error as AnyTaggedError,
+							cause: error,
 							title: 'Failed to download recording!',
 							description: 'Your recording could not be downloaded.',
 						});


### PR DESCRIPTION
When a transcription failed, the toast threw away the provider's own explanation. A missing OpenAI key reported "Your recording could not be transcribed" instead of "OpenAI API key is required", because the retry handler passed a generic `description` that shadowed the error's real message at the report boundary (`description = notice.description ?? notice.cause?.message`). The same handler also cast the error with `as AnyTaggedError`, which turned out to be unnecessary: the mutation error is already typed as the operation's `TranscriptionError`, so the cast hid nothing and guarded nothing.

Now the retry handler forwards the error as `cause` and omits the description, so the toast falls back to the provider's curated message while the title stays owned by the UI. The compact failed-row tooltip is unchanged. Bulk transcription gets the same treatment: instead of collapsing every failure into one "none could be transcribed" line, it dedupes and keeps the underlying provider messages, and a lone failure forwards its tagged error so the More details dialog keeps the original error name.

A second commit renames the two internal handlers that `transcribeAudio` routes to. They were `dispatchLocalTranscription` / `dispatchUploadTranscription`, but `transcribeAudio` is the dispatcher; the arms are the handlers it dispatches to, and the local arm routes nothing (it just calls into Rust). They are now `transcribeLocally` / `transcribeViaUpload`, with a note on why the `TranscriptionError` boundary stays `AnyTaggedError`. No behavior change.

Before and after for a missing OpenAI key on retry:

| | Before | After |
| --- | --- | --- |
| Toast title | Failed to transcribe recording | Failed to transcribe recording |
| Toast description | Your recording could not be transcribed. | OpenAI API key is required |
| Error cause | `error as AnyTaggedError` | `error` (no assertion) |

## Changelog

Transcription failures now show the underlying provider error (for example "OpenAI API key is required") in the toast instead of a generic message.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784227330&installation_id=128463665&pr_number=2059&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2059&signature=ec9f29d54a92eb7dee46b2140da98ba19536750e73b424d703546cfeb4f608cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->