### PR TITLE
fix(apps): allow disabling mount git autosave

### DIFF
--- a/apps/fuji/src/lib/workspace/mount.ts
+++ b/apps/fuji/src/lib/workspace/mount.ts
@@ -32,7 +32,7 @@ import { fujiWorkspace } from './index.js';
 
 export type FujiMountOptions = {
 	/** Enable per-materializer Git autosave for markdown output. */
-	git?: GitAutosaveConfig;
+	git?: GitAutosaveConfig | false;
 	/**
 	 * Base URL of the Epicenter cloud API used for entry-body reads and sync.
 	 * Defaults to `process.env.EPICENTER_API_URL`, falling back to the hosted API.

--- a/apps/honeycrisp/mount.ts
+++ b/apps/honeycrisp/mount.ts
@@ -18,7 +18,7 @@ import {
 import { honeycrispWorkspace } from './honeycrisp.js';
 
 export type HoneycrispMountOptions = {
-	git?: GitAutosaveConfig;
+	git?: GitAutosaveConfig | false;
 	/**
 	 * Base URL of the Epicenter cloud API used for sync.
 	 * Defaults to `process.env.EPICENTER_API_URL`, falling back to the hosted API.

--- a/apps/tab-manager/mount.ts
+++ b/apps/tab-manager/mount.ts
@@ -19,7 +19,7 @@ import { tabManagerWorkspace } from './src/lib/workspace/definition.js';
 
 export type TabManagerMountOptions = {
 	/** Enable per-materializer Git autosave for markdown output. */
-	git?: GitAutosaveConfig;
+	git?: GitAutosaveConfig | false;
 	/**
 	 * Base URL of the Epicenter cloud API used for sync.
 	 * Defaults to `process.env.EPICENTER_API_URL`, falling back to the hosted API.


### PR DESCRIPTION
The app mount wrappers already default `git` to `false`, matching the downstream markdown mount helper where `false` means do not enable git autosave. Their local option types lagged behind that contract and only accepted `GitAutosaveConfig`, so Fuji, Honeycrisp, and Tab Manager failed typecheck even though the runtime value was valid.

This widens the three app mount option types to accept `GitAutosaveConfig | false`, keeping the wrappers aligned with `attachMountMarkdown` without changing runtime behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784239437&installation_id=128463665&pr_number=2064&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2064&signature=a16a57cf16f25bd01daafc49d25833e09df6e2f7841e6775d1da8a85097ce2a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->