### PR TITLE
fix(whispering): normalize VAD asset copy paths

### DIFF
--- a/.github/workflows/pr-preview.whispering.yml
+++ b/.github/workflows/pr-preview.whispering.yml
@@ -39,6 +39,7 @@ on:
       - 'apps/whispering/src-tauri/**'
       - 'apps/whispering/**/Cargo.toml'
       - 'apps/whispering/**/Cargo.lock'
+      - 'apps/whispering/vite.config.ts'
       - '.github/workflows/pr-preview.whispering.yml'
       - '.github/actions/setup-whispering-build/**'
       - '.github/actions/process-whispering-appimage/**'

--- a/apps/whispering/vite.config.ts
+++ b/apps/whispering/vite.config.ts
@@ -2,7 +2,12 @@ import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { APPS } from '@epicenter/constants/apps';
 import { workspaceAppViteConfig } from '@epicenter/vite-config';
-import { defaultClientConditions, defineConfig, mergeConfig } from 'vite';
+import {
+	defaultClientConditions,
+	defineConfig,
+	mergeConfig,
+	normalizePath,
+} from 'vite';
 import devtoolsJson from 'vite-plugin-devtools-json';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 
@@ -21,12 +26,14 @@ const require = createRequire(import.meta.url);
 const distOf = (pkg: string) => dirname(require.resolve(pkg));
 const vadDist = distOf('@ricky0123/vad-web');
 const ortDist = distOf('onnxruntime-web');
+// vite-plugin-static-copy treats src as a glob, so Windows backslashes must
+// become forward slashes before tinyglobby tries to match these files.
 const vadAssetSources = [
 	join(vadDist, 'vad.worklet.bundle.min.js'),
 	join(vadDist, 'silero_vad_v5.onnx'),
 	join(ortDist, 'ort-wasm-simd-threaded.mjs'),
 	join(ortDist, 'ort-wasm-simd-threaded.wasm'),
-];
+].map(normalizePath);
 
 export default defineConfig(
 	mergeConfig(workspaceAppViteConfig(APPS.WHISPERING), {


### PR DESCRIPTION
Windows preview builds were failing before Tauri packaging because vite-plugin-static-copy could not match the VAD worklet path under node_modules. The file existed, but the source path was built with Node's platform-native separators, so Windows handed tinyglobby a backslash path like C:\runner\...\vad.worklet.bundle.min.js.

Normalize the resolved VAD and ONNX Runtime asset paths before passing them to vite-plugin-static-copy. macOS and Linux already produced forward-slash paths; Windows now gets the same glob-friendly shape.

The PR Preview workflow now treats the Whispering Vite config as native-build-affecting plumbing, so this fix and future config changes run the preview matrix instead of only the web deploy checks.