### PR TITLE
refactor(whispering): drop setup-wizard fossil naming

### DIFF
--- a/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
+++ b/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
@@ -154,7 +154,7 @@
 		<div class="space-y-4">
 			<Card.Root>
 				<Card.Header>
-					<Card.Title class="text-lg">Speaches Setup</Card.Title>
+					<Card.Title class="text-lg">Speaches</Card.Title>
 					<Card.Description>
 						Install Speaches server and configure Whispering. Speaches is the
 						successor to faster-whisper-server with improved features and
@@ -176,7 +176,7 @@
 							target="_blank"
 							rel="noopener noreferrer"
 						>
-							Speech-to-Text Setup
+							Speech-to-Text Guide
 						</Button>
 					</div>
 

--- a/apps/whispering/src/lib/components/settings/index.ts
+++ b/apps/whispering/src/lib/components/settings/index.ts
@@ -13,4 +13,4 @@ export { default as RecordingModeSelector } from './selectors/RecordingModeSelec
 export { default as TranscriptionSelector } from './selectors/TranscriptionSelector.svelte';
 export { default as TransformationSelector } from './selectors/TransformationSelector.svelte';
 export { default as VadDeviceSelector } from './selectors/VadDeviceSelector.svelte';
-export { default as TranscriptionRuntimeSetup } from './TranscriptionRuntimeSetup.svelte';
+export { default as TranscriptionRuntimeConfig } from './TranscriptionRuntimeConfig.svelte';

--- a/apps/whispering/src/lib/settings/transcription-validation.ts
+++ b/apps/whispering/src/lib/settings/transcription-validation.ts
@@ -61,7 +61,7 @@ export function isTranscriptionServiceConfigured(
 	}
 }
 
-export type TranscriptionSetupReadiness = {
+export type TranscriptionReadiness = {
 	service: TranscriptionProviderEntry | undefined;
 	isServiceAvailable: boolean;
 	isRuntimeConfigured: boolean;
@@ -69,7 +69,7 @@ export type TranscriptionSetupReadiness = {
 	primaryIssue: string | null;
 };
 
-export function getTranscriptionSetupReadiness(): TranscriptionSetupReadiness {
+export function getTranscriptionReadiness(): TranscriptionReadiness {
 	const service = getSelectedTranscriptionProvider();
 	const isServiceAvailable = service
 		? isTranscriptionServiceAvailable(service)

--- a/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import * as Field from '@epicenter/ui/field';
-	import TranscriptionRuntimeSetup from '$lib/components/settings/TranscriptionRuntimeSetup.svelte';
+	import TranscriptionRuntimeConfig from '$lib/components/settings/TranscriptionRuntimeConfig.svelte';
 </script>
 
 <svelte:head> <title>Transcription Settings - Whispering</title> </svelte:head>
@@ -12,5 +12,5 @@
 		hints work.
 	</Field.Description>
 	<Field.Separator />
-	<TranscriptionRuntimeSetup />
+	<TranscriptionRuntimeConfig />
 </Field.Set>

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -21,7 +21,7 @@
 	import TranscriptDialog from '$lib/components/copyable/TranscriptDialog.svelte';
 	import {
 		TranscriptionSelector,
-		TranscriptionRuntimeSetup,
+		TranscriptionRuntimeConfig,
 		TransformationSelector,
 	} from '$lib/components/settings';
 	import ManualDeviceSelector from '$lib/components/settings/selectors/ManualDeviceSelector.svelte';
@@ -31,7 +31,7 @@
 		RECORDING_MODE_OPTIONS,
 		type RecordingMode,
 	} from '$lib/constants/audio';
-	import { getTranscriptionSetupReadiness } from '$lib/settings/transcription-validation';
+	import { getTranscriptionReadiness } from '$lib/settings/transcription-validation';
 	import { getShortcutDisplayLabel } from '$lib/utils/keyboard';
 	import { keyBindingToLabel } from '$lib/utils/key-binding';
 	import { os } from '#platform/os';
@@ -56,7 +56,7 @@
 	import VadRecordingAction from './_components/VadRecordingAction.svelte';
 
 	const latestRecording = $derived(recordings.sorted[0]);
-	const transcriptionReadiness = $derived(getTranscriptionSetupReadiness());
+	const transcriptionReadiness = $derived(getTranscriptionReadiness());
 	const globalToggleBinding = $derived(
 		deviceConfig.get('shortcuts.global.toggleManualRecording'),
 	);
@@ -65,7 +65,7 @@
 	);
 
 	const PageError = defineErrors({
-		SetupDragDropFailed: ({ cause }: { cause: unknown }) => ({
+		DragDropListenerFailed: ({ cause }: { cause: unknown }) => ({
 			message: `Failed to set up drag drop listener: ${extractErrorMessage(cause)}`,
 			cause,
 		}),
@@ -185,7 +185,7 @@
 				);
 			},
 			catch: (error) =>
-				PageError.SetupDragDropFailed({
+				PageError.DragDropListenerFailed({
 					cause: error,
 				}),
 		});
@@ -260,7 +260,7 @@
 
 	{#if !transcriptionReadiness.isReady}
 		<div class="w-full">
-			<TranscriptionRuntimeSetup
+			<TranscriptionRuntimeConfig
 				id="home-transcription-service"
 				label="Runtime"
 				description={transcriptionReadiness.primaryIssue ??


### PR DESCRIPTION
The reason for this shape is:

PR #2026 deleted the first-run setup wizard. First run is now a pure read of `getTranscriptionReadiness().isReady`, rendered inline on the home screen: if no transcription engine is ready, home shows that engine's missing field; once it's filled, the same screen becomes the recorder. There is no separate setup mode, no stored `setup.completed` flag, and no `/setup` route.

What remained was **fossil naming**: a handful of symbols and strings still carried the `Setup` token, which invites a future reader to assume a wizard still exists. This PR removes that token so the code matches the architecture.

## Changes (pure renames, no behavior change)

| Before | After |
| --- | --- |
| `getTranscriptionSetupReadiness()` | `getTranscriptionReadiness()` |
| `TranscriptionSetupReadiness` (type) | `TranscriptionReadiness` |
| `TranscriptionRuntimeSetup.svelte` | `TranscriptionRuntimeConfig.svelte` |
| `SetupDragDropFailed` (error) | `DragDropListenerFailed` |
| "Speaches Setup" | "Speaches" |
| "Speech-to-Text Setup" | "Speech-to-Text Guide" |

Readiness stays a **derived function of config** (settings + deviceConfig), not a stored flag or route state, so there is no second source of truth that can drift.

After this, `rg -i setup apps/whispering/src` returns only generic English ("at setup time", "async setup") with zero onboarding-flavored hits.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784243111&installation_id=128463665&pr_number=2067&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2067&signature=ffa8a0a566ca6c010a0fcd2d7aa390ebeaa88d4aa7f142d6b0bd4d30b8cef0fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->