### PR TITLE
refactor(whispering): reconcile shortcut-reorg follow-ups onto main

### DIFF
--- a/apps/whispering/src/lib/components/MacosAccessibilityGuideDialog.svelte
+++ b/apps/whispering/src/lib/components/MacosAccessibilityGuideDialog.svelte
@@ -5,9 +5,9 @@
 	/**
 	 * Global opener for the macOS Accessibility guide. Mirrors the
 	 * `confirmationDialog` idiom: mount `<MacosAccessibilityGuideDialog />` once at
-	 * the app root, then call `accessibilityGuide.open()` from anywhere (the
-	 * home/setup notice, the shortcut recorder) to surface the remove/re-add
-	 * walkthrough. The guide content is fixed, so the store carries no payload: it
+	 * the app root, then call `accessibilityGuide.open()` from anywhere (the home
+	 * notice, the shortcut recorder) to surface the remove/re-add walkthrough. The
+	 * guide content is fixed, so the store carries no payload: it
 	 * is open or closed and nothing else.
 	 *
 	 * The guide is user-opened, never auto-popped: the ambient "you still need

--- a/apps/whispering/src/lib/state/global-listener.svelte.ts
+++ b/apps/whispering/src/lib/state/global-listener.svelte.ts
@@ -195,6 +195,23 @@ function createGlobalListener() {
 
 	return {
 		/**
+		 * Spawn the rdev thread right now for a caller that needs it immediately:
+		 * the settings recorder entering capture mode, which streams nothing if the
+		 * thread is down (e.g. the supervisor is `degraded` after a death storm).
+		 * Routes through the supervisor so `status` and the standing notice stay
+		 * coherent, instead of the caller calling `start()` behind the owner's back.
+		 * The caller must have already confirmed the grant (the capture UI only
+		 * renders when granted).
+		 */
+		async ensureRunning(): Promise<void> {
+			if (!tauri || detached) return;
+			if (status === 'running' || status === 'unsupported') return;
+			clearTimer();
+			restartAttempt = 0;
+			await spawn();
+		},
+
+		/**
 		 * Wire the supervisor and reconcile to the current grant. Returns a cleanup
 		 * to call on unmount. No-op on the browser build, where in-app keydown owns
 		 * shortcuts and there is no rdev thread to supervise.

--- a/apps/whispering/src/lib/state/permissions.svelte.ts
+++ b/apps/whispering/src/lib/state/permissions.svelte.ts
@@ -2,28 +2,26 @@ import { on } from 'svelte/events';
 import { Ok } from 'wellcrafted/result';
 import { os } from '#platform/os';
 import { tauri } from '#platform/tauri';
-import { report } from '$lib/report';
 
 export type PermissionStatus = 'checking' | 'granted' | 'denied';
 
 /**
- * Single owner of the macOS OS-permission facts the desktop dictation flow
- * depends on: Accessibility (the gate for the rdev global listener and
- * paste-back) and Microphone. One app-wide instance — the always-on listener
- * starter, the Accessibility notice, the shortcut recorder, and the guide
- * dialog all READ this instead of each calling `tauri.permissions.*.check()` on
- * their own.
+ * Single owner of the macOS Accessibility grant the desktop dictation flow
+ * depends on: the gate for the rdev global listener and paste-back. One app-wide
+ * instance — the always-on listener starter, the Accessibility notice, the
+ * shortcut recorder, and the guide dialog all READ this instead of each calling
+ * `tauri.permissions.accessibility.check()` on their own. (Microphone is
+ * request-on-demand at the recorder, so it is not owned here.)
  *
  * Re-check policy (no steady-state poll): seed once at `attach()`, then
  * re-check whenever the window regains focus. Returning from System Settings
  * is a window-focus event, which is the only moment a grant realistically
  * flips, so a 1 Hz timer would only burn cycles to catch a transition the OS
- * already announces for free. Off macOS desktop there is no gate, so both
- * facts read `granted` and the focus listener is never installed.
+ * already announces for free. Off macOS desktop there is no gate, so the grant
+ * reads `granted` and the focus listener is never installed.
  */
 function createPermissions() {
 	let accessibility = $state<PermissionStatus>('checking');
-	let microphone = $state<PermissionStatus>('checking');
 
 	// Dev-only override to exercise the Accessibility notice and guide without
 	// touching System Settings. `null` means "use the live OS value". The
@@ -59,34 +57,23 @@ function createPermissions() {
 	async function probe(): Promise<void> {
 		if (!tauri || !isGated) {
 			accessibility = 'granted';
-			microphone = 'granted';
 			return;
 		}
-		const [acc, mic] = await Promise.all([
-			tauri.permissions.accessibility.check(),
-			tauri.permissions.microphone.check(),
-		]);
+		const acc = await tauri.permissions.accessibility.check();
 		// A failed check reads as denied: we would rather guide the user than
 		// silently start a listener that can never see keys.
 		accessibility = acc.data ? 'granted' : 'denied';
-		microphone = mic.data ? 'granted' : 'denied';
 	}
 
 	return {
 		get accessibility(): PermissionStatus {
 			return effectiveAccessibility();
 		},
-		get microphone(): PermissionStatus {
-			return microphone;
-		},
 		get accessibilityGranted(): boolean {
 			return effectiveAccessibility() === 'granted';
 		},
-		get microphoneGranted(): boolean {
-			return microphone === 'granted';
-		},
 
-		/** Re-probe both permissions. Called at launch and on every window focus. */
+		/** Re-probe the Accessibility grant. Called at launch and on every window focus. */
 		refresh,
 
 		/**
@@ -122,17 +109,6 @@ function createPermissions() {
 			return tauri.permissions.accessibility.openSettings();
 		},
 
-		/** Prompt for Microphone. */
-		async requestMicrophone(): Promise<void> {
-			if (!tauri) return;
-			const { data, error } = await tauri.permissions.microphone.request();
-			if (error) {
-				report.error({ title: 'Microphone permission failed', cause: error });
-				return;
-			}
-			microphone = data ? 'granted' : 'denied';
-		},
-
 		/**
 		 * Seed the initial probe and re-check on every window focus. Returns a
 		 * cleanup that removes the focus listener. Call once from the root layout
@@ -148,6 +124,3 @@ function createPermissions() {
 }
 
 export const permissions = createPermissions();
-
-/** The permissions owner's public shape (for consumers that take it by prop). */
-export type Permissions = ReturnType<typeof createPermissions>;

--- a/apps/whispering/src/lib/tauri.tauri.ts
+++ b/apps/whispering/src/lib/tauri.tauri.ts
@@ -390,10 +390,10 @@ const globalShortcuts = {
 	/**
 	 * Subscribe to the listener's stop event: the rdev thread exited (a tap
 	 * break, or a missing/stale Accessibility grant). Returns the unlisten fn.
-	 * The caller (AppLayout) re-probes permissions and respawns when shortcuts
-	 * should still be running, which is the self-heal that neither the focus
-	 * re-check nor the `accessibilityGranted` effect provides for a death that
-	 * leaves the grant value unchanged (a thread that just died under it).
+	 * The caller (the `globalListener` supervisor) re-probes permissions and
+	 * respawns when shortcuts should still be running, which is the self-heal
+	 * that the focus re-check alone cannot provide for a death that leaves the
+	 * grant value unchanged (a thread that just died under it).
 	 */
 	onListenerStopped: (onStopped: (reason: string | null) => void) =>
 		events.keyboardListenerStoppedEvent.listen(({ payload }) =>

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/GlobalKeyboardShortcutRecorder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/GlobalKeyboardShortcutRecorder.svelte
@@ -8,6 +8,7 @@
 	import { shortcuts } from '#platform/shortcuts';
 	import type { Tauri } from '#platform/tauri';
 	import { deviceConfig } from '$lib/state/device-config.svelte';
+	import { globalListener } from '$lib/state/global-listener.svelte';
 	import { permissions } from '$lib/state/permissions.svelte';
 	import type { Key, KeyBinding, Modifier } from '$lib/tauri/commands';
 	import { os } from '#platform/os';
@@ -52,9 +53,11 @@
 	let unlisten: (() => void) | undefined;
 
 	async function startCapture() {
-		// Accessibility is already guaranteed: the capture UI only renders when
-		// `canRecord` (see template), so this is never reached ungranted.
-		await tauri.globalShortcuts.start();
+		// Capture streams off the rdev thread, so make sure it is alive first.
+		// Routed through the supervisor (not a raw `start()`) so it owns liveness
+		// alone. Accessibility is already guaranteed: the capture UI only renders
+		// when `canRecord` (see template), so this is never reached ungranted.
+		await globalListener.ensureRunning();
 		isListening = true;
 		capturedModifiers = new Set();
 		capturedKeys = new Set();


### PR DESCRIPTION
After #2026 reorganized macOS shortcut and Accessibility ownership, a few useful follow-up fixes were left on a branch that no longer matched main's `_runtime/` shape. This ports only the pieces main still needs, without pulling in the branch's broader structural rename.

The permissions owner now owns only the Accessibility grant. Microphone access is already requested by the recorder and device flows that need it, so the old `microphone`, `microphoneGranted`, `requestMicrophone`, and exported `Permissions` surface were dead weight. Removing them also drops the extra microphone `check()` IPC that ran during each permission probe.

The shortcut recorder now wakes capture through `globalListener.ensureRunning()` instead of calling `tauri.globalShortcuts.start()` directly. That matters in the degraded listener state: a raw start can revive the rdev thread while leaving the supervisor status and standing notice stale. Routing through the supervisor keeps liveness, status, and notices owned in one place.

The docstring cleanup came along for the ride because the old comments still named AppLayout, the removed `accessibilityGranted` effect, and the old setup notice as owners.

One source-branch follow-up is intentionally left out: the `.svelte.ts` to `.ts` runtime-owner rename plus teardown-return changes. That collides with main's current `_runtime/*.svelte.ts` convention and deserves its own structural decision.
