### PR TITLE
refactor(whispering): give shortcut state one owner on the platform seam

### DIFF
--- a/apps/whispering/src/lib/platform/shortcuts.browser.ts
+++ b/apps/whispering/src/lib/platform/shortcuts.browser.ts
@@ -86,10 +86,15 @@ function defaultLabel(commandId: Command['id']): string {
 	return getShortcutDisplayLabel(settings.getDefault(localKey(commandId)));
 }
 
+function currentLabel(commandId: Command['id']): string {
+	return getShortcutDisplayLabel(settings.get(localKey(commandId)));
+}
+
 export const shortcuts: Shortcuts = {
 	sync,
 	reset,
 	resetIfDuplicates,
 	label,
 	defaultLabel,
+	currentLabel,
 };

--- a/apps/whispering/src/lib/platform/shortcuts.browser.ts
+++ b/apps/whispering/src/lib/platform/shortcuts.browser.ts
@@ -1,5 +1,4 @@
 import { partitionResults } from 'wellcrafted/result';
-import { goto } from '$app/navigation';
 import { type Command, commands } from '$lib/commands';
 import { report } from '$lib/report';
 import {
@@ -55,33 +54,6 @@ function reset(): void {
 	void sync();
 }
 
-function resetIfDuplicates(): boolean {
-	const seen = new Map<string, string>();
-	for (const command of commands) {
-		const shortcut = settings.get(localKey(command.id));
-		if (!shortcut) continue;
-		if (seen.has(String(shortcut))) {
-			reset();
-			report.success({
-				title: 'Shortcuts reset',
-				description:
-					'Duplicate local shortcuts detected. All local shortcuts have been reset to defaults.',
-				action: {
-					label: 'Configure shortcuts',
-					onClick: () => goto('/settings/shortcuts'),
-				},
-			});
-			return true;
-		}
-		seen.set(String(shortcut), command.id);
-	}
-	return false;
-}
-
-function label(commandId: Command['id']): string {
-	return getShortcutDisplayLabel(settings.get(localKey(commandId)));
-}
-
 function defaultLabel(commandId: Command['id']): string {
 	return getShortcutDisplayLabel(settings.getDefault(localKey(commandId)));
 }
@@ -93,8 +65,6 @@ function currentLabel(commandId: Command['id']): string {
 export const shortcuts: Shortcuts = {
 	sync,
 	reset,
-	resetIfDuplicates,
-	label,
 	defaultLabel,
 	currentLabel,
 };

--- a/apps/whispering/src/lib/platform/shortcuts.browser.ts
+++ b/apps/whispering/src/lib/platform/shortcuts.browser.ts
@@ -1,6 +1,5 @@
 import { partitionResults } from 'wellcrafted/result';
-import { type Command, commands } from '$lib/commands';
-import { report } from '$lib/report';
+import type { Command } from '$lib/commands';
 import {
 	type CommandId,
 	localShortcuts,
@@ -8,6 +7,7 @@ import {
 } from '$lib/services/local-shortcut-manager';
 import { settings } from '$lib/state/settings.svelte';
 import { getShortcutDisplayLabel } from '$lib/utils/keyboard';
+import { createShortcuts } from './shortcuts.shared';
 import type { Shortcuts } from './types';
 
 /**
@@ -17,54 +17,30 @@ import type { Shortcuts } from './types';
 
 const localKey = (id: Command['id']) => `shortcut.${id}` as const;
 
-async function sync(): Promise<void> {
-	const results = await Promise.all(
-		commands
-			.map((command) => {
-				const keyCombination = settings.get(localKey(command.id));
-				if (!keyCombination) {
-					return localShortcuts.unregisterCommand({
-						commandId: command.id as CommandId,
-					});
-				}
-				return localShortcuts.registerCommand({
-					command,
-					keyCombination: shortcutStringToArray(String(keyCombination)),
-				});
-			})
-			.filter((result) => result !== undefined),
-	);
-	const { errs } = partitionResults(results);
-	if (errs.length > 0) {
-		report.error({
-			title: 'Error registering local commands',
-			cause: {
-				name: 'LocalShortcutRegistrationFailed',
-				message: errs.map((err) => err.error.message).join('\n'),
-			},
-		});
-	}
-}
-
-function reset(): void {
-	for (const command of commands) {
-		const key = localKey(command.id);
-		settings.set(key, settings.getDefault(key));
-	}
-	void sync();
-}
-
-function defaultLabel(commandId: Command['id']): string {
-	return getShortcutDisplayLabel(settings.getDefault(localKey(commandId)));
-}
-
-function currentLabel(commandId: Command['id']): string {
-	return getShortcutDisplayLabel(settings.get(localKey(commandId)));
-}
-
-export const shortcuts: Shortcuts = {
-	sync,
-	reset,
-	defaultLabel,
-	currentLabel,
-};
+export const shortcuts: Shortcuts = createShortcuts<string>({
+	read: (id) => settings.get(localKey(id)),
+	getDefault: (id) => settings.getDefault(localKey(id)),
+	write: (id, binding) => settings.set(localKey(id), binding),
+	label: (binding) => getShortcutDisplayLabel(binding),
+	syncErrorTitle: 'Error registering local commands',
+	async push(entries) {
+		const results = await Promise.all(
+			entries.map(({ command, binding }) =>
+				binding
+					? localShortcuts.registerCommand({
+							command,
+							keyCombination: shortcutStringToArray(binding),
+						})
+					: localShortcuts.unregisterCommand({
+							commandId: command.id as CommandId,
+						}),
+			),
+		);
+		const { errs } = partitionResults(results);
+		if (errs.length === 0) return null;
+		return {
+			name: 'LocalShortcutRegistrationFailed',
+			message: errs.map((err) => err.error.message).join('\n'),
+		};
+	},
+});

--- a/apps/whispering/src/lib/platform/shortcuts.shared.ts
+++ b/apps/whispering/src/lib/platform/shortcuts.shared.ts
@@ -1,0 +1,67 @@
+import type { AnyTaggedError } from 'wellcrafted/error';
+import { type Command, commands } from '$lib/commands';
+import { report } from '$lib/report';
+import type { Shortcuts } from './types';
+
+/** A command paired with its current stored binding (`null` = unbound). */
+export type ShortcutEntry<TBinding> = {
+	command: Command;
+	binding: TBinding | null;
+};
+
+/**
+ * Per-platform binding adapter. The two shortcut backends (browser in-app KV,
+ * desktop rdev device-config) differ only in where a binding is stored, how it
+ * is formatted, and how it is pushed to the runtime. Everything around that
+ * (sync orchestration, reset, label dispatch) is identical and lives in
+ * {@link createShortcuts}, so each backend supplies just these primitives.
+ */
+export type ShortcutBackend<TBinding> = {
+	/** This command's currently stored binding (`null` = unbound). */
+	read(commandId: Command['id']): TBinding | null;
+	/** This command's default binding (`null` = unbound by default). */
+	getDefault(commandId: Command['id']): TBinding | null;
+	/** Persist a binding for this command. */
+	write(commandId: Command['id'], binding: TBinding | null): void;
+	/** Format a binding for display (`''` when unbound). */
+	label(binding: TBinding | null): string;
+	/**
+	 * Push the full set of current bindings to the platform runtime. Returns the
+	 * error to surface, or `null` on success.
+	 */
+	push(entries: ShortcutEntry<TBinding>[]): Promise<AnyTaggedError | null>;
+	/** Toast title when a push fails. */
+	syncErrorTitle: string;
+};
+
+/**
+ * Build the platform-agnostic `Shortcuts` surface over a {@link ShortcutBackend}.
+ * The browser and desktop backends are otherwise structural twins; this is their
+ * single source for sync, reset, and the default/current label dispatch.
+ */
+export function createShortcuts<TBinding>(
+	backend: ShortcutBackend<TBinding>,
+): Shortcuts {
+	async function sync(): Promise<void> {
+		const entries = commands.map((command) => ({
+			command,
+			binding: backend.read(command.id),
+		}));
+		const error = await backend.push(entries);
+		if (error) report.error({ title: backend.syncErrorTitle, cause: error });
+	}
+
+	function reset(): void {
+		for (const command of commands) {
+			backend.write(command.id, backend.getDefault(command.id));
+		}
+		void sync();
+	}
+
+	return {
+		sync,
+		reset,
+		defaultLabel: (id) => backend.label(backend.getDefault(id)),
+		currentLabel: (id) => backend.label(backend.read(id)),
+	};
+}

--- a/apps/whispering/src/lib/platform/shortcuts.tauri.ts
+++ b/apps/whispering/src/lib/platform/shortcuts.tauri.ts
@@ -1,8 +1,7 @@
 import { extractErrorMessage } from 'wellcrafted/error';
 import { Err, tryAsync } from 'wellcrafted/result';
 import { os } from '#platform/os';
-import { type Command, commands } from '$lib/commands';
-import { report } from '$lib/report';
+import type { Command } from '$lib/commands';
 import {
 	DEFAULT_GLOBAL_BINDINGS,
 	deviceConfig,
@@ -10,6 +9,7 @@ import {
 import type { CommandBinding, KeyBinding } from '$lib/tauri/commands';
 import { tauriOnly } from '$lib/tauri.tauri';
 import { keyBindingToLabel } from '$lib/utils/key-binding';
+import { createShortcuts } from './shortcuts.shared';
 import type { Shortcuts } from './types';
 
 /**
@@ -21,53 +21,38 @@ import type { Shortcuts } from './types';
 
 const globalKey = (id: Command['id']) => `shortcuts.global.${id}` as const;
 
-async function sync(): Promise<void> {
-	const bindings: CommandBinding[] = [];
-	for (const command of commands) {
-		const binding = deviceConfig.get(globalKey(command.id));
-		if (!binding) continue;
+function readBinding(id: Command['id']) {
+	return deviceConfig.get(globalKey(id));
+}
+
+/** The stored global-binding shape (`keys` are plain strings, validated by Rust). */
+type GlobalBinding = NonNullable<ReturnType<typeof readBinding>>;
+
+export const shortcuts: Shortcuts = createShortcuts<GlobalBinding>({
+	read: readBinding,
+	getDefault: (id) => DEFAULT_GLOBAL_BINDINGS[id] ?? null,
+	write: (id, binding) => deviceConfig.set(globalKey(id), binding),
+	label: (binding) => (binding ? keyBindingToLabel(binding, os.isApple) : ''),
+	syncErrorTitle: 'Error registering global shortcuts',
+	async push(entries) {
 		// Storage validates keys as plain strings; Rust validates them by name on
 		// register. The cast bridges the stored `string[]` to the IPC `Key[]`.
-		bindings.push({ commandId: command.id, binding: binding as KeyBinding });
-	}
-	// Keys are validated by Rust at the IPC boundary, so a single bad key fails
-	// the whole replace-all call. Surface it instead of silently unregistering.
-	const { error } = await tryAsync({
-		try: () => tauriOnly.globalShortcuts.setBindings(bindings),
-		catch: (cause) =>
-			Err({
-				name: 'GlobalShortcutRegistrationFailed',
-				message: extractErrorMessage(cause),
-			}),
-	});
-	if (error) {
-		report.error({ title: 'Error registering global shortcuts', cause: error });
-	}
-}
-
-function reset(): void {
-	for (const command of commands) {
-		deviceConfig.set(
-			globalKey(command.id),
-			DEFAULT_GLOBAL_BINDINGS[command.id] ?? null,
-		);
-	}
-	void sync();
-}
-
-function defaultLabel(commandId: Command['id']): string {
-	const binding = DEFAULT_GLOBAL_BINDINGS[commandId];
-	return binding ? keyBindingToLabel(binding, os.isApple) : '';
-}
-
-function currentLabel(commandId: Command['id']): string {
-	const binding = deviceConfig.get(globalKey(commandId));
-	return binding ? keyBindingToLabel(binding, os.isApple) : '';
-}
-
-export const shortcuts: Shortcuts = {
-	sync,
-	reset,
-	defaultLabel,
-	currentLabel,
-};
+		const bindings: CommandBinding[] = entries
+			.filter((entry) => entry.binding !== null)
+			.map((entry) => ({
+				commandId: entry.command.id,
+				binding: entry.binding as KeyBinding,
+			}));
+		// Keys are validated by Rust at the IPC boundary, so a single bad key fails
+		// the whole replace-all call. Surface it instead of silently unregistering.
+		const { error } = await tryAsync({
+			try: () => tauriOnly.globalShortcuts.setBindings(bindings),
+			catch: (cause) =>
+				Err({
+					name: 'GlobalShortcutRegistrationFailed',
+					message: extractErrorMessage(cause),
+				}),
+		});
+		return error ?? null;
+	},
+});

--- a/apps/whispering/src/lib/platform/shortcuts.tauri.ts
+++ b/apps/whispering/src/lib/platform/shortcuts.tauri.ts
@@ -101,10 +101,16 @@ function defaultLabel(commandId: Command['id']): string {
 	return binding ? keyBindingToLabel(binding, os.isApple) : '';
 }
 
+function currentLabel(commandId: Command['id']): string {
+	const binding = deviceConfig.get(globalKey(commandId));
+	return binding ? keyBindingToLabel(binding, os.isApple) : '';
+}
+
 export const shortcuts: Shortcuts = {
 	sync,
 	reset,
 	resetIfDuplicates,
 	label,
 	defaultLabel,
+	currentLabel,
 };

--- a/apps/whispering/src/lib/platform/shortcuts.tauri.ts
+++ b/apps/whispering/src/lib/platform/shortcuts.tauri.ts
@@ -1,7 +1,6 @@
 import { extractErrorMessage } from 'wellcrafted/error';
 import { Err, tryAsync } from 'wellcrafted/result';
 import { os } from '#platform/os';
-import { goto } from '$app/navigation';
 import { type Command, commands } from '$lib/commands';
 import { report } from '$lib/report';
 import {
@@ -21,17 +20,6 @@ import type { Shortcuts } from './types';
  */
 
 const globalKey = (id: Command['id']) => `shortcuts.global.${id}` as const;
-
-/** Canonical string for a binding, so structurally-equal bindings dedupe. */
-function bindingKey(binding: {
-	modifiers: readonly string[];
-	keys: readonly string[];
-}): string {
-	return JSON.stringify({
-		modifiers: [...binding.modifiers].sort(),
-		keys: [...binding.keys].sort(),
-	});
-}
 
 async function sync(): Promise<void> {
 	const bindings: CommandBinding[] = [];
@@ -67,35 +55,6 @@ function reset(): void {
 	void sync();
 }
 
-function resetIfDuplicates(): boolean {
-	const seen = new Map<string, string>();
-	for (const command of commands) {
-		const binding = deviceConfig.get(globalKey(command.id));
-		if (!binding) continue;
-		const key = bindingKey(binding);
-		if (seen.has(key)) {
-			reset();
-			report.success({
-				title: 'Shortcuts reset',
-				description:
-					'Duplicate global shortcuts detected. All global shortcuts have been reset to defaults.',
-				action: {
-					label: 'Configure shortcuts',
-					onClick: () => goto('/settings/shortcuts'),
-				},
-			});
-			return true;
-		}
-		seen.set(key, command.id);
-	}
-	return false;
-}
-
-function label(commandId: Command['id']): string {
-	const binding = deviceConfig.get(globalKey(commandId));
-	return binding ? keyBindingToLabel(binding, os.isApple) : '';
-}
-
 function defaultLabel(commandId: Command['id']): string {
 	const binding = DEFAULT_GLOBAL_BINDINGS[commandId];
 	return binding ? keyBindingToLabel(binding, os.isApple) : '';
@@ -109,8 +68,6 @@ function currentLabel(commandId: Command['id']): string {
 export const shortcuts: Shortcuts = {
 	sync,
 	reset,
-	resetIfDuplicates,
-	label,
 	defaultLabel,
 	currentLabel,
 };

--- a/apps/whispering/src/lib/platform/types.ts
+++ b/apps/whispering/src/lib/platform/types.ts
@@ -39,6 +39,13 @@ export type Shortcuts = {
 	label(commandId: Command['id']): string;
 	/** A command's default binding, formatted for display (`''` when unbound). */
 	defaultLabel(commandId: Command['id']): string;
+	/**
+	 * The command's *current* binding on this platform, formatted for display
+	 * (`''` when unbound). The single owner of "what key is live for this
+	 * command": display-only consumers (action cards, home-page hints) read this
+	 * instead of reaching into platform storage and re-deriving the `tauri` branch.
+	 */
+	currentLabel(commandId: Command['id']): string;
 };
 
 /**

--- a/apps/whispering/src/lib/platform/types.ts
+++ b/apps/whispering/src/lib/platform/types.ts
@@ -25,18 +25,6 @@ export type Shortcuts = {
 	sync(): Promise<void>;
 	/** Restore every shortcut to its default binding, then re-sync. */
 	reset(): void;
-	/**
-	 * If two commands share a binding, reset all to defaults and surface it.
-	 * Returns whether a reset happened.
-	 */
-	resetIfDuplicates(): boolean;
-	/**
-	 * A command's live binding, formatted for display (`''` when unbound). The
-	 * single owner of "what shortcut is actually bound here": consumers that do
-	 * not own the binding (status cards, tooltips) read this instead of reaching
-	 * into the platform's storage and formatter themselves.
-	 */
-	label(commandId: Command['id']): string;
 	/** A command's default binding, formatted for display (`''` when unbound). */
 	defaultLabel(commandId: Command['id']): string;
 	/**

--- a/apps/whispering/src/lib/state/device-config.svelte.ts
+++ b/apps/whispering/src/lib/state/device-config.svelte.ts
@@ -174,44 +174,9 @@ const DEVICE_DEFINITIONS = {
 type DeviceConfigDefs = typeof DEVICE_DEFINITIONS;
 export type DeviceConfigKey = keyof DeviceConfigDefs & string;
 
-// ── Legacy migration ─────────────────────────────────────────────────────────
+// ── Singleton ────────────────────────────────────────────────────────────────
 
 const DEVICE_CONFIG_PREFIX = 'whispering.device.';
-
-const LEGACY_LOCAL_MODEL_SELECTIONS = [
-	{
-		from: 'transcription.whispercpp.modelPath',
-		to: 'transcription.whispercpp.model',
-	},
-	{
-		from: 'transcription.parakeet.modelPath',
-		to: 'transcription.parakeet.model',
-	},
-	{
-		from: 'transcription.moonshine.modelPath',
-		to: 'transcription.moonshine.model',
-	},
-] as const satisfies readonly {
-	from: string;
-	to: DeviceConfigKey;
-}[];
-
-function modelEntryNameFromLegacyPath(path: string) {
-	return path.replace(/\\/g, '/').replace(/\/+$/, '').split('/').at(-1) ?? '';
-}
-
-function readLegacyString(key: string) {
-	const raw = window.localStorage.getItem(`${DEVICE_CONFIG_PREFIX}${key}`);
-	if (raw === null) return null;
-	try {
-		const value = JSON.parse(raw) as unknown;
-		return typeof value === 'string' ? value : null;
-	} catch {
-		return null;
-	}
-}
-
-// ── Singleton ────────────────────────────────────────────────────────────────
 
 export const deviceConfig = createPersistedMap({
 	prefix: DEVICE_CONFIG_PREFIX,
@@ -230,15 +195,10 @@ export const deviceConfig = createPersistedMap({
 	},
 });
 
-for (const migration of LEGACY_LOCAL_MODEL_SELECTIONS) {
-	if (deviceConfig.get(migration.to)) continue;
-	const legacyPath = readLegacyString(migration.from);
-	if (!legacyPath) continue;
-	const entryName = modelEntryNameFromLegacyPath(legacyPath);
-	if (entryName) deviceConfig.set(migration.to, entryName);
-}
-
-// Global shortcuts are NOT migrated from the old accelerator-string format. A
-// clean break: a legacy value fails the `globalBinding` schema on read and falls
-// back to the default (see `createPersistedMap`), so upgrading users get the new
-// defaults. We refuse to carry a parser for a format nothing writes anymore.
+// Nothing here is migrated from a legacy format; both prior formats take a clean
+// break. Local model selections once lived under `transcription.*.modelPath` as
+// filesystem paths: that key is simply orphaned now and the `transcription.*.model`
+// entry reads its default. Global shortcuts once stored accelerator strings under
+// the same key: a legacy value fails the `globalBinding` schema on read and falls
+// back to the default (see `createPersistedMap`). Either way upgrading users get
+// the new defaults, and we carry no parser for a format nothing writes anymore.

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/LocalKeyboardShortcutRecorder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/LocalKeyboardShortcutRecorder.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 	import * as Alert from '@epicenter/ui/alert';
 	import AlertTriangle from '@lucide/svelte/icons/alert-triangle';
-	import type { Command } from '$lib/commands';
+	import { type Command, commands } from '$lib/commands';
 	import type { KeyboardEventSupportedKey } from '$lib/constants/keyboard';
 	import { report } from '$lib/report';
 	import { localShortcuts } from '$lib/services/local-shortcut-manager';
 	import {
 		arrayToShortcutString,
 		type CommandId,
+		shortcutStringToArray,
 	} from '$lib/services/local-shortcut-manager';
 	import { settings } from '$lib/state/settings.svelte';
 	import { os } from '#platform/os';
@@ -31,10 +32,41 @@
 		shortcutValue ? getShortcutDisplayLabel(shortcutValue) : null,
 	);
 
+	// The other command whose in-app binding is the same key set as `next`, if
+	// any. The keydown matcher fires every command whose set matches, so two
+	// commands sharing a set would both trigger. Refuse the collision at write
+	// time, the way the global recorder refuses an overlapping rdev gesture.
+	function conflictingCommand(
+		next: KeyboardEventSupportedKey[],
+	): Command | null {
+		const nextKey = [...next].sort().join('+');
+		for (const other of commands) {
+			if (other.id === command.id) continue;
+			const otherValue = settings.get(`shortcut.${other.id}`);
+			if (!otherValue) continue;
+			if (shortcutStringToArray(otherValue).sort().join('+') === nextKey) {
+				return other;
+			}
+		}
+		return null;
+	}
+
 	// svelte-ignore state_referenced_locally -- pressedKeys is the stable recorder handle for this mounted shortcut table.
 	const keyRecorder = createKeyRecorder({
 		pressedKeys,
 		onRegister: async (keyCombination: KeyboardEventSupportedKey[]) => {
+			const conflict = conflictingCommand(keyCombination);
+			if (conflict) {
+				report.error({
+					title: 'That shortcut is already in use',
+					description: `Those keys already trigger "${conflict.title}". Pick a different combination.`,
+					cause: {
+						name: 'DuplicateLocalShortcut',
+						message: `${getShortcutDisplayLabel(arrayToShortcutString(keyCombination))} is bound to "${conflict.title}".`,
+					},
+				});
+				return;
+			}
 			const { error: unregisterError } = await localShortcuts.unregisterCommand({
 				commandId: command.id as CommandId,
 			});

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -33,8 +33,7 @@
 	} from '$lib/constants/audio';
 	import { getTranscriptionReadiness } from '$lib/settings/transcription-validation';
 	import { getShortcutDisplayLabel } from '$lib/utils/keyboard';
-	import { keyBindingToLabel } from '$lib/utils/key-binding';
-	import { os } from '#platform/os';
+	import { shortcuts } from '#platform/shortcuts';
 	import {
 		stopManualRecording,
 		stopVadRecording,
@@ -44,7 +43,6 @@
 	import { rpc } from '$lib/rpc';
 	import { services } from '$lib/services';
 	import { tauri } from '#platform/tauri';
-	import { deviceConfig } from '$lib/state/device-config.svelte';
 	import { manualRecorder } from '$lib/state/manual-recorder.svelte';
 	import { recordings } from '$lib/state/recordings.svelte';
 	import { settings } from '$lib/state/settings.svelte';
@@ -57,11 +55,10 @@
 
 	const latestRecording = $derived(recordings.sorted[0]);
 	const transcriptionReadiness = $derived(getTranscriptionReadiness());
-	const globalToggleBinding = $derived(
-		deviceConfig.get('shortcuts.global.toggleManualRecording'),
-	);
+	// On desktop the live binding for this command is the global (rdev) gesture;
+	// this `{#if tauri}`-gated label reads it through the platform seam.
 	const globalToggleLabel = $derived(
-		globalToggleBinding ? keyBindingToLabel(globalToggleBinding, os.isApple) : '',
+		shortcuts.currentLabel('toggleManualRecording'),
 	);
 
 	const PageError = defineErrors({

--- a/apps/whispering/src/routes/(app)/_components/ManualRecordingAction.svelte
+++ b/apps/whispering/src/routes/(app)/_components/ManualRecordingAction.svelte
@@ -34,7 +34,7 @@
 	const isStopping = $derived(stopMutation.isPending);
 	const isPending = $derived(isStarting || isStopping);
 	const isRecording = $derived(manualRecorder.state === 'RECORDING');
-	const shortcutLabel = $derived(shortcuts.label('toggleManualRecording'));
+	const shortcutLabel = $derived(shortcuts.currentLabel('toggleManualRecording'));
 	const icon = $derived(isRecording ? SquareIcon : MicIcon);
 	const label = $derived(isRecording ? 'Stop recording' : 'Start recording');
 	const idleDescription = $derived(

--- a/apps/whispering/src/routes/(app)/_components/VadRecordingAction.svelte
+++ b/apps/whispering/src/routes/(app)/_components/VadRecordingAction.svelte
@@ -23,7 +23,7 @@
 	// Idle and listening share the radio glyph (tone distinguishes them); only an
 	// active speech burst swaps to the waveform.
 	const icon = $derived(isSpeechDetected ? AudioLinesIcon : RadioIcon);
-	const shortcutLabel = $derived(shortcuts.label('toggleVadRecording'));
+	const shortcutLabel = $derived(shortcuts.currentLabel('toggleVadRecording'));
 	const label = $derived(isListening ? 'Stop listening' : 'Start listening');
 	const description = $derived.by(() => {
 		if (toggleMutation.isPending) return 'Updating voice activation';

--- a/apps/whispering/src/routes/(app)/_runtime/attach-global-shortcuts.ts
+++ b/apps/whispering/src/routes/(app)/_runtime/attach-global-shortcuts.ts
@@ -6,7 +6,6 @@ export function attachGlobalShortcuts() {
 	let shortcutListenerDestroyed = false;
 
 	void shortcuts.sync();
-	shortcuts.resetIfDuplicates();
 
 	if (tauri) {
 		void tauri.globalShortcuts.startListening().then((unlisten) => {


### PR DESCRIPTION
Whispering's shortcut state had no single owner. #2069 took the first step by giving the *live label* one owner on the `#platform/shortcuts` seam, but the seam still carried structural twins, a too-late uniqueness invariant, and a legacy-migration loop. This builds on #2069: every shortcut fact gets exactly one owner reachable through the seam, the uniqueness invariant moves to write time, and the twin backends collapse onto a shared core.

## Labels: one owner, symmetric name

#2069 already moved the live label onto the seam as `label(commandId)`. This renames it to `currentLabel(commandId)` so it reads as a pair with `defaultLabel(commandId)`: "the key that is live" beside "the key it would default to." The home page's global-shortcut hint and the manual/VAD recording cards read `shortcuts.currentLabel`. `utils/effective-shortcut.ts` stays deleted.

```ts
shortcuts.defaultLabel('toggleManualRecording'); // the default binding
shortcuts.currentLabel('toggleManualRecording'); // the binding live right now
```

## Uniqueness moves to write time

`resetIfDuplicates` is gone from the contract, both backends, and the startup path. It was a boot-time repair for an invariant checked too late: it nuked every binding to defaults on the next launch when two commands collided. The global recorder already rejected an overlapping gesture as it was set; the local recorder now does the same, so a duplicate in-app shortcut is refused at bind time instead of silently allowed and reset on next launch.

## The twin backends collapse

`shortcuts.browser.ts` and `shortcuts.tauri.ts` were structural twins. The shared orchestration (sync, reset, default/current label dispatch) now lives once in `createShortcuts`, and each platform file is just a `ShortcutBackend` config: where a binding is stored, how it is formatted, and how it is pushed to the runtime.

```
#platform/shortcuts
├─ shortcuts.shared.ts   createShortcuts(backend): sync · reset · defaultLabel · currentLabel
├─ shortcuts.tauri.ts    config: { read deviceConfig, keyBindingToLabel, setBindings push }
└─ shortcuts.browser.ts  config: { read settings KV, getShortcutDisplayLabel, register/unregister push }
```

## Legacy model-path migration deleted (separate clean break)

This is a distinct change from the shortcut work, kept here for one review pass. The `device-config` boot loop (and its `readLegacyString` / `modelEntryNameFromLegacyPath` / `LEGACY_LOCAL_MODEL_SELECTIONS` helpers) is removed. Local model selections take the same clean break global shortcuts already take: the old key is orphaned and the new entry reads its default. No parser for a format nothing writes anymore.

## Ownership after

Every shortcut fact (defaults, current bindings, both label flavors, sync, reset, uniqueness) has one owner reachable through `#platform/shortcuts`. The recorders still read raw storage because they are the editor UI that owns the binding being edited; the home page still reads the in-app label directly because the local shortcut is live on both platforms while the global one exists only on desktop, so it is a real dual fact, not duplication.

Rebased onto `main` after #2069 merged.
