### PR TITLE
fix(whispering): teach the recording shortcut that actually fires

### DIFF
--- a/apps/whispering/src/lib/utils/recording-shortcut.ts
+++ b/apps/whispering/src/lib/utils/recording-shortcut.ts
@@ -1,0 +1,37 @@
+import { shortcuts } from '#platform/shortcuts';
+import type { Command } from '$lib/commands';
+
+/**
+ * Preference order for the shortcut that starts each recording mode: the first
+ * command with a binding live on this platform wins.
+ *
+ * Manual recording has two start commands. Desktop binds push-to-talk (Fn) by
+ * default and ships the tap-toggle unbound; the browser ships push-to-talk
+ * unbound and the toggle bound. So push-to-talk leads and the toggle backs it
+ * up, and whichever the user actually bound is the one we show. VAD has a single
+ * command, so its list has one entry.
+ */
+const RECORDING_SHORTCUT_PREFERENCE = {
+	manual: ['pushToTalk', 'toggleManualRecording'],
+	vad: ['toggleVadRecording'],
+} as const satisfies Record<string, readonly Command['id'][]>;
+
+export type RecordingShortcutMode = keyof typeof RECORDING_SHORTCUT_PREFERENCE;
+
+/**
+ * The display label for the shortcut that actually starts this recording mode on
+ * this platform, resolved through the `#platform/shortcuts` label seam.
+ *
+ * Reading a single command (`shortcuts.label('toggleManualRecording')`) rendered
+ * an empty key on a fresh desktop install, where the toggle ships unbound and
+ * push-to-talk (Fn) is the gesture that works. Routing through the preference
+ * list shows the bound gesture instead. Returns `''` when nothing in the list is
+ * bound; callers hide the hint and fall back to "click".
+ */
+export function getRecordingShortcutLabel(mode: RecordingShortcutMode): string {
+	for (const commandId of RECORDING_SHORTCUT_PREFERENCE[mode]) {
+		const label = shortcuts.currentLabel(commandId);
+		if (label) return label;
+	}
+	return '';
+}

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -32,8 +32,7 @@
 		type RecordingMode,
 	} from '$lib/constants/audio';
 	import { getTranscriptionReadiness } from '$lib/settings/transcription-validation';
-	import { getShortcutDisplayLabel } from '$lib/utils/keyboard';
-	import { shortcuts } from '#platform/shortcuts';
+	import { getRecordingShortcutLabel } from '$lib/utils/recording-shortcut';
 	import {
 		stopManualRecording,
 		stopVadRecording,
@@ -55,11 +54,12 @@
 
 	const latestRecording = $derived(recordings.sorted[0]);
 	const transcriptionReadiness = $derived(getTranscriptionReadiness());
-	// On desktop the live binding for this command is the global (rdev) gesture;
-	// this `{#if tauri}`-gated label reads it through the platform seam.
-	const globalToggleLabel = $derived(
-		shortcuts.currentLabel('toggleManualRecording'),
-	);
+	// The recording shortcut that actually fires on this platform, via the
+	// `#platform/shortcuts` label seam: desktop binds push-to-talk (Fn) globally
+	// and ships the toggle unbound, so prefer it; the browser shows the local
+	// toggle. `''` means nothing is bound (hide the hint, fall back to "click").
+	const manualShortcutLabel = $derived(getRecordingShortcutLabel('manual'));
+	const vadShortcutLabel = $derived(getRecordingShortcutLabel('vad'));
 
 	const PageError = defineErrors({
 		DragDropListenerFailed: ({ cause }: { cause: unknown }) => ({
@@ -392,55 +392,37 @@
 		<div class="flex flex-col items-center gap-3">
 			{#if settings.get('recording.mode') === 'manual'}
 				<p class="text-foreground/75 text-center text-sm">
-					Click the microphone or press
-					<Link
-						tooltip="Go to local shortcut in settings"
-						href="/settings/shortcuts"
-					>
-						<Kbd.Root
-							>{getShortcutDisplayLabel(
-								settings.get('shortcut.toggleManualRecording'),
-							)}</Kbd.Root
-						>
-					</Link>
-					to start recording here.
-				</p>
-				{#if tauri}
-					<p class="text-foreground/75 text-sm">
-						Press
+					Click the microphone{#if manualShortcutLabel}
+						or press
 						<Link
-							tooltip="Go to global shortcut in settings"
+							tooltip="Configure the recording shortcut"
 							href="/settings/shortcuts"
 						>
-							<Kbd.Root>{globalToggleLabel}</Kbd.Root>
-						</Link>
-						to start recording anywhere.
-					</p>
-				{/if}
+							<Kbd.Root>{manualShortcutLabel}</Kbd.Root>
+						</Link>{/if}
+					to start recording{tauri ? ' from anywhere' : ''}.
+				</p>
 			{:else if settings.get('recording.mode') === 'vad'}
 				<p class="text-foreground/75 text-center text-sm">
-					Click the microphone or press
-					<Link
-						tooltip="Go to local shortcut in settings"
-						href="/settings/shortcuts"
-					>
-						<Kbd.Root
-							>{getShortcutDisplayLabel(
-								settings.get('shortcut.toggleVadRecording'),
-							)}</Kbd.Root
+					Click the microphone{#if vadShortcutLabel}
+						or press
+						<Link
+							tooltip="Configure the voice activation shortcut"
+							href="/settings/shortcuts"
 						>
-					</Link>
+							<Kbd.Root>{vadShortcutLabel}</Kbd.Root>
+						</Link>{/if}
 					to start a voice activated session.
 				</p>
 			{:else if settings.get('recording.mode') === 'upload'}
-				{#if tauri}
+				{#if tauri && manualShortcutLabel}
 					<p class="text-foreground/75 text-sm">
 						Press
 						<Link
-							tooltip="Go to global shortcut in settings"
+							tooltip="Configure the recording shortcut"
 							href="/settings/shortcuts"
 						>
-							<Kbd.Root>{globalToggleLabel}</Kbd.Root>
+							<Kbd.Root>{manualShortcutLabel}</Kbd.Root>
 						</Link>
 						to start recording instead.
 					</p>

--- a/apps/whispering/src/routes/(app)/_components/ManualRecordingAction.svelte
+++ b/apps/whispering/src/routes/(app)/_components/ManualRecordingAction.svelte
@@ -8,7 +8,7 @@
 		stopManualRecording,
 	} from '$lib/operations/recording';
 	import { manualRecorder } from '$lib/state/manual-recorder.svelte';
-	import { shortcuts } from '#platform/shortcuts';
+	import { getRecordingShortcutLabel } from '$lib/utils/recording-shortcut';
 	import RecordingActionCard from './RecordingActionCard.svelte';
 
 	let {
@@ -34,7 +34,7 @@
 	const isStopping = $derived(stopMutation.isPending);
 	const isPending = $derived(isStarting || isStopping);
 	const isRecording = $derived(manualRecorder.state === 'RECORDING');
-	const shortcutLabel = $derived(shortcuts.currentLabel('toggleManualRecording'));
+	const shortcutLabel = $derived(getRecordingShortcutLabel('manual'));
 	const icon = $derived(isRecording ? SquareIcon : MicIcon);
 	const label = $derived(isRecording ? 'Stop recording' : 'Start recording');
 	const idleDescription = $derived(

--- a/apps/whispering/src/routes/(app)/_components/VadRecordingAction.svelte
+++ b/apps/whispering/src/routes/(app)/_components/VadRecordingAction.svelte
@@ -5,7 +5,7 @@
 	import type { Snippet } from 'svelte';
 	import { toggleVadRecording } from '$lib/operations/recording';
 	import { vadRecorder } from '$lib/state/vad-recorder.svelte';
-	import { shortcuts } from '#platform/shortcuts';
+	import { getRecordingShortcutLabel } from '$lib/utils/recording-shortcut';
 	import RecordingActionCard from './RecordingActionCard.svelte';
 
 	let {
@@ -23,7 +23,7 @@
 	// Idle and listening share the radio glyph (tone distinguishes them); only an
 	// active speech burst swaps to the waveform.
 	const icon = $derived(isSpeechDetected ? AudioLinesIcon : RadioIcon);
-	const shortcutLabel = $derived(shortcuts.currentLabel('toggleVadRecording'));
+	const shortcutLabel = $derived(getRecordingShortcutLabel('vad'));
 	const label = $derived(isListening ? 'Stop listening' : 'Start listening');
 	const description = $derived.by(() => {
 		if (toggleMutation.isPending) return 'Updating voice activation';


### PR DESCRIPTION
On a fresh desktop install, the home page and the record buttons showed an empty key hint where the recording shortcut should be. The shortcut that actually works there, push-to-talk on Fn, went untaught.

The reason for this shape is:

Manual recording has two start commands: push-to-talk (hold) and toggle (tap). Desktop binds push-to-talk (Fn) by default and ships the tap-toggle unbound; the browser ships the reverse. But every display resolved a single fixed command, `toggleManualRecording`:

- the action buttons called `shortcuts.label('toggleManualRecording')`
- the home page read `shortcuts.global.toggleManualRecording` (and the local toggle) straight out of `deviceConfig`/`settings`, the last surface still reaching into storage instead of the label seam it was told to use

So on desktop, where that command is unbound by default, the hint rendered empty even though Fn was live.

This change does the following:

- Add `getRecordingShortcutLabel(mode)`: resolves the first bound command in a per-mode preference list (`pushToTalk`, then `toggleManualRecording` for manual; `toggleVadRecording` for VAD) through the `#platform/shortcuts` label seam. One owner of "which gesture do we teach."
- Route both action buttons and the home page through it.
- Collapse the desktop home copy: the old `here` (local) / `anywhere` (global) split showed a local in-app shortcut that never registers on desktop. It is now one honest line per mode that hides when nothing is bound.

Stacked conceptually on the #2026 accessibility/shortcut rework and the #2069 label seam; this finishes routing the last raw-storage reader through the seam.

## Changelog

- Show the recording shortcut that is actually bound on each platform (push-to-talk on desktop), instead of an empty hint for the unbound toggle.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784244909&installation_id=128463665&pr_number=2071&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2071&signature=82c68e17a17a4c783af078130881bd74fcb993270c0e3a9a58c4218d19d15e5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->