### PR TITLE
fix(whispering): clean up recordings zip export

### DIFF
--- a/apps/whispering/src/lib/whispering/recordings-markdown-export.ts
+++ b/apps/whispering/src/lib/whispering/recordings-markdown-export.ts
@@ -13,14 +13,14 @@
  * env factories rather than in the iso `createWhispering`.
  */
 
-import { defineMutation } from '@epicenter/workspace';
+import { defineMutation, type Table } from '@epicenter/workspace';
 import { strToU8, zipSync } from 'fflate';
 import yaml from 'js-yaml';
 import { Err, Ok, type Result } from 'wellcrafted/result';
 import { type DownloadError, DownloadServiceLive } from '#platform/download';
-import type { createWhispering, Recording } from '$lib/workspace';
+import type { Recording } from '$lib/workspace';
 
-type WhisperingWorkspace = ReturnType<typeof createWhispering>;
+type RecordingsTable = Table<Recording>;
 
 /** Render one recording row as Markdown: YAML frontmatter + transcript body. */
 function recordingToMarkdown(recording: Recording): string {
@@ -29,12 +29,12 @@ function recordingToMarkdown(recording: Recording): string {
 	return `---\n${yamlStr}---\n${transcript || ''}\n`;
 }
 
-export function defineRecordingsMarkdownExport(workspace: WhisperingWorkspace) {
+export function defineRecordingsMarkdownExport(recordings: RecordingsTable) {
 	return defineMutation({
 		title: 'Export recordings',
 		description: 'Download every recording as a zip of Markdown files',
 		handler: async (): Promise<Result<{ written: number }, DownloadError>> => {
-			const { rows } = workspace.tables.recordings.scan();
+			const { rows } = recordings.scan();
 			if (rows.length === 0) return Ok({ written: 0 });
 
 			const files: Record<string, Uint8Array> = {};

--- a/apps/whispering/src/lib/whispering/recordings-markdown-export.ts
+++ b/apps/whispering/src/lib/whispering/recordings-markdown-export.ts
@@ -20,8 +20,6 @@ import { Err, Ok, type Result } from 'wellcrafted/result';
 import { type DownloadError, DownloadServiceLive } from '#platform/download';
 import type { Recording } from '$lib/workspace';
 
-type RecordingsTable = Table<Recording>;
-
 /** Render one recording row as Markdown: YAML frontmatter + transcript body. */
 function recordingToMarkdown(recording: Recording): string {
 	const { transcript, ...frontmatter } = recording;
@@ -29,7 +27,7 @@ function recordingToMarkdown(recording: Recording): string {
 	return `---\n${yamlStr}---\n${transcript || ''}\n`;
 }
 
-export function defineRecordingsMarkdownExport(recordings: RecordingsTable) {
+export function defineRecordingsMarkdownExport(recordings: Table<Recording>) {
 	return defineMutation({
 		title: 'Export recordings',
 		description: 'Download every recording as a zip of Markdown files',

--- a/apps/whispering/src/lib/whispering/whispering.browser.ts
+++ b/apps/whispering/src/lib/whispering/whispering.browser.ts
@@ -27,7 +27,9 @@ export function openWhispering() {
 		...workspace,
 		actions: defineActions({
 			...workspace.actions,
-			recordings_export_markdown: defineRecordingsMarkdownExport(workspace),
+			recordings_export_markdown: defineRecordingsMarkdownExport(
+				workspace.tables.recordings,
+			),
 		}),
 		whenReady: idb.whenLoaded,
 	});

--- a/apps/whispering/src/lib/whispering/whispering.tauri.ts
+++ b/apps/whispering/src/lib/whispering/whispering.tauri.ts
@@ -27,7 +27,9 @@ export function openWhispering() {
 		...workspace,
 		actions: defineActions({
 			...workspace.actions,
-			recordings_export_markdown: defineRecordingsMarkdownExport(workspace),
+			recordings_export_markdown: defineRecordingsMarkdownExport(
+				workspace.tables.recordings,
+			),
 		}),
 		whenReady: idb.whenLoaded,
 	});

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
@@ -151,7 +151,7 @@
 							}
 							report.success({
 								title: 'Recordings exported',
-								description: `Saved ${data.written} ${data.written === 1 ? 'recording' : 'recordings'} to recordings.zip.`,
+								description: `Saved ${data.written} ${data.written === 1 ? 'recording' : 'recordings'} as a zip file.`,
 							});
 						},
 						onError: (error) => {

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
@@ -23,9 +23,9 @@
 	import ManualSelectRecordingDevice from './ManualSelectRecordingDevice.svelte';
 	import VadSelectRecordingDevice from './VadSelectRecordingDevice.svelte';
 
-	const exportMarkdown = createMutation(() =>
+	const exportRecordings = createMutation(() =>
 		mutationOptions({
-			mutationKey: ['recordings', 'exportMarkdown'],
+			mutationKey: ['recordings', 'export'],
 			mutationFn: whispering.actions.recordings_export_markdown,
 		}),
 	);
@@ -140,7 +140,7 @@
 				variant="outline"
 				class="w-fit"
 				onclick={() => {
-					exportMarkdown.mutate(undefined, {
+					exportRecordings.mutate(undefined, {
 						onSuccess: (data) => {
 							if (data.written === 0) {
 								report.info({
@@ -164,9 +164,9 @@
 						},
 					});
 				}}
-				disabled={exportMarkdown.isPending}
+				disabled={exportRecordings.isPending}
 			>
-				{exportMarkdown.isPending ? 'Exporting...' : 'Export recordings (.zip)'}
+				{exportRecordings.isPending ? 'Exporting...' : 'Export recordings (.zip)'}
 			</Button>
 			<Field.Description>
 				Download every recording as a zip of Markdown files. This is a


### PR DESCRIPTION
Follow-up to #2060. That PR merged before the review cleanup commit landed on `main`, so this replays the small dependency narrowing on top of current `origin/main`.

The export action now takes the recordings table it actually reads instead of the full Whispering workspace. This keeps the shared action boundary from #2060, but makes its dependency honest.

It also adjusts the success toast from `recordings.zip` to `a zip file`. The web download uses that default filename, but the desktop Save dialog lets the user rename the export target, so the UI should not claim a specific filename after success.

## Changelog

- Tightens the recordings zip export action dependency to the recordings table.
- Makes the export success toast accurate when desktop users rename the saved zip.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784254222&installation_id=128463665&pr_number=2078&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2078&signature=ae24d1db4e7f900d6eabaf03829e99ada681c45e3b8fe798706aaa4ce6cc7886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->