### PR TITLE
fix(whispering): give Tauri dev a stable macOS Accessibility identity

### DIFF
--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -68,7 +68,9 @@
 	"scripts": {
 		"dev:web": "vite dev",
 		"dev": "bun run dev:local",
-		"dev:local": "bun tauri dev --config '{\"identifier\": \"so.epicenter.whispering.dev\"}'",
+		"dev:local": "bun run scripts/launch-dev.ts",
+		"dev:doctor": "bun run scripts/dev-doctor.ts",
+		"test": "bun test tests/",
 		"build": "NODE_ENV=production vite build",
 		"check": "bun run typecheck",
 		"preview": "vite preview",

--- a/apps/whispering/scripts/dev-doctor.ts
+++ b/apps/whispering/scripts/dev-doctor.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env bun
+/**
+ * Diagnose the macOS dev Accessibility identity in one command:
+ *
+ *   bun run dev:doctor
+ *
+ * It reports the STATIC identity facts that decide whether the TCC grant will
+ * stick: where the dev binary is, its code-signing Identifier and authority,
+ * whether that matches the dev identifier, and the reset command to copy. The
+ * LIVE facts (AXIsProcessTrusted, the current DictationCapability, the rdev
+ * listener's last stop reason) are owned by the running app's Rust supervisor
+ * and surface in the app itself plus the Tauri log, so this script points there
+ * rather than guessing them from outside the process.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SRC_TAURI = join(import.meta.dir, "..", "src-tauri");
+
+function run(command: string, args: string[]): string {
+	const result = Bun.spawnSync([command, ...args]);
+	return (
+		new TextDecoder().decode(result.stdout) +
+		new TextDecoder().decode(result.stderr)
+	).trim();
+}
+
+function readDevIdentity(): { identifier: string; productName: string } {
+	const config = JSON.parse(
+		readFileSync(join(SRC_TAURI, "tauri.dev.conf.json"), "utf8"),
+	);
+	return { identifier: config.identifier, productName: config.productName };
+}
+
+const { identifier: expectedIdentifier, productName } = readDevIdentity();
+
+console.log("Whispering dev Accessibility doctor");
+console.log("==================================");
+console.log(`platform:           ${process.platform}`);
+console.log(`expected identifier: ${expectedIdentifier}`);
+console.log(`expected name:       ${productName}`);
+
+if (process.platform !== "darwin") {
+	console.log("\nNot macOS: no Accessibility/TCC identity to check.");
+	process.exit(0);
+}
+
+const binary = join(SRC_TAURI, "target", "debug", "whispering");
+console.log(`\ndev binary:         ${binary}`);
+if (!existsSync(binary)) {
+	console.log("  (not built yet — run `bun run dev:local` first)");
+	process.exit(0);
+}
+
+const codesign = run("codesign", ["-dv", "--verbose=2", binary]);
+const identifierLine = codesign.match(/^Identifier=(.*)$/m)?.[1] ?? "(none)";
+const authority = codesign.match(/^Authority=(.*)$/m)?.[1] ?? "(none)";
+const flags = codesign.match(/flags=(\S+)/)?.[1] ?? "(none)";
+
+console.log(`  signed Identifier: ${identifierLine}`);
+console.log(`  authority:         ${authority}`);
+console.log(`  flags:             ${flags}`);
+
+const isAdhoc = /adhoc/.test(flags);
+const identifierMatches = identifierLine === expectedIdentifier;
+
+console.log("\nverdict:");
+if (isAdhoc) {
+	console.log(
+		"  ✗ ad-hoc signature — the grant will NOT survive rebuilds. Install a",
+	);
+	console.log(
+		"    codesigning cert or set WHISPERING_DEV_SIGNING_IDENTITY, then rebuild.",
+	);
+} else if (!identifierMatches) {
+	console.log(
+		`  ✗ signed identifier is "${identifierLine}", expected "${expectedIdentifier}".`,
+	);
+	console.log("    The runner may not be wired in; re-run `bun run dev:local`.");
+} else {
+	console.log("  ✓ stable signature with the dev identifier. Grant should persist.");
+}
+
+console.log("\navailable codesigning identities:");
+console.log(`  ${run("security", ["find-identity", "-v", "-p", "codesigning"]).replace(/\n/g, "\n  ")}`);
+
+console.log("\nreset the dev grant (after the app has launched at least once):");
+console.log(`  tccutil reset Accessibility ${expectedIdentifier}`);
+console.log("  then relaunch dev and grant the new Accessibility entry.");
+
+console.log("\nlive trust / capability / listener health:");
+console.log("  shown in the app (DictationCapability) and the Tauri log; the Rust");
+console.log("  supervisor in src-tauri/src/keyboard/mod.rs owns those values.");

--- a/apps/whispering/scripts/dev-doctor.ts
+++ b/apps/whispering/scripts/dev-doctor.ts
@@ -12,10 +12,10 @@
  * and surface in the app itself plus the Tauri log, so this script points there
  * rather than guessing them from outside the process.
  */
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
-const SRC_TAURI = join(import.meta.dir, "..", "src-tauri");
+const SRC_TAURI = join(import.meta.dir, '..', 'src-tauri');
 
 function run(command: string, args: string[]): string {
 	const result = Bun.spawnSync([command, ...args]);
@@ -27,35 +27,35 @@ function run(command: string, args: string[]): string {
 
 function readDevIdentity(): { identifier: string; productName: string } {
 	const config = JSON.parse(
-		readFileSync(join(SRC_TAURI, "tauri.dev.conf.json"), "utf8"),
+		readFileSync(join(SRC_TAURI, 'tauri.dev.conf.json'), 'utf8'),
 	);
 	return { identifier: config.identifier, productName: config.productName };
 }
 
 const { identifier: expectedIdentifier, productName } = readDevIdentity();
 
-console.log("Whispering dev Accessibility doctor");
-console.log("==================================");
+console.log('Whispering dev Accessibility doctor');
+console.log('==================================');
 console.log(`platform:           ${process.platform}`);
 console.log(`expected identifier: ${expectedIdentifier}`);
 console.log(`expected name:       ${productName}`);
 
-if (process.platform !== "darwin") {
-	console.log("\nNot macOS: no Accessibility/TCC identity to check.");
+if (process.platform !== 'darwin') {
+	console.log('\nNot macOS: no Accessibility/TCC identity to check.');
 	process.exit(0);
 }
 
-const binary = join(SRC_TAURI, "target", "debug", "whispering");
+const binary = join(SRC_TAURI, 'target', 'debug', 'whispering');
 console.log(`\ndev binary:         ${binary}`);
 if (!existsSync(binary)) {
-	console.log("  (not built yet — run `bun run dev:local` first)");
+	console.log('  (not built yet — run `bun run dev:local` first)');
 	process.exit(0);
 }
 
-const codesign = run("codesign", ["-dv", "--verbose=2", binary]);
-const identifierLine = codesign.match(/^Identifier=(.*)$/m)?.[1] ?? "(none)";
-const authority = codesign.match(/^Authority=(.*)$/m)?.[1] ?? "(none)";
-const flags = codesign.match(/flags=(\S+)/)?.[1] ?? "(none)";
+const codesign = run('codesign', ['-dv', '--verbose=2', binary]);
+const identifierLine = codesign.match(/^Identifier=(.*)$/m)?.[1] ?? '(none)';
+const authority = codesign.match(/^Authority=(.*)$/m)?.[1] ?? '(none)';
+const flags = codesign.match(/flags=(\S+)/)?.[1] ?? '(none)';
 
 console.log(`  signed Identifier: ${identifierLine}`);
 console.log(`  authority:         ${authority}`);
@@ -64,30 +64,40 @@ console.log(`  flags:             ${flags}`);
 const isAdhoc = /adhoc/.test(flags);
 const identifierMatches = identifierLine === expectedIdentifier;
 
-console.log("\nverdict:");
+console.log('\nverdict:');
 if (isAdhoc) {
 	console.log(
-		"  ✗ ad-hoc signature — the grant will NOT survive rebuilds. Install a",
+		'  ✗ ad-hoc signature — the grant will NOT survive rebuilds. Install a',
 	);
 	console.log(
-		"    codesigning cert or set WHISPERING_DEV_SIGNING_IDENTITY, then rebuild.",
+		'    codesigning cert or set WHISPERING_DEV_SIGNING_IDENTITY, then rebuild.',
 	);
 } else if (!identifierMatches) {
 	console.log(
 		`  ✗ signed identifier is "${identifierLine}", expected "${expectedIdentifier}".`,
 	);
-	console.log("    The runner may not be wired in; re-run `bun run dev:local`.");
+	console.log(
+		'    The runner may not be wired in; re-run `bun run dev:local`.',
+	);
 } else {
-	console.log("  ✓ stable signature with the dev identifier. Grant should persist.");
+	console.log(
+		'  ✓ stable signature with the dev identifier. Grant should persist.',
+	);
 }
 
-console.log("\navailable codesigning identities:");
-console.log(`  ${run("security", ["find-identity", "-v", "-p", "codesigning"]).replace(/\n/g, "\n  ")}`);
+console.log('\navailable codesigning identities:');
+console.log(
+	`  ${run('security', ['find-identity', '-v', '-p', 'codesigning']).replace(/\n/g, '\n  ')}`,
+);
 
-console.log("\nreset the dev grant (after the app has launched at least once):");
+console.log(
+	'\nreset the dev grant (after the app has launched at least once):',
+);
 console.log(`  tccutil reset Accessibility ${expectedIdentifier}`);
-console.log("  then relaunch dev and grant the new Accessibility entry.");
+console.log('  then relaunch dev and grant the new Accessibility entry.');
 
-console.log("\nlive trust / capability / listener health:");
-console.log("  shown in the app (DictationCapability) and the Tauri log; the Rust");
-console.log("  supervisor in src-tauri/src/keyboard/mod.rs owns those values.");
+console.log('\nlive trust / capability / listener health:');
+console.log(
+	'  shown in the app (DictationCapability) and the Tauri log; the Rust',
+);
+console.log('  supervisor in src-tauri/src/keyboard/mod.rs owns those values.');

--- a/apps/whispering/scripts/launch-dev.ts
+++ b/apps/whispering/scripts/launch-dev.ts
@@ -9,21 +9,21 @@
  * the runner shells out to `codesign`, which only exists on macOS, so it is
  * wired in there and nowhere else.
  */
-import { spawn } from "node:child_process";
+import { spawn } from 'node:child_process';
 
-const configs = ["src-tauri/tauri.dev.conf.json"];
-if (process.platform === "darwin") {
-	configs.push("src-tauri/tauri.dev.macos.conf.json");
+const configs = ['src-tauri/tauri.dev.conf.json'];
+if (process.platform === 'darwin') {
+	configs.push('src-tauri/tauri.dev.macos.conf.json');
 }
 
-const args = ["tauri", "dev"];
+const args = ['tauri', 'dev'];
 for (const config of configs) {
-	args.push("--config", config);
+	args.push('--config', config);
 }
 args.push(...process.argv.slice(2));
 
-const child = spawn("bun", args, { stdio: "inherit" });
-child.on("exit", (code, signal) => {
+const child = spawn('bun', args, { stdio: 'inherit' });
+child.on('exit', (code, signal) => {
 	if (signal) {
 		process.kill(process.pid, signal);
 	} else {

--- a/apps/whispering/scripts/launch-dev.ts
+++ b/apps/whispering/scripts/launch-dev.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env bun
+/**
+ * Cross-platform `tauri dev` launcher.
+ *
+ * Every platform gets the dev identity (productName "Whispering Dev",
+ * identifier so.epicenter.whispering.dev) so dev never wears production's
+ * identity. macOS additionally gets a codesigning runner so the Accessibility
+ * grant survives Rust rebuilds (see src-tauri/scripts/dev-codesign-runner.sh);
+ * the runner shells out to `codesign`, which only exists on macOS, so it is
+ * wired in there and nowhere else.
+ */
+import { spawn } from "node:child_process";
+
+const configs = ["src-tauri/tauri.dev.conf.json"];
+if (process.platform === "darwin") {
+	configs.push("src-tauri/tauri.dev.macos.conf.json");
+}
+
+const args = ["tauri", "dev"];
+for (const config of configs) {
+	args.push("--config", config);
+}
+args.push(...process.argv.slice(2));
+
+const child = spawn("bun", args, { stdio: "inherit" });
+child.on("exit", (code, signal) => {
+	if (signal) {
+		process.kill(process.pid, signal);
+	} else {
+		process.exit(code ?? 0);
+	}
+});

--- a/apps/whispering/src-tauri/scripts/README.md
+++ b/apps/whispering/src-tauri/scripts/README.md
@@ -1,0 +1,56 @@
+# Dev macOS Accessibility identity
+
+`bun run dev` launches Whispering under its own macOS identity,
+`so.epicenter.whispering.dev`, separate from the released **Whispering**
+(`so.epicenter.whispering`). Grant Accessibility once and global shortcuts keep
+working across rebuilds.
+
+Because dev runs a bare binary rather than a `.app`, its System Settings entry
+may be labelled `whispering` rather than `Whispering Dev`; what is guaranteed is
+that it is a *distinct* entry from production, so granting one never touches the
+other.
+
+## Why this is not just a flag
+
+`tauri dev` runs the bare `target/debug/whispering` binary, not a `.app` bundle,
+and it ignores `bundle.macOS.signingIdentity`. Cargo's linker leaves that binary
+ad-hoc signed, so its code-signing identity is its cdhash, which changes on every
+relink. macOS Accessibility (TCC) keys the grant on that identity, so each Rust
+rebuild looked like a brand-new app and the grant went stale. The Rust
+supervisor then reported `DictationCapability::Broken`.
+
+The fix is a stable signature, not a bundle id. Tauri's `build.runner` hook
+(`tauri.dev.macos.conf.json`) points `tauri dev` at
+[`dev-codesign-runner.sh`](./dev-codesign-runner.sh), which builds, re-signs the
+binary with a stable cert and the fixed identifier `so.epicenter.whispering.dev`,
+then `exec`s it. The resulting designated requirement depends only on the
+identifier and the certificate, never the cdhash, so the grant survives rebuilds.
+
+The signing cert defaults to the first Developer ID or Apple Development identity
+on the machine. Override it with `WHISPERING_DEV_SIGNING_IDENTITY`. With no cert
+the runner falls back to ad-hoc and warns that the grant will not persist.
+
+## Granting and resetting
+
+First `bun run dev` after this change re-prompts for Accessibility (the identity
+changed). Grant the new entry in System Settings > Accessibility, once.
+
+To start clean (the binary must have launched at least once so the entry exists):
+
+```sh
+tccutil reset Accessibility so.epicenter.whispering.dev
+```
+
+Then relaunch dev and grant Accessibility again.
+
+## Diagnosing
+
+```sh
+bun run dev:doctor
+```
+
+prints the dev binary path, its signed identifier and authority, whether the
+signature is stable, and the reset command. Live trust, the current
+`DictationCapability`, and the rdev listener's health are owned by the running
+app's supervisor (`src/keyboard/mod.rs`) and show up in the app and the Tauri
+log.

--- a/apps/whispering/src-tauri/scripts/dev-codesign-runner.sh
+++ b/apps/whispering/src-tauri/scripts/dev-codesign-runner.sh
@@ -56,7 +56,9 @@ done
 # `--bin whispering` mirrors the default `cargo run` Tauri would invoke: build the
 # app binary and its deps, not every target (a bare `cargo build` also produces
 # the lib's multi-hundred-MB staticlib, which the app never needs).
-cargo build --manifest-path "$SRC_TAURI/Cargo.toml" --bin whispering "${cargo_flags[@]}"
+# The `${arr[@]+"${arr[@]}"}` form expands to nothing when the array is empty,
+# which `set -u` otherwise rejects on the bash 3.2 that ships with macOS.
+cargo build --manifest-path "$SRC_TAURI/Cargo.toml" --bin whispering ${cargo_flags[@]+"${cargo_flags[@]}"}
 
 # Mirror cargo's output layout to find what we just built: honor CARGO_TARGET_DIR
 # and any --target/--release the flags carried.
@@ -96,5 +98,7 @@ codesign --force \
 	"$binary"
 
 # Become the app. Tauri monitors and kills THIS pid to restart, so replacing the
-# process (rather than spawning a child) means no orphaned app on rebuild.
-exec "$binary" "${app_args[@]}"
+# process (rather than spawning a child) means no orphaned app on rebuild. The
+# array guard matters here: Tauri usually passes no app args, so `app_args` is
+# empty, and a bare "${app_args[@]}" would trip `set -u` and abort before exec.
+exec "$binary" ${app_args[@]+"${app_args[@]}"}

--- a/apps/whispering/src-tauri/scripts/dev-codesign-runner.sh
+++ b/apps/whispering/src-tauri/scripts/dev-codesign-runner.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Tauri dev `build.runner` for macOS: build, codesign, then BECOME the app.
+#
+# Why this exists
+# ---------------
+# `tauri dev` runs the bare `target/debug/whispering` binary, never a `.app`
+# bundle, and `bundle.macOS.signingIdentity` is ignored in dev. Cargo's linker
+# leaves the binary ad-hoc signed, so its code-signing identity is its cdhash:
+# a fresh hash on every relink. macOS Accessibility (TCC) keys the grant on that
+# identity, so every Rust rebuild looks like a brand-new app and the grant goes
+# stale, which the Rust supervisor then surfaces as DictationCapability::Broken.
+#
+# Tauri offers no after-build/before-launch hook, but it does let you replace
+# cargo with a custom `build.runner` that it invokes as `<runner> run <args>`
+# and then treats as the long-lived app process (it kills this PID to restart
+# on file changes). So this runner does the one thing dev is missing: it builds,
+# re-signs the binary with a STABLE identity + identifier (constant designated
+# requirement across relinks, so the TCC grant sticks), then `exec`s the binary
+# so Tauri's monitored PID is the app itself.
+#
+# The signing identity is the only stable code-signing cert on the machine; a
+# DISTINCT identifier (so.epicenter.whispering.dev, not the production
+# so.epicenter.whispering) keeps dev and production as separate TCC entries, so
+# granting one never touches the other. Override the cert with
+# WHISPERING_DEV_SIGNING_IDENTITY if you have a dedicated one.
+#
+# This runner is wired in only on macOS (see scripts/launch-dev.ts); other
+# platforms run plain `tauri dev`.
+set -euo pipefail
+
+# The dev TCC identity. Keep in lockstep with tauri.dev.conf.json and
+# tests/dev-identity.test.ts (the regression guard asserts they match).
+readonly DEV_IDENTIFIER="so.epicenter.whispering.dev"
+
+# Resolve src-tauri from this script's location so cargo and the binary path are
+# correct regardless of the cwd Tauri happens to invoke us with.
+SRC_TAURI="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Tauri calls us as `run <cargo flags...> [-- <app args...>]`. Drop `run`, then
+# split cargo flags from the app args at the `--` separator.
+shift || true
+cargo_flags=()
+app_args=()
+seen_separator=0
+for arg in "$@"; do
+	if [ "$seen_separator" -eq 1 ]; then
+		app_args+=("$arg")
+	elif [ "$arg" = "--" ]; then
+		seen_separator=1
+	else
+		cargo_flags+=("$arg")
+	fi
+done
+
+# `--bin whispering` mirrors the default `cargo run` Tauri would invoke: build the
+# app binary and its deps, not every target (a bare `cargo build` also produces
+# the lib's multi-hundred-MB staticlib, which the app never needs).
+cargo build --manifest-path "$SRC_TAURI/Cargo.toml" --bin whispering "${cargo_flags[@]}"
+
+# Mirror cargo's output layout to find what we just built: honor CARGO_TARGET_DIR
+# and any --target/--release the flags carried.
+target_dir="${CARGO_TARGET_DIR:-$SRC_TAURI/target}"
+profile="debug"
+triple=""
+index=0
+while [ "$index" -lt "${#cargo_flags[@]}" ]; do
+	case "${cargo_flags[$index]}" in
+		--release) profile="release" ;;
+		--target) index=$((index + 1)); triple="${cargo_flags[$index]:-}" ;;
+		--target=*) triple="${cargo_flags[$index]#--target=}" ;;
+	esac
+	index=$((index + 1))
+done
+binary="$target_dir/${triple:+$triple/}$profile/whispering"
+
+# Pick the signing identity: an explicit override, else the first real cert
+# (Developer ID or Apple Development). A stable cert is what makes the grant
+# survive rebuilds; ad-hoc ("-") cannot, so say so loudly rather than pretend.
+identity="${WHISPERING_DEV_SIGNING_IDENTITY:-}"
+if [ -z "$identity" ]; then
+	identity="$(security find-identity -v -p codesigning \
+		| awk -F'"' '/Developer ID Application|Apple Development/ { print $2; exit }')"
+fi
+if [ -z "$identity" ]; then
+	echo "dev-codesign-runner: no stable signing identity found; falling back to ad-hoc." >&2
+	echo "dev-codesign-runner: the Accessibility grant will NOT persist across rebuilds." >&2
+	echo "dev-codesign-runner: set WHISPERING_DEV_SIGNING_IDENTITY or install a codesigning cert." >&2
+	identity="-"
+fi
+
+codesign --force \
+	--sign "$identity" \
+	--identifier "$DEV_IDENTIFIER" \
+	--entitlements "$SRC_TAURI/entitlements.plist" \
+	"$binary"
+
+# Become the app. Tauri monitors and kills THIS pid to restart, so replacing the
+# process (rather than spawning a child) means no orphaned app on rebuild.
+exec "$binary" "${app_args[@]}"

--- a/apps/whispering/src-tauri/tauri.dev.conf.json
+++ b/apps/whispering/src-tauri/tauri.dev.conf.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://schema.tauri.app/config/2",
+	"productName": "Whispering Dev",
+	"identifier": "so.epicenter.whispering.dev"
+}

--- a/apps/whispering/src-tauri/tauri.dev.macos.conf.json
+++ b/apps/whispering/src-tauri/tauri.dev.macos.conf.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "https://schema.tauri.app/config/2",
+	"build": {
+		"runner": {
+			"cmd": "./scripts/dev-codesign-runner.sh"
+		}
+	}
+}

--- a/apps/whispering/tests/dev-identity.test.ts
+++ b/apps/whispering/tests/dev-identity.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Guards the macOS dev Accessibility identity against silent regression.
+ *
+ * The dev grant only survives rebuilds while three things agree on one
+ * identifier and dev stays distinct from production. If any of these drift, dev
+ * Accessibility quietly breaks again, so assert them instead of trusting code
+ * review to notice a one-character edit.
+ */
+const SRC_TAURI = join(import.meta.dir, "..", "src-tauri");
+const DEV_IDENTIFIER = "so.epicenter.whispering.dev";
+
+const read = (name: string) => readFileSync(join(SRC_TAURI, name), "utf8");
+const json = (name: string) => JSON.parse(read(name));
+
+describe("dev macOS identity", () => {
+	test("dev config carries the distinct dev identity", () => {
+		const dev = json("tauri.dev.conf.json");
+		expect(dev.identifier).toBe(DEV_IDENTIFIER);
+		expect(dev.productName).toBe("Whispering Dev");
+	});
+
+	test("production identity is untouched", () => {
+		const prod = json("tauri.conf.json");
+		expect(prod.identifier).toBe("so.epicenter.whispering");
+		expect(prod.productName).toBe("Whispering");
+	});
+
+	test("the codesign runner signs with the same dev identifier", () => {
+		const runner = read("scripts/dev-codesign-runner.sh");
+		expect(runner).toContain(`DEV_IDENTIFIER="${DEV_IDENTIFIER}"`);
+	});
+
+	test("the macOS dev config wires in the codesign runner", () => {
+		const macos = json("tauri.dev.macos.conf.json");
+		expect(macos.build.runner.cmd).toBe("./scripts/dev-codesign-runner.sh");
+	});
+});

--- a/apps/whispering/tests/dev-identity.test.ts
+++ b/apps/whispering/tests/dev-identity.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 /**
  * Guards the macOS dev Accessibility identity against silent regression.
@@ -10,32 +10,32 @@ import { join } from "node:path";
  * Accessibility quietly breaks again, so assert them instead of trusting code
  * review to notice a one-character edit.
  */
-const SRC_TAURI = join(import.meta.dir, "..", "src-tauri");
-const DEV_IDENTIFIER = "so.epicenter.whispering.dev";
+const SRC_TAURI = join(import.meta.dir, '..', 'src-tauri');
+const DEV_IDENTIFIER = 'so.epicenter.whispering.dev';
 
-const read = (name: string) => readFileSync(join(SRC_TAURI, name), "utf8");
+const read = (name: string) => readFileSync(join(SRC_TAURI, name), 'utf8');
 const json = (name: string) => JSON.parse(read(name));
 
-describe("dev macOS identity", () => {
-	test("dev config carries the distinct dev identity", () => {
-		const dev = json("tauri.dev.conf.json");
+describe('dev macOS identity', () => {
+	test('dev config carries the distinct dev identity', () => {
+		const dev = json('tauri.dev.conf.json');
 		expect(dev.identifier).toBe(DEV_IDENTIFIER);
-		expect(dev.productName).toBe("Whispering Dev");
+		expect(dev.productName).toBe('Whispering Dev');
 	});
 
-	test("production identity is untouched", () => {
-		const prod = json("tauri.conf.json");
-		expect(prod.identifier).toBe("so.epicenter.whispering");
-		expect(prod.productName).toBe("Whispering");
+	test('production identity is untouched', () => {
+		const prod = json('tauri.conf.json');
+		expect(prod.identifier).toBe('so.epicenter.whispering');
+		expect(prod.productName).toBe('Whispering');
 	});
 
-	test("the codesign runner signs with the same dev identifier", () => {
-		const runner = read("scripts/dev-codesign-runner.sh");
+	test('the codesign runner signs with the same dev identifier', () => {
+		const runner = read('scripts/dev-codesign-runner.sh');
 		expect(runner).toContain(`DEV_IDENTIFIER="${DEV_IDENTIFIER}"`);
 	});
 
-	test("the macOS dev config wires in the codesign runner", () => {
-		const macos = json("tauri.dev.macos.conf.json");
-		expect(macos.build.runner.cmd).toBe("./scripts/dev-codesign-runner.sh");
+	test('the macOS dev config wires in the codesign runner', () => {
+		const macos = json('tauri.dev.macos.conf.json');
+		expect(macos.build.runner.cmd).toBe('./scripts/dev-codesign-runner.sh');
 	});
 });


### PR DESCRIPTION
Granting macOS Accessibility to Whispering under `tauri dev` never stuck: every Rust rebuild silently invalidated the grant, global shortcuts stopped firing, and the supervisor reported `DictationCapability::Broken`. The cause is that `tauri dev` runs the bare `target/debug/whispering` binary, not a `.app`, and ignores `bundle.macOS.signingIdentity`. Cargo leaves that binary ad-hoc (linker) signed, so its code-signing identity is its cdhash, and macOS TCC keys the Accessibility grant on that identity. A fresh cdhash on every relink reads to macOS as a brand-new app. The old `dev:local` `--config '{"identifier": ...}'` override could not help: dev produces no bundle, so there is no bundle id for TCC, and `tccutil reset Accessibility so.epicenter.whispering.dev` failed with "No such bundle identifier".

The fix is a stable signature, not a bundle id. Tauri exposes no after-build hook in dev, but its `build.runner` replaces cargo and becomes the long-lived app process. A macOS-only runner now builds, re-signs the dev binary with a stable certificate and the fixed identifier `so.epicenter.whispering.dev`, then `exec`s it. The resulting designated requirement depends only on the identifier and certificate, never the cdhash:

```
identifier "so.epicenter.whispering.dev" and anchor apple generic and ... certificate leaf[subject.OU] = "<team>"
```

so one grant survives every rebuild. The identifier is deliberately distinct from production's `so.epicenter.whispering`, keeping dev and production as separate TCC entries that never poison each other. A cross-platform launcher applies the `Whispering Dev` identity on every platform and wires the codesign runner only on macOS; `bun run dev:doctor` reports the live signing state, and a test guards the identity against silent regression. Production identity and the released app are unchanged.

The signing cert defaults to the first Developer ID or Apple Development identity on the machine, overridable with `WHISPERING_DEV_SIGNING_IDENTITY`; with no cert the runner falls back to ad-hoc and warns that the grant will not persist.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784351823&installation_id=128463665&pr_number=2084&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2084&signature=c52670ad2d0e609b8c664b6651d5dfe89b984ddb4aab0e56e548da8c2b4d1771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->