### PR TITLE
fix(whispering): open the Accessibility pane with a working URL scheme

### DIFF
--- a/apps/whispering/src-tauri/src/command.rs
+++ b/apps/whispering/src-tauri/src/command.rs
@@ -11,8 +11,13 @@ use std::process::Command;
 pub async fn open_accessibility_settings() -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
+        // Deep-link straight to Privacy & Security > Accessibility. This
+        // `x-apple.systempreferences:` scheme is honored by System Settings from
+        // Ventura through Sequoia; the older `x-apple.systemsettings:` form was
+        // not claimed by any app and failed with kLSApplicationNotFoundErr, so
+        // the button only ever hit its manual-instructions fallback.
         let status = Command::new("/usr/bin/open")
-            .arg("x-apple.systemsettings:com.apple.SystemSettings.extension")
+            .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
             .status()
             .map_err(|e| format!("Failed to open accessibility settings: {}", e))?;
 


### PR DESCRIPTION
The "Open System Settings" button on the macOS Accessibility notice has never opened anything.

`open_accessibility_settings` handed `/usr/bin/open` the URL `x-apple.systemsettings:com.apple.SystemSettings.extension`, which names no real pane and is claimed by no app. LaunchServices fails it with `kLSApplicationNotFoundErr (-10814)`, the Tauri command returns an error, and the frontend (`MacosAccessibilityGuideDialog.svelte`) falls through to its "Open System Settings manually" toast every single time. The button looked like it worked because the fallback worked; the deep-link itself never did.

This swaps in the canonical scheme:

```
x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility
```

System Settings honors `x-apple.systempreferences:` from Ventura through Sequoia, and this anchor opens directly on Privacy & Security > Accessibility. The manual-instructions toast stays as the fallback if `open` ever fails.

You can confirm the URL resolves before rebuilding:

```sh
open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
```

A Rust rebuild is needed for the button itself to pick up the change. Independent of the dev-identity tooling work in #2084.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784354335&installation_id=128463665&pr_number=2087&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2087&signature=bf9ad4b0f5941a4363a170001dd1ab2ffe7ac63c18e3fdd378a4bf4de2320883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->