### PR TITLE
fix(whispering): stop the dictation notice from asserting a single cause

### DIFF
--- a/apps/whispering/src/lib/components/DictationCapabilityNotice.svelte
+++ b/apps/whispering/src/lib/components/DictationCapabilityNotice.svelte
@@ -30,16 +30,19 @@ branch order is load-bearing: `broken` is caught before the plain untrusted case
 		</Alert.Description>
 	</Alert.Root>
 {:else if dictationCapability.isStale}
-	<!-- A macOS grant that went stale after an update, where toggling does
-	nothing: the fix is remove-and-re-add, so the guide leads. -->
+	<!-- macOS reports Whispering as trusted, but the global tap is not delivering
+	events. The common cause is a grant left stale by an app update, which a
+	remove-and-re-add fixes, so the guide leads. We do not assert that as the only
+	cause: the tap can also stall for reasons re-granting won't touch, so the copy
+	stays honest about what we know (it is not firing) and what usually helps. -->
 	<Alert.Root class="w-full text-left">
 		<TriangleAlertIcon class="size-4" aria-hidden="true" />
-		<Alert.Title>Your global shortcut stopped working</Alert.Title>
+		<Alert.Title>Your global shortcut isn't working</Alert.Title>
 		<Alert.Description>
-			Whispering's macOS Accessibility access went stale after an update, so your
-			global shortcut and paste-back are off. Toggling it won't help: remove
-			Whispering from Accessibility and add it back to restore them. Until then,
-			transcripts go to your clipboard.
+			Whispering appears to have macOS Accessibility, but your global shortcut and
+			paste-back aren't firing. Re-granting access (remove Whispering from
+			Accessibility, then add it back) usually fixes it. Until then, transcripts
+			go to your clipboard.
 		</Alert.Description>
 		<Alert.Action>
 			<Button size="sm" onclick={() => accessibilityGuide.open()}>


### PR DESCRIPTION
The `broken` dictation-capability notice told users their "macOS Accessibility access went stale after an update" and that the fix was to "remove Whispering from Accessibility and add it back."

But `broken` does not mean that. In the Rust supervisor it means only: the keyboard tap died while the process was trusted (`AXIsProcessTrusted()` returned true). That has several causes, and a stale post-update grant is just one of them. When the cause is something re-granting cannot touch, the old copy is actively misleading: it asserts both a diagnosis and a cure that may be wrong, and points people at System Settings for a problem that is not about permissions.

This rewords the `broken` panel to:
- state only what is actually known: the global shortcut and paste-back are not firing even though the process appears trusted,
- offer re-granting (remove then re-add) as what *usually* helps, not as the definitive cause and cure.

The remediation guide still leads via "Show me how." No behavior change; copy only.

Context: this exact string sent two of us on a multi-hour Accessibility hunt for what turned out to be a run-loop-threading bug in the keyboard tap. The deeper fix for that is tracked separately (see the keyboard-tap foundation research spec); this PR just stops the notice from misdiagnosing.

Independent of #2084 (dev identity) and #2087 (settings URL).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784359033&installation_id=128463665&pr_number=2091&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2091&signature=da67797a0ade602ad9e05fad0d87f6fa3f3f00b57bee313f170df186eb376b69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->