### PR TITLE
feat(whispering): default transcript output to clipboard, not auto-paste

### DIFF
--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -199,16 +199,18 @@ const sound = {
  * configuration: avoids polluting `transcription.*` and `transformation.*`
  * namespaces with unrelated concerns.
  *
- * Cursor default asymmetry (transcription=true, transformation=false): when a
- * transformation runs on the just-finished transcription, the transcription
- * has already typed itself at the cursor. Defaulting transformation.cursor to
- * true would double-type. Users who turn off transcription.cursor specifically
- * to let the transformation be the cursor output can flip the transformation
- * toggle on.
+ * Clipboard is the permission-free default; cursor paste is opt-in. Pasting at
+ * the cursor synthesizes a Cmd/Ctrl+V keystroke (`write_text` -> enigo), and on
+ * macOS injecting keystrokes into another app requires Accessibility. So both
+ * cursor defaults are `false`: out of the box the transcript lands on the
+ * clipboard (no permission, works on first launch) and the user pastes it.
+ * Turning cursor paste on is the deliberate step that asks for Accessibility.
+ * Transformation cursor also stays off so it cannot double-type over a
+ * transcription that already pasted itself once a user turns both on.
  */
 const output = {
 	'output.transcription.clipboard': defineKv(field.boolean(), () => true),
-	'output.transcription.cursor': defineKv(field.boolean(), () => true),
+	'output.transcription.cursor': defineKv(field.boolean(), () => false),
 	'output.transcription.enter': defineKv(field.boolean(), () => false),
 	'output.transformation.clipboard': defineKv(field.boolean(), () => true),
 	'output.transformation.cursor': defineKv(field.boolean(), () => false),


### PR DESCRIPTION
Whispering's paste-back synthesizes a Cmd/Ctrl+V keystroke (`write_text` ->
`enigo`). On macOS, injecting keystrokes into another app requires Accessibility,
so auto-paste-by-default makes a fresh install ask for Accessibility before it
does anything useful. Copying to the clipboard needs no permission at all.

This defaults `output.transcription.cursor` to `false`: out of the box a
transcript lands on the clipboard and you paste it yourself. Auto-paste is still
one toggle away in Settings for anyone who wants it (and grants Accessibility).
It matches what the web build already does, and it's the first step toward a
default experience that needs no Accessibility grant.

Note: this changes the default for existing users who relied on auto-paste
without explicitly enabling it. Their transcripts now copy to the clipboard
until they re-enable "paste at cursor" in Settings.

## Changelog

Transcripts now copy to your clipboard by default instead of pasting at your
cursor. To paste automatically, turn on "paste at cursor" in Settings (macOS
will ask for Accessibility).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784365400&installation_id=128463665&pr_number=2094&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2094&signature=28eb845117139e7c6ded8cba787415b41d26c364ed6ec7f4e853fa92e91edd02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->