### PR TITLE
refactor(matter): the SQLite mirror's identity is the stem, not the filename

### DIFF
--- a/apps/matter/src/lib/components/TableGrid.svelte
+++ b/apps/matter/src/lib/components/TableGrid.svelte
@@ -14,6 +14,7 @@
 	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 	import type { Kind } from '@epicenter/field';
 	import type { Cell } from '$lib/core/conformance';
+	import { stemOf } from '$lib/core/parse';
 	import type {
 		ReferenceVerdict,
 		TableAssessment,
@@ -72,8 +73,8 @@
 		return referenceVerdicts.get(fileName)?.get(fieldName);
 	}
 
-	// The file names the WHERE clause matched, or undefined when no clause is active.
-	const matchedFileNames = $derived(filter?.matchedFileNames);
+	// The row stems the WHERE clause matched, or undefined when no clause is active.
+	const matchedStems = $derived(filter?.matchedStems);
 
 	const read = $derived(table.read);
 	const folder = $derived(table.folderName);
@@ -88,11 +89,11 @@
 
 	const filteredRows = $derived.by(() => {
 		if (view.mode !== 'typed') return [];
-		// The WHERE filter (matched row file names from the mirror, computed by the page)
+		// The WHERE filter (matched row stems from the mirror, computed by the page)
 		// narrows the visible set; no active filter leaves it undefined, nothing to do. The
 		// local alias is load-bearing: it narrows `Set | undefined` to `Set` in the closure.
-		const fileNames = matchedFileNames;
-		if (fileNames) return view.conformance.filter((c) => fileNames.has(c.row.fileName));
+		const stems = matchedStems;
+		if (stems) return view.conformance.filter((c) => stems.has(stemOf(c.row.fileName)));
 		return view.conformance;
 	});
 
@@ -103,29 +104,29 @@
 	});
 
 	// "X of Y rows" whenever a lens is narrowing the table (attention OR a WHERE clause).
-	const isFiltered = $derived(rowFilter !== 'all' || matchedFileNames !== undefined);
+	const isFiltered = $derived(rowFilter !== 'all' || matchedStems !== undefined);
 
 	// The typed empty-state copy as ONE mutually exclusive decision, so the title and the
 	// description always describe the same case. Reads top-down like the question a person
 	// asks ("is a filter on? is attention on? otherwise it is just empty") instead of two
 	// nested ternaries in the markup that have to be kept in sync by hand.
 	const emptyState = $derived.by(() => {
-		if (matchedFileNames && filteredRows.length === 0)
+		if (matchedStems && filteredRows.length === 0)
 			return {
 				title: 'No rows match the filter',
 				description: 'No rows match this WHERE clause.',
 			};
 		if (rowFilter === 'attention')
 			return {
-				title: matchedFileNames ? 'No matching rows need attention' : 'No rows need attention',
-				description: matchedFileNames
+				title: matchedStems ? 'No matching rows need attention' : 'No rows need attention',
+				description: matchedStems
 					? 'Rows matched by this WHERE clause are valid.'
 					: 'Every readable row matches this contract.',
 			};
 		if (rowFilter === 'ready')
 			return {
-				title: matchedFileNames ? 'No matching ready rows' : 'No ready rows',
-				description: matchedFileNames
+				title: matchedStems ? 'No matching ready rows' : 'No ready rows',
+				description: matchedStems
 					? 'Rows matched by this WHERE clause need attention.'
 					: 'Fix required or invalid fields to make rows ready.',
 			};

--- a/apps/matter/src/lib/core/sqlite.test.ts
+++ b/apps/matter/src/lib/core/sqlite.test.ts
@@ -62,12 +62,12 @@ const invalid: Row = {
 };
 
 describe('schema script (DROP + CREATE, one execute_batch)', () => {
-	test('drops then recreates: file PK, one nullable column per field by storage class, _extra JSON', () => {
+	test('drops then recreates: stem PK, one nullable column per field by storage class, _extra JSON', () => {
 		const { schema } = projectToSqlite('posts', m, []);
 		expect(schema).toBe(
 			'DROP TABLE IF EXISTS "posts";\n' +
 				'CREATE TABLE "posts" (' +
-				'"file" TEXT PRIMARY KEY, ' +
+				'"stem" TEXT PRIMARY KEY, ' +
 				'"title" TEXT, ' +
 				'"status" TEXT, ' +
 				'"count" INTEGER, ' +
@@ -99,10 +99,10 @@ describe('insert template (one ? per column, bound positionally)', () => {
 		const { insert } = projectToSqlite('posts', m, []);
 		expect(insert).toBe(
 			'INSERT INTO "posts" (' +
-				'"file", "title", "status", "count", "score", "live", "tags", "url", "_extra"' +
+				'"stem", "title", "status", "count", "score", "live", "tags", "url", "_extra"' +
 				') VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
 		);
-		// name + 7 typed fields + _extra = 9 placeholders.
+		// stem + 7 typed fields + _extra = 9 placeholders.
 		expect((insert.match(/\?/g) ?? []).length).toBe(9);
 	});
 });
@@ -113,13 +113,13 @@ describe('rows (every readable row, serialized by conformance state)', () => {
 
 	test('valid AND incomplete rows both project, in folder order', () => {
 		expect(proj.rows).toHaveLength(2);
-		expect(proj.rows.map((r) => r[0])).toEqual(['post-1.md', 'post-2.md']);
+		expect(proj.rows.map((r) => r[0])).toEqual(['post-1', 'post-2']);
 	});
 
 	test('an OK cell is serialized to its storage class', () => {
-		const [file, title, status, count, score, live, tags, url, extra] =
+		const [stem, title, status, count, score, live, tags, url, extra] =
 			proj.rows[0]!;
-		expect(file).toBe('post-1.md');
+		expect(stem).toBe('post-1');
 		expect(title).toBe('Hello');
 		expect(status).toBe('draft');
 		expect(count).toBe(3); // INTEGER stays a number
@@ -131,8 +131,8 @@ describe('rows (every readable row, serialized by conformance state)', () => {
 	});
 
 	test('a missing required cell binds NULL (the draft is still a row)', () => {
-		const [file, title, status, count, , , tags, url, extra] = proj.rows[1]!;
-		expect(file).toBe('post-2.md');
+		const [stem, title, status, count, , , tags, url, extra] = proj.rows[1]!;
+		expect(stem).toBe('post-2');
 		expect(title).toBe('Partial');
 		expect(status).toBeNull();
 		expect(count).toBeNull();
@@ -161,13 +161,13 @@ describe('rows (every readable row, serialized by conformance state)', () => {
 			'MISSING_OPTIONAL',
 		]);
 		const p = projectToSqlite('posts', optionalContract, conformance);
-		expect(p.rows[0]).toEqual(['person.md', 'Alice', null, '{}']);
+		expect(p.rows[0]).toEqual(['person', 'Alice', null, '{}']);
 	});
 
 	test('an out-of-domain cell keeps its raw value so the draft stays filterable', () => {
 		const p = projectToSqlite('posts', m, classifyRows(m.fields, [invalid]));
-		const [file, title, status, count] = p.rows[0]!;
-		expect(file).toBe('post-3.md');
+		const [stem, title, status, count] = p.rows[0]!;
+		expect(stem).toBe('post-3');
 		expect(title).toBe('Bad');
 		expect(status).toBe('bogus'); // not in the enum, kept raw
 		expect(count).toBe(1.5); // not an integer, kept raw
@@ -200,29 +200,30 @@ describe('projects a vault into one db whose tables JOIN', () => {
 			for (const row of rows) stmt.run(...row);
 		}
 
-		// `adaptations.page` holds a page's basename (no extension); the mirror's `file` column keeps
-		// the `.md`, so the JOIN key is `page || '.md' = file`. An INNER JOIN naturally drops the
-		// deliberately-dangling orphan-adaptation (page `ghost-page`, which has no pages row).
+		// `adaptations.page` holds a page's stem (basename, no extension), and the mirror's `stem`
+		// column IS that same reference identity, so the JOIN key is just `a.page = p.stem` — no
+		// `.md` juggling. An INNER JOIN naturally drops the deliberately-dangling orphan-adaptation
+		// (page `ghost-page`, which has no pages row).
 		const joined = db
 			.query(
-				`SELECT a."file" AS adaptation, p."file" AS page
-				 FROM adaptations a JOIN pages p ON a."page" || '.md' = p."file"
-				 ORDER BY a."file"`,
+				`SELECT a."stem" AS adaptation, p."stem" AS page
+				 FROM adaptations a JOIN pages p ON a."page" = p."stem"
+				 ORDER BY a."stem"`,
 			)
 			.all() as { adaptation: string; page: string }[];
 
 		expect(joined).toEqual([
 			{
-				adaptation: 'become-the-source-carousel.md',
-				page: 'become-the-source.md',
+				adaptation: 'become-the-source-carousel',
+				page: 'become-the-source',
 			},
 			{
-				adaptation: 'become-the-source-thread.md',
-				page: 'become-the-source.md',
+				adaptation: 'become-the-source-thread',
+				page: 'become-the-source',
 			},
 			{
-				adaptation: 'plan-yourself-short.md',
-				page: 'how-we-plan-ourselves.md',
+				adaptation: 'plan-yourself-short',
+				page: 'how-we-plan-ourselves',
 			},
 		]);
 	});

--- a/apps/matter/src/lib/core/sqlite.ts
+++ b/apps/matter/src/lib/core/sqlite.ts
@@ -30,6 +30,7 @@
 import { type Field, storageOf } from '@epicenter/field';
 import type { RowConformance } from './conformance';
 import type { Contract } from './contract';
+import { stemOf } from './parse';
 
 /** A SQLite-bindable scalar. Missing cells bind NULL, so values are nullable. */
 export type SqlValue = string | number | null;
@@ -101,14 +102,16 @@ function serializeInvalid(value: unknown): SqlValue {
 }
 
 /**
- * Build the `CREATE TABLE` for a folder: `file` primary key (the row's basename
- * identity), one NULLABLE column per typed field (typed by its storage class so the
- * filter coerces by affinity; a missing cell binds NULL), and an `_extra` JSON column
- * (always present) for the untyped keys, so an agent can see extras too.
+ * Build the `CREATE TABLE` for a folder: `stem` primary key (the row's reference
+ * identity, basename without `.md` — the exact value a reference field stores, so a
+ * cross-table JOIN matches references directly with no `.md` juggling), one NULLABLE
+ * column per typed field (typed by its storage class so the filter coerces by affinity;
+ * a missing cell binds NULL), and an `_extra` JSON column (always present) for the
+ * untyped keys, so an agent can see extras too.
  */
 function buildDdl(tableName: string, fields: readonly Field[]): string {
 	const defs = [
-		`${quoteIdent('file')} TEXT PRIMARY KEY`,
+		`${quoteIdent('stem')} TEXT PRIMARY KEY`,
 		...fields.map((c) => `${quoteIdent(c.name)} ${storageOf(c.kind)}`),
 		`${quoteIdent('_extra')} TEXT NOT NULL`,
 	];
@@ -128,7 +131,7 @@ export function projectToSqlite(
 	contract: Contract,
 	conformance: readonly RowConformance[],
 ): SqliteProjection {
-	const columns = ['file', ...contract.fields.map((c) => c.name), '_extra'];
+	const columns = ['stem', ...contract.fields.map((c) => c.name), '_extra'];
 	const rows = conformance.map((c) => {
 		const cells = c.cells.map((cell): SqlValue => {
 			switch (cell.state) {
@@ -146,7 +149,7 @@ export function projectToSqlite(
 		const extra = JSON.stringify(
 			Object.fromEntries(c.extras.map((e) => [e.key, e.value])),
 		);
-		return [c.row.fileName, ...cells, extra];
+		return [stemOf(c.row.fileName), ...cells, extra];
 	});
 
 	const placeholders = columns.map(() => '?').join(', ');

--- a/apps/matter/src/lib/mirror.svelte.ts
+++ b/apps/matter/src/lib/mirror.svelte.ts
@@ -76,15 +76,16 @@ export function createMirror(root: string) {
 	}
 
 	/**
-	 * Run a WHERE clause against one folder's SQL table and return the matching file names. The clause
-	 * is the user's own raw SQL against their own read-only local db, so the worst a bad clause does is
-	 * return an error. No limit: a name-only filter returns every match, never a silent cap.
+	 * Run a WHERE clause against one folder's SQL table and return the matching row stems (the table's
+	 * `stem` primary key, the row's reference identity). The clause is the user's own raw SQL against
+	 * their own read-only local db, so the worst a bad clause does is return an error. No limit: a
+	 * name-only filter returns every match, never a silent cap.
 	 */
 	function query(
 		name: string,
 		where: string,
 	): Promise<Result<Set<string>, { message: string }>> {
-		const sql = `SELECT "file" FROM ${quoteIdent(name)} WHERE ${where}`;
+		const sql = `SELECT "stem" FROM ${quoteIdent(name)} WHERE ${where}`;
 		return tryAsync({
 			try: async () => {
 				const { rows } = await invoke<{ rows: unknown[][] }>('query_mirror', {

--- a/apps/matter/src/lib/where-filter.svelte.ts
+++ b/apps/matter/src/lib/where-filter.svelte.ts
@@ -2,9 +2,9 @@
  * The per-tab SQL WHERE filter over one table's slice of the vault mirror.
  *
  * Bundles the three things a filter is, the input (`text`), the result
- * (`matchedFileNames`), and a bad-clause `error`, plus the debounced query and its own
+ * (`matchedStems`), and a bad-clause `error`, plus the debounced query and its own
  * reactive lifecycle, into ONE unit. TableGrid binds `filter.text` and reads
- * `filter.matchedFileNames` instead of carrying three loose `$state`s and a standing effect
+ * `filter.matchedStems` instead of carrying three loose `$state`s and a standing effect
  * a reader has to mentally group.
  *
  * The mirror is the query seam (the vault's SQLite projection); `tableName` names which folder's SQL
@@ -28,7 +28,7 @@ const DEBOUNCE_MS = 200;
 
 export function createWhereFilter(mirror: Mirror, tableName: () => string) {
 	let text = $state('');
-	let matchedFileNames = $state<Set<string>>();
+	let matchedStems = $state<Set<string>>();
 	let error = $state<string>();
 
 	// Resolve the current clause to matched names whenever the clause or the mirror changes.
@@ -40,7 +40,7 @@ export function createWhereFilter(mirror: Mirror, tableName: () => string) {
 		void mirror.version; // re-run after the mirror is rebuilt (downstream of row edits)
 		// Empty clause: there is no filter, so show every row.
 		if (!clause) {
-			matchedFileNames = undefined;
+			matchedStems = undefined;
 			error = undefined;
 			return;
 		}
@@ -50,7 +50,7 @@ export function createWhereFilter(mirror: Mirror, tableName: () => string) {
 			if (cancelled) return; // a newer clause, a rebuild, or this tab being torn down won
 			if (failure) error = failure.message;
 			else {
-				matchedFileNames = data;
+				matchedStems = data;
 				error = undefined;
 			}
 		}, DEBOUNCE_MS);
@@ -68,11 +68,11 @@ export function createWhereFilter(mirror: Mirror, tableName: () => string) {
 		set text(value: string) {
 			text = value;
 		},
-		/** The names the clause matched, or `undefined` when no clause is active. */
-		get matchedFileNames() {
-			return matchedFileNames;
+		/** The stems the clause matched, or `undefined` when no clause is active. */
+		get matchedStems() {
+			return matchedStems;
 		},
-		/** A bad clause's message; the last good `matchedFileNames` is kept until it parses. */
+		/** A bad clause's message; the last good `matchedStems` is kept until it parses. */
 		get error() {
 			return error;
 		},


### PR DESCRIPTION
The per-vault SQLite mirror keyed each row on the filename **with** `.md` (a `file` primary key holding `become-the-source.md`). But a reference resolves by **stem** (`page: become-the-source`). So the cross-table JOIN that the per-vault mirror exists to enable could not match a reference to its target without hand-appending the extension:

```sql
-- before: the stored key (file, with .md) ≠ the reference value (stem)
... JOIN pages p ON a."page" || '.md' = p."file"
```

This makes the mirror's primary key the **`stem`** (the row's reference identity, basename without `.md`), so a reference JOINs its target directly:

```sql
-- after: the join key IS the reference identity
SELECT a.stem AS adaptation, p.stem AS page
FROM adaptations a JOIN pages p ON a."page" = p."stem"
```

The reason for this shape is:

The repo's own model says *"identity is the stem; no id is minted"* (`parse.ts`, the spec, the reference validator). But the implementation stored a **second** identity in the mirror — the filename-with-`.md` — and the two only ever met at the cross-table JOIN, where the seam showed as a `|| '.md'` hack. That hack was the messenger; two identities for one row was the problem.

This collapses them to one. `.md` is a **storage detail**, not identity, so it's now confined to the **disk handle** (`Row.fileName`, used only by the grid's row label, the save path, and the watcher). The **queryable/reference surface** — the mirror PK, the WHERE filter's result, and references — is pure stem.

## Shape

- `core/sqlite.ts`: the projected PK column is `stem` (value `stemOf(row.fileName)`), not `file`.
- `mirror.svelte.ts`: the WHERE filter queries `SELECT "stem"`.
- `where-filter.svelte.ts`: returns `matchedStems`.
- `TableGrid.svelte`: matches rows via the canonical `stemOf(row.fileName)`.
- `core/sqlite.test.ts`: the content-vault JOIN test drops `|| '.md'` and asserts `ON a."page" = p."stem"`.

## Refusals

- **No second `file` column.** An agent that wants the filename writes `stem || '.md'` — folders are `.md`-only (`watch.rs` gates on `name.ends_with(".md")`), so a redundant stored column would only be drift.
- **No reconstruction.** Nothing rebuilds `stem + '.md'`; the disk handle (`fileName`) is kept as the watcher delivered it. We only derive stem ← filename (one direction, via the single-source `stemOf`).

Follow-up to #2090 (the per-vault mirror), settling the one rough edge that PR left in its cross-table query surface.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784367055&installation_id=128463665&pr_number=2095&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2095&signature=85010fa1bf26dd987680ede4ebeb279c9ddff82a5a95fa39cc73602b5e5256cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->