### PR TITLE
feat(whispering): quick capture-behavior popover on the home pipeline row

### DIFF
--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -49,6 +49,7 @@
 	import { viewTransition } from '$lib/utils/viewTransitions';
 	import studioMicrophone from '$lib/assets/studio-microphone.png';
 	import { tauri } from '#platform/tauri';
+	import CaptureBehaviorPopover from './_components/CaptureBehaviorPopover.svelte';
 	import CapturePipeline from './_components/CapturePipeline.svelte';
 	import ManualRecordingAction from './_components/ManualRecordingAction.svelte';
 	import VadRecordingAction from './_components/VadRecordingAction.svelte';
@@ -242,6 +243,7 @@
 				<TransformationSelector
 					iconViewTransitionName={transformationViewTransitionName}
 				/>
+				<CaptureBehaviorPopover />
 			</CapturePipeline>
 		{/snippet}
 
@@ -257,6 +259,7 @@
 				<TransformationSelector
 					iconViewTransitionName={transformationViewTransitionName}
 				/>
+				<CaptureBehaviorPopover />
 			</CapturePipeline>
 		{/snippet}
 

--- a/apps/whispering/src/routes/(app)/_components/CaptureBehaviorPopover.svelte
+++ b/apps/whispering/src/routes/(app)/_components/CaptureBehaviorPopover.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { Button } from '@epicenter/ui/button';
+	import * as Popover from '@epicenter/ui/popover';
+	import SlidersHorizontalIcon from '@lucide/svelte/icons/sliders-horizontal';
+	import { SettingSwitch } from '$lib/components/settings';
+
+	// Quick access to the per-session capture behaviors that otherwise live in
+	// Settings. The trailing bookend of the capture pipeline row, matching the
+	// device/model/transformation popover grammar. Booleans only: pickers stay as
+	// pills, set-and-forget config stays in Settings. Each switch reuses the same
+	// SettingSwitch as the Settings page, so home and Settings write one source of
+	// truth with no drift.
+	let open = $state(false);
+</script>
+
+<Popover.Root bind:open>
+	<Popover.Trigger>
+		{#snippet child({ props })}
+			<Button
+				{...props}
+				tooltip="More options"
+				aria-label="More options"
+				aria-expanded={open}
+				variant="ghost"
+				size="icon"
+			>
+				<SlidersHorizontalIcon class="size-4" />
+			</Button>
+		{/snippet}
+	</Popover.Trigger>
+	<Popover.Content class="w-80">
+		<div class="flex flex-col gap-3">
+			<SettingSwitch
+				key="recording.pausePlayback"
+				label="Pause playback while recording"
+				description="Pause music or video while your voice is captured, then resume it."
+			/>
+			<SettingSwitch
+				key="output.transcription.cursor"
+				label="Paste at cursor"
+				description="Paste the transcript where your cursor is, not just copy it to the clipboard."
+			/>
+		</div>
+	</Popover.Content>
+</Popover.Root>

--- a/bun.lock
+++ b/bun.lock
@@ -3141,7 +3141,7 @@
 
     "nano-spawn": ["nano-spawn@2.1.0", "", {}, "sha512-yTW+2okrElHiH4fsiz/+/zc0EDo9BDDoC3iKk8dpv1GeRc9nUWzUZHx6TofMWErchhUQR8hY9/Eu1Uja9x1nqA=="],
 
-    "nanoid": ["nanoid@3.3.13", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q=="],
+    "nanoid": ["nanoid@5.1.14", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-5c8l8kVzqpnDPaicbEop/fV0Q1w16FmbWtVhMqugTozAwYdlIQojWH5a/M7UfziFmGdQRrUdV+EPzc9Xng3VAQ=="],
 
     "nanospinner": ["nanospinner@1.2.2", "", { "dependencies": { "picocolors": "^1.1.1" } }, "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA=="],
 


### PR DESCRIPTION
The home pipeline row is where recording actually happens, but a few runtime capture behaviors still lived only in Settings. That made pause-playback especially awkward after the default-on change: the user needed a quick "not right now" escape without leaving the recording surface.

This adds a trailing `sliders-horizontal` ghost icon to the manual and VAD pipeline rows. The icon opens `CaptureBehaviorPopover`, a small per-session behavior surface that mirrors the existing device, model, and transformation popover grammar with `Popover.Root` and a ghost `Button` trigger.

The popover hosts only per-session behavioral booleans:

- `recording.pausePlayback`
- `output.transcription.cursor` (paste at cursor)

It reuses the Settings page's `SettingSwitch`, so home and Settings write the same workspace-KV keys. Pickers stay as pills, and set-and-forget configuration stays in Settings. The file-import pipeline does not render the popover because it has no live capture behavior to toggle.

This is part of the playback-pause UX pass in `apps/whispering/specs/20260618T113342-playback-pause-speaking-window.md`, independent of the default-on PR and the VAD per-utterance change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784407771&installation_id=128463665&pr_number=2098&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2098&signature=b704edaf25553845905e4673a53772b55a9efafa281c72202e4bb20cb0d9c7b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
