### PR TITLE
feat(whispering): VAD pauses playback per utterance, not per armed session

### DIFF
--- a/apps/whispering/src/lib/operations/recording.ts
+++ b/apps/whispering/src/lib/operations/recording.ts
@@ -76,6 +76,9 @@ export async function startManualRecording() {
 		description: 'Setting up your recording environment...',
 	});
 
+	// Manual owns playback for the whole recording; drop any leftover VAD
+	// per-utterance resume so it cannot fire mid-recording.
+	cancelPendingVadResume();
 	recordingMedia.pause();
 
 	const { data: outcome, error } = await manualRecorder.startRecording();
@@ -184,6 +187,46 @@ export async function cancelRecording() {
 	if (isVadRecordingActive()) await stopVadRecording();
 }
 
+// VAD pauses playback per utterance (the speaking window), not for the whole
+// armed session: music keeps playing while you are armed-and-silent and stops
+// only while you actually speak. A return to listening (speech end or a misfire)
+// schedules a debounced resume so back-to-back utterances do not flutter the
+// music; the next speech start cancels that pending resume. Ending the session
+// resumes immediately. See ADR-0021.
+let vadResumeTimer: ReturnType<typeof setTimeout> | undefined;
+const VAD_RESUME_DELAY_MS = 1500;
+
+function pausePlaybackForSpeech() {
+	clearTimeout(vadResumeTimer);
+	vadResumeTimer = undefined;
+	recordingMedia.pause();
+}
+
+function scheduleResumeAfterSpeech() {
+	clearTimeout(vadResumeTimer);
+	vadResumeTimer = setTimeout(() => {
+		vadResumeTimer = undefined;
+		void recordingMedia.resume();
+	}, VAD_RESUME_DELAY_MS);
+}
+
+/** Resume now and drop any pending debounce: the VAD session is ending. */
+function resumePlaybackForVadEnd() {
+	clearTimeout(vadResumeTimer);
+	vadResumeTimer = undefined;
+	void recordingMedia.resume();
+}
+
+/**
+ * Drop a pending VAD resume without resuming. Used when a manual recording
+ * starts: manual owns playback for its whole window, so a debounce left over
+ * from a prior VAD utterance must not fire and resume music mid-recording.
+ */
+function cancelPendingVadResume() {
+	clearTimeout(vadResumeTimer);
+	vadResumeTimer = undefined;
+}
+
 export async function startVadRecording() {
 	settings.set('recording.trigger', 'vad');
 	// A capture just started, so leave the import overlay if it was open (see
@@ -202,17 +245,20 @@ export async function startVadRecording() {
 		description: 'Your voice activated capture is starting...',
 	});
 
-	recordingMedia.pause();
-
 	const { data: outcome, error } = await vadRecorder.startActiveListening({
 		onLevel: (level) => recordingOverlay.reportLevel(level),
 		onSpeechStart: () => {
+			// Speaking window opened: pause whatever is playing.
+			pausePlaybackForSpeech();
 			report.success({
 				title: 'Speech started',
 				description: 'Recording started. Speak clearly and loudly.',
 			});
 		},
 		onSpeechEnd: async (blob) => {
+			// Speaking window closed: resume after a short debounce so a quick
+			// next utterance does not flutter the music.
+			scheduleResumeAfterSpeech();
 			report.success({
 				title: 'Voice activated speech captured',
 				description: 'Your voice activated speech has been captured.',
@@ -235,10 +281,14 @@ export async function startVadRecording() {
 				durationMs: null,
 			});
 		},
+		onVADMisfire: () => {
+			// False start: undo the pause we took on speech start.
+			scheduleResumeAfterSpeech();
+		},
 	});
 
 	if (error) {
-		void recordingMedia.resume();
+		resumePlaybackForVadEnd();
 		loading.reject({ cause: error });
 		return;
 	}
@@ -265,7 +315,7 @@ export async function stopVadRecording() {
 	});
 	const { data, error } = await vadRecorder.stopActiveListening();
 	if (error) {
-		void recordingMedia.resume();
+		resumePlaybackForVadEnd();
 		loading.reject({ cause: error });
 		return;
 	}
@@ -273,13 +323,15 @@ export async function stopVadRecording() {
 		title: 'Voice activated capture stopped',
 		description: 'Your voice activated capture has been stopped.',
 	};
+	// Disarming ends the session: restore playback now, do not wait on the
+	// per-utterance debounce.
+	resumePlaybackForVadEnd();
 	if (data.status === 'idle') {
 		loading.resolve(stoppedNotice);
 		return;
 	}
 	loading.resolve(stoppedNotice);
 	sound.playSoundIfEnabled('vad-stop');
-	void recordingMedia.resume();
 }
 
 export function toggleVadRecording() {

--- a/apps/whispering/src/lib/operations/recording.ts
+++ b/apps/whispering/src/lib/operations/recording.ts
@@ -282,7 +282,8 @@ export async function startVadRecording() {
 			});
 		},
 		onVADMisfire: () => {
-			// False start: undo the pause we took on speech start.
+			// False start: schedule the same debounced resume as a real speech
+			// end, so an immediate retry does not flutter the music.
 			scheduleResumeAfterSpeech();
 		},
 	});

--- a/apps/whispering/src/lib/operations/recording.ts
+++ b/apps/whispering/src/lib/operations/recording.ts
@@ -192,7 +192,7 @@ export async function cancelRecording() {
 // only while you actually speak. A return to listening (speech end or a misfire)
 // schedules a debounced resume so back-to-back utterances do not flutter the
 // music; the next speech start cancels that pending resume. Ending the session
-// resumes immediately. See ADR-0021.
+// resumes immediately. See ADR-0027.
 let vadResumeTimer: ReturnType<typeof setTimeout> | undefined;
 const VAD_RESUME_DELAY_MS = 1500;
 

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
@@ -53,7 +53,7 @@
 		<SettingSwitch
 			key="recording.pausePlayback"
 			label="Pause playback while recording"
-			description="When recording starts, Whispering pauses media playing on your computer (music, video, browser tabs) and resumes it when you stop. Works with most apps that appear in your system media controls; a few apps can't be paused this way."
+			description="Whispering pauses media playing on your computer (music, video, browser tabs) while your voice is being captured, and resumes it after. In voice activated mode it pauses only while you actually speak, so music keeps playing between phrases. Works with most apps in your system media controls; a few can't be paused this way."
 		/>
 
 		{#if settings.get('recording.trigger') === 'manual'}

--- a/docs/adr/0027-playback-pause-tracks-the-speaking-window.md
+++ b/docs/adr/0027-playback-pause-tracks-the-speaking-window.md
@@ -1,0 +1,81 @@
+# 0027. Playback pause tracks the speaking window; VAD pauses per utterance
+
+- **Status:** Accepted
+- **Date:** 2026-06-18
+
+## Context
+
+[ADR-0017](0017-pause-system-media-playback-while-recording.md) decided that
+Whispering pauses system media while recording, and that VAD pauses for the
+**whole armed listening session** (pause on arm, resume on disarm). It rejected
+per-utterance VAD pausing on a capture-quality argument: background audio
+degrades VAD detection, so pausing only during detected speech is too late.
+
+That framing assumed the feature exists to keep the *recording* clean (the mic
+must not hear the music). But the user-held reason is different and simpler:
+**hearing music while you talk disrupts dictation.** That is a courtesy concern,
+not a capture concern, and it implies headphones (you hear your own music). On
+headphones the recording is already clean (the mic never hears the music), so
+ADR-0017's capture-quality rationale does not apply, and its degradation
+objection dissolves: VAD detection is clean because the mic hears no music.
+
+Under arm-time pausing, an always-armed "listen from anywhere" VAD session keeps
+your music dead for its entire duration, including the long idle gaps between
+dictations. That violates the actual invariant, which only asks for silence
+*while speaking*.
+
+## Decision
+
+Pause playback only while the user's voice is being captured (the **speaking
+window**), and derive the per-mode behavior from that one rule:
+
+- **Manual** (press-to-talk): the whole press -> release hold *is* the speaking
+  window. Pause for the whole recording. **Unchanged from ADR-0017.**
+- **VAD**: the speaking window is each **detected utterance**. Pause on
+  `onSpeechStart`, resume on `onSpeechEnd`. The arm-time pause is removed.
+
+Resume after speech end is **debounced** (~1.5 s) so back-to-back utterances do
+not flutter the music; the next `onSpeechStart` cancels the pending resume, a
+misfire schedules it, and ending the session (disarm, stop, or starting a manual
+recording) resumes immediately and drops the debounce. The debounce timer is
+owned by the VAD coupling in `operations/recording.ts`, not by the playback
+chain in `operations/media.ts`, which stays a dumb serialized pause/resume chain
+so manual keeps its immediate resume.
+
+ADR-0017's cross-platform machinery is unchanged: the `pause_playback` /
+`resume_playback` command pair, the opaque session tokens, the per-OS modules,
+and the "only resume what we paused" invariant all stand. Only the *when* for
+VAD changes.
+
+## Consequences
+
+- The always-armed VAD workflow keeps playing music except while you actually
+  speak, which is the behavior the invariant asks for.
+- **Accepted limitation: VAD on speakers degrades.** With music on speakers the
+  mic hears it during the armed-idle gaps, so (a) VAD onset detection is worse
+  and (b) the first ~200 ms of each utterance plays over the music before the
+  async pause lands. This is the exact case ADR-0017 protected and we are
+  trading it away. We assume headphones (the invariant's premise) and **do not**
+  detect output routing: auto-detecting headphone-vs-speaker to branch behavior
+  re-introduces the two behaviors this collapse removed and is fragile across
+  OSes. The quick-toggle popover and the Settings switch are the escape hatch
+  for anyone who wants playback left alone.
+- Manual recording is untouched, so the press-to-talk experience is identical.
+
+## Considered alternatives
+
+- **Keep arm-time pausing (ADR-0017 as written).** Correct for VAD on speakers,
+  but it kills music for the whole armed session, which is the wart the invariant
+  rejects. Chosen against because the held reason is courtesy on headphones, not
+  capture on speakers.
+- **Detect headphones vs speakers and branch.** Would let speakers keep
+  arm-time and headphones get per-utterance, but it un-collapses the design back
+  into two behaviors and depends on fragile, OS-specific output-routing reads.
+  Refused.
+- **Duck (lower) volume instead of pausing.** Gentler, but the system media APIs
+  (MediaRemote / GSMTC / MPRIS) expose pause, not per-session volume, and ducking
+  does not actually clean a speaker recording. Out of scope.
+- **No debounce (resume immediately on speech end).** Flutters the music on
+  every pause between phrases. The debounce is the cheap fix.
+
+This revises ADR-0017's VAD-timing decision; that ADR otherwise stands.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -84,7 +84,7 @@ Each option and the one reason it lost. Terse. This is not the spec.
 | [0014](0014-view-transitions-morph-a-re-expressed-glyph-not-its-container.md) | View transitions morph a re-expressed glyph, not its container | Accepted |
 | [0015](0015-the-brand-mark-has-one-canonical-source-every-other-form-is-generated.md) | The brand mark has one canonical source; every other form is generated | Proposed |
 | [0016](0016-prewarm-the-cold-model-load-and-refuse-the-rest-of-the-latency-menu.md) | Prewarm the cold model load and refuse the rest of the latency menu | Accepted |
-| [0017](0017-pause-system-media-playback-while-recording.md) | Pause system media playback while recording through one cross-platform controller | Accepted |
+| [0017](0017-pause-system-media-playback-while-recording.md) | Pause system media playback while recording through one cross-platform controller | Accepted (VAD timing revised by 0027) |
 | [0018](0018-macos-resume-is-gated-on-a-coreaudio-output-read.md) | macOS resume is gated on a CoreAudio output read, not a MediaRemote read shim | Accepted |
 | [0019](0019-global-shortcuts-have-a-permission-free-floor-and-accessibility-is-an-opt-in-tier.md) | Global shortcuts have a permission-free floor; Accessibility is an opt-in tier | Accepted |
 | [0020](0020-macos-drives-its-keyboard-tap-with-an-owned-cgeventtap.md) | macOS drives its keyboard tap with an owned CGEventTap, not the rdev fork | Accepted |
@@ -94,5 +94,6 @@ Each option and the one reason it lost. Terse. This is not the spec.
 | [0024](0024-an-always-on-actor-runs-app-semantics-beside-the-app-blind-anchor.md) | An always-on actor runs app semantics beside the app-blind anchor | Proposed |
 | [0025](0025-agent-conversations-are-durable-child-docs-driven-by-an-observing-actor.md) | Agent conversations are durable child docs driven by an observing actor | Proposed |
 | [0026](0026-matter-vault-sqlite-is-a-projection-never-a-verdict-source.md) | The Matter vault's SQLite mirror is a read-only projection, never a verdict source | Accepted |
+| [0027](0027-playback-pause-tracks-the-speaking-window.md) | Playback pause tracks the speaking window; VAD pauses per utterance | Accepted |
 
 When you add an ADR, add its row here.


### PR DESCRIPTION
Pausing playback for an entire armed VAD session is too broad. An always-armed "listen from anywhere" session can sit idle for long stretches, and killing music during those gaps makes the pause feature feel broken even though the user is not speaking.

This changes VAD to pause playback only during the speaking window. `operations/recording.ts` stops pausing at arm time; it now pauses on `onSpeechStart` and resumes after `onSpeechEnd` with a roughly 1.5 second debounce so back-to-back utterances do not flutter the music. A new speech start cancels a pending resume, a misfire schedules one, and ending the session through stop, error, or a manual recording resumes immediately and drops the timer. Manual recording keeps its existing whole-recording behavior because the press-to-talk hold is the speaking window.

The debounce belongs in `operations/recording.ts`, not `operations/media.ts`, because media stays a dumb serialized pause/resume chain and manual capture still needs immediate resume semantics.

## Trade-Off

VAD on speakers degrades under this model: the mic hears music during armed-idle gaps, onset detection gets noisier, and the first slice of each utterance can play over music before the async pause lands. The decision assumes headphones, which is the premise that makes pause-playback useful in the first place, and deliberately avoids detecting output routing. The Settings switch and the home-row quick toggle remain the escape hatch.

This records the revised decision as ADR-0021, superseding ADR-0017's VAD-timing call. It is the final PR in the playback-pause UX pass; the draft spec `apps/whispering/specs/20260618T113342-playback-pause-speaking-window.md` should be deleted once the pass lands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784408199&installation_id=128463665&pr_number=2102&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2102&signature=f32955ebf762008ef46757f4db2904592c542621d312cad0cc3704a4565ff873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
