### PR TITLE
feat(whispering): output delivery toggles in the capture popover

### DIFF
--- a/apps/whispering/src/lib/components/OutputDeliveryControls.svelte
+++ b/apps/whispering/src/lib/components/OutputDeliveryControls.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+	import { Button } from '@epicenter/ui/button';
+	import LockIcon from '@lucide/svelte/icons/lock';
+	import {
+		clipboardFallback,
+		pasteBack,
+	} from '$lib/components/accessibility-feature-copy';
+	import { openSystemSettings } from '$lib/components/MacosAccessibilityGuideDialog.svelte';
+	import { SettingSwitch } from '$lib/components/settings';
+	import { dictationCapability } from '$lib/state/dictation-capability.svelte';
+	import type { BooleanSettingKey } from '$lib/state/settings.svelte';
+	import { settings } from '$lib/state/settings.svelte';
+	import { tauri } from '#platform/tauri';
+
+	// One scope's full output delivery UI: copy to clipboard, paste at cursor (with
+	// its macOS Accessibility notice), and the dependent "press Enter" sub-toggle.
+	// These three always travel together because delivery.ts routes both the
+	// transcription and transformation scopes through the same path (clipboard,
+	// then a synthetic Cmd+V for cursor, then Enter), so the same trio and the same
+	// Accessibility caveat apply to both. Driving every surface (the two Settings
+	// output groups and the home capture popover) from this one component keeps the
+	// labels, the remediation copy, and the gating from ever drifting.
+	//
+	// Scope is the only axis that varies: the keys are `output.<scope>.*` and every
+	// label is the scope's noun plugged into one phrasing, so a label change happens
+	// in exactly one place. Paste-at-cursor stays interactive without the grant (it
+	// records intent); the capability recheck on window focus starts the paste the
+	// moment Accessibility lands, with no second visit to flip it back on.
+	type OutputScope = 'transcription' | 'transformation';
+	let { scope }: { scope: OutputScope } = $props();
+
+	const SCOPES = {
+		transcription: {
+			noun: 'transcript',
+			clipboard: 'output.transcription.clipboard',
+			cursor: 'output.transcription.cursor',
+			enter: 'output.transcription.enter',
+		},
+		transformation: {
+			noun: 'transformed text',
+			clipboard: 'output.transformation.clipboard',
+			cursor: 'output.transformation.cursor',
+			enter: 'output.transformation.enter',
+		},
+	} satisfies Record<
+		OutputScope,
+		{
+			noun: string;
+			clipboard: BooleanSettingKey;
+			cursor: BooleanSettingKey;
+			enter: BooleanSettingKey;
+		}
+	>;
+	const delivery = $derived(SCOPES[scope]);
+</script>
+
+<SettingSwitch
+	key={delivery.clipboard}
+	label={`Copy ${delivery.noun} to clipboard`}
+/>
+
+<SettingSwitch key={delivery.cursor} label={`Paste ${delivery.noun} at cursor`} />
+
+{#if tauri && dictationCapability.isUnavailable}
+	<!-- The toggle stays on and interactive (it records intent), but the paste
+	can't fire without the macOS Accessibility grant. Annotate the current
+	capability inline; offer the grant only when there is one to give (untrusted
+	or stale, not Wayland). -->
+	<div
+		class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground"
+	>
+		<LockIcon class="size-3.5 shrink-0" aria-hidden="true" />
+		<span>{pasteBack} {clipboardFallback}</span>
+		{#if dictationCapability.needsAccessibility}
+			<Button
+				variant="link"
+				class="h-auto p-0 text-sm font-normal"
+				onclick={openSystemSettings}
+			>
+				Open Settings
+			</Button>
+		{/if}
+	</div>
+{/if}
+
+{#if tauri && settings.get(delivery.cursor)}
+	<div class:opacity-50={dictationCapability.isUnavailable}>
+		<SettingSwitch
+			key={delivery.enter}
+			label={`Press Enter after pasting ${delivery.noun}`}
+		/>
+	</div>
+{/if}

--- a/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
@@ -1,19 +1,12 @@
 <script lang="ts">
 	import * as Field from '@epicenter/ui/field';
-	import { Button } from '@epicenter/ui/button';
 	import { Switch } from '@epicenter/ui/switch';
-	import LockIcon from '@lucide/svelte/icons/lock';
 	import { createMutation, createQuery } from '@tanstack/svelte-query';
-	import {
-		clipboardFallback,
-		pasteBack,
-	} from '$lib/components/accessibility-feature-copy';
-	import { openSystemSettings } from '$lib/components/MacosAccessibilityGuideDialog.svelte';
+	import OutputDeliveryControls from '$lib/components/OutputDeliveryControls.svelte';
 	import { SettingSelect, SettingSwitch } from '$lib/components/settings';
 	import { report } from '$lib/report';
 	import { autostartKeys } from '$lib/tauri/autostart-keys';
 	import { tauri } from '#platform/tauri';
-	import { dictationCapability } from '$lib/state/dictation-capability.svelte';
 	import { settings } from '$lib/state/settings.svelte';
 
 	const retentionItems = [
@@ -91,46 +84,7 @@
 				Applies immediately after an audio transcription finishes.
 			</Field.Description>
 			<Field.Group>
-				<SettingSwitch
-					key="output.transcription.clipboard"
-					label="Copy transcript to clipboard"
-				/>
-
-				<SettingSwitch
-					key="output.transcription.cursor"
-					label="Paste transcript at cursor"
-				/>
-
-				{#if tauri && dictationCapability.isUnavailable}
-					<!-- The toggle stays on and interactive (it records intent), but the
-					paste can't fire without the macOS Accessibility grant. Annotate the
-					current capability inline; offer the grant only when there is one to
-					give (untrusted or stale, not Wayland). -->
-					<div
-						class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground"
-					>
-						<LockIcon class="size-3.5 shrink-0" aria-hidden="true" />
-						<span>{pasteBack} {clipboardFallback}</span>
-						{#if dictationCapability.needsAccessibility}
-							<Button
-								variant="link"
-								class="h-auto p-0 text-sm font-normal"
-								onclick={openSystemSettings}
-							>
-								Open Settings
-							</Button>
-						{/if}
-					</div>
-				{/if}
-
-				{#if tauri && settings.get('output.transcription.cursor')}
-					<div class={dictationCapability.isUnavailable ? 'opacity-50' : ''}>
-						<SettingSwitch
-							key="output.transcription.enter"
-							label="Press Enter after pasting transcript"
-						/>
-					</div>
-				{/if}
+				<OutputDeliveryControls scope="transcription" />
 			</Field.Group>
 		</Field.Set>
 
@@ -142,22 +96,7 @@
 				Applies after you run a saved transformation on a transcription.
 			</Field.Description>
 			<Field.Group>
-				<SettingSwitch
-					key="output.transformation.clipboard"
-					label="Copy transformed text to clipboard"
-				/>
-
-				<SettingSwitch
-					key="output.transformation.cursor"
-					label="Paste transformed text at cursor"
-				/>
-
-				{#if tauri && settings.get('output.transformation.cursor')}
-					<SettingSwitch
-						key="output.transformation.enter"
-						label="Press Enter after pasting transformed text"
-					/>
-				{/if}
+				<OutputDeliveryControls scope="transformation" />
 			</Field.Group>
 		</Field.Set>
 

--- a/apps/whispering/src/routes/(app)/_components/CaptureBehaviorPopover.svelte
+++ b/apps/whispering/src/routes/(app)/_components/CaptureBehaviorPopover.svelte
@@ -2,15 +2,33 @@
 	import { Button } from '@epicenter/ui/button';
 	import * as Popover from '@epicenter/ui/popover';
 	import SlidersHorizontalIcon from '@lucide/svelte/icons/sliders-horizontal';
+	import OutputDeliveryControls from '$lib/components/OutputDeliveryControls.svelte';
 	import { SettingSwitch } from '$lib/components/settings';
+	import { captureSurface } from '$lib/state/capture-surface.svelte';
 
 	// Quick access to the per-session capture behaviors that otherwise live in
 	// Settings. The trailing bookend of the capture pipeline row, matching the
 	// device/model/transformation popover grammar. Booleans only: pickers stay as
-	// pills, set-and-forget config stays in Settings. Each switch reuses the same
-	// SettingSwitch as the Settings page, so home and Settings write one source of
-	// truth with no drift.
+	// pills, set-and-forget config stays in Settings. This is the one surface that
+	// curates a capture behavior (pause playback) next to the transcription output
+	// delivery, and both reuse the same components the Settings page renders, so
+	// there is one source of truth with no drift.
 	let open = $state(false);
+
+	// The pause window differs by mode (ADR-0027): manual holds the pause for the
+	// whole recording, VAD pauses per utterance and resumes shortly after you stop
+	// speaking. Word the description to match the surface on screen. Import shares
+	// the recording phrasing: it never captures a live speaking window, and its
+	// underlying durable trigger is the one that runs on the next capture.
+	const pausePlaybackDescription = $derived.by(() => {
+		switch (captureSurface.current) {
+			case 'vad':
+				return 'Pause music or video while you are speaking, then resume shortly after you stop.';
+			case 'manual':
+			case 'import':
+				return 'Pause music or video while you are recording, then resume when you stop.';
+		}
+	});
 </script>
 
 <Popover.Root bind:open>
@@ -33,13 +51,9 @@
 			<SettingSwitch
 				key="recording.pausePlayback"
 				label="Pause playback while recording"
-				description="Pause music or video while your voice is captured, then resume it."
+				description={pausePlaybackDescription}
 			/>
-			<SettingSwitch
-				key="output.transcription.cursor"
-				label="Paste at cursor"
-				description="Paste the transcript where your cursor is, not just copy it to the clipboard."
-			/>
+			<OutputDeliveryControls scope="transcription" />
 		</div>
 	</Popover.Content>
 </Popover.Root>


### PR DESCRIPTION
The home "More options" popover only exposed pause playback and a single paste-at-cursor toggle. It now carries the full transcription output trio, so the per-session choices people reach for most (copy to clipboard, paste at cursor, press Enter) are one click away from the capture row instead of buried in Settings.

Both Settings output groups and the popover render the same trio because delivery routes the transcription and transformation scopes through one path. That trio is now one component driven by the scope alone:

```svelte
<OutputDeliveryControls scope="transcription" />
<OutputDeliveryControls scope="transformation" />
```

It derives the setting keys (`output.<scope>.*`) and every label from the scope, so the labels cannot drift across the three surfaces, and a label change happens in exactly one place.

Folding transformation output into the same component fixed a quiet gap: pasting at the cursor is a synthetic Cmd+V that needs the macOS Accessibility grant for either scope, but only the transcription toggle warned about it. The transformation toggle was silently falling back to clipboard-only with no explanation. Now both warn inline and offer to open the grant, and the toggle stays interactive meanwhile so it records intent and starts pasting the moment Accessibility lands.

The popover's pause-playback copy is now worded per capture mode (ADR-0027): manual holds the pause for the whole recording, VAD pauses per utterance and resumes shortly after you stop speaking.

## Changelog

- The home "More options" popover now has quick toggles for copy to clipboard, paste at cursor, and press Enter after pasting, alongside pause playback.
- Paste-at-cursor for transformation output now warns when it needs macOS Accessibility, instead of silently copying to the clipboard.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784416507&installation_id=128463665&pr_number=2109&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2109&signature=a6e5f94be5f2b7d6486b0de19e11984cac7cbcf6584d104d7433f35fce0d16e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->