### PR TITLE
fix(whispering): catch web-bundle-in-Tauri loads and frame first-run setup

### DIFF
--- a/apps/whispering/src/lib/tauri.browser.ts
+++ b/apps/whispering/src/lib/tauri.browser.ts
@@ -16,4 +16,19 @@ import type { Tauri } from './tauri.tauri';
 
 export type { Tauri };
 
+// Invariant: if this web seam loaded, we are not in a Tauri runtime. A
+// violation means the build resolved the `default` (web) condition instead of
+// `tauri`, so `@tauri-apps/*` is missing from the bundle even though the
+// runtime supports it, and the app silently masquerades as the web app. The
+// usual cause is a stale `dev:web` server squatting on the dev port, which
+// `tauri dev` then connects to instead of its own. Read the raw
+// `__TAURI_INTERNALS__` marker rather than `isTauri()` from `@tauri-apps/api`,
+// which would pull Tauri into the web bundle; `typeof window` keeps it inert
+// during SSR.
+if (typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window) {
+	throw new Error(
+		'Whispering loaded its web build inside a Tauri runtime: the `tauri` Vite condition was not applied, so native capabilities are missing from the bundle. A stale `vite dev` (from `dev:web`) is usually squatting on the dev port. Stop all dev servers, delete `.svelte-kit` and `node_modules/.vite`, then relaunch with `bun run dev`.',
+	);
+}
+
 export const tauri: Tauri | null = null;

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -200,12 +200,17 @@
 	<DictationCapabilityNotice />
 
 	{#if !transcriptionReadiness.isReady}
-		<div class="w-full">
+		<div class="w-full space-y-3">
+			<div class="space-y-1">
+				<h2 class="text-base font-semibold">Set up transcription</h2>
+				<p class="text-sm text-muted-foreground">
+					{transcriptionReadiness.primaryIssue ??
+						'Choose how Whispering turns your speech into text.'}
+				</p>
+			</div>
 			<TranscriptionRuntimeConfig
 				id="home-transcription-service"
-				label="Runtime"
-				description={transcriptionReadiness.primaryIssue ??
-					'Choose a runtime and fill in the required fields.'}
+				label="Service"
 				showAdvanced={false}
 			/>
 		</div>


### PR DESCRIPTION
Two fixes to how Whispering presents itself on first run: one for a silent dev failure, one for the home setup copy.

**Fail loudly when the web bundle loads inside Tauri.** The `#platform/*` seams resolve at build time through the `tauri` Vite condition. When that condition does not apply, most often a stale `dev:web` server squatting on the dev port that `tauri dev` then connects to instead of its own, the desktop webview loads the web bundle: `tauri` is `null`, every native capability is missing, and the app silently masquerades as the web app. The visible symptom is a desktop-only transcription service reported as unavailable inside the native app. The web seam now asserts its own invariant at load: if `__TAURI_INTERNALS__` is present, it throws with the fix instructions, so the mismatch fails loudly instead of limping along. It reads the raw marker rather than importing `isTauri()` (which would pull Tauri into the web bundle and defeat the split) and stays inert during SSR.

**Frame the first-run transcription setup as a step.** The home not-ready state dropped the full service config under a jargon "Runtime" label with no framing. It now leads with a "Set up transcription" heading and the specific next step the readiness check names (download a model, add an API key, or choose a service), and labels the field "Service". First run reads as one guided step rather than a settings dump.

## Changelog

- Whispering now fails loudly with fix instructions if the desktop app accidentally loads its web build, instead of silently appearing as the web app with native features missing.
- The first-run "Set up transcription" screen leads with a clear heading and the specific next step instead of an unlabeled config dump.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784421237&installation_id=128463665&pr_number=2110&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2110&signature=04cdf5b97d7ef8ab309a33e3e299e3278f4c53edd1320012d8ae36da62795433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->