### PR TITLE
refactor(whispering): inline the home capture pipeline into each recording action

### DIFF
--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -236,41 +236,33 @@
 			{/each}
 		</ToggleGroup.Root>
 
-		{#snippet manualPipeline()}
-			<CapturePipeline>
-				<ManualDeviceSelector
-					iconViewTransitionName={viewTransition.pipeline.device}
-				/>
-				<TranscriptionSelector
-					variant="pipeline"
-					iconViewTransitionName={viewTransition.pipeline.transcription}
-				/>
-				<TransformationSelector
-					iconViewTransitionName={transformationViewTransitionName}
-				/>
-				<CaptureBehaviorPopover />
-			</CapturePipeline>
-		{/snippet}
-
-		{#snippet vadPipeline()}
-			<CapturePipeline>
-				<VadDeviceSelector
-					iconViewTransitionName={viewTransition.pipeline.device}
-				/>
-				<TranscriptionSelector
-					variant="pipeline"
-					iconViewTransitionName={viewTransition.pipeline.transcription}
-				/>
-				<TransformationSelector
-					iconViewTransitionName={transformationViewTransitionName}
-				/>
-				<CaptureBehaviorPopover />
-			</CapturePipeline>
-		{/snippet}
-
+		<!--
+			The capture pipeline is each recording action's idle footer (the action
+			hides it while live), so it's defined inline per surface. Manual and VAD
+			differ only by their device selector; each owns a distinct one backed by a
+			different recorder config. The shared tail repeats, but that keeps each
+			surface's footer co-located with the branch that already chose it, rather
+			than re-deriving the surface inside a shared snippet.
+		-->
 		{#if captureSurface.current === 'manual'}
 			<div class="flex w-full flex-col items-center gap-3">
-				<ManualRecordingAction pipeline={manualPipeline} />
+				<ManualRecordingAction>
+					{#snippet pipeline()}
+						<CapturePipeline>
+							<ManualDeviceSelector
+								iconViewTransitionName={viewTransition.pipeline.device}
+							/>
+							<TranscriptionSelector
+								variant="pipeline"
+								iconViewTransitionName={viewTransition.pipeline.transcription}
+							/>
+							<TransformationSelector
+								iconViewTransitionName={transformationViewTransitionName}
+							/>
+							<CaptureBehaviorPopover />
+						</CapturePipeline>
+					{/snippet}
+				</ManualRecordingAction>
 				{#if manualRecorder.state === 'RECORDING'}
 					<Button
 						tooltip="Cancel recording and discard audio"
@@ -285,7 +277,23 @@
 			</div>
 		{:else if captureSurface.current === 'vad'}
 			<div class="flex w-full flex-col items-center gap-3">
-				<VadRecordingAction pipeline={vadPipeline} />
+				<VadRecordingAction>
+					{#snippet pipeline()}
+						<CapturePipeline>
+							<VadDeviceSelector
+								iconViewTransitionName={viewTransition.pipeline.device}
+							/>
+							<TranscriptionSelector
+								variant="pipeline"
+								iconViewTransitionName={viewTransition.pipeline.transcription}
+							/>
+							<TransformationSelector
+								iconViewTransitionName={transformationViewTransitionName}
+							/>
+							<CaptureBehaviorPopover />
+						</CapturePipeline>
+					{/snippet}
+				</VadRecordingAction>
 			</div>
 		{:else if captureSurface.current === 'import'}
 			<div class="flex w-full flex-col items-center gap-4">


### PR DESCRIPTION
The manual and VAD capture pipelines on the home page were top-level named snippets that the recording actions consumed through a `pipeline` prop, so reading the page meant jumping from `pipeline={manualPipeline}` up to the definition.

Each pipeline is really the idle footer of its own recording action (the action hides it while recording or listening), so it now lives inline inside that action's tags via `{#snippet pipeline()}`. The active surface is decided once, by the surrounding `{#if captureSurface.current}`, and each pipeline sits with the action whose footer it is. No top-level definition, no reference hop, and no shared snippet re-deriving the surface it is already rendered inside.

The model, transformation, and behavior tail repeats across the two surfaces on purpose: two instances that may plausibly diverge read better co-located than hidden behind a shared snippet, and the only real difference between them, the device selector, stays explicit in each branch. `CapturePipeline` remains a dumb layout wrapper and the import surface is unchanged.