### PR TITLE
refactor(ai-adapters): single-home the provider house-key env var

### DIFF
--- a/apps/zhongwen/mount.ts
+++ b/apps/zhongwen/mount.ts
@@ -33,7 +33,10 @@
  * answered twice.
  */
 
-import { createAdapterForModel } from '@epicenter/ai-adapters';
+import {
+	createAdapterForModel,
+	HOUSE_KEY_ENV_VAR,
+} from '@epicenter/ai-adapters';
 import { MODELS_BY_ID } from '@epicenter/constants/ai-providers';
 import type { AgentId } from '@epicenter/workspace';
 import { attachChatWorker, type ChatStream } from '@epicenter/workspace/ai';
@@ -96,21 +99,12 @@ export function zhongwen({ baseURL, agentId }: ZhongwenMountOptions = {}) {
  * change, no code edit.
  */
 function resolveChatStream(): ChatStream {
-	// Key policy: the catalog gives the provider, the provider picks its house-key
-	// env var (exhaustive, so a new provider is a compile error here, not a silent
-	// wrong key). Construction is delegated to `@epicenter/ai-adapters`.
+	// Key policy: the catalog gives the provider, and the provider -> house-key
+	// env var mapping is single-homed in `@epicenter/ai-adapters` (exhaustive, so
+	// a new provider is a compile error there, not a silent wrong key here).
+	// Construction is delegated to the same leaf.
 	const { provider } = MODELS_BY_ID[ZHONGWEN_MODEL];
-	let envVar: 'OPENAI_API_KEY' | 'GEMINI_API_KEY';
-	switch (provider) {
-		case 'openai':
-			envVar = 'OPENAI_API_KEY';
-			break;
-		case 'gemini':
-			envVar = 'GEMINI_API_KEY';
-			break;
-		default:
-			return provider satisfies never;
-	}
+	const envVar = HOUSE_KEY_ENV_VAR[provider];
 	const apiKey = process.env[envVar];
 	if (!apiKey) {
 		log.warn(

--- a/packages/ai-adapters/src/index.ts
+++ b/packages/ai-adapters/src/index.ts
@@ -1,4 +1,5 @@
 import {
+	type AiProvider,
 	MODELS_BY_ID,
 	type ServableModel,
 } from '@epicenter/constants/ai-providers';
@@ -32,3 +33,18 @@ export function createAdapterForModel(
 			return entry satisfies never;
 	}
 }
+
+/**
+ * The deployment env var that holds each provider's house key, in one place.
+ * Both house-key consumers (`resolveAdapter` in `@epicenter/server` and the
+ * zhongwen daemon's `resolveChatStream`) read this rather than re-deriving the
+ * name, so the provider -> env-var fact is single-homed. `satisfies Record<…>`
+ * keeps it exhaustive: a new provider that lacks an entry is a compile error.
+ *
+ * It lives in this server/daemon-only leaf, not the browser-facing catalog, so
+ * the secret-naming never reaches a browser bundle.
+ */
+export const HOUSE_KEY_ENV_VAR = {
+	openai: 'OPENAI_API_KEY',
+	gemini: 'GEMINI_API_KEY',
+} as const satisfies Record<AiProvider, string>;

--- a/packages/server/src/routes/ai.ts
+++ b/packages/server/src/routes/ai.ts
@@ -32,7 +32,10 @@
  * both at deploy time; see apps/api/wrangler.jsonc for why.
  */
 
-import { createAdapterForModel } from '@epicenter/ai-adapters';
+import {
+	createAdapterForModel,
+	HOUSE_KEY_ENV_VAR,
+} from '@epicenter/ai-adapters';
 import {
 	AiChatError,
 	AiChatErrorStatus,
@@ -101,21 +104,11 @@ export function resolveAdapter({
 	ReturnType<typeof AiChatError.ProviderNotConfigured>['error']
 > {
 	// Key policy stays here: BYOK wins, else the deployment's per-provider house
-	// key, else `ProviderNotConfigured`. The catalog entry is discriminated on
-	// `provider`, so the switch picks the matching env key exhaustively; adapter
-	// construction is delegated to `@epicenter/ai-adapters`.
+	// key, else `ProviderNotConfigured`. The env var that holds each house key is
+	// single-homed in `@epicenter/ai-adapters`; adapter construction is delegated
+	// there too.
 	const entry = MODELS_BY_ID[model];
-	let houseKey: string | undefined;
-	switch (entry.provider) {
-		case 'openai':
-			houseKey = env.OPENAI_API_KEY;
-			break;
-		case 'gemini':
-			houseKey = env.GEMINI_API_KEY;
-			break;
-		default:
-			return entry satisfies never;
-	}
+	const houseKey = env[HOUSE_KEY_ENV_VAR[entry.provider]];
 	const apiKey = userApiKey ?? houseKey;
 	if (!apiKey) {
 		return AiChatError.ProviderNotConfigured({ provider: entry.provider });


### PR DESCRIPTION
Both house-key consumers encoded the same provider-to-env-var fact in local switches: `@epicenter/server` used it while resolving hosted adapters, and the Zhongwen daemon used the same mapping while resolving local chat streams.

This moves that mapping into `@epicenter/ai-adapters` beside `createAdapterForModel`:

```ts
const HOUSE_KEY_ENV_VAR = {
  openai: "OPENAI_API_KEY",
  gemini: "GEMINI_API_KEY",
} satisfies Record<AiProvider, string>;
```

The leaf is server/daemon-only, so secret naming stays out of browser bundles. The `satisfies` check keeps provider additions exhaustive in one place instead of spreading the compile-time failure across callers.

Policy stays with each caller. Hosted routes can keep their BYOK or house-key behavior, while the daemon can keep its fallback behavior; this PR only single-homes the shared data. The larger metered-daemon backend idea remains separate because it needs daemon cloud identity, not just a cleaner env-var lookup.