### PR TITLE
docs(adr): commit to the daemon inference backend priority chain (ADR-0038)

### DIFF
--- a/docs/adr/0038-a-daemon-answers-through-the-first-inference-backend-it-can-satisfy.md
+++ b/docs/adr/0038-a-daemon-answers-through-the-first-inference-backend-it-can-satisfy.md
@@ -1,0 +1,69 @@
+# 0038. A daemon answers through the first inference backend it can satisfy
+
+- **Status:** Proposed
+- **Date:** 2026-06-20
+
+## Context
+
+ADR-0033 names three inference backends, orthogonal to who writes the doc: the
+metered Epicenter provider (posts to `/api/ai/chat`, house key, billed), BYOK
+(the user's own provider key), and local (a model on the machine). It never says
+how a single daemon *chooses* among them. Today the choice is hardcoded per host:
+the zhongwen daemon's `resolveChatStream` is BYOK-only (read the house key from
+`process.env`, else a placeholder), and the browser is metered-only
+(`createEpicenterProviderChatStream`). A daemon that wants to answer on the
+user's metered Epicenter account, with no raw provider key on the box, has no
+path, even though the daemon already holds a cloud sync session
+(`@epicenter/workspace/daemon` mount runtime: `session.ownerId` + `openWebSocket`).
+
+This ADR refines ADR-0033: it settles how a daemon resolves which backend serves
+a turn. It relates to ADR-0037, whose leaf package builds the BYOK arm's adapter.
+
+## Decision
+
+A daemon resolves its `ChatStream` as a priority chain over the backends it can
+satisfy, not a hardcoded constant:
+
+```txt
+byok(key)              if a local provider key is present  (via @epicenter/ai-adapters)
+?? metered(authFetch)  else if the daemon holds a cloud identity  (the browser's /api/ai/chat path)
+?? placeholder         else  (the deterministic claim -> stream -> finish stand-in)
+```
+
+The three backends are sibling `ChatStream` constructors; the resolver is a `??`
+chain, not a `switch`. The metered arm reuses the browser's
+`createEpicenterProviderChatStream` unchanged; the daemon supplies its `AuthFetch`
+by surfacing the credential its sync session already holds. BYOK stays (we refuse
+the metered-only fork): an offline or self-hosted daemon must answer without a
+cloud round-trip.
+
+## Consequences
+
+- A daemon's transport becomes a runtime property of what the host holds, not a
+  compile-time import. A daemon with a key runs locally and free; a keyless
+  daemon with a cloud login spends metered credits; a bare daemon still exercises
+  the full path with the placeholder.
+- The browser and the daemon share one metered constructor
+  (`createEpicenterProviderChatStream`); the metered path is written once.
+- `@epicenter/ai-adapters` keeps two consumers (the hosted route and the BYOK
+  daemon arm), so it stays a leaf and ADR-0037 holds. Contingency, recorded so it
+  is not rediscovered: if BYOK-daemon is ever dropped (the metered-only fork), the
+  leaf has a single consumer and folds back into `@epicenter/server`. The leaf's
+  life is contingent on two or more SDK-needing hosts.
+- The "second adapter -> `ChatStream` caller" the leaf was waiting for now exists
+  (the daemon's BYOK arm as a named builder), so extracting a BYOK `ChatStream`
+  constructor into the leaf is no longer premature.
+- Keystone, and the reason this is `Proposed` not `Accepted`: the metered arm
+  needs the daemon to expose its sync session credential as an `AuthFetch`
+  (`createAiChatFetch` wraps one). The mount runtime holds the session but does
+  not yet surface an HTTP `AuthFetch`. This ADR lands when that one seam exists.
+
+## Considered alternatives
+
+- **BYOK-only (status quo).** Simplest today, but a daemon must hold a raw
+  provider key and can never answer on the user's metered account. Lost because
+  ambient daemons should answer on an Epicenter login without keys on the box.
+- **Metered-only.** Deletes the leaf (folds into the server) and makes the daemon
+  SDK-free. Lost because it refuses offline and self-hosted inference and forces a
+  cloud identity plus credit spend on every daemon. Kept as the documented
+  contingency above, not the default.

--- a/docs/adr/0038-a-daemon-answers-through-the-first-inference-backend-it-can-satisfy.md
+++ b/docs/adr/0038-a-daemon-answers-through-the-first-inference-backend-it-can-satisfy.md
@@ -13,8 +13,8 @@ the zhongwen daemon's `resolveChatStream` is BYOK-only (read the house key from
 `process.env`, else a placeholder), and the browser is metered-only
 (`createEpicenterProviderChatStream`). A daemon that wants to answer on the
 user's metered Epicenter account, with no raw provider key on the box, has no
-path, even though the daemon already holds a cloud sync session
-(`@epicenter/workspace/daemon` mount runtime: `session.ownerId` + `openWebSocket`).
+path, even though the daemon's signed-in `MountSession` already carries an
+`AuthedFetch` (`session.fetch`) beside `ownerId` and `openWebSocket`.
 
 This ADR refines ADR-0033: it settles how a daemon resolves which backend serves
 a turn. It relates to ADR-0037, whose leaf package builds the BYOK arm's adapter.
@@ -53,10 +53,15 @@ cloud round-trip.
 - The "second adapter -> `ChatStream` caller" the leaf was waiting for now exists
   (the daemon's BYOK arm as a named builder), so extracting a BYOK `ChatStream`
   constructor into the leaf is no longer premature.
-- Keystone, and the reason this is `Proposed` not `Accepted`: the metered arm
-  needs the daemon to expose its sync session credential as an `AuthFetch`
-  (`createAiChatFetch` wraps one). The mount runtime holds the session but does
-  not yet surface an HTTP `AuthFetch`. This ADR lands when that one seam exists.
+- Keystone, and the reason this is `Proposed` not `Accepted`: the credential
+  already exists. `MountSession.fetch` is an `AuthedFetch`, byte-identical to the
+  `AuthFetch` that `createAiChatFetch` wraps, so the metered arm needs no new auth
+  plumbing. The gap is structural: `resolveChatStream()` runs at config-build time
+  (inside `zhongwen({...})`) where no session exists yet, and the mount runtime
+  forwards `ownerId` / `openWebSocket` to workers but not `fetch`. The work is to
+  thread `session.fetch` to the worker factory and resolve the `ChatStream`
+  per-body, with the session in hand, instead of once at construction. This ADR
+  lands when that wiring exists.
 
 ## Considered alternatives
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -105,5 +105,6 @@ Each option and the one reason it lost. Terse. This is not the spec.
 | [0035](0035-durable-storage-is-one-per-person-coordination-box.md) | Durable storage is one per-person coordination box: an app-blind anchor and store | Accepted |
 | [0036](0036-answer-bodies-are-native-parts-arrays-streamed-into-y-text.md) | An answer body is a native parts array; its text streams into Y.Text | Accepted |
 | [0037](0037-adapter-construction-is-a-shared-leaf-package-keyed-on-the-model-catalog.md) | Adapter construction is a shared leaf package keyed on the model catalog | Accepted |
+| [0038](0038-a-daemon-answers-through-the-first-inference-backend-it-can-satisfy.md) | A daemon answers through the first inference backend it can satisfy: byok, else metered, else placeholder | Proposed |
 
 When you add an ADR, add its row here.

--- a/specs/20260620T050257-daemon-inference-backend-priority-chain.md
+++ b/specs/20260620T050257-daemon-inference-backend-priority-chain.md
@@ -26,23 +26,29 @@ host into a priority `??` chain.
 
 ## Keystone (do this first; the rest is blocked on it)
 
-The metered arm needs `createAiChatFetch(authFetch: AuthFetch)`. The daemon mount
-runtime (`packages/workspace/src/daemon/mount-runtime.ts`) holds a `session` with
-`ownerId` + `openWebSocket` but exposes no HTTP `AuthFetch`. Surface the session's
-existing credential as an `AuthFetch` (e.g. `session.authFetch`) alongside
-`openWebSocket`. This is the one new seam; verify it before building the chain.
+The credential already exists: `MountSession.fetch`
+(`packages/workspace/src/daemon/define-mount.ts:52`) is an `AuthedFetch`,
+byte-identical to the `AuthFetch` that `createAiChatFetch` wraps, so
+`createAiChatFetch(session.fetch)` typechecks directly: no new auth plumbing. The
+gap is structural. `resolveChatStream()` runs at config-build time inside
+`zhongwen({...})` (`apps/zhongwen/mount.ts`), where no session exists, and the
+mount runtime forwards `ownerId` / `openWebSocket` to workers but not `fetch`. So
+thread `session.fetch` to the worker factory and resolve the `ChatStream`
+per-body, session in hand, instead of once at construction.
 
 ## Plan
 
 Each wave independently green and revertible; separate commit per wave.
 
-### Wave 1: Surface the daemon session credential as an `AuthFetch` (the keystone)
+### Wave 1: Thread the existing session `AuthedFetch` to per-body resolution (the keystone)
 
-- [ ] **1.1** In `@epicenter/workspace/daemon`, expose the sync session's credential
-  as an `AuthFetch` (the shape `@epicenter/auth` exports and `createAiChatFetch`
-  wraps). Type-only at the consumer; the runtime constructs it at the host edge.
-- [ ] Checkpoint: a Node smoke that the daemon's `AuthFetch` authenticates a GET
-  against the cloud (same credential the WebSocket sync already uses). Commit.
+- [ ] **1.1** Forward `session.fetch` from the `.mount()` coordinator
+  (`SessionMountContext`) into the worker factory context (`ChildDocWorkerContext`,
+  today `{ ydoc }` only), and move `resolveChatStream()` out of `zhongwen({...})`
+  construction into the per-body factory so it sees the session. No new auth type:
+  `createAiChatFetch(session.fetch)` typechecks directly.
+- [ ] Checkpoint: a Node smoke that `session.fetch` GETs the cloud with the same
+  credential sync uses. Commit.
 
 ### Wave 2: Name the three backends as sibling `ChatStream` constructors
 

--- a/specs/20260620T050257-daemon-inference-backend-priority-chain.md
+++ b/specs/20260620T050257-daemon-inference-backend-priority-chain.md
@@ -1,0 +1,116 @@
+# Daemon inference backend priority chain: byok ?? metered ?? placeholder
+
+**Date**: 2026-06-20
+**Status**: Draft
+**Owner**: Braden
+**Implements**: [ADR-0038](../docs/adr/0038-a-daemon-answers-through-the-first-inference-backend-it-can-satisfy.md) (refines [ADR-0033](../docs/adr/0033-a-conversation-has-one-transport-and-two-triggers.md); relates to [ADR-0037](../docs/adr/0037-adapter-construction-is-a-shared-leaf-package-keyed-on-the-model-catalog.md))
+
+## One Sentence
+
+A daemon resolves its `ChatStream` as a `??` chain over three sibling
+constructors, `byok(key) ?? metered(authFetch) ?? placeholder`, so the same
+always-on worker answers locally when it holds a provider key and answers on the
+user's metered Epicenter account when it holds only a cloud login, with no host
+code edit between the two.
+
+## Why
+
+Post #2118 / #2119 the construction surface is clean but the daemon's *transport*
+is hardcoded: `resolveChatStream` (`apps/zhongwen/mount.ts`) is BYOK-or-placeholder
+and the browser is metered-only. ADR-0033 already names the backends; nothing lets
+a daemon *pick* between them. The metered arm is the browser's existing
+`createEpicenterProviderChatStream`, so the only genuinely new machinery is handing
+the daemon an `AuthFetch`, and the daemon already authenticates to the cloud for
+sync. This unifies browser + daemon onto one metered path and turns a `switch`-shaped
+host into a priority `??` chain.
+
+## Keystone (do this first; the rest is blocked on it)
+
+The metered arm needs `createAiChatFetch(authFetch: AuthFetch)`. The daemon mount
+runtime (`packages/workspace/src/daemon/mount-runtime.ts`) holds a `session` with
+`ownerId` + `openWebSocket` but exposes no HTTP `AuthFetch`. Surface the session's
+existing credential as an `AuthFetch` (e.g. `session.authFetch`) alongside
+`openWebSocket`. This is the one new seam; verify it before building the chain.
+
+## Plan
+
+Each wave independently green and revertible; separate commit per wave.
+
+### Wave 1: Surface the daemon session credential as an `AuthFetch` (the keystone)
+
+- [ ] **1.1** In `@epicenter/workspace/daemon`, expose the sync session's credential
+  as an `AuthFetch` (the shape `@epicenter/auth` exports and `createAiChatFetch`
+  wraps). Type-only at the consumer; the runtime constructs it at the host edge.
+- [ ] Checkpoint: a Node smoke that the daemon's `AuthFetch` authenticates a GET
+  against the cloud (same credential the WebSocket sync already uses). Commit.
+
+### Wave 2: Name the three backends as sibling `ChatStream` constructors
+
+- [ ] **2.1** Extract the daemon's inline `chat({ adapter, systemPrompts, abortController })`
+  arm (plus the `AbortSignal` -> `AbortController` bridge) into a named
+  `chatStreamFromAdapter(adapter, systemPrompts)` in `@epicenter/ai-adapters`. The
+  second adapter -> `ChatStream` caller now exists, so ADR-0037's extraction gate
+  has tripped; this is no longer premature.
+- [ ] **2.2** `metered` is `createEpicenterProviderChatStream` (already in
+  `@epicenter/client`), unchanged. `placeholder` is the daemon's `fakeChatStream`,
+  unchanged. No new abstraction beyond naming the BYOK builder.
+- [ ] Checkpoint: `bun run --filter @epicenter/ai-adapters typecheck`; workspace tests. Commit.
+
+### Wave 3: Rewrite `resolveChatStream` as the priority chain
+
+- [ ] **3.1** Replace `resolveChatStream` with `byok(key) ?? metered(authFetch) ?? placeholder`:
+  read the house key (BYOK arm via `chatStreamFromAdapter` + `createAdapterForModel`),
+  else build the metered arm from the daemon `AuthFetch` (Wave 1) + the catalog
+  model, else placeholder. No `switch`; the `HOUSE_KEY_ENV_VAR` lookup stays for the
+  BYOK arm's key read.
+- [ ] **3.2** Keep the log line for the placeholder fall-through, generalized to name
+  which arms were unavailable (no key and no cloud identity).
+- [ ] Checkpoint: `bun run --filter @epicenter/zhongwen typecheck`; daemon smoke per
+  ADR-0033 Part 1 (key set -> local reply; key unset + cloud login -> metered reply;
+  neither -> placeholder). Commit.
+
+## What we deliberately do NOT collapse
+
+- **BYOK stays** (refuse the metered-only fork). The leaf keeps two consumers and
+  remains a leaf; ADR-0037 holds. Do not fold `@epicenter/ai-adapters` into the
+  server. The contingency for the metered-only fork is recorded in ADR-0038, not
+  taken here.
+- **The waist (`ChatStream`) and `streamAnswer` are untouched.** This spec changes
+  only how a daemon *constructs* a `ChatStream`, never the loop or the doc sink.
+- **The placeholder is not deleted.** It is the explicit "real inference not wired
+  on this host" boundary and exercises the claim -> stream -> finish path.
+
+## Out of scope (separable threads, do not bundle)
+
+- **Model-as-data.** Letting a daemon answer as *any* model per conversation (the
+  browser already switches model per turn via its `data()` thunk; the daemon fixes
+  `ZHONGWEN_MODEL` at config) is a catalog/agent-field change, separable from this
+  transport fork. Track separately.
+- **Single-homing the wire contract.** `EpicenterProviderData` (client) is a
+  hand-written subset of `aiChatBody.data` (server arktype). Deriving both from one
+  shared schema in `@epicenter/constants` is marginal; not now.
+
+## Invariants (hold throughout)
+
+- One transport: the cloud never writes a conversation doc; only an in-process peer
+  does (ADR-0033). This spec changes only how tokens are sourced.
+- `ChatStream` stays the single sink-facing contract; `streamAnswer` is untouched.
+- Existence-is-the-claim (`findUnansweredTurn`) remains the only double-answer guard.
+
+## Verify Commands
+
+```
+bun run --filter @epicenter/ai-adapters typecheck
+bun run --filter @epicenter/server typecheck
+bun run --filter @epicenter/client typecheck
+bun run --filter @epicenter/zhongwen typecheck
+(cd packages/workspace && bun test)
+bun scripts/check-doc-hygiene.ts
+```
+
+## Post-landing
+
+When Wave 3 lands, flip ADR-0038 to `Accepted` and delete this spec per the
+two-state lifecycle (git keeps the body). If the keystone (Wave 1) proves the
+session cannot cheaply mint an `AuthFetch`, stop and re-grill ADR-0038's fork
+before building Waves 2 to 3.


### PR DESCRIPTION
ADR-0033 named the daemon's possible inference backends, but it never said how a daemon chooses among them. ADR-0038 records the missing rule: a daemon answers through the first backend it can satisfy.

```ts
byok(key)
  ?? metered(authFetch)
  ?? placeholder()
```

That keeps BYOK alive for offline and self-hosted daemons, uses the same metered constructor the browser path already uses, and records the contingency without taking it: if the BYOK daemon path ever disappears, `@epicenter/ai-adapters` loses one of its two SDK-needing hosts and can fold back into `@epicenter/server`.

ADR-0038 stays `Proposed` because the runtime still has to thread `session.fetch` to the worker factory and resolve the `ChatStream` per body. The session already owns an authenticated fetch; the missing piece is structural, since `resolveChatStream()` currently runs during config construction before a session exists.

The paired spec carries the three implementation waves: thread the session fetch, name the three backend constructors, and rewrite `resolveChatStream` as the priority chain above.