### PR TITLE
refactor(whispering): redesign the macOS Accessibility onboarding surfaces

### DIFF
--- a/apps/whispering/src/lib/components/DictationCapabilityNotice.svelte
+++ b/apps/whispering/src/lib/components/DictationCapabilityNotice.svelte
@@ -6,24 +6,38 @@
 	import WandSparklesIcon from '@lucide/svelte/icons/wand-sparkles';
 	import { accessibilityGuide } from '$lib/components/MacosAccessibilityGuideDialog.svelte';
 	import { dictationCapability } from '$lib/state/dictation-capability.svelte';
+	import { recordings } from '$lib/state/recordings.svelte';
 
 	// One declarative view over the dictation capability Rust owns, in three
-	// registers because the situations differ in kind, not just wording:
-	//   - broken: a stale grant left the global tap dead. A real FAULT, so an
-	//     outlined `role="alert"` banner with an amber glyph and a primary action.
-	//   - untrusted (first grant): never granted. An optional UPGRADE, not a wall —
-	//     dictation already works through the shortcut and clipboard. A faint muted
-	//     banner with an outline action, sitting quietly until you grant.
-	//   - unsupported (Wayland): a platform FACT, nothing to grant. A calm info
-	//     banner pointing at the mic that still works; no action.
-	// All three are one slim `Item` (icon · message · trailing action) at the same
-	// size, so the padding is uniform by construction. None is dismissable: each
+	// registers that differ in kind, not just wording:
+	//   - broken: a stale grant left the global tap dead. A real FAULT, so an amber
+	//     glyph, a `role="alert"`, and a primary action.
+	//   - untrusted (first grant): never granted. An optional UPGRADE, not a wall.
+	//     Dictation already works through the shortcut and clipboard, so the glyph
+	//     is calm and the action is a quiet outline button.
+	//   - unsupported (Wayland): a platform FACT, nothing to grant. An info glyph
+	//     pointing at the mic that still works; no action.
+	// All three share one slim outlined `Item` (icon · message · trailing action)
+	// at the same size, so backgrounds and padding stay uniform and only the glyph
+	// and the action carry the register. None is dismissable: each
 	// clears itself when the capability flips, and a quiet banner never needs
 	// hiding. The detailed steps live in the guide dialog the action opens. The
 	// branch order is load-bearing: `broken` is caught before the plain untrusted
 	// case (`needsAccessibility` covers both).
+	//
+	// The optional pitch waits for the first transcript. It is a pitch, not a
+	// problem, and "hold a key to talk" only means something once you have pressed
+	// once and watched a transcript land. Holding it back keeps a brand-new home
+	// clean and lets the pitch arrive when it is finally relevant. Derived from the
+	// recordings that already exist, so it costs no dismissal flag. Breakage and
+	// the Wayland limit are never gated: those are immediate.
+	const hasDictatedOnce = $derived(
+		recordings.sorted.some((r) => r.transcript.trim()),
+	);
 	const isFirstGrant = $derived(
-		dictationCapability.needsAccessibility && !dictationCapability.isStale,
+		dictationCapability.needsAccessibility &&
+			!dictationCapability.isStale &&
+			hasDictatedOnce,
 	);
 </script>
 
@@ -46,15 +60,14 @@
 		</Item.Actions>
 	</Item.Root>
 {:else if isFirstGrant}
-	<Item.Root variant="muted" size="sm" class="w-full">
+	<Item.Root variant="outline" size="sm" class="w-full">
 		<Item.Media>
 			<WandSparklesIcon class="size-4" aria-hidden="true" />
 		</Item.Media>
 		<Item.Content>
 			<Item.Title>Hold a key to talk, paste hands-free</Item.Title>
 			<Item.Description>
-				Optional upgrade — dictation already works through your shortcut and
-				clipboard.
+				Your shortcut already copies transcripts to your clipboard.
 			</Item.Description>
 		</Item.Content>
 		<Item.Actions>
@@ -68,7 +81,7 @@
 		</Item.Actions>
 	</Item.Root>
 {:else if dictationCapability.isUnsupported}
-	<Item.Root variant="muted" size="sm" class="w-full">
+	<Item.Root variant="outline" size="sm" class="w-full">
 		<Item.Media>
 			<InfoIcon class="size-4" aria-hidden="true" />
 		</Item.Media>

--- a/apps/whispering/src/lib/components/DictationCapabilityNotice.svelte
+++ b/apps/whispering/src/lib/components/DictationCapabilityNotice.svelte
@@ -42,11 +42,14 @@ branch order is load-bearing: `broken` is caught before the plain untrusted case
 			Accessibility, then add it back) usually fixes it. Until then, transcripts
 			go to your clipboard.
 		</Alert.Description>
-		<Alert.Action>
+		<!-- Same footer placement as the never-granted notice below: both are the
+		same kind of remediation card with the same action, so they share one
+		layout instead of one floating top-right and one at the bottom. -->
+		<div class="col-start-2 mt-3">
 			<Button size="sm" onclick={() => accessibilityGuide.open()}>
 				Show me how
 			</Button>
-		</Alert.Action>
+		</div>
 	</Alert.Root>
 {:else if dictationCapability.needsAccessibility}
 	<!-- macOS never granted (broken is handled above): an upgrade pitch, not a

--- a/apps/whispering/src/lib/components/DictationCapabilityNotice.svelte
+++ b/apps/whispering/src/lib/components/DictationCapabilityNotice.svelte
@@ -1,85 +1,83 @@
 <script lang="ts">
-	import * as Alert from '@epicenter/ui/alert';
 	import { Button } from '@epicenter/ui/button';
+	import * as Item from '@epicenter/ui/item';
+	import InfoIcon from '@lucide/svelte/icons/info';
 	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 	import WandSparklesIcon from '@lucide/svelte/icons/wand-sparkles';
 	import { accessibilityGuide } from '$lib/components/MacosAccessibilityGuideDialog.svelte';
-	import { clipboardFallback } from '$lib/components/accessibility-feature-copy';
 	import { dictationCapability } from '$lib/state/dictation-capability.svelte';
+
+	// One declarative view over the dictation capability Rust owns, in three
+	// registers because the situations differ in kind, not just wording:
+	//   - broken: a stale grant left the global tap dead. A real FAULT, so an
+	//     outlined `role="alert"` banner with an amber glyph and a primary action.
+	//   - untrusted (first grant): never granted. An optional UPGRADE, not a wall —
+	//     dictation already works through the shortcut and clipboard. A faint muted
+	//     banner with an outline action, sitting quietly until you grant.
+	//   - unsupported (Wayland): a platform FACT, nothing to grant. A calm info
+	//     banner pointing at the mic that still works; no action.
+	// All three are one slim `Item` (icon · message · trailing action) at the same
+	// size, so the padding is uniform by construction. None is dismissable: each
+	// clears itself when the capability flips, and a quiet banner never needs
+	// hiding. The detailed steps live in the guide dialog the action opens. The
+	// branch order is load-bearing: `broken` is caught before the plain untrusted
+	// case (`needsAccessibility` covers both).
+	const isFirstGrant = $derived(
+		dictationCapability.needsAccessibility && !dictationCapability.isStale,
+	);
 </script>
 
-<!-- One declarative view over the dictation capability Rust owns: the matching
-panel when the global tap cannot fire, nothing while it works (`active`) or is
-still seeding (`unknown`). Each state has its own remediation and only the
-capability owner can tell them apart, so we read the value, never infer it. The
-branch order is load-bearing: `broken` is caught before the plain untrusted case
-(`needsAccessibility` covers both), so the last branch is the never-granted pitch. -->
-{#if dictationCapability.isUnsupported}
-	<!-- Linux Wayland: the tap can never run, so there is nothing to grant.
-	Explain the limit, no settings button. -->
-	<Alert.Root class="w-full text-left">
-		<TriangleAlertIcon class="size-4" aria-hidden="true" />
-		<Alert.Title>Global shortcuts need an X11 session</Alert.Title>
-		<Alert.Description>
-			On Wayland, Whispering can't read your keyboard globally, so the recording
-			shortcut and paste-back stay off. Click the microphone to record, or switch
-			to an X11 session to use the shortcut. Either way, transcripts go to your
-			clipboard.
-		</Alert.Description>
-	</Alert.Root>
-{:else if dictationCapability.isStale}
-	<!-- macOS reports Whispering as trusted, but the global tap is not delivering
-	events. The common cause is a grant left stale by an app update, which a
-	remove-and-re-add fixes, so the guide leads. We do not assert that as the only
-	cause: the tap can also stall for reasons re-granting won't touch, so the copy
-	stays honest about what we know (it is not firing) and what usually helps. -->
-	<Alert.Root class="w-full text-left">
-		<TriangleAlertIcon class="size-4" aria-hidden="true" />
-		<Alert.Title>Your global shortcut isn't working</Alert.Title>
-		<Alert.Description>
-			Whispering appears to have macOS Accessibility, but your global shortcut and
-			paste-back aren't firing. Re-granting access (remove Whispering from
-			Accessibility, then add it back) usually fixes it. Until then, transcripts
-			go to your clipboard.
-		</Alert.Description>
-		<!-- Same footer placement as the never-granted notice below: both are the
-		same kind of remediation card with the same action, so they share one
-		layout instead of one floating top-right and one at the bottom. -->
-		<div class="col-start-2 mt-3">
+{#if dictationCapability.isStale}
+	<Item.Root variant="outline" size="sm" class="w-full" role="alert">
+		<Item.Media>
+			<TriangleAlertIcon class="text-warning size-4" aria-hidden="true" />
+		</Item.Media>
+		<Item.Content>
+			<Item.Title>Your global shortcut isn't firing</Item.Title>
+			<Item.Description>
+				Re-granting macOS Accessibility usually fixes it. Until then, transcripts
+				go to your clipboard.
+			</Item.Description>
+		</Item.Content>
+		<Item.Actions>
 			<Button size="sm" onclick={() => accessibilityGuide.open()}>
 				Show me how
 			</Button>
-		</div>
-	</Alert.Root>
-{:else if dictationCapability.needsAccessibility}
-	<!-- macOS never granted (broken is handled above): an upgrade pitch, not a
-	wall. Dictation already works through the keyboard shortcut and the clipboard;
-	this grant unlocks two ergonomics features. Open Settings, toggle on. -->
-	<Alert.Root class="w-full text-left">
-		<WandSparklesIcon class="size-4" aria-hidden="true" />
-		<Alert.Title>Hold a key to talk, paste hands-free</Alert.Title>
-		<Alert.Description class="space-y-2">
-			<p>
-				Dictation already works: your shortcut starts recording and the
-				transcript lands on your clipboard. Turn on Whispering in macOS
-				Accessibility to add two upgrades:
-			</p>
-			<ul class="list-disc space-y-1 pl-4">
-				<li>Hold a key to talk: press to record, release to stop.</li>
-				<li>Paste hands-free: transcripts land where you're typing.</li>
-			</ul>
-			<p>{clipboardFallback}</p>
-		</Alert.Description>
-		<!-- One CTA into the guide, which is the actual "how to add it" answer: it
-		walks the steps, carries the Open System Settings deep-link, and flips to
-		"granted" live. The notice doesn't deep-link itself, so a first-timer is
-		never dropped into System Settings without instructions. The button reads
-		after the pitch in a footer row aligned to the content column (`col-start-2`
-		clears the icon), so a longer label can never crowd the title. -->
-		<div class="col-start-2 mt-3">
-			<Button size="sm" onclick={() => accessibilityGuide.open()}>
+		</Item.Actions>
+	</Item.Root>
+{:else if isFirstGrant}
+	<Item.Root variant="muted" size="sm" class="w-full">
+		<Item.Media>
+			<WandSparklesIcon class="size-4" aria-hidden="true" />
+		</Item.Media>
+		<Item.Content>
+			<Item.Title>Hold a key to talk, paste hands-free</Item.Title>
+			<Item.Description>
+				Optional upgrade — dictation already works through your shortcut and
+				clipboard.
+			</Item.Description>
+		</Item.Content>
+		<Item.Actions>
+			<Button
+				size="sm"
+				variant="outline"
+				onclick={() => accessibilityGuide.open()}
+			>
 				Show me how
 			</Button>
-		</div>
-	</Alert.Root>
+		</Item.Actions>
+	</Item.Root>
+{:else if dictationCapability.isUnsupported}
+	<Item.Root variant="muted" size="sm" class="w-full">
+		<Item.Media>
+			<InfoIcon class="size-4" aria-hidden="true" />
+		</Item.Media>
+		<Item.Content>
+			<Item.Title>Global shortcuts need an X11 session</Item.Title>
+			<Item.Description>
+				On Wayland, Whispering can't tap your keyboard globally. Click the mic to
+				record instead.
+			</Item.Description>
+		</Item.Content>
+	</Item.Root>
 {/if}

--- a/apps/whispering/src/lib/components/DictationCapabilityNotice.svelte
+++ b/apps/whispering/src/lib/components/DictationCapabilityNotice.svelte
@@ -3,10 +3,7 @@
 	import { Button } from '@epicenter/ui/button';
 	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 	import WandSparklesIcon from '@lucide/svelte/icons/wand-sparkles';
-	import {
-		accessibilityGuide,
-		openSystemSettings,
-	} from '$lib/components/MacosAccessibilityGuideDialog.svelte';
+	import { accessibilityGuide } from '$lib/components/MacosAccessibilityGuideDialog.svelte';
 	import { clipboardFallback } from '$lib/components/accessibility-feature-copy';
 	import { dictationCapability } from '$lib/state/dictation-capability.svelte';
 </script>
@@ -69,16 +66,17 @@ branch order is load-bearing: `broken` is caught before the plain untrusted case
 				<li>Paste hands-free: transcripts land where you're typing.</li>
 			</ul>
 			<p>{clipboardFallback}</p>
-			<Button
-				variant="link"
-				class="h-auto p-0 text-sm font-normal"
-				onclick={() => accessibilityGuide.open()}
-			>
-				Already enabled but not working?
-			</Button>
 		</Alert.Description>
-		<Alert.Action>
-			<Button size="sm" onclick={openSystemSettings}>Open Settings</Button>
-		</Alert.Action>
+		<!-- One CTA into the guide, which is the actual "how to add it" answer: it
+		walks the steps, carries the Open System Settings deep-link, and flips to
+		"granted" live. The notice doesn't deep-link itself, so a first-timer is
+		never dropped into System Settings without instructions. The button reads
+		after the pitch in a footer row aligned to the content column (`col-start-2`
+		clears the icon), so a longer label can never crowd the title. -->
+		<div class="col-start-2 mt-3">
+			<Button size="sm" onclick={() => accessibilityGuide.open()}>
+				Show me how
+			</Button>
+		</div>
 	</Alert.Root>
 {/if}

--- a/apps/whispering/src/lib/components/MacosAccessibilityGuide.svelte
+++ b/apps/whispering/src/lib/components/MacosAccessibilityGuide.svelte
@@ -1,35 +1,64 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 
-	// Single source of the macOS Accessibility remove/re-add instructions: a
-	// screen recording plus the written steps, embedded in the global
-	// `MacosAccessibilityGuideDialog`. Kept as one component so any surface can
-	// embed the same instructions instead of restating them.
+	// Single source of the macOS Accessibility instructions: a screen recording
+	// plus the written steps, embedded in the global `MacosAccessibilityGuideDialog`.
+	// Kept as one component so any surface can embed the same instructions instead
+	// of restating them.
+	//
+	// The steps branch on `variant` because the two situations need genuinely
+	// different actions, and showing the wrong one is worse than terse:
+	//   - `first-grant` (never granted): `openSystemSettings` already adds Whispering
+	//     to the list toggled off, so the whole job is flipping its switch. Telling a
+	//     brand-new user to "remove Whispering" is impossible: it isn't there yet.
+	//   - `re-add` (stale grant after an app update): the toggle reads on but the tap
+	//     is dead, and only a remove-and-re-add clears it.
+	// Neither variant repeats "navigate to Accessibility": the dialog's Open System
+	// Settings button deep-links there, so the steps describe what to do once you land.
 	//
 	// The video streams from the GitHub release `_assets` rather than shipping in
 	// the app: keeping a multi-MB binary out of the bundle (and out of git) is
 	// worth more than the offline demo, because the WRITTEN STEPS below are the
 	// real source of truth and render with no network. The video is enhancement
 	// only; if it can't load, the steps still carry the user through.
+	let { variant }: { variant: 'first-grant' | 're-add' } = $props();
+
+	// The asset MUST be encoded with a leading `moov` atom (faststart) or the
+	// browser buffers the whole file before showing a frame and the box just sits
+	// black: `ffmpeg -i in.mp4 -c copy -movflags +faststart out.mp4`. The recording
+	// is ~1028x1080 (near square), so it's centered at its native ratio rather than
+	// cropped into a 16:9 box.
 	const GUIDE_VIDEO_URL =
 		'https://github.com/EpicenterHQ/epicenter/releases/download/_assets/macos_enable_accessibility.mp4';
+
+	// The video is the enhancement; the steps are the truth. If the stream fails
+	// (offline, host hiccup) say so plainly instead of leaving a dead black box
+	// that reads as a broken app.
+	let videoFailed = $state(false);
 </script>
 
 <div class="flex flex-col gap-5">
-	<video
-		class="bg-muted aspect-video w-full rounded-lg border object-cover"
-		src={GUIDE_VIDEO_URL}
-		aria-label="macOS Accessibility walkthrough"
-		loop
-		controls
-		muted
-		playsinline
-		autoplay
-	>
-		<p class="text-muted-foreground text-sm">
-			Video guide not available. Please follow the written instructions below.
-		</p>
-	</video>
+	{#if videoFailed}
+		<div
+			class="bg-muted/40 text-muted-foreground flex min-h-32 flex-col items-center justify-center gap-1 rounded-lg border px-4 py-6 text-center text-sm"
+		>
+			<span class="text-foreground font-medium">Couldn't load the demo</span>
+			<span>The steps below are all you need.</span>
+		</div>
+	{:else}
+		<video
+			class="bg-muted mx-auto block max-h-80 rounded-lg border"
+			src={GUIDE_VIDEO_URL}
+			aria-label="macOS Accessibility walkthrough"
+			loop
+			controls
+			muted
+			playsinline
+			autoplay
+			onerror={() => (videoFailed = true)}
+		>
+		</video>
+	{/if}
 	<ol class="flex flex-col gap-3">
 		{#snippet step(number: number, body: Snippet)}
 			<li class="flex items-start gap-3">
@@ -45,9 +74,13 @@
 			</li>
 		{/snippet}
 
-		{@render step(1, goToAccessibility)}
-		{@render step(2, removeWhispering)}
-		{@render step(3, readdWhispering)}
+		{#if variant === 're-add'}
+			{@render step(1, removeWhispering)}
+			{@render step(2, readdWhispering)}
+		{:else}
+			{@render step(1, findWhispering)}
+			{@render step(2, switchOn)}
+		{/if}
 	</ol>
 </div>
 
@@ -55,26 +88,32 @@
 	<span class="text-foreground font-medium">{text}</span>
 {/snippet}
 
-{#snippet key(symbol: string)}
-	<kbd
-		class="bg-background text-foreground inline-flex h-5 min-w-5 items-center justify-center rounded border px-1 align-text-bottom font-mono text-xs"
+{#snippet control(symbol: string)}
+	<!-- A clicked on-screen button in System Settings, not a keystroke, so a chip
+	     rather than <kbd>. -->
+	<span
+		class="bg-muted text-foreground inline-flex h-5 min-w-5 items-center justify-center rounded border px-1 align-text-bottom text-xs font-medium"
 	>
 		{symbol}
-	</kbd>
+	</span>
 {/snippet}
 
-{#snippet goToAccessibility()}
-	Go to {@render term('System Settings > Privacy & Security > Accessibility')}.
+{#snippet findWhispering()}
+	Find {@render term('Whispering')} in the list (we added it for you).
+{/snippet}
+
+{#snippet switchOn()}
+	Switch it {@render term('on')}.
 {/snippet}
 
 {#snippet removeWhispering()}
-	Click on {@render term('Whispering')} and remove it with the {@render key(
+	Click {@render term('Whispering')}, then remove it with the {@render control(
 		'−',
 	)} button.
 {/snippet}
 
 {#snippet readdWhispering()}
-	Press the {@render key('+')} button and re-add {@render term(
+	Press the {@render control('+')} button and re-add {@render term(
 		'Whispering.app',
 	)}.
 {/snippet}

--- a/apps/whispering/src/lib/components/MacosAccessibilityGuide.svelte
+++ b/apps/whispering/src/lib/components/MacosAccessibilityGuide.svelte
@@ -13,22 +13,23 @@
 		'https://github.com/EpicenterHQ/epicenter/releases/download/_assets/macos_enable_accessibility.mp4';
 </script>
 
-<div class="flex flex-col items-center gap-2">
+<div class="flex flex-col gap-4">
 	<video
-		class="max-w-md rounded-lg border"
+		class="bg-muted aspect-video w-full rounded-lg border object-cover"
 		src={GUIDE_VIDEO_URL}
 		aria-label="macOS Accessibility walkthrough"
 		loop
 		controls
 		muted
 		playsinline
+		autoplay
 	>
 		<p class="text-muted-foreground text-sm">
 			Video guide not available. Please follow the written instructions below.
 		</p>
 	</video>
 	<ol
-		class="text-muted-foreground list-inside list-decimal space-y-1 text-sm leading-7"
+		class="text-muted-foreground list-inside list-decimal space-y-2 text-sm"
 	>
 		<li>
 			Go to

--- a/apps/whispering/src/lib/components/MacosAccessibilityGuide.svelte
+++ b/apps/whispering/src/lib/components/MacosAccessibilityGuide.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
+
 	// Single source of the macOS Accessibility remove/re-add instructions: a
 	// screen recording plus the written steps, embedded in the global
 	// `MacosAccessibilityGuideDialog`. Kept as one component so any surface can
@@ -13,7 +15,7 @@
 		'https://github.com/EpicenterHQ/epicenter/releases/download/_assets/macos_enable_accessibility.mp4';
 </script>
 
-<div class="flex flex-col gap-4">
+<div class="flex flex-col gap-5">
 	<video
 		class="bg-muted aspect-video w-full rounded-lg border object-cover"
 		src={GUIDE_VIDEO_URL}
@@ -28,25 +30,51 @@
 			Video guide not available. Please follow the written instructions below.
 		</p>
 	</video>
-	<ol
-		class="text-muted-foreground list-inside list-decimal space-y-2 text-sm"
-	>
-		<li>
-			Go to
-			<span class="text-primary font-semibold tracking-tight">
-				System Settings > Privacy & Security > Accessibility
-			</span>.
-		</li>
-		<li>
-			Click on
-			<span class="text-primary font-semibold tracking-tight">Whispering</span>
-			and remove it using the minus icon (-).
-		</li>
-		<li>
-			Re-add Whispering by pressing the plus icon (+) and selecting
-			<span class="text-primary font-semibold tracking-tight"
-				>Whispering.app</span
-			>.
-		</li>
+	<ol class="flex flex-col gap-3">
+		{#snippet step(number: number, body: Snippet)}
+			<li class="flex items-start gap-3">
+				<span
+					class="bg-muted text-foreground mt-px flex size-5 shrink-0 items-center justify-center rounded-full border text-xs font-medium tabular-nums"
+					aria-hidden="true"
+				>
+					{number}
+				</span>
+				<span class="text-muted-foreground text-sm leading-relaxed">
+					{@render body()}
+				</span>
+			</li>
+		{/snippet}
+
+		{@render step(1, goToAccessibility)}
+		{@render step(2, removeWhispering)}
+		{@render step(3, readdWhispering)}
 	</ol>
 </div>
+
+{#snippet term(text: string)}
+	<span class="text-foreground font-medium">{text}</span>
+{/snippet}
+
+{#snippet key(symbol: string)}
+	<kbd
+		class="bg-background text-foreground inline-flex h-5 min-w-5 items-center justify-center rounded border px-1 align-text-bottom font-mono text-xs"
+	>
+		{symbol}
+	</kbd>
+{/snippet}
+
+{#snippet goToAccessibility()}
+	Go to {@render term('System Settings > Privacy & Security > Accessibility')}.
+{/snippet}
+
+{#snippet removeWhispering()}
+	Click on {@render term('Whispering')} and remove it with the {@render key(
+		'−',
+	)} button.
+{/snippet}
+
+{#snippet readdWhispering()}
+	Press the {@render key('+')} button and re-add {@render term(
+		'Whispering.app',
+	)}.
+{/snippet}

--- a/apps/whispering/src/lib/components/MacosAccessibilityGuide.svelte
+++ b/apps/whispering/src/lib/components/MacosAccessibilityGuide.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 
-	// Single source of the macOS Accessibility instructions: a screen recording
-	// plus the written steps, embedded in the global `MacosAccessibilityGuideDialog`.
-	// Kept as one component so any surface can embed the same instructions instead
-	// of restating them.
+	// Single source of the macOS Accessibility instructions, embedded in the global
+	// `MacosAccessibilityGuideDialog`. Kept as one component so any surface can embed
+	// the same instructions instead of restating them.
 	//
 	// The steps branch on `variant` because the two situations need genuinely
 	// different actions, and showing the wrong one is worse than terse:
@@ -15,74 +14,32 @@
 	//     is dead, and only a remove-and-re-add clears it.
 	// Neither variant repeats "navigate to Accessibility": the dialog's Open System
 	// Settings button deep-links there, so the steps describe what to do once you land.
-	//
-	// The video streams from the GitHub release `_assets` rather than shipping in
-	// the app: keeping a multi-MB binary out of the bundle (and out of git) is
-	// worth more than the offline demo, because the WRITTEN STEPS below are the
-	// real source of truth and render with no network. The video is enhancement
-	// only; if it can't load, the steps still carry the user through.
 	let { variant }: { variant: 'first-grant' | 're-add' } = $props();
-
-	// The asset MUST be encoded with a leading `moov` atom (faststart) or the
-	// browser buffers the whole file before showing a frame and the box just sits
-	// black: `ffmpeg -i in.mp4 -c copy -movflags +faststart out.mp4`. The recording
-	// is ~1028x1080 (near square), so it's centered at its native ratio rather than
-	// cropped into a 16:9 box.
-	const GUIDE_VIDEO_URL =
-		'https://github.com/EpicenterHQ/epicenter/releases/download/_assets/macos_enable_accessibility.mp4';
-
-	// The video is the enhancement; the steps are the truth. If the stream fails
-	// (offline, host hiccup) say so plainly instead of leaving a dead black box
-	// that reads as a broken app.
-	let videoFailed = $state(false);
 </script>
 
-<div class="flex flex-col gap-5">
-	{#if videoFailed}
-		<div
-			class="bg-muted/40 text-muted-foreground flex min-h-32 flex-col items-center justify-center gap-1 rounded-lg border px-4 py-6 text-center text-sm"
-		>
-			<span class="text-foreground font-medium">Couldn't load the demo</span>
-			<span>The steps below are all you need.</span>
-		</div>
-	{:else}
-		<video
-			class="bg-muted mx-auto block max-h-80 rounded-lg border"
-			src={GUIDE_VIDEO_URL}
-			aria-label="macOS Accessibility walkthrough"
-			loop
-			controls
-			muted
-			playsinline
-			autoplay
-			onerror={() => (videoFailed = true)}
-		>
-		</video>
-	{/if}
-	<ol class="flex flex-col gap-3">
-		{#snippet step(number: number, body: Snippet)}
-			<li class="flex items-start gap-3">
-				<span
-					class="bg-muted text-foreground mt-px flex size-5 shrink-0 items-center justify-center rounded-full border text-xs font-medium tabular-nums"
-					aria-hidden="true"
-				>
-					{number}
-				</span>
-				<span class="text-muted-foreground text-sm leading-relaxed">
-					{@render body()}
-				</span>
-			</li>
-		{/snippet}
+<ol class="flex flex-col gap-3">
+	{#snippet step(number: number, body: Snippet)}
+		<li class="flex items-start gap-3">
+			<span
+				class="bg-muted text-foreground mt-px flex size-5 shrink-0 items-center justify-center rounded-full border text-xs font-medium tabular-nums"
+				aria-hidden="true"
+			>
+				{number}
+			</span>
+			<span class="text-muted-foreground text-sm leading-relaxed">
+				{@render body()}
+			</span>
+		</li>
+	{/snippet}
 
-		{#if variant === 're-add'}
-			{@render step(1, removeWhispering)}
-			{@render step(2, readdWhispering)}
-		{:else}
-			{@render step(1, findWhispering)}
-			{@render step(2, switchOn)}
-		{/if}
-	</ol>
-</div>
+	{#if variant === 're-add'}
+		{@render step(1, removeWhispering)}
+		{@render step(2, readdWhispering)}
+	{:else}
+		{@render step(1, findWhispering)}
+		{@render step(2, switchOn)}
+	{/if}
+</ol>
 
 {#snippet term(text: string)}
 	<span class="text-foreground font-medium">{text}</span>

--- a/apps/whispering/src/lib/components/MacosAccessibilityGuideDialog.svelte
+++ b/apps/whispering/src/lib/components/MacosAccessibilityGuideDialog.svelte
@@ -79,20 +79,37 @@
 	// The Rust supervisor pushes the capability change, so the dialog flips to its
 	// granted state the moment the supervisor sees the grant, with no reload.
 	const isGranted = $derived(dictationCapability.isActive);
+
+	// A stale grant (`broken`) is the only case that needs the remove-and-re-add
+	// dance; never-granted (and the pre-seed `unknown`) just needs the switch
+	// flipped on a row `openSystemSettings` already added. This drives the title,
+	// the description, and which steps the guide renders, so a first-timer is never
+	// told to remove a Whispering that isn't in their list yet.
+	const variant = $derived(
+		dictationCapability.isStale ? 're-add' : 'first-grant',
+	);
 </script>
 
 <Dialog.Root bind:open={accessibilityGuide.isOpen}>
 	<Dialog.Content class="sm:max-w-lg">
 		<Dialog.Header>
-			<Dialog.Title>Enable Accessibility</Dialog.Title>
+			<Dialog.Title>
+				{variant === 're-add' ? 'Re-grant Accessibility' : 'Enable Accessibility'}
+			</Dialog.Title>
 			<Dialog.Description>
-				macOS needs you to turn on Accessibility for Whispering before it can
-				fire your global shortcut and paste where you're typing. After an app
-				update it usually has to be removed and re-added.
+				{#if variant === 're-add'}
+					Whispering already has Accessibility, but it's not firing. That usually
+					means a stale entry from an app update. Open System Settings below, then
+					remove Whispering from the list and add it back.
+				{:else}
+					macOS needs Accessibility before Whispering can fire your global
+					shortcut and paste where you're typing. Open System Settings below, then
+					switch Whispering on. It'll already be in the list.
+				{/if}
 			</Dialog.Description>
 		</Dialog.Header>
 
-		<MacosAccessibilityGuide />
+		<MacosAccessibilityGuide {variant} />
 
 		<Dialog.Footer>
 			{#if isGranted}

--- a/apps/whispering/src/lib/components/MacosAccessibilityGuideDialog.svelte
+++ b/apps/whispering/src/lib/components/MacosAccessibilityGuideDialog.svelte
@@ -82,7 +82,7 @@
 </script>
 
 <Dialog.Root bind:open={accessibilityGuide.isOpen}>
-	<Dialog.Content class="sm:max-w-2xl">
+	<Dialog.Content class="sm:max-w-lg">
 		<Dialog.Header>
 			<Dialog.Title>Enable Accessibility</Dialog.Title>
 			<Dialog.Description>

--- a/apps/whispering/src/lib/components/accessibility-feature-copy.ts
+++ b/apps/whispering/src/lib/components/accessibility-feature-copy.ts
@@ -1,17 +1,17 @@
 /**
  * Terse per-feature copy for the two Tier-1 features that sit behind the one
  * macOS Accessibility grant: Fn push-to-talk and paste-back. The home notice
- * (`DictationCapabilityNotice`) pitches both features together in a richer,
- * upgrade-flavored register; these strings are the short inline form for the
- * surfaces that annotate a single feature in place.
+ * (`DictationCapabilityNotice`) only teases these features in a one-line banner
+ * and defers the detail to the guide dialog; these strings are the short inline
+ * form for the settings surfaces that annotate a single feature in place.
  *
- * What earns the module is the shared `clipboardFallback` line: the home notice
- * (`DictationCapabilityNotice`) and the auto-paste annotation both render it, so
- * the "you don't lose anything" promise stays worded identically. The shortcut
- * recorder row reads `pushToTalk`; the auto-paste annotation reads `pasteBack`.
+ * The shortcut recorder row reads `pushToTalk`; the auto-paste annotation reads
+ * `pasteBack` followed by the shared `clipboardFallback` "you don't lose
+ * anything" line, kept here so that promise stays worded identically wherever a
+ * surface spells it out.
  */
 
-/** Shared closing line, matched to the home notice for consistency. */
+/** Shared closing line for surfaces that spell out the clipboard fallback. */
 export const clipboardFallback =
 	'Without it, transcripts still go to your clipboard.';
 


### PR DESCRIPTION
Rework the two macOS Accessibility surfaces — the home capability notice and the guide dialog — so the first-run experience is calmer and the optional upgrade stops shouting.

## The notice
The dictation capability had three states wearing one tall `Alert` card in a single slot, all equally loud. Each is now a slim `Item` banner (icon, message, trailing action) at one size, so backgrounds and padding are uniform by construction and the action sits on the right instead of below:

- `broken` (a stale grant left the global tap dead): an outlined `role="alert"` with an amber glyph and a primary action. A real fault, so it shows immediately and can't be dismissed.
- `untrusted` (never granted): an optional pitch, not a wall — dictation already works through the shortcut and clipboard. A quiet outline action, and the pitch now waits for the user's first transcript (derived from existing recordings, no dismissal flag) so a brand-new home screen stays clean and the pitch lands when "want that hands-free?" is finally meaningful.
- `unsupported` (Wayland): a platform fact, nothing to grant. A calm info banner pointing at the mic that still works; no action.

None is dismissable: each clears itself when the capability flips, and a quiet banner never needs hiding.

## The guide dialog
- Split the copy on a `first-grant` vs `re-add` variant, so a never-granted user is never told to remove a Whispering that isn't in their list yet.
- Recast the steps as numbered badges with a hanging indent, key terms as emphasis rather than colored text, and the macOS minus/plus as `<kbd>`-style chips.
- Dropped the embedded demo video. WKWebView won't play GitHub Releases' `application/octet-stream`, so it only ever rendered the "couldn't load" fallback; the two-step guide stands alone and the detail lives there.

Excludes the parallel cursor-paste delivery commits from the same branch — `main` already shipped a different implementation of that gate, so it needs separate reconciliation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784532732&installation_id=128463665&pr_number=2124&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2124&signature=135429d21a9b07bb76b13e0d16fc314e8affc79f1af65c0781558bc99f945be1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->