### PR TITLE
feat(whispering): make Rust the single owner of OS permission dispatch

### DIFF
--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -152,7 +152,6 @@
 		"nanoid": "catalog:",
 		"openai": "^5.7.0",
 		"tailwind-variants": "catalog:",
-		"tauri-plugin-macos-permissions-api": "^2.3.0",
 		"typebox": "catalog:",
 		"wellcrafted": "catalog:",
 		"yjs": "catalog:"

--- a/apps/whispering/src-tauri/Cargo.lock
+++ b/apps/whispering/src-tauri/Cargo.lock
@@ -7739,6 +7739,7 @@ dependencies = [
  "tracing",
  "transcribe-rs",
  "windows 0.62.2",
+ "winreg 0.55.0",
  "zbus",
 ]
 

--- a/apps/whispering/src-tauri/Cargo.toml
+++ b/apps/whispering/src-tauri/Cargo.toml
@@ -84,6 +84,11 @@ transcribe-rs = { version = "=0.3.8", features = ["whisper-vulkan", "ort-directm
 # `GetSessions()`; `Win32_System_Com` provides the `CoInitializeEx` the crate
 # does not call for us. See src/media/windows.rs.
 windows = { version = "0.62", features = ["Media_Control", "Foundation", "Foundation_Collections", "Win32_System_Com"] }
+# Reads the microphone privacy choice from the CapabilityAccessManager
+# ConsentStore registry keys. Windows exposes no programmatic mic-permission
+# API for an unpackaged desktop app, only this user-visible Allow/Deny, so the
+# proactive check in `command.rs` is a registry read. See `get_microphone_permission`.
+winreg = "0.55"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 transcribe-rs = { version = "=0.3.8", features = ["whisper-cpp", "whisper-metal", "onnx", "ort-coreml"] }

--- a/apps/whispering/src-tauri/src/command.rs
+++ b/apps/whispering/src-tauri/src/command.rs
@@ -31,8 +31,156 @@ pub async fn open_accessibility_settings() -> Result<(), String> {
         ));
     }
 
+    // Off macOS there is no such pane; the nudge is a no-op, not a failure (the
+    // only caller is the macOS Accessibility guide, which never opens elsewhere).
     #[cfg(not(target_os = "macos"))]
     {
-        Err("Accessibility settings are only available on macOS.".to_string())
+        Ok(())
     }
+}
+
+/// Show the macOS Accessibility permission prompt.
+///
+/// macOS never lets an app grant itself Accessibility, so this only surfaces the
+/// system prompt (which also adds the app to the Accessibility list, toggled
+/// off); the live grant is observed by the Rust tap supervisor, not returned
+/// here. Off macOS there is no such prompt, so this does nothing. Pairs with
+/// `open_accessibility_settings` the way `request_microphone_permission` does
+/// with the microphone privacy page.
+#[tauri::command]
+#[specta::specta]
+pub async fn request_accessibility_permission() {
+    #[cfg(target_os = "macos")]
+    tauri_plugin_macos_permissions::request_accessibility_permission().await;
+}
+
+/// The OS-level microphone authorization, read from the platform privacy store.
+///
+/// Only an explicit `Denied` gates recording. `Unknown` (no entry in the store,
+/// or a platform with no such gate) means "can't tell from here": the caller
+/// treats it as available and lets the recorder's stream-open fallback
+/// (`recorder::error::classify_cpal`) classify any real denial from the error
+/// itself. So this signal can only *add* a pre-record denial; it never newly
+/// blocks a setup that was already working.
+#[derive(Debug, Clone, Copy, serde::Serialize, specta::Type)]
+#[serde(rename_all = "snake_case")]
+pub enum MicrophonePermission {
+    Granted,
+    Denied,
+    Unknown,
+}
+
+/// Read the microphone authorization the OS records up front.
+///
+/// One owner for every platform. macOS answers through
+/// `tauri-plugin-macos-permissions` (AVFoundation), which reports a definitive
+/// authorized-or-not, so macOS only ever reads `Granted` or `Denied` (a
+/// not-yet-determined status reads as `Denied` and is resolved by the prompt in
+/// `request_microphone_permission`). Windows reads the CapabilityAccessManager
+/// ConsentStore. Every other platform (Linux) returns `Unknown`, where there is
+/// no such store and the stream-open fallback stays the sole classifier.
+#[tauri::command]
+#[specta::specta]
+pub async fn get_microphone_permission() -> MicrophonePermission {
+    #[cfg(target_os = "macos")]
+    {
+        if tauri_plugin_macos_permissions::check_microphone_permission().await {
+            MicrophonePermission::Granted
+        } else {
+            MicrophonePermission::Denied
+        }
+    }
+    #[cfg(target_os = "windows")]
+    {
+        windows_microphone_permission()
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        MicrophonePermission::Unknown
+    }
+}
+
+/// Windows records the microphone privacy choice as an `"Allow"`/`"Deny"` string
+/// under CapabilityAccessManager\ConsentStore. Three scopes gate a desktop app:
+/// the machine default (HKLM), the per-user default (HKCU), and the "let desktop
+/// apps access the microphone" toggle (HKCU\...\NonPackaged). A deny in any one
+/// blocks us, so report `Denied` if any is explicitly deny, `Granted` only when
+/// all three explicitly allow, and `Unknown` otherwise: the keys are absent on
+/// many installs, and a missing entry must not be read as a denial.
+#[cfg(target_os = "windows")]
+fn windows_microphone_permission() -> MicrophonePermission {
+    use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE};
+    use winreg::{RegKey, HKEY};
+
+    const MICROPHONE: &str = r"Software\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\microphone";
+    const NON_PACKAGED: &str = r"Software\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\microphone\NonPackaged";
+
+    // `Some(true)` allow, `Some(false)` deny, `None` no readable entry.
+    fn access(root: HKEY, path: &str) -> Option<bool> {
+        let value: String = RegKey::predef(root)
+            .open_subkey(path)
+            .ok()?
+            .get_value("Value")
+            .ok()?;
+        match value.to_ascii_lowercase().as_str() {
+            "allow" => Some(true),
+            "deny" => Some(false),
+            _ => None,
+        }
+    }
+
+    let scopes = [
+        access(HKEY_LOCAL_MACHINE, MICROPHONE),
+        access(HKEY_CURRENT_USER, MICROPHONE),
+        access(HKEY_CURRENT_USER, NON_PACKAGED),
+    ];
+
+    if scopes.iter().any(|scope| *scope == Some(false)) {
+        MicrophonePermission::Denied
+    } else if scopes.iter().all(|scope| *scope == Some(true)) {
+        MicrophonePermission::Granted
+    } else {
+        MicrophonePermission::Unknown
+    }
+}
+
+/// Elicit a microphone grant the way each platform allows, then let the caller
+/// re-read `get_microphone_permission`.
+///
+/// macOS shows the system permission prompt (its only programmatic grant path).
+/// Windows has no programmatic grant for an unpackaged desktop app, so when the
+/// consent store reads `Denied` it deep-links the privacy page for the user to
+/// toggle; an `Unknown`/`Granted` reading needs no nudge. Other platforms (Linux)
+/// have no such affordance and do nothing.
+#[tauri::command]
+#[specta::specta]
+pub async fn request_microphone_permission() -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        tauri_plugin_macos_permissions::request_microphone_permission().await
+    }
+    #[cfg(target_os = "windows")]
+    {
+        if matches!(windows_microphone_permission(), MicrophonePermission::Denied) {
+            open_windows_microphone_settings()?;
+        }
+        Ok(())
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        Ok(())
+    }
+}
+
+/// Deep-link the Windows microphone privacy page so the user can toggle access.
+#[cfg(target_os = "windows")]
+fn open_windows_microphone_settings() -> Result<(), String> {
+    use std::process::Command;
+    // `ms-settings:` URIs are launched by the shell, not run directly; go
+    // through `cmd /C start` so the OS resolves the privacy-microphone page.
+    Command::new("cmd")
+        .args(["/C", "start", "", "ms-settings:privacy-microphone"])
+        .spawn()
+        .map_err(|e| format!("Failed to open microphone privacy settings: {e}"))?;
+    Ok(())
 }

--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -22,7 +22,10 @@ use transcription::{
 };
 
 pub mod command;
-use command::open_accessibility_settings;
+use command::{
+    get_microphone_permission, open_accessibility_settings, request_accessibility_permission,
+    request_microphone_permission,
+};
 
 pub mod download;
 use download::{cancel_download, DownloadManager};
@@ -68,6 +71,9 @@ fn make_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             transcribe_recording,
             prewarm_model,
             open_accessibility_settings,
+            request_accessibility_permission,
+            get_microphone_permission,
+            request_microphone_permission,
             set_unload_policy,
             get_transcription_state,
             link_local_model,

--- a/apps/whispering/src/lib/tauri.tauri.ts
+++ b/apps/whispering/src/lib/tauri.tauri.ts
@@ -57,7 +57,6 @@ import { exit } from '@tauri-apps/plugin-process';
 import mime from 'mime';
 import { defineErrors, extractErrorMessage } from 'wellcrafted/error';
 import { Ok, tryAsync } from 'wellcrafted/result';
-import { os } from '#platform/os';
 import { goto } from '$app/navigation';
 import type { WhisperingRecordingState } from '$lib/constants/audio';
 import { defineMutation, defineQuery, queryClient } from '$lib/rpc/client';
@@ -133,22 +132,19 @@ const PermissionsError = defineErrors({
 
 const permissions = {
 	accessibility: {
+		// Rust owns the platform dispatch (macOS prompts via the permissions
+		// plugin, elsewhere a no-op), so the FE just calls the command. The prompt
+		// cannot grant in place; the live grant is observed by the Rust tap
+		// supervisor, so the Result here only reports whether the nudge fired.
 		async request() {
-			if (!os.isApple) return Ok(true);
 			return tryAsync({
-				try: async () => {
-					const { requestAccessibilityPermission } = await import(
-						'tauri-plugin-macos-permissions-api'
-					);
-					return requestAccessibilityPermission();
-				},
+				try: () => commands.requestAccessibilityPermission(),
 				catch: (error) =>
 					PermissionsError.RequestAccessibility({ cause: error }),
 			});
 		},
 
 		async openSettings() {
-			if (!os.isApple) return Ok(undefined);
 			const { error } = await commands.openAccessibilitySettings();
 			if (error !== null) {
 				return PermissionsError.OpenAccessibilitySettings({ cause: error });
@@ -158,30 +154,29 @@ const permissions = {
 	},
 
 	microphone: {
+		// One transport for every platform: Rust owns "what does the OS say about
+		// mic access" (macOS via the permissions plugin, Windows via the consent
+		// store, `unknown` elsewhere). Only an explicit `denied` gates; `granted`
+		// and `unknown` both read as available, so a missing consent entry never
+		// newly blocks a setup that was recording fine, and the recorder's
+		// stream-open fallback still classifies any real denial.
 		async check() {
-			if (!os.isApple) return Ok(true);
 			return tryAsync({
-				try: async () => {
-					const { checkMicrophonePermission } = await import(
-						'tauri-plugin-macos-permissions-api'
-					);
-					return checkMicrophonePermission();
-				},
+				try: async () =>
+					(await commands.getMicrophonePermission()) !== 'denied',
 				catch: (error) => PermissionsError.CheckMicrophone({ cause: error }),
 			});
 		},
 
+		// Elicit a grant the way the platform allows (macOS prompt, Windows privacy
+		// page when denied); the caller re-checks afterward. No platform can grant
+		// in place, so this only reports whether the nudge itself succeeded.
 		async request() {
-			if (!os.isApple) return Ok(true);
-			return tryAsync({
-				try: async () => {
-					const { requestMicrophonePermission } = await import(
-						'tauri-plugin-macos-permissions-api'
-					);
-					return requestMicrophonePermission();
-				},
-				catch: (error) => PermissionsError.RequestMicrophone({ cause: error }),
-			});
+			const { error } = await commands.requestMicrophonePermission();
+			if (error !== null) {
+				return PermissionsError.RequestMicrophone({ cause: error });
+			}
+			return Ok(undefined);
 		},
 	},
 };

--- a/apps/whispering/src/lib/tauri/bindings.gen.ts
+++ b/apps/whispering/src/lib/tauri/bindings.gen.ts
@@ -136,6 +136,43 @@ export const commands = {
 	openAccessibilitySettings: () =>
 		typedError<null, string>(__TAURI_INVOKE('open_accessibility_settings')),
 	/**
+	 *  Show the macOS Accessibility permission prompt.
+	 *
+	 *  macOS never lets an app grant itself Accessibility, so this only surfaces the
+	 *  system prompt (which also adds the app to the Accessibility list, toggled
+	 *  off); the live grant is observed by the Rust tap supervisor, not returned
+	 *  here. Off macOS there is no such prompt, so this does nothing. Pairs with
+	 *  `open_accessibility_settings` the way `request_microphone_permission` does
+	 *  with the microphone privacy page.
+	 */
+	requestAccessibilityPermission: () =>
+		__TAURI_INVOKE<void>('request_accessibility_permission'),
+	/**
+	 *  Read the microphone authorization the OS records up front.
+	 *
+	 *  One owner for every platform. macOS answers through
+	 *  `tauri-plugin-macos-permissions` (AVFoundation), which reports a definitive
+	 *  authorized-or-not, so macOS only ever reads `Granted` or `Denied` (a
+	 *  not-yet-determined status reads as `Denied` and is resolved by the prompt in
+	 *  `request_microphone_permission`). Windows reads the CapabilityAccessManager
+	 *  ConsentStore. Every other platform (Linux) returns `Unknown`, where there is
+	 *  no such store and the stream-open fallback stays the sole classifier.
+	 */
+	getMicrophonePermission: () =>
+		__TAURI_INVOKE<MicrophonePermission>('get_microphone_permission'),
+	/**
+	 *  Elicit a microphone grant the way each platform allows, then let the caller
+	 *  re-read `get_microphone_permission`.
+	 *
+	 *  macOS shows the system permission prompt (its only programmatic grant path).
+	 *  Windows has no programmatic grant for an unpackaged desktop app, so when the
+	 *  consent store reads `Denied` it deep-links the privacy page for the user to
+	 *  toggle; an `Unknown`/`Granted` reading needs no nudge. Other platforms (Linux)
+	 *  have no such affordance and do nothing.
+	 */
+	requestMicrophonePermission: () =>
+		typedError<null, string>(__TAURI_INVOKE('request_microphone_permission')),
+	/**
 	 *  Reconcile the current local-model unload policy into the native idle
 	 *  watcher. The frontend owns the value and pushes it on every change; Rust
 	 *  owns the clock. Unlike the old ambient config, it carries no model
@@ -534,6 +571,18 @@ export type LocalModelState = {
 	modelName: string | null;
 	status: ModelStatus;
 };
+
+/**
+ *  The OS-level microphone authorization, read from the platform privacy store.
+ *
+ *  Only an explicit `Denied` gates recording. `Unknown` (no entry in the store,
+ *  or a platform with no such gate) means "can't tell from here": the caller
+ *  treats it as available and lets the recorder's stream-open fallback
+ *  (`recorder::error::classify_cpal`) classify any real denial from the error
+ *  itself. So this signal can only *add* a pre-record denial; it never newly
+ *  blocks a setup that was already working.
+ */
+export type MicrophonePermission = 'granted' | 'denied' | 'unknown';
 
 /**  One selectable entry in an engine's models folder. */
 export type ModelEntry = {

--- a/bun.lock
+++ b/bun.lock
@@ -509,7 +509,6 @@
         "nanoid": "catalog:",
         "openai": "^5.7.0",
         "tailwind-variants": "catalog:",
-        "tauri-plugin-macos-permissions-api": "^2.3.0",
         "typebox": "catalog:",
         "wellcrafted": "catalog:",
         "yjs": "catalog:",
@@ -3728,8 +3727,6 @@
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
-    "tauri-plugin-macos-permissions-api": ["tauri-plugin-macos-permissions-api@2.3.0", "", { "dependencies": { "@tauri-apps/api": "^2.5.0" } }, "sha512-pZp0jmDySysBqrGueknd1a7Rr4XEO9aXpMv9TNrT2PDHP0MSH20njieOagsFYJ5MCVb8A+wcaK0cIkjUC2dOww=="],
-
     "temporal-polyfill": ["temporal-polyfill@0.3.2", "", { "dependencies": { "temporal-spec": "0.3.1" } }, "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg=="],
 
     "temporal-spec": ["temporal-spec@0.3.1", "", {}, "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw=="],
@@ -4391,8 +4388,6 @@
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
-
-    "tauri-plugin-macos-permissions-api/@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
 
     "to-buffer/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 


### PR DESCRIPTION
Microphone and accessibility permission each had two transports for one concept. The frontend branched on `os.isApple` to call the macOS permissions plugin in JavaScript, while Windows went through a Rust command that read the registry. The cfg-aware Rust layer is the better-positioned owner of "what does the OS say about access," so this folds every platform into it and the frontend stops dispatching on the operating system.

**Old shape:** the `permissions` bag in `tauri.tauri.ts` was the platform dispatcher. `microphone.check()` and `microphone.request()` each carried an `if (os.isApple)` arm that dynamically imported `tauri-plugin-macos-permissions-api` (the JavaScript sibling), with a separate Rust path for everyone else. `accessibility` mirrored the same shape.

**New shape:** Rust answers for every platform, and the frontend just calls the command.

- `get_microphone_permission` resolves macOS through the permissions plugin's AVFoundation check (the plugin re-exports its commands as plain Rust functions, so they are callable directly, not only over IPC), Windows through the CapabilityAccessManager consent store, and `Unknown` elsewhere.
- `request_microphone_permission` (new) prompts on macOS, deep-links the privacy page on Windows when the consent store reads denied, and is a no-op on Linux. It replaces the Windows-only `open_microphone_settings`.
- `request_accessibility_permission` (new) surfaces the macOS Accessibility prompt and is a no-op elsewhere. `open_accessibility_settings` now returns `Ok` off macOS instead of an error, so its frontend guard drops with identical behavior.

The frontend `permissions` bag becomes pure transport with no `os` import, and the `tauri-plugin-macos-permissions-api` JavaScript dependency is removed. The Rust plugin (`tauri-plugin-macos-permissions`, already registered) stays, now called from Rust.

**Ownership.** "What does the OS say about microphone or accessibility access" has exactly one owner per concept, the Rust command, across every platform. The tri-state `MicrophonePermission` (granted / denied / unknown) stays because Rust's own Windows request path needs to tell `denied` (open settings) from `unknown` or `granted` (do nothing), and because it is the honest model of what the OS reports. Only an explicit `denied` gates recording; `unknown` and `granted` both read as available, so a missing consent entry never newly blocks a setup that was already recording, and the recorder's stream-open fallback (`classify_cpal`) still classifies any real denial from the error itself.

Behavior is unchanged on macOS, Windows, and Linux.

## Changelog

- Whispering now reads your Windows microphone privacy setting before recording and sends you to the privacy page when access is turned off, instead of only failing the moment it tries to open the microphone.
