### PR TITLE
refactor: split answerer resolution into owner ⊥ engine

### DIFF
--- a/apps/zhongwen/epicenter-engine.ts
+++ b/apps/zhongwen/epicenter-engine.ts
@@ -1,0 +1,46 @@
+/**
+ * The metered Epicenter engine: a zhongwen {@link Engine} that answers on the
+ * user's Epicenter account over the `/api/ai/chat` SSE stream (the Epicenter
+ * provider, ADR-0033). Both peers that can power it (an open browser tab, a
+ * signed-in daemon) build it the same way, so the wire shape (the AI-chat fetch
+ * wrapper, the route, the `model` + `systemPrompts` body) is single-homed here
+ * instead of duplicated at each call site.
+ *
+ * It lives outside the dep-free contract (`zhongwen.ts`) on purpose: it pulls in
+ * `@epicenter/client`, so it is its own subpath (`@epicenter/zhongwen/engine`),
+ * and each peer constructs it from its own session fetch and base URL.
+ */
+
+import type { AuthFetch } from '@epicenter/auth';
+import {
+	createAiChatFetch,
+	createEpicenterProviderChatStream,
+} from '@epicenter/client';
+import { API_ROUTES } from '@epicenter/constants/api-routes';
+import {
+	type Engine,
+	ZHONGWEN_MODEL,
+	ZHONGWEN_SYSTEM_PROMPT,
+} from './zhongwen.js';
+
+/**
+ * Build the metered Epicenter {@link Engine} for one peer.
+ *
+ * @param sessionFetch the peer's authenticated fetch (the browser's `auth.fetch`,
+ *   the daemon's `session.fetch`); wrapped here for the AI-chat route.
+ * @param baseURL the Epicenter API origin the SSE route lives under.
+ */
+export function epicenterMeteredEngine(
+	sessionFetch: AuthFetch,
+	baseURL: string,
+): Engine {
+	return () =>
+		createEpicenterProviderChatStream({
+			fetch: createAiChatFetch(sessionFetch),
+			url: API_ROUTES.ai.chat.url(baseURL),
+			data: () => ({
+				model: ZHONGWEN_MODEL,
+				systemPrompts: [ZHONGWEN_SYSTEM_PROMPT],
+			}),
+		});
+}

--- a/apps/zhongwen/mount.ts
+++ b/apps/zhongwen/mount.ts
@@ -15,7 +15,7 @@
  * (`startStream(messages, signal) => AsyncIterable<StreamChunk>`), the one
  * contract every inference backend speaks. The daemon resolves which backend
  * serves a turn as a priority chain over the backends it can satisfy
- * ({@link resolveChatStream}, ADR-0038), not a hardcoded constant:
+ * ({@link resolveDaemonStream}, ADR-0038), not a hardcoded constant:
  *
  * ```txt
  * byok(key)                if a local provider key is present (answer free)
@@ -34,9 +34,9 @@
  * (`row.agent === selfAgentId`), so the factory supplies behavior alone. The
  * `agentId` option names which catalog agent this daemon answers as (a
  * `ZHONGWEN_AGENTS` id like `zhongwen-home`); omit it and the daemon hosts
- * nothing, leaving every conversation to its bound agent. The browser nudges the
- * HTTP route only for cloud-runtime conversations, so a single turn is never
- * answered twice.
+ * nothing, leaving every conversation to its bound agent. The browser answers
+ * in-process only the conversations it claims (an `'ephemeral'`-owner agent), so
+ * a single turn is never answered twice.
  */
 
 import {
@@ -55,6 +55,8 @@ import { attachChatWorker, type ChatStream } from '@epicenter/workspace/ai';
 import { nodeMountRuntime } from '@epicenter/workspace/node';
 import { createLogger } from 'wellcrafted/logger';
 import {
+	type Engine,
+	resolveEngine,
 	ZHONGWEN_MODEL,
 	ZHONGWEN_SYSTEM_PROMPT,
 	zhongwenWorkspace,
@@ -90,7 +92,7 @@ export function zhongwen({ baseURL, agentId }: ZhongwenMountOptions = {}) {
 		workers: {
 			conversations: {
 				messages: (ctx) => {
-					backend ??= { startStream: resolveChatStream(ctx) };
+					backend ??= { startStream: resolveDaemonStream(ctx, agentId) };
 					return backend.startStream
 						? attachChatWorker({
 								ydoc: ctx.ydoc,
@@ -104,9 +106,12 @@ export function zhongwen({ baseURL, agentId }: ZhongwenMountOptions = {}) {
 }
 
 /**
- * Resolve the daemon's inference backend as ADR-0038's priority `??` chain over
- * the three sibling `ChatStream` constructors, returning the first the host can
- * satisfy or `null` when it can satisfy none:
+ * The daemon's inference backend for this mount: the first engine its host can
+ * power, ADR-0038's priority chain ({@link resolveEngine}) over the engines
+ * below. This resolves only the *engine* (where tokens come from); *designation*
+ * (which conversations are this daemon's) is the observe loop's job, which hosts
+ * only the conversations bound to this daemon's agent (`row.agent === agentId`,
+ * ADR-0025), so by here the turn is already its own.
  *
  *  - **byok**: a local provider key (`OPENAI_API_KEY` / `GEMINI_API_KEY`, the
  *    catalog picks which) answers free, with no cloud round-trip. The only path
@@ -117,60 +122,61 @@ export function zhongwen({ baseURL, agentId }: ZhongwenMountOptions = {}) {
  *    only ({@link isMeteredEnabled}): spending credits is a deliberate choice,
  *    symmetric with BYOK needing a key, so a keyless signed-in daemon never
  *    silently bills the user.
- *  - **neither**: host the conversation's sync but answer nothing. The daemon
- *    writes no placeholder into a real, synced conversation; the turn stays
- *    unanswered for a configured answerer (a keyed daemon, or an open browser tab
- *    on the metered account).
+ *
+ * `null` (neither engine satisfiable) means host the conversation's sync but
+ * answer nothing: the daemon writes no placeholder into a real, synced
+ * conversation, and the turn stays unanswered for a configured answerer (a keyed
+ * daemon, or an open browser tab on the metered account).
  *
  * Switching the provider is a catalog + env-key change, no code edit. The
  * `session` and `baseURL` are the mount environment the worker factory receives
  * (ADR-0038's keystone): the credential the metered arm needs only exists once
  * the mount is open, never at `zhongwen({...})` construction.
  */
-function resolveChatStream({
-	session,
-	baseURL,
-}: Pick<
-	MountWorkerContext<string, unknown>,
-	'session' | 'baseURL'
->): ChatStream | null {
+function resolveDaemonStream(
+	{
+		session,
+		baseURL,
+	}: Pick<MountWorkerContext<string, unknown>, 'session' | 'baseURL'>,
+	agentId: AgentId | undefined,
+): ChatStream | null {
 	// The catalog gives the provider, and the provider -> house-key env var
 	// mapping is single-homed in `@epicenter/ai-adapters` (exhaustive, so a new
 	// provider is a compile error there, not a silent wrong key here).
 	const { provider } = MODELS_BY_ID[ZHONGWEN_MODEL];
 	const envVar = HOUSE_KEY_ENV_VAR[provider];
 
-	const byok = (): ChatStream | null => {
-		const apiKey = process.env[envVar];
-		return apiKey
-			? chatStreamFromAdapter(createAdapterForModel(ZHONGWEN_MODEL, apiKey), [
-					ZHONGWEN_SYSTEM_PROMPT,
-				])
-			: null;
-	};
+	const engines: readonly Engine[] = [
+		() => {
+			const apiKey = process.env[envVar];
+			return apiKey
+				? chatStreamFromAdapter(createAdapterForModel(ZHONGWEN_MODEL, apiKey), [
+						ZHONGWEN_SYSTEM_PROMPT,
+					])
+				: null;
+		},
+		() =>
+			isMeteredEnabled()
+				? createEpicenterProviderChatStream({
+						fetch: createAiChatFetch(session.fetch),
+						url: API_ROUTES.ai.chat.url(baseURL),
+						data: () => ({
+							model: ZHONGWEN_MODEL,
+							systemPrompts: [ZHONGWEN_SYSTEM_PROMPT],
+						}),
+					})
+				: null,
+	];
 
-	const metered = (): ChatStream | null =>
-		isMeteredEnabled()
-			? createEpicenterProviderChatStream({
-					fetch: createAiChatFetch(session.fetch),
-					url: API_ROUTES.ai.chat.url(baseURL),
-					data: () => ({
-						model: ZHONGWEN_MODEL,
-						systemPrompts: [ZHONGWEN_SYSTEM_PROMPT],
-					}),
-				})
-			: null;
-
-	const hostWithoutAnswering = (): null => {
+	const stream = resolveEngine(engines);
+	if (agentId && !stream) {
 		log.warn(
 			new Error(
 				`The Zhongwen daemon has no inference backend: ${envVar} is unset and ZHONGWEN_USE_METERED is off. It hosts conversation sync but does not answer. Set ${envVar} for local inference, or ZHONGWEN_USE_METERED=1 to answer on your metered Epicenter account.`,
 			),
 		);
-		return null;
-	};
-
-	return byok() ?? metered() ?? hostWithoutAnswering();
+	}
+	return stream;
 }
 
 /**

--- a/apps/zhongwen/mount.ts
+++ b/apps/zhongwen/mount.ts
@@ -44,16 +44,12 @@ import {
 	createAdapterForModel,
 	HOUSE_KEY_ENV_VAR,
 } from '@epicenter/ai-adapters';
-import {
-	createAiChatFetch,
-	createEpicenterProviderChatStream,
-} from '@epicenter/client';
 import { MODELS_BY_ID } from '@epicenter/constants/ai-providers';
-import { API_ROUTES } from '@epicenter/constants/api-routes';
 import type { AgentId, MountWorkerContext } from '@epicenter/workspace';
 import { attachChatWorker, type ChatStream } from '@epicenter/workspace/ai';
 import { nodeMountRuntime } from '@epicenter/workspace/node';
 import { createLogger } from 'wellcrafted/logger';
+import { epicenterMeteredEngine } from './epicenter-engine.js';
 import {
 	type Engine,
 	resolveEngine,
@@ -116,12 +112,12 @@ export function zhongwen({ baseURL, agentId }: ZhongwenMountOptions = {}) {
  *  - **byok**: a local provider key (`OPENAI_API_KEY` / `GEMINI_API_KEY`, the
  *    catalog picks which) answers free, with no cloud round-trip. The only path
  *    for an offline or self-hosted daemon, so it stays first.
- *  - **metered**: answer on the user's metered Epicenter account through the same
- *    `/api/ai/chat` SSE path the browser uses (`createEpicenterProviderChatStream`),
- *    authenticated with the `AuthedFetch` the daemon already syncs with. Opt-in
- *    only ({@link isMeteredEnabled}): spending credits is a deliberate choice,
- *    symmetric with BYOK needing a key, so a keyless signed-in daemon never
- *    silently bills the user.
+ *  - **metered**: answer on the user's metered Epicenter account over the same
+ *    `/api/ai/chat` SSE path the browser uses ({@link epicenterMeteredEngine}, the
+ *    shared builder), authenticated with the `AuthedFetch` the daemon already
+ *    syncs with. Opt-in only ({@link isMeteredEnabled}): spending credits is a
+ *    deliberate choice, symmetric with BYOK needing a key, so a keyless signed-in
+ *    daemon never silently bills the user.
  *
  * `null` (neither engine satisfiable) means host the conversation's sync but
  * answer nothing: the daemon writes no placeholder into a real, synced
@@ -146,6 +142,9 @@ function resolveDaemonStream(
 	const { provider } = MODELS_BY_ID[ZHONGWEN_MODEL];
 	const envVar = HOUSE_KEY_ENV_VAR[provider];
 
+	// The metered engine builds the same way for every peer; only the opt-in gate
+	// is the daemon's (a keyless signed-in daemon must not silently spend credits).
+	const metered = epicenterMeteredEngine(session.fetch, baseURL);
 	const engines: readonly Engine[] = [
 		() => {
 			const apiKey = process.env[envVar];
@@ -155,17 +154,7 @@ function resolveDaemonStream(
 					])
 				: null;
 		},
-		() =>
-			isMeteredEnabled()
-				? createEpicenterProviderChatStream({
-						fetch: createAiChatFetch(session.fetch),
-						url: API_ROUTES.ai.chat.url(baseURL),
-						data: () => ({
-							model: ZHONGWEN_MODEL,
-							systemPrompts: [ZHONGWEN_SYSTEM_PROMPT],
-						}),
-					})
-				: null,
+		() => (isMeteredEnabled() ? metered() : null),
 	];
 
 	const stream = resolveEngine(engines);

--- a/apps/zhongwen/package.json
+++ b/apps/zhongwen/package.json
@@ -7,6 +7,7 @@
 	"exports": {
 		".": "./zhongwen.ts",
 		"./browser": "./zhongwen.browser.ts",
+		"./engine": "./epicenter-engine.ts",
 		"./mount": "./mount.ts"
 	},
 	"scripts": {

--- a/apps/zhongwen/src/agents.test.ts
+++ b/apps/zhongwen/src/agents.test.ts
@@ -2,11 +2,11 @@
  * The agent catalog's routing invariants (ADR-0025/0033).
  *
  * The browser answers a conversation in-process (the Epicenter provider sourcing
- * tokens from `/api/ai/chat`) for, and only for, a bound agent that is NOT
- * daemon-runtime; a daemon-runtime agent is a resident listener left to answer
- * ambiently over sync (`ConversationView` reads `agentConfig().runtime`). These
- * tests pin the catalog data that fork reads, so flipping the cloud agent's
- * runtime (which would silently strand it: the browser would stop answering and
+ * tokens from `/api/ai/chat`) for, and only for, a bound agent the open tab owns
+ * (`owner: 'ephemeral'`); a `'durable'`-owner agent is a resident daemon left to
+ * answer ambiently over sync (`ConversationView` reads `agentConfig().owner`).
+ * These tests pin the catalog data that fork reads, so flipping the cloud agent's
+ * owner (which would silently strand it: the browser would stop answering and
  * defer to a daemon that isn't there) fails here instead of in the UI.
  */
 
@@ -20,16 +20,16 @@ import {
 } from '../zhongwen.js';
 
 describe('agent catalog', () => {
-	test('the cloud agent is cloud-runtime so the browser answers it in-process', () => {
-		expect(agentConfig(CLOUD_AGENT_ID)?.runtime).toBe('cloud');
+	test('the cloud agent is ephemeral-owned so the browser answers it in-process', () => {
+		expect(agentConfig(CLOUD_AGENT_ID)?.owner).toBe('ephemeral');
 	});
 
-	test('the default agent resolves to a cloud-runtime agent (no daemon required)', () => {
-		expect(agentConfig(DEFAULT_AGENT_ID)?.runtime).toBe('cloud');
+	test('the default agent resolves to an ephemeral-owned agent (no daemon required)', () => {
+		expect(agentConfig(DEFAULT_AGENT_ID)?.owner).toBe('ephemeral');
 	});
 
-	test('the home daemon is daemon-runtime so the browser leaves it to sync', () => {
-		expect(agentConfig(asAgentId('zhongwen-home'))?.runtime).toBe('daemon');
+	test('the home daemon is durable-owned so the browser leaves it to sync', () => {
+		expect(agentConfig(asAgentId('zhongwen-home'))?.owner).toBe('durable');
 	});
 
 	test('an id no longer in the catalog resolves to undefined, never answered', () => {

--- a/apps/zhongwen/src/agents.test.ts
+++ b/apps/zhongwen/src/agents.test.ts
@@ -15,15 +15,15 @@ import { asAgentId } from '@epicenter/workspace';
 import type { ChatStream } from '@epicenter/workspace/ai';
 import {
 	agentConfig,
-	CLOUD_AGENT_ID,
 	DEFAULT_AGENT_ID,
 	resolveEngine,
+	THIS_DEVICE_AGENT_ID,
 	ZHONGWEN_AGENTS,
 } from '../zhongwen.js';
 
 describe('agent catalog', () => {
-	test('the cloud agent is ephemeral-owned so the browser answers it in-process', () => {
-		expect(agentConfig(CLOUD_AGENT_ID)?.owner).toBe('ephemeral');
+	test('the this-device agent is ephemeral-owned so the browser answers it in-process', () => {
+		expect(agentConfig(THIS_DEVICE_AGENT_ID)?.owner).toBe('ephemeral');
 	});
 
 	test('the default agent resolves to an ephemeral-owned agent (no daemon required)', () => {

--- a/apps/zhongwen/src/agents.test.ts
+++ b/apps/zhongwen/src/agents.test.ts
@@ -12,10 +12,12 @@
 
 import { describe, expect, test } from 'bun:test';
 import { asAgentId } from '@epicenter/workspace';
+import type { ChatStream } from '@epicenter/workspace/ai';
 import {
 	agentConfig,
 	CLOUD_AGENT_ID,
 	DEFAULT_AGENT_ID,
+	resolveEngine,
 	ZHONGWEN_AGENTS,
 } from '../zhongwen.js';
 
@@ -39,5 +41,27 @@ describe('agent catalog', () => {
 	test('every catalog id is unique (one entry per agent)', () => {
 		const ids = ZHONGWEN_AGENTS.map((agent) => agent.id);
 		expect(new Set(ids).size).toBe(ids.length);
+	});
+});
+
+describe('resolveEngine', () => {
+	// Distinct sentinel streams so a test can assert *which* engine won.
+	const primary: ChatStream = async function* () {};
+	const fallback: ChatStream = async function* () {};
+
+	test('takes the first engine the host can power', () => {
+		expect(resolveEngine([() => primary, () => fallback])).toBe(primary);
+	});
+
+	test('falls through a null engine to the next in priority order', () => {
+		expect(resolveEngine([() => null, () => fallback])).toBe(fallback);
+	});
+
+	test('no satisfiable engine hosts without answering (null)', () => {
+		expect(resolveEngine([() => null, () => null])).toBeNull();
+	});
+
+	test('an empty engine list answers nothing', () => {
+		expect(resolveEngine([])).toBeNull();
 	});
 });

--- a/apps/zhongwen/src/routes/(signed-in)/components/ConversationView.svelte
+++ b/apps/zhongwen/src/routes/(signed-in)/components/ConversationView.svelte
@@ -1,16 +1,40 @@
 <script module lang="ts">
-	import { createAiChatFetch } from '@epicenter/client';
+	import {
+		createAiChatFetch,
+		createEpicenterProviderChatStream,
+	} from '@epicenter/client';
+	import { API_ROUTES } from '@epicenter/constants/api-routes';
+	import { APP_URLS } from '@epicenter/constants/vite';
+	import {
+		type Engine,
+		ZHONGWEN_MODEL,
+		ZHONGWEN_SYSTEM_PROMPT,
+	} from '@epicenter/zhongwen';
 	import { auth } from '$platform/auth';
 
 	// auth is a module singleton, so the wrapped fetch is built once and shared
 	// across every mounted ConversationView.
 	const aiChatFetch = createAiChatFetch(auth.fetch);
+
+	// The engines this tab can power, highest priority first, sharing the one
+	// wrapped fetch. Today just the metered Epicenter account over the
+	// `/api/ai/chat` SSE stream; adding a local-key engine ahead of it is the whole
+	// of "engine unification" (the same list the daemon walks). Built once, shared
+	// across every mounted view.
+	const browserEngines: readonly Engine[] = [
+		() =>
+			createEpicenterProviderChatStream({
+				fetch: aiChatFetch,
+				url: API_ROUTES.ai.chat.url(APP_URLS.API),
+				data: () => ({
+					model: ZHONGWEN_MODEL,
+					systemPrompts: [ZHONGWEN_SYSTEM_PROMPT],
+				}),
+			}),
+	];
 </script>
 
 <script lang="ts">
-	import { createEpicenterProviderChatStream } from '@epicenter/client';
-	import { API_ROUTES } from '@epicenter/constants/api-routes';
-	import { APP_URLS } from '@epicenter/constants/vite';
 	import { bindConversation } from '@epicenter/svelte';
 	import { Button } from '@epicenter/ui/button';
 	import * as Chat from '@epicenter/ui/chat';
@@ -18,8 +42,7 @@
 	import {
 		agentConfig,
 		type ConversationId,
-		ZHONGWEN_MODEL,
-		ZHONGWEN_SYSTEM_PROMPT,
+		resolveEngine,
 	} from '@epicenter/zhongwen';
 	import { onDestroy } from 'svelte';
 	import { requireZhongwen } from '$lib/session';
@@ -39,27 +62,21 @@
 		return zhongwen.tables.conversations.get(conversationId).data;
 	}
 
-	// Who answers this conversation? A `'durable'`-owner agent is a resident daemon
-	// that answers ambiently over sync, so the browser stays out (answering too
-	// would double-answer one turn). An `'ephemeral'`-owner binding (the cloud
-	// agent) is owned by this tab and answered in-process: the browser runs the
-	// same answerer the daemon does, sourcing tokens from the Epicenter provider
-	// (the metered /api/ai/chat SSE stream). The bound agent is immutable, so this
-	// never flips mid-conversation.
-	// ADR-0033: a conversation is a synced doc only an in-process peer writes.
+	// Who answers this conversation? Two orthogonal questions (ADR-0033). First,
+	// designation: does this tab write the turn? A tab answers only the agents it
+	// owns (an `'ephemeral'` owner); a `'durable'` owner is a resident daemon that
+	// answers ambiently over sync, so the tab stays out (answering too would answer
+	// one turn twice). The bound agent is immutable, so this never flips
+	// mid-conversation. Then engine: which backend powers the answer
+	// (`resolveEngine`, ADR-0038). ADR-0033: a conversation is a synced doc only an
+	// in-process peer writes.
 	// svelte-ignore state_referenced_locally
 	const boundAgent = readRow()?.agent;
-	const answer =
-		boundAgent !== undefined && agentConfig(boundAgent)?.owner === 'ephemeral'
-			? createEpicenterProviderChatStream({
-					fetch: aiChatFetch,
-					url: API_ROUTES.ai.chat.url(APP_URLS.API),
-					data: () => ({
-						model: ZHONGWEN_MODEL,
-						systemPrompts: [ZHONGWEN_SYSTEM_PROMPT],
-					}),
-				})
-			: undefined;
+	const answersHere =
+		boundAgent !== undefined && agentConfig(boundAgent)?.owner === 'ephemeral';
+	const answer = answersHere
+		? (resolveEngine(browserEngines) ?? undefined)
+		: undefined;
 
 	// The component is keyed on conversationId, so it mounts fresh per
 	// conversation: open the transcript doc and bind it (the answerer, the clock,

--- a/apps/zhongwen/src/routes/(signed-in)/components/ConversationView.svelte
+++ b/apps/zhongwen/src/routes/(signed-in)/components/ConversationView.svelte
@@ -39,17 +39,18 @@
 		return zhongwen.tables.conversations.get(conversationId).data;
 	}
 
-	// Who answers this conversation? A daemon-runtime agent is a resident listener
+	// Who answers this conversation? A `'durable'`-owner agent is a resident daemon
 	// that answers ambiently over sync, so the browser stays out (answering too
-	// would double-answer one turn). Any other binding (the cloud agent) is
-	// answered in-process: the browser runs the same answerer the daemon does,
-	// sourcing tokens from the Epicenter provider (the metered /api/ai/chat SSE
-	// stream). The bound agent is immutable, so this never flips mid-conversation.
+	// would double-answer one turn). An `'ephemeral'`-owner binding (the cloud
+	// agent) is owned by this tab and answered in-process: the browser runs the
+	// same answerer the daemon does, sourcing tokens from the Epicenter provider
+	// (the metered /api/ai/chat SSE stream). The bound agent is immutable, so this
+	// never flips mid-conversation.
 	// ADR-0033: a conversation is a synced doc only an in-process peer writes.
 	// svelte-ignore state_referenced_locally
 	const boundAgent = readRow()?.agent;
 	const answer =
-		boundAgent !== undefined && agentConfig(boundAgent)?.runtime !== 'daemon'
+		boundAgent !== undefined && agentConfig(boundAgent)?.owner === 'ephemeral'
 			? createEpicenterProviderChatStream({
 					fetch: aiChatFetch,
 					url: API_ROUTES.ai.chat.url(APP_URLS.API),

--- a/apps/zhongwen/src/routes/(signed-in)/components/ConversationView.svelte
+++ b/apps/zhongwen/src/routes/(signed-in)/components/ConversationView.svelte
@@ -1,36 +1,15 @@
 <script module lang="ts">
-	import {
-		createAiChatFetch,
-		createEpicenterProviderChatStream,
-	} from '@epicenter/client';
-	import { API_ROUTES } from '@epicenter/constants/api-routes';
 	import { APP_URLS } from '@epicenter/constants/vite';
-	import {
-		type Engine,
-		ZHONGWEN_MODEL,
-		ZHONGWEN_SYSTEM_PROMPT,
-	} from '@epicenter/zhongwen';
+	import type { Engine } from '@epicenter/zhongwen';
+	import { epicenterMeteredEngine } from '@epicenter/zhongwen/engine';
 	import { auth } from '$platform/auth';
 
-	// auth is a module singleton, so the wrapped fetch is built once and shared
-	// across every mounted ConversationView.
-	const aiChatFetch = createAiChatFetch(auth.fetch);
-
-	// The engines this tab can power, highest priority first, sharing the one
-	// wrapped fetch. Today just the metered Epicenter account over the
-	// `/api/ai/chat` SSE stream; adding a local-key engine ahead of it is the whole
-	// of "engine unification" (the same list the daemon walks). Built once, shared
-	// across every mounted view.
+	// The engines this tab can power, highest priority first. Today just the
+	// metered Epicenter account over the `/api/ai/chat` SSE stream; adding a
+	// local-key engine ahead of it is the whole of "engine unification" (the same
+	// list the daemon walks). Built once, shared across every mounted view.
 	const browserEngines: readonly Engine[] = [
-		() =>
-			createEpicenterProviderChatStream({
-				fetch: aiChatFetch,
-				url: API_ROUTES.ai.chat.url(APP_URLS.API),
-				data: () => ({
-					model: ZHONGWEN_MODEL,
-					systemPrompts: [ZHONGWEN_SYSTEM_PROMPT],
-				}),
-			}),
+		epicenterMeteredEngine(auth.fetch, APP_URLS.API),
 	];
 </script>
 

--- a/apps/zhongwen/zhongwen.ts
+++ b/apps/zhongwen/zhongwen.ts
@@ -53,14 +53,17 @@ export const generateConversationId = (): ConversationId =>
 export const ZHONGWEN_MODEL = 'gemini-3.5-flash' satisfies ServableModel;
 
 /**
- * The hosted cloud agent's stable address (ADR-0025). A new conversation is bound
- * to this agent, so the browser answers it in-process, sourcing tokens from the
- * metered `/api/ai/chat` stream via the Epicenter provider (ADR-0033).
- * The binding is immutable: to talk to a different agent you fork the conversation,
- * so a conversation's history only ever reaches its one bound agent. An always-on
- * daemon answers instead when a conversation is bound to that daemon's agent id.
+ * The ephemeral agent's stable address (ADR-0025): the one the open browser tab
+ * owns and answers in-process, sourcing tokens from the metered `/api/ai/chat`
+ * stream via the Epicenter provider (ADR-0033). The id names the *owner* (the
+ * device's tab, which is why the answer stops when you close it), not the engine
+ * (the cloud credits the tokens are billed to): owner ⊥ engine. A new conversation
+ * binds to this agent by default. The binding is immutable: to talk to a different
+ * agent you fork the conversation, so a conversation's history only ever reaches
+ * its one bound agent. An always-on daemon answers instead when a conversation is
+ * bound to that daemon's agent id.
  */
-export const CLOUD_AGENT_ID: AgentId = asAgentId('epicenter-cloud');
+export const THIS_DEVICE_AGENT_ID: AgentId = asAgentId('this-device');
 
 // Re-export the agent address type so app UI binds against one import surface
 // (`@epicenter/zhongwen`) for the agent catalog and the ids it hands the picker.
@@ -74,7 +77,7 @@ export type { AgentId };
  *
  * `owner` is the routing fork the browser reads, and it names who writes the
  * transcript, not where tokens come from (ADR-0025). An `'ephemeral'` agent
- * (`epicenter-cloud`) is owned by the open browser tab, which answers in-process
+ * (`this-device`) is owned by the open browser tab, which answers in-process
  * and stops when it closes. A `'durable'` agent is an always-on resident daemon,
  * which answers over sync and survives the tab closing, so the browser stays out
  * of the way (both answering would answer one turn twice, the D3 hazard). The
@@ -97,15 +100,15 @@ export type AgentConfig = {
  * daemon waits in the doc until that daemon wakes and answers. Presence only ever
  * decorates this list with a live/offline hint; it never gates what can be bound.
  *
- * The hosted cloud agent is always available (the browser answers it in-process
+ * The this-device agent is always available (the open tab answers it in-process
  * against the hosted inference stream, no daemon required). The home daemon is the
  * always-on worker a user co-deploys; binding a
  * conversation to it is what a later "co-deploy a live daemon" slice brings online.
  */
 export const ZHONGWEN_AGENTS = [
 	{
-		id: CLOUD_AGENT_ID,
-		label: 'Epicenter Cloud',
+		id: THIS_DEVICE_AGENT_ID,
+		label: 'This device',
 		model: ZHONGWEN_MODEL,
 		tools: [],
 		owner: 'ephemeral',
@@ -121,10 +124,10 @@ export const ZHONGWEN_AGENTS = [
 
 /**
  * The agent a new conversation binds to when the user does not pick one: the
- * always-available cloud agent, so the fast "New Conversation" path answers with
- * no daemon required.
+ * always-available this-device agent, so the fast "New Conversation" path answers
+ * with no daemon required.
  */
-export const DEFAULT_AGENT_ID: AgentId = CLOUD_AGENT_ID;
+export const DEFAULT_AGENT_ID: AgentId = THIS_DEVICE_AGENT_ID;
 
 /**
  * The catalog entry for a bound `agent`, or `undefined` for an id no longer in
@@ -201,7 +204,7 @@ const conversationsTable = defineTable({
 	updatedAt: field.instant(),
 	/**
 	 * The agent this conversation is bound to (ADR-0025), set once at creation and
-	 * never reassigned. {@link CLOUD_AGENT_ID} routes to the browser answering
+	 * never reassigned. {@link THIS_DEVICE_AGENT_ID} routes to the browser answering
 	 * in-process (the Epicenter provider); a daemon's agent id routes to that
 	 * always-on worker over sync, and the browser stays out. One immutable
 	 * field is who was addressed and who answered, for every turn: the history

--- a/apps/zhongwen/zhongwen.ts
+++ b/apps/zhongwen/zhongwen.ts
@@ -66,21 +66,25 @@ export type { AgentId };
 /**
  * One agent Zhongwen can bind a conversation to: its durable {@link AgentId},
  * a display `label` for the picker, the `model` it answers with, the action keys
- * it may call as tools (ADR-0021; none yet), and where its runtime lives.
+ * it may call as tools (ADR-0021; none yet), and the `owner` kind that writes its
+ * conversations.
  *
- * `runtime` is the routing fork the browser reads: a `'cloud'` agent is answered
- * in-process by the browser (the Epicenter provider sourcing tokens from the
- * metered `/api/ai/chat` stream); a `'daemon'` agent is an always-on resident
- * worker that answers over sync, so the browser stays out of the way (both
- * answering would answer one turn twice, the D3 hazard). The catalog is the one
- * place that fork is declared (ADR-0033).
+ * `owner` is the routing fork the browser reads, and it names who writes the
+ * transcript, not where tokens come from (ADR-0025). An `'ephemeral'` agent
+ * (`epicenter-cloud`) is owned by the open browser tab, which answers in-process
+ * and stops when it closes. A `'durable'` agent is an always-on resident daemon,
+ * which answers over sync and survives the tab closing, so the browser stays out
+ * of the way (both answering would answer one turn twice, the D3 hazard). The
+ * engine each writer uses (a local key, the user's metered account) is an
+ * orthogonal sub-choice it resolves for itself (ADR-0038), never a property of
+ * the owner. The catalog is the one place the owner fork is declared (ADR-0033).
  */
 export type AgentConfig = {
 	readonly id: AgentId;
 	readonly label: string;
 	readonly model: ServableModel;
 	readonly tools: readonly string[];
-	readonly runtime: 'cloud' | 'daemon';
+	readonly owner: 'ephemeral' | 'durable';
 };
 
 /**
@@ -101,14 +105,14 @@ export const ZHONGWEN_AGENTS = [
 		label: 'Epicenter Cloud',
 		model: ZHONGWEN_MODEL,
 		tools: [],
-		runtime: 'cloud',
+		owner: 'ephemeral',
 	},
 	{
 		id: asAgentId('zhongwen-home'),
 		label: 'Home daemon',
 		model: ZHONGWEN_MODEL,
 		tools: [],
-		runtime: 'daemon',
+		owner: 'durable',
 	},
 ] as const satisfies readonly AgentConfig[];
 
@@ -122,8 +126,8 @@ export const DEFAULT_AGENT_ID: AgentId = CLOUD_AGENT_ID;
 /**
  * The catalog entry for a bound `agent`, or `undefined` for an id no longer in
  * the catalog (a conversation bound before the agent was removed). Callers read
- * `runtime` to route: anything that is not a resident `'daemon'` the browser
- * answers in-process; a `'daemon'` agent is left to answer over sync.
+ * `owner` to route: an `'ephemeral'` agent the browser answers in-process; a
+ * `'durable'` agent is left to its resident daemon over sync.
  */
 export function agentConfig(id: AgentId): AgentConfig | undefined {
 	return ZHONGWEN_AGENTS.find((agent) => agent.id === id);

--- a/apps/zhongwen/zhongwen.ts
+++ b/apps/zhongwen/zhongwen.ts
@@ -28,7 +28,10 @@ import {
 	type Id,
 	type InferTableRow,
 } from '@epicenter/workspace';
-import { attachChatConversation } from '@epicenter/workspace/ai';
+import {
+	attachChatConversation,
+	type ChatStream,
+} from '@epicenter/workspace/ai';
 import { Type } from 'typebox';
 import type { Brand } from 'wellcrafted/brand';
 
@@ -131,6 +134,37 @@ export const DEFAULT_AGENT_ID: AgentId = CLOUD_AGENT_ID;
  */
 export function agentConfig(id: AgentId): AgentConfig | undefined {
 	return ZHONGWEN_AGENTS.find((agent) => agent.id === id);
+}
+
+/**
+ * One inference backend a peer can power, built lazily: it returns a
+ * {@link ChatStream} when the host can satisfy it (a key is present, the account
+ * is opted in) or `null` when it cannot, so {@link resolveEngine} can fall
+ * through to the next engine in priority order (ADR-0038).
+ */
+export type Engine = () => ChatStream | null;
+
+/**
+ * The `ChatStream` to answer with, taken from the first engine this host can
+ * power, or `null` when it can power none: host the conversation's sync, write
+ * nothing, leave the turn for a configured answerer.
+ *
+ * This is only the *engine* half of answering, where tokens come from. The other
+ * half, *designation* (is this turn mine to write?), is the owner fork and is
+ * decided where each peer naturally decides it, never here: a daemon's observe
+ * loop hosts only the conversations bound to its agent (`row.agent ===
+ * selfAgentId`, ADR-0025), so by the time it resolves an engine the turn is
+ * already its own; a browser tab reads the bound agent's `owner` kind before it
+ * mounts an answerer at all. The two halves are orthogonal (owner ⊥ engine,
+ * ADR-0033/0038), so they are not forced through one function: doing so made the
+ * daemon's designation a tautology (it would only ever pass its own agent).
+ */
+export function resolveEngine(engines: readonly Engine[]): ChatStream | null {
+	for (const engine of engines) {
+		const stream = engine();
+		if (stream) return stream; // first engine this host can power
+	}
+	return null; // no engine here → host, don't answer
 }
 
 /**

--- a/docs/adr/0025-agent-conversations-are-durable-child-docs-driven-by-an-observing-worker.md
+++ b/docs/adr/0025-agent-conversations-are-durable-child-docs-driven-by-an-observing-worker.md
@@ -1,6 +1,6 @@
 # 0025. Agent conversations are durable child docs driven by an observing worker
 
-- **Status:** Proposed
+- **Status:** Accepted (amended 2026-06-19)
 - **Date:** 2026-06-16
 
 ## Context
@@ -29,9 +29,22 @@ process that answers as it (the role distinction is pinned in
 [ADR-0024](0024-an-always-on-worker-runs-app-semantics-beside-the-app-blind-anchor.md)).
 Presence can decorate the configured agent list
 with live/offline status and capabilities, but it is not durable routing truth.
-The binding is the row field. The cloud agent is `epicenter-cloud`, whose current
-runtime is the metered HTTP route; a daemon answers when a conversation is bound
-to its agent id.
+The binding is the row field, and it names a *writer* of the transcript, not a
+token source. A binding is one of two kinds. A **durable writer** is an always-on
+daemon agent (a home or laptop daemon): it answers ambiently over sync and
+survives the client closing, so a turn it owns is answered even while every
+browser is shut. An **ephemeral writer** is the open browser tab itself, bound
+through the `epicenter-cloud` agent: it answers in-process while it is open and
+stops when it closes. The cloud is never a writer and never an owner:
+`epicenter-cloud` does not name a server that answers, it names the open tab
+answering with Epicenter's metered inference as its engine. Which engine a writer
+uses (a local key, the user's metered account, a proxied cloud stream) is an
+orthogonal sub-choice it resolves for itself
+([ADR-0038](0038-a-daemon-answers-through-the-first-inference-backend-it-can-satisfy.md)),
+and the metered route streams tokens while writing no doc
+([ADR-0033](0033-a-conversation-has-one-transport-and-two-triggers.md)). Whether
+the writer survives you leaving is the whole reason the choice matters, and it is
+the only thing the binding decides.
 
 This single field is the whole binding, and the collapse it buys is the reason it is
 immutable. Because the agent never changes, the conversation's content only ever
@@ -49,8 +62,15 @@ in to keep history honest; the immutable binding refuses both.
 Each daemon reconciles the conversations bound to the agent it answers as: it
 observes their transcripts, answers any unanswered turn, and is idempotent through
 the durable client-minted `generationId` used as the assistant message id. There is
-no claim and no race, because exactly one agent is named per conversation (and CRDT
-merges could not enforce a claimant anyway).
+no claim *field* and no lock: the assistant message keyed to the `generationId`
+is itself the claim (existence is the claim,
+[ADR-0033](0033-a-conversation-has-one-transport-and-two-triggers.md)), so
+whoever appends it first wins and any other observer reconciles the same
+predicate and stops. Naming exactly one owner per conversation is what makes
+contention rare in the first place (and CRDT merges could not enforce a claimant
+anyway); the existence-claim then covers the seams one owner still leaves: a
+restart re-observing its own already-answered turn, or the open tab and its
+daemon overlapping for an instant.
 
 The worker observes the transcript mid-answer so it can honor a durable, client-owned
 cancel field, and it writes the write-once `finish`. Tool calls are the workspace's
@@ -85,15 +105,16 @@ doorbell), never the durable queue (the doc is the mailbox).
   app-aware worker out of the app-blind anchor's availability job
   ([ADR-0024](0024-an-always-on-worker-runs-app-semantics-beside-the-app-blind-anchor.md)).
   The worker itself carries no designation concept. The browser supplies the
-  complementary half: it nudges the cloud agent's HTTP route only when the
-  conversation is bound to the cloud agent (`epicenter-cloud`), and does nothing for
-  a conversation bound to a daemon agent (that daemon answers over sync). So a
-  daemon-bound conversation is answered only by its daemon and a cloud-bound one only
-  by the HTTP path; neither ever answers a turn the other does. The bound agent is
-  immutable, so this split never flips mid-conversation. The cloud agent is therefore
-  never deleted (it is an always-available answerer whose runtime is the metered,
-  serverless route); what C4 removes is the `null`-as-cloud special case, not the
-  route.
+  complementary half by deriving the same fact from the same field: for an
+  ephemeral (`epicenter-cloud`) binding the open tab answers in-process, calling
+  the metered route only as its engine; for a daemon binding it does nothing and
+  lets that daemon answer over sync. So a daemon-bound conversation is answered
+  only by its daemon and an ephemeral one only by the tab that owns it; neither
+  ever answers a turn the other does. The bound agent is immutable, so this split
+  never flips mid-conversation. The `epicenter-cloud` binding is therefore never
+  deleted (it is the always-available ephemeral writer, whose engine is the
+  metered, serverless route); what C4 removes is the `null`-as-cloud special case,
+  not the route.
 - The conversation is a row plus a transcript child doc, and that split is the
   portability seam. The agent is named once on the row at creation and never
   reassigned; the transcript carries no agent identity, so it stays portable content.

--- a/packages/svelte-utils/src/bind-conversation.svelte.ts
+++ b/packages/svelte-utils/src/bind-conversation.svelte.ts
@@ -39,7 +39,7 @@ export type BoundConversation = Disposable & {
  * ```svelte
  * const convo = bindConversation(
  *   workspace.tables.conversations.docs.messages.open(conversationId),
- *   { answer: runtime === 'daemon' ? undefined : epicenterStream({ ... }) },
+ *   { answer: owner === 'durable' ? undefined : epicenterStream({ ... }) },
  * );
  * // {#each convo.render.visibleMessages as m} … convo.send(t) / convo.stop()
  * ```


### PR DESCRIPTION
Stacked on #2122 (now merged). Separates the two orthogonal questions a Zhongwen answerer resolves, which were previously tangled in one place, into the two axes named by ADR-0033/0038:

- **owner** (designation): *who writes the transcript?* An `'ephemeral'` agent (`this-device`) is owned by the open browser tab, which answers in-process and stops when it closes. A `'durable'` agent is an always-on resident daemon that answers over sync. Each peer decides designation where it naturally can: a daemon's observe loop hosts only conversations bound to its agent; a browser reads the bound agent's `owner` before mounting an answerer.
- **engine** (where tokens come from): a local key, the user's metered account. Resolved as a priority walk (`resolveEngine`) the same way on both peers, never a property of the owner.

This change:
- The agent catalog declares an `owner` kind (`'ephemeral' | 'durable'`), not a `runtime`: the routing fork is about who writes, not where the runtime lives.
- The ephemeral agent is renamed `epicenter-cloud` → `this-device`: the id names the *owner* (the device's tab, which is why the answer stops when you close it), not the engine (the cloud the tokens bill to). owner ⊥ engine.
- The engine walk is shared, leaving designation where each peer decides it (a daemon funnelling designation through the same function made it a tautology).
- The metered Epicenter engine is single-homed in `epicenterMeteredEngine(sessionFetch, baseURL)` on a new `@epicenter/zhongwen/engine` subpath: both peers (browser tab, signed-in daemon) build the same wire shape (AI-chat fetch wrap, `/api/ai/chat` route, `{ model, systemPrompts }`) from one place, kept out of the dep-free `zhongwen.ts` contract.

Unblocks the picker's live/offline presence decoration (which reads the `owner` fork) and the larger agentic tool-loop work, both as follow-ups.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784566791&installation_id=128463665&pr_number=2127&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2127&signature=4330caa7cc779d576288b5f2fcb310d2655c58979a41f031eaed7a778f3a70f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->