### PR TITLE
feat(workspace,server): carry agent designation through presence

### DIFF
--- a/packages/server/src/room/backends/cloudflare/durable-object.test.ts
+++ b/packages/server/src/room/backends/cloudflare/durable-object.test.ts
@@ -266,6 +266,7 @@ type WirePeer = {
 	nodeId: string;
 	connectedAt: number;
 	actions: Record<string, unknown>;
+	agentId?: string;
 };
 type PresenceFrame = { type: 'presence'; peers: WirePeer[] };
 
@@ -353,6 +354,38 @@ describe('Room presence: directed frame on upgrade', () => {
 		expect(nodeA!.nodeId).toBe('A');
 		expect(typeof nodeA!.connectedAt).toBe('number');
 		expect(nodeA!.actions).toEqual({});
+	});
+});
+
+describe('Room presence: agent designation', () => {
+	test('a published agentId rides the peer entry to other nodes', async () => {
+		const { room } = await makeRoom();
+		const daemonWs = await upgrade(room, 'daemon');
+		await room.webSocketMessage(
+			daemonWs,
+			JSON.stringify({
+				type: 'presence_publish',
+				actions: {},
+				agentId: 'zhongwen-home',
+			}),
+		);
+		// A node connecting after the publish sees the daemon's designation in its
+		// directed snapshot: the join key a picker uses to light up that agent.
+		const observer = await upgrade(room, 'observer');
+		const daemon = presenceFrames(observer)[0]!.peers.find(
+			(p) => p.nodeId === 'daemon',
+		);
+		expect(daemon!.agentId).toBe('zhongwen-home');
+	});
+
+	test('a peer that never publishes an agentId omits it', async () => {
+		const { room } = await makeRoom();
+		await upgrade(room, 'plain');
+		const observer = await upgrade(room, 'observer');
+		const plain = presenceFrames(observer)[0]!.peers.find(
+			(p) => p.nodeId === 'plain',
+		);
+		expect(plain!.agentId).toBeUndefined();
 	});
 });
 

--- a/packages/server/src/room/core.ts
+++ b/packages/server/src/room/core.ts
@@ -247,6 +247,7 @@ export function createRoomCore({ updateLog }: { updateLog: RoomUpdateLog }) {
 				nodeId: attachment.nodeId,
 				connectedAt: attachment.connectedAt,
 				actions: attachment.actions,
+				agentId: attachment.agentId,
 			});
 		}
 		return Array.from(seen.values()).sort((a, b) =>
@@ -437,18 +438,22 @@ export function createRoomCore({ updateLog }: { updateLog: RoomUpdateLog }) {
 	}
 
 	/**
-	 * Node -> relay: publish this socket's action manifest. The relay stores
-	 * the manifest against the connection attachment, persists it via
-	 * `serializeAttachment` when the runtime supports hibernation, and
-	 * rebroadcasts presence so peers see the update. A malformed payload is
-	 * dropped silently: the relay never trusts client input but never tears
-	 * down a sync socket for one bad manifest publish either.
+	 * Node -> relay: publish this socket's action manifest and optional agent
+	 * designation. The relay stores both against the connection attachment,
+	 * persists them via `serializeAttachment` when the runtime supports
+	 * hibernation, and rebroadcasts presence so peers see the update. A malformed
+	 * payload is dropped silently: the relay never trusts client input but never
+	 * tears down a sync socket for one bad manifest publish either.
 	 */
 	function handlePresencePublish(socket: RoomSocket, frame: unknown): void {
 		if (!checkPresencePublishFrame.Check(frame)) return;
 		const existing = connections.get(socket);
 		if (!existing) return;
-		const updated: Connection = { ...existing, actions: frame.actions };
+		const updated: Connection = {
+			...existing,
+			actions: frame.actions,
+			agentId: frame.agentId,
+		};
 		connections.set(socket, updated);
 		socket.serializeAttachment?.(updated);
 		broadcastPresence();

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -42,6 +42,13 @@ export type Connection = {
 	nodeId: string;
 	connectedAt: number;
 	actions: ActionManifest;
+	/**
+	 * The catalog agent this connection answers as (ADR-0025), set from the
+	 * node's `presence_publish` and mirrored on the wire so a picker can decorate
+	 * a durable agent as live. Undefined until published; ordinary participants
+	 * never set it. Opaque to the relay (forwarded, never inspected).
+	 */
+	agentId?: string;
 };
 
 /**

--- a/packages/workspace/src/daemon/attach-mount-infrastructure.ts
+++ b/packages/workspace/src/daemon/attach-mount-infrastructure.ts
@@ -47,6 +47,12 @@ export type AttachMountInfrastructureOptions<TActions extends ActionRegistry> =
 		baseURL: string;
 		actions: TActions;
 		/**
+		 * The catalog agent this daemon answers as (ADR-0025), published in
+		 * presence so peers can decorate it as live. Omit for a mount that hosts
+		 * sync without answering as a named agent.
+		 */
+		agentId?: string;
+		/**
 		 * Materializer attachments composed around the same ydoc. Their teardown
 		 * drains are awaited alongside collaboration and log teardown, so a daemon
 		 * shutdown cannot drop projection writes mid-flight. Each drain is bounded
@@ -61,6 +67,7 @@ export function attachMountInfrastructure<TActions extends ActionRegistry>(
 	{
 		baseURL,
 		actions,
+		agentId,
 		materializers = [],
 	}: AttachMountInfrastructureOptions<TActions>,
 ) {
@@ -80,6 +87,7 @@ export function attachMountInfrastructure<TActions extends ActionRegistry>(
 		openWebSocket: ctx.session.openWebSocket,
 		onReconnectSignal: ctx.session.onReconnectSignal,
 		actions,
+		agentId,
 	});
 
 	return {

--- a/packages/workspace/src/document/open-collaboration.ts
+++ b/packages/workspace/src/document/open-collaboration.ts
@@ -115,6 +115,12 @@ export type OpenCollaborationConfig<TActions extends ActionRegistry> = {
 	 * with `ActionNotFound`.
 	 */
 	actions: TActions;
+	/**
+	 * The catalog agent this peer answers as (ADR-0025), published in presence so
+	 * peers can see which agent ids are live. Set only by a resident agent mount
+	 * (e.g. a daemon); omit for ordinary participants and content docs.
+	 */
+	agentId?: string;
 };
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -206,6 +212,7 @@ export function openCollaboration<TActions extends ActionRegistry>(
 	const presencePublishFrame = JSON.stringify({
 		type: 'presence_publish',
 		actions: ownManifest,
+		agentId: config.agentId,
 	} satisfies PresencePublishFrame);
 
 	function handleDispatchResultFrame(text: string): boolean {

--- a/packages/workspace/src/document/presence-protocol.ts
+++ b/packages/workspace/src/document/presence-protocol.ts
@@ -40,12 +40,17 @@ export const ActionManifestSchema = Type.Record(
  *
  * `nodeId` routes dispatches; `connectedAt` lets receivers render an
  * "online since" affordance; `actions` is the peer's published manifest, or
- * `{}` if the peer has not (yet) published one.
+ * `{}` if the peer has not (yet) published one. `agentId` is the catalog agent
+ * this peer answers as (ADR-0025), present only on a peer that mounted with one
+ * (a resident daemon) and absent for ordinary participants. It is the join key
+ * a picker uses to decorate a durable agent as live: the catalog owns the
+ * agent's properties, presence only reports which agent ids are online now.
  */
 export const PeerSchema = Type.Object({
 	nodeId: Type.String(),
 	connectedAt: Type.Number(),
 	actions: ActionManifestSchema,
+	agentId: Type.Optional(Type.String()),
 });
 export type Peer = Static<typeof PeerSchema>;
 
@@ -62,14 +67,17 @@ export const PresenceFrameSchema = Type.Object({
 export type PresenceFrame = Static<typeof PresenceFrameSchema>;
 
 /**
- * Client -> server: publish this node's action manifest. The relay stores
- * the manifest against the sending socket's nodeId and rebroadcasts
- * presence so peers see the update. Sent once on connect; re-sent if the
- * local action registry changes.
+ * Client -> server: publish this node's action manifest, and optionally the
+ * catalog agent it answers as. The relay stores both against the sending
+ * socket's nodeId and rebroadcasts presence so peers see the update. Sent once
+ * on connect; re-sent if the local action registry changes. `agentId` is set
+ * only by a peer that mounted as a resident agent (ADR-0025); ordinary
+ * participants omit it.
  */
 export const PresencePublishFrameSchema = Type.Object({
 	type: Type.Literal('presence_publish'),
 	actions: ActionManifestSchema,
+	agentId: Type.Optional(Type.String()),
 });
 export type PresencePublishFrame = Static<typeof PresencePublishFrameSchema>;
 

--- a/packages/workspace/src/document/workspace.ts
+++ b/packages/workspace/src/document/workspace.ts
@@ -821,6 +821,10 @@ export function defineWorkspace<
 					{
 						baseURL,
 						actions: composition.actions,
+						// Publish the mount's agent so peers can decorate it as live in
+						// a picker (ADR-0025); the same id the child-doc workers use for
+						// designation. Absent when the mount answers as no named agent.
+						agentId: mountOptions.agentId,
 						materializers: drains,
 					},
 				);


### PR DESCRIPTION
Slice 1 of daemon-liveness presence for the agent picker (ADR-0025).

The problem this addresses is:
A presence `Peer` announces `nodeId` + action manifest but **not which catalog agent it answers as**. The Zhongwen agent picker keys off `agent.id` (e.g. `zhongwen-home`), so with the peer list alone it can see *a* peer is online but can't tell that the resident daemon serving a given durable agent is live.

## Change
Carry an optional `agentId` on the presence wire as the **join key** the picker needs:

```
MountOptions.agentId (already first-class)
  → attachMountInfrastructure({ …, agentId })
    → openCollaboration({ …, agentId })
      → presence_publish frame { type, actions, agentId }
        → relay stores it on the Connection, echoes it in the peer snapshot
          → peers.list()[].agentId   ← picker join key
```

- `PeerSchema` / `PresencePublishFrameSchema` gain an optional `agentId` (TypeBox `Type.Optional`).
- The daemon's mount publishes its `agentId`; ordinary participants and content docs omit it.
- The relay stores it against the connection (like the action manifest) and mirrors it in `snapshotPeers`.

The reason for this shape is:
The node→agent binding is exactly as ephemeral as the connection. Putting it in a durable Y.Doc map would only go stale the moment a daemon dies (you'd still need presence to know it's live) and duplicate what the transport already owns. `agentId` is the join key only; the catalog stays the source of truth for an agent's label, model, and tools.

The scope is intentionally bounded:
Framework only; the Zhongwen mount already passes `agentId`, so this lights up end-to-end with no app change. The picker decoration that consumes it (reading `owner` from the catalog) is a follow-up slice on top of #2127.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784567709&installation_id=128463665&pr_number=2128&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2128&signature=f980134c2daf4ba7f4534ec1f3459f11031ff4f713d105399b02aad5edb90fba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->