### PR TITLE
ci: stop double-running and pile-up of the Code quality / autofix workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -54,8 +54,8 @@ spctl -a -vvv -t execute /Volumes/Whispering/Whispering.app                  # a
 
 | File | Trigger | What it does |
 |---|---|---|
-| `ci.format.yml` | Push, pull requests | Runs `bun run lint:check` and `bun run typecheck`. |
-| `ci.autofix.yml` | Push, pull requests | Runs `bun run format` and commits fixes back via autofix-ci. |
+| `ci.format.yml` | Push to `main`, pull requests | Runs `bun run lint:check` and `bun run typecheck`. Cancels older runs for the same branch or PR. |
+| `ci.autofix.yml` | Push to `main`, pull requests | Runs `bun run format` and commits fixes back via autofix-ci. Cancels older runs for the same branch or PR. |
 
 ### Automation
 

--- a/.github/workflows/ci.autofix.yml
+++ b/.github/workflows/ci.autofix.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/ci.format.yml
+++ b/.github/workflows/ci.format.yml
@@ -2,6 +2,7 @@ name: Code quality
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.format.yml
+++ b/.github/workflows/ci.format.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   quality:
     runs-on: blacksmith-4vcpu-ubuntu-2404


### PR DESCRIPTION
The Code quality workflow was running twice for every pushed PR commit: once from the bare `push` trigger and once from the `pull_request` synchronize event on the same SHA. The pull request run is the one reviewers see and the one that gates merge, so the PR-branch push run was duplicate CI spend.

This scopes `ci.format.yml` push runs to `main`, matching the existing `ci.autofix.yml` push behavior. PR branches still run the full quality job through `pull_request`, and `main` keeps its post-merge check.

`ci.format.yml` and `ci.autofix.yml` also gain concurrency groups keyed by PR number, falling back to the ref for main pushes. A new commit cancels the stale run for the previous commit, so lint, typecheck, doc/path gates, and autofix work only finish for the latest SHA that can still matter.