### PR TITLE
fix(whispering): make playback-pause an honest opt-in

### DIFF
--- a/apps/whispering/src/lib/operations/media.ts
+++ b/apps/whispering/src/lib/operations/media.ts
@@ -1,7 +1,5 @@
 import { tauri } from '#platform/tauri';
-import { goto } from '$app/navigation';
-import { log, report } from '$lib/report';
-import { deviceConfig } from '$lib/state/device-config.svelte';
+import { log } from '$lib/report';
 import { settings } from '$lib/state/settings.svelte';
 
 // The one best-effort side effect for recording: pause whatever the system is
@@ -49,34 +47,14 @@ async function resumeSessions(sessions: string[]): Promise<void> {
 	}
 }
 
-// The feature is on by default, so the first time it actually pauses something
-// we explain it once (per device): on-by-default should be discoverable and
-// consensual, not a silent surprise. Fires only when a real session was paused,
-// never on a no-op pause.
-function explainFirstPauseOnce(): void {
-	if (deviceConfig.get('notices.pausePlaybackExplained')) return;
-	deviceConfig.set('notices.pausePlaybackExplained', true);
-	report.info({
-		title: 'Paused your playback while recording',
-		description:
-			'Whispering pauses media while it captures your voice, then resumes it. You can turn this off anytime.',
-		action: {
-			label: 'Recording settings',
-			onClick: () => goto('/settings/recording'),
-		},
-	});
-}
-
 export const recordingMedia = {
 	/** Pause active playback if enabled. Fire-and-forget: recording never waits. */
 	pause(): void {
 		if (!shouldPausePlayback()) return;
 		// Already paused? Keep that set; otherwise pause what's playing now.
-		chain = chain.then(async (paused) => {
-			const next = paused.length > 0 ? paused : await pausePlayingSessions();
-			if (next.length > 0) explainFirstPauseOnce();
-			return next;
-		});
+		chain = chain.then(async (paused) =>
+			paused.length > 0 ? paused : await pausePlayingSessions(),
+		);
 	},
 
 	/**

--- a/apps/whispering/src/lib/state/device-config.svelte.ts
+++ b/apps/whispering/src/lib/state/device-config.svelte.ts
@@ -168,13 +168,6 @@ const DEVICE_DEFINITIONS = {
 		globalBinding,
 		DEFAULT_GLOBAL_BINDINGS.runTransformationOnClipboard,
 	),
-
-	// ── One-time UI notices (device-local: a per-install nudge, not synced) ─
-	// Set true the first time `recording.pausePlayback` actually pauses
-	// something, so the explanatory toast (operations/media.ts) shows once per
-	// device and never again. Device-local because it tracks "has this install
-	// shown the toast," not a user preference that should roam.
-	'notices.pausePlaybackExplained': defineEntry(type('boolean'), false),
 };
 
 // ── Types ────────────────────────────────────────────────────────────────────

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -243,13 +243,15 @@ const recording = {
 		() => 'manual' as const,
 	),
 	// Pause system media playback while your voice is being captured, resume it
-	// after. On by default: hearing music while you talk disrupts dictation, and
-	// pausing media during voice capture is the least-astonishing behavior (it is
-	// what a phone call does to your music). Discoverable without a nudge via the
-	// settings toggle's description and the home-row quick toggle. A roaming
-	// preference, not a per-device capability, so it follows you across machines
-	// like the sound toggles.
-	'recording.pausePlayback': defineKv(field.boolean(), () => true),
+	// after. Off by default (opt-in): the resume cannot keep its promise on macOS,
+	// where MediaRemote's Play is single-target so it can wake whatever app the OS
+	// last marked now-playing, not the app we actually paused (see ADR-0041). A
+	// convenience that can occasionally start unrelated media should be chosen, not
+	// sprung. Discoverable via the settings toggle's description and the home-row
+	// quick toggle, both of which explain it at the moment you turn it on. A
+	// roaming preference, not a per-device capability, so it follows you across
+	// machines like the sound toggles.
+	'recording.pausePlayback': defineKv(field.boolean(), () => false),
 } as const;
 
 /**

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
@@ -53,7 +53,7 @@
 		<SettingSwitch
 			key="recording.pausePlayback"
 			label="Pause playback while recording"
-			description="Whispering pauses media playing on your computer (music, video, browser tabs) while your voice is being captured, and resumes it after. In voice activated mode it pauses only while you actually speak, so music keeps playing between phrases. Works with most apps in your system media controls; a few can't be paused this way."
+			description="Whispering pauses media playing on your computer (music, video, browser tabs) while your voice is being captured, then tries to resume it after. In voice activated mode it pauses only while you actually speak, so music keeps playing between phrases. Works with most apps in your system media controls. A few can't be paused, and on macOS the resume can occasionally wake a different app that was already paused."
 		/>
 
 		{#if settings.get('recording.trigger') === 'manual'}

--- a/apps/whispering/src/routes/(app)/_components/CaptureBehaviorPopover.svelte
+++ b/apps/whispering/src/routes/(app)/_components/CaptureBehaviorPopover.svelte
@@ -23,10 +23,10 @@
 	const pausePlaybackDescription = $derived.by(() => {
 		switch (captureSurface.current) {
 			case 'vad':
-				return 'Pause music or video while you are speaking, then resume shortly after you stop.';
+				return 'Pause music or video while you are speaking, then try to resume shortly after you stop.';
 			case 'manual':
 			case 'import':
-				return 'Pause music or video while you are recording, then resume when you stop.';
+				return 'Pause music or video while you are recording, then try to resume when you stop.';
 		}
 	});
 </script>

--- a/docs/adr/0041-playback-pause-is-opt-in-because-resume-can-start-unrelated-media.md
+++ b/docs/adr/0041-playback-pause-is-opt-in-because-resume-can-start-unrelated-media.md
@@ -1,0 +1,65 @@
+# 0041. Playback pause ships opt-in because macOS resume can start unrelated media
+
+- **Status:** Accepted
+- **Date:** 2026-06-20
+
+## Context
+
+[ADR-0017](0017-pause-system-media-playback-while-recording.md) shipped
+`recording.pausePlayback` off by default; a later change (`e3c4b1920`) flipped it
+on by default on a least-astonishment argument, without an ADR.
+[ADR-0018](0018-macos-resume-is-gated-on-a-coreaudio-output-read.md) justified
+the on-by-default macOS resume by claiming "the worst realistic outcome is a
+no-op (Play to an already-playing app) rather than a surprise start, which the
+pause-time gate forecloses." That claim assumes the app the CoreAudio gate
+observed is the app MediaRemote's Play will reach. It is not: the gate measures
+*any* process producing output audio (`kAudioProcessPropertyIsRunningOutput`),
+while MediaRemote's Play is **single-target**, aimed at whatever the OS last
+marked now-playing. When those differ (a browser tab, a game, or even a
+notification arms the gate while Music or Spotify sits paused as the now-playing
+app), the resume wakes the paused app and starts media the user never had
+playing. The gate does not foreclose this; it only forecloses resuming from total
+silence. Windows (GSMTC by AUMID) and Linux (MPRIS by bus name) resume the exact
+sessions they paused, so this is macOS-only.
+
+## Decision
+
+`recording.pausePlayback` ships **off by default**. A best-effort convenience
+that can occasionally start unrelated media must be chosen, not sprung. The
+settings toggle's description and the home-row quick toggle explain the behavior
+at the moment the user turns it on, which is the consent point an opt-in feature
+needs, so the first-pause explanatory toast (and its
+`notices.pausePlaybackExplained` device-config flag) are deleted: their only job
+was after-the-fact consent for an on-by-default feature. The toggle copy is also
+corrected from "resume it" to "try to resume it," and the Settings copy names the
+macOS caveat outright.
+
+The pause/resume machinery, the CoreAudio gate of ADR-0018, and the
+speaking-window timing of [ADR-0027](0027-playback-pause-tracks-the-speaking-window.md)
+are unchanged. Only the default and the framing change.
+
+## Consequences
+
+- No user gets surprise playback they never enabled; the macOS contamination case
+  can only reach someone who deliberately opted in and read the caveat.
+- The happy-path majority who would have benefited from auto-pause now have to
+  discover and enable it. Accepted: the home quick toggle and Settings switch
+  make that one tap, and the cost of a wrong-default surprise in a tool whose
+  value is being unobtrusive outweighs the convenience of a right-default guess.
+- This corrects ADR-0018's "worst case is a no-op" consequence; that ADR's
+  decision (gate resume on a CoreAudio read rather than the perl shim) still
+  stands, and the contamination is the residual cost the opt-in default absorbs.
+- A precise macOS resume would need the now-playing read, which 15.4
+  entitlement-gated; the `ungive/mediaremote-adapter` shim restores it but was
+  rejected in ADR-0018 as disproportionate, and remains so for a convenience
+  feature.
+
+## Considered alternatives
+
+- **Keep on by default (status quo).** Springs surprise media on users who never
+  asked, in the exact tool that should be unobtrusive. Rejected.
+- **Pause only, never resume.** Removes contamination but discards the most
+  useful half of the feature. Rejected; opt-in keeps resume for those who want it.
+- **Bundle `ungive/mediaremote-adapter` for an identity-matched resume.** Already
+  rejected in ADR-0018; a perl + private-framework sidecar is wildly out of
+  proportion to a best-effort convenience.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -84,8 +84,8 @@ Each option and the one reason it lost. Terse. This is not the spec.
 | [0014](0014-view-transitions-morph-a-re-expressed-glyph-not-its-container.md) | View transitions morph a re-expressed glyph, not its container | Accepted |
 | [0015](0015-the-brand-mark-has-one-canonical-source-every-other-form-is-generated.md) | The brand mark has one canonical source; every other form is generated | Proposed |
 | [0016](0016-prewarm-the-cold-model-load-and-refuse-the-rest-of-the-latency-menu.md) | Prewarm the cold model load and refuse the rest of the latency menu | Accepted |
-| [0017](0017-pause-system-media-playback-while-recording.md) | Pause system media playback while recording through one cross-platform controller | Accepted (VAD timing revised by 0027) |
-| [0018](0018-macos-resume-is-gated-on-a-coreaudio-output-read.md) | macOS resume is gated on a CoreAudio output read, not a MediaRemote read shim | Accepted |
+| [0017](0017-pause-system-media-playback-while-recording.md) | Pause system media playback while recording through one cross-platform controller | Accepted (VAD timing revised by 0027; default reaffirmed by 0041) |
+| [0018](0018-macos-resume-is-gated-on-a-coreaudio-output-read.md) | macOS resume is gated on a CoreAudio output read, not a MediaRemote read shim | Accepted (no-op consequence corrected by 0041) |
 | [0019](0019-global-shortcuts-have-a-permission-free-floor-and-accessibility-is-an-opt-in-tier.md) | Global shortcuts have a permission-free floor; Accessibility is an opt-in tier | Accepted |
 | [0020](0020-macos-drives-its-keyboard-tap-with-an-owned-cgeventtap.md) | macOS drives its keyboard tap with an owned CGEventTap, not the rdev fork | Accepted |
 | [0021](0021-actions-are-the-only-surface-that-crosses-a-process-boundary.md) | Actions are the only surface that crosses a process boundary | Accepted |
@@ -108,5 +108,6 @@ Each option and the one reason it lost. Terse. This is not the spec.
 | [0038](0038-a-daemon-answers-through-the-first-inference-backend-it-can-satisfy.md) | A daemon answers through the first inference backend it can satisfy: byok, else opted-in metered, else host without answering | Accepted |
 | [0039](0039-dictation-feedback-is-a-projection-of-one-lifecycle-state.md) | Dictation feedback is a projection of one lifecycle state, not an event log | Accepted |
 | [0040](0040-a-cursor-write-that-cannot-paste-falls-back-to-the-clipboard-decided-from-the-grant.md) | A cursor write that cannot paste falls back to the clipboard, decided from the grant | Accepted |
+| [0041](0041-playback-pause-is-opt-in-because-resume-can-start-unrelated-media.md) | Playback pause ships opt-in because macOS resume can start unrelated media | Accepted |
 
 When you add an ADR, add its row here.

--- a/docs/release-notes/v8.0.0.md
+++ b/docs/release-notes/v8.0.0.md
@@ -105,16 +105,16 @@ On macOS, the overlay is built as a non-activating panel, so clicking stop does 
 
 ## Playback Pauses While You Speak
 
-Whispering can now pause system playback while it captures your voice, then resume what it paused afterward. The point is simple: music, podcasts, and videos should not talk over you while you are dictating.
+Whispering can now pause system playback while it captures your voice, then try to resume it afterward. The point is simple: music, podcasts, and videos should not talk over you while you are dictating.
 
 The timing follows the capture mode:
 
 - Manual press-to-talk pauses for the whole press -> release recording window.
 - Voice activation pauses only for each detected utterance, not for the whole armed listening session.
 
-VAD resume is debounced, so playback does not flutter between short phrases. The next detected utterance cancels the pending resume; disarming voice activation resumes immediately. On macOS, resume is gated by a CoreAudio output-activity read so Whispering does not accidentally start media that was not playing when it paused.
+VAD resume is debounced, so playback does not flutter between short phrases. The next detected utterance cancels the pending resume; disarming voice activation resumes immediately. On macOS, resume only fires when a CoreAudio output-activity read saw something playing when you paused. Because the macOS Play command is system-wide, it can still occasionally wake a different app than the one you paused.
 
-The feature is on by default. The first real pause explains what happened, and the capture-behavior popover on the home pipeline row gives you a quick way to turn it off.
+The feature is off by default, so it never surprises you with playback you did not ask for. Turn it on from the capture-behavior popover on the home pipeline row, or in Recording settings.
 
 ## Capture and Delivery Defaults
 


### PR DESCRIPTION
The reason for this shape is:

"Pause playback while recording" shipped on by default (commit `e3c4b1920`, never recorded in an ADR). On macOS the resume cannot keep that promise: MediaRemote's Play is **single-target**, aimed at whatever the OS last marked now-playing, while the CoreAudio gate that arms resume measures *any* process producing output audio. When those differ (a browser tab, a game, or a notification arms the gate while Music or Spotify sits paused as the now-playing app), the resume wakes the paused app and **starts media the user never had playing**.

ADR-0018 had claimed the worst case here was a no-op; that assumed the gated app and the Play target are the same app, which is not true. For a tool whose value is being unobtrusive, surprise playback nobody asked for is the wrong default.

This change:

- **Default flipped to off (opt-in).** A convenience that can start unrelated media should be chosen, not sprung. The Settings toggle and the home capture-behavior popover explain it at the moment you turn it on. This realigns with ADR-0017, which originally shipped it off.
- **Honest copy.** "resume it" becomes "try to resume it" on the home popover and Settings page, and the Settings copy now names the macOS caveat outright.
- **Dropped the first-pause toast.** It existed to make the on-by-default feature consensual after the fact; with opt-in, the toggle is the consent point, so the toast (and its `notices.pausePlaybackExplained` device-config flag) are removed.
- **ADR-0041** records the opt-in decision and corrects ADR-0018's no-op claim.
- **v8.0.0 release notes** updated to match (off by default, no toast, honest macOS caveat).

Windows (GSMTC by AUMID) and Linux (MPRIS by bus name) resume the exact sessions they paused, so the contamination is macOS-only; the pause/resume machinery, the CoreAudio gate, and the ADR-0027 speaking-window timing are all unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784579952&installation_id=128463665&pr_number=2133&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2133&signature=b99977f1692b2773082261d8d44f521b534d80e59a4ecac222675fed922b60ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->