### PR TITLE
docs(adr): the answerer collapse — browser never answers (0041, 0042)

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -38,9 +38,20 @@ shapes, see `docs/adr/`.
   through `ws.tables.X.docs.field.open(rowId)`. The workspace owns guid derivation.
 - **Worker**: running behavior that observes workspace state and writes results
   back. Workers may be local (every node runs them) or agent-bound (one
-  configured agent answers).
+  configured agent answers). Every conversation answer is written by a worker;
+  the browser never answers, it writes user turns and renders the synced doc
+  (ADR-0041).
 - **Agent**: the durable address a row or conversation binds to. An agent names
-  who should answer; the worker is the runtime that answers as it.
+  who should answer; the worker is the runtime that answers as it. Every agent
+  is durable, distinguished only by **trust location** (ADR-0030).
+- **Trust location**: where an agent's worker runs, and therefore where its data
+  goes. **Managed** = an Epicenter-hosted worker (the user chose Epicenter's
+  metered inference, so its prompt and transcript flow there). **Home daemon** =
+  the user's own always-on box (nothing leaves the house). Blindness is per-agent,
+  not global (ADR-0041).
+- **Answerer**: an in-process peer that observes a conversation child doc and
+  writes the reply into it. Always a worker (hosted or daemon); never the cloud
+  relay/anchor, which stays blind, and never the browser.
 - **Materializer**: a local, addressless worker that projects workspace data into
   another store (markdown, sqlite).
 - **`attach*` vs `create*`**: `attach*` are side-effectful primitives that register

--- a/docs/adr/0024-an-always-on-worker-runs-app-semantics-beside-the-app-blind-anchor.md
+++ b/docs/adr/0024-an-always-on-worker-runs-app-semantics-beside-the-app-blind-anchor.md
@@ -1,7 +1,8 @@
 # 0024. An always-on worker runs app semantics beside the app-blind anchor
 
-- **Status:** Proposed
+- **Status:** Proposed (load-bearing for [ADR-0041](0041-every-answerer-is-a-worker-the-browser-never-answers.md), 2026-06-20)
 - **Date:** 2026-06-16
+- **Note (2026-06-20):** ADR-0041 resolves the latent tension between this ADR and [ADR-0033](0033-a-conversation-has-one-transport-and-two-triggers.md) in favor of the grid below: the "hosted anchor / hosted worker" quadrant is realized as the on-demand Epicenter-hosted answerer for the managed agent. The worker stays a separate app-aware spoke beside the app-blind anchor; it never fuses into the anchor/room DO.
 
 ## Context
 

--- a/docs/adr/0025-agent-conversations-are-durable-child-docs-driven-by-an-observing-worker.md
+++ b/docs/adr/0025-agent-conversations-are-durable-child-docs-driven-by-an-observing-worker.md
@@ -1,7 +1,8 @@
 # 0025. Agent conversations are durable child docs driven by an observing worker
 
-- **Status:** Accepted (amended 2026-06-19)
+- **Status:** Accepted (amended 2026-06-19; amended 2026-06-20 by [ADR-0041](0041-every-answerer-is-a-worker-the-browser-never-answers.md))
 - **Date:** 2026-06-16
+- **Amendment (2026-06-20):** The **ephemeral writer** is removed. ADR-0041 makes every answerer a worker (Epicenter-hosted or a user daemon), so the open browser tab is no longer a writer of any kind, and the `epicenter-cloud` / `this-device` ephemeral binding dissolves into a *managed* (hosted-worker) agent. Every binding is now a **durable** writer distinguished only by trust location (managed vs the user's box). Everything else here stands: the immutable per-conversation agent binding, the unanswered turn as the work queue, existence-is-the-claim, the durable client-owned cancel, and approval as a durable doc record any device resolves.
 
 ## Context
 

--- a/docs/adr/0033-a-conversation-has-one-transport-and-two-triggers.md
+++ b/docs/adr/0033-a-conversation-has-one-transport-and-two-triggers.md
@@ -1,7 +1,8 @@
 # 0033. A conversation is a synced doc answered only by in-process peers; the cloud is a metered inference stream, not a doc writer
 
-- **Status:** Accepted
+- **Status:** Accepted (amended 2026-06-20 by [ADR-0041](0041-every-answerer-is-a-worker-the-browser-never-answers.md))
 - **Date:** 2026-06-18
+- **Amendment:** The doc-as-transport doctrine stands: a conversation is a synced doc only an in-process peer writes, and the relay/anchor stays blind. ADR-0041 revises *which* in-process peer answers a managed conversation — an Epicenter-hosted worker (a separate app-aware spoke), not the open browser tab. The browser never answers; blindness becomes per-agent. The "cloud is never a doc writer" clause narrows to "the relay/anchor is never a doc writer."
 - **Relates:** [ADR-0031](0031-collaboration-is-addressed-single-writer-regions-in-a-child-doc.md) (the addressed regions a reply is written into), [ADR-0036](0036-answer-bodies-are-native-parts-arrays-streamed-into-y-text.md) (the parts body streamed into Y.Text), [ADR-0021](0021-actions-are-the-only-surface-that-crosses-a-process-boundary.md) (actions are the tools), [ADR-0035](0035-durable-storage-is-one-per-person-coordination-box.md) (the anchor never thinks; workers are peer spokes), [ADR-0030](0030-agents-are-immutable-capability-bundles.md) (agents), [ADR-0034](0034-the-cloud-doc-generation-queue-is-withdrawn.md) (the withdrawn server-side cloud generation this supersedes)
 
 > **Vocabulary:** a **transport** is how an answer reaches the people watching a

--- a/docs/adr/0041-every-answerer-is-a-worker-the-browser-never-answers.md
+++ b/docs/adr/0041-every-answerer-is-a-worker-the-browser-never-answers.md
@@ -1,0 +1,49 @@
+# 0041. Every answerer is a worker; the browser never answers
+
+- **Status:** Accepted
+- **Date:** 2026-06-20
+- **Refines:** [ADR-0033](0033-a-conversation-has-one-transport-and-two-triggers.md) (keeps the doc-as-transport doctrine; revises which in-process peer answers a managed conversation), [ADR-0024](0024-an-always-on-worker-runs-app-semantics-beside-the-app-blind-anchor.md) (resolves the latent contradiction toward the hosted-worker quadrant), [ADR-0025](0025-agent-conversations-are-durable-child-docs-driven-by-an-observing-worker.md) (the ephemeral browser writer dissolves)
+- **Relates:** [ADR-0030](0030-agents-are-immutable-capability-bundles.md) (trust location), [ADR-0035](0035-durable-storage-is-one-per-person-coordination-box.md) (workers are peer spokes, the anchor stays blind), [ADR-0021](0021-actions-are-the-only-surface-that-crosses-a-process-boundary.md), [ADR-0038](0038-a-daemon-answers-through-the-first-inference-backend-it-can-satisfy.md) (the engine the worker resolves)
+
+## Context
+
+ADR-0033 made the open **browser tab** the in-process answerer for cloud conversations, to delete the server-side doc-generation vertical (`runDocGeneration`). That single choice is the root of the answering stack's complexity. From it descend: an in-process browser answer loop, the `owner: 'ephemeral' | 'durable'` routing fork (PR #2127), a browser-side engine walk (`browserEngines` / `resolveEngine`), the metered-SSE-token-passthrough the browser proxies through, and the behavior that **closing the tab kills an in-flight cloud answer**. That last point directly contradicts the product goal that a cloud answer survive the browser closing and be caught up on resync.
+
+Meanwhile ADR-0024 already blesses a **hosted worker** running beside a hosted anchor as the "cloud default shape," and ADR-0035 makes workers peer spokes. So there was a latent contradiction: 0024 says a hosted worker is fine, 0033 says the cloud never writes a doc. The browser-as-answerer was load-bearing for the second only because the first was never built.
+
+## Decision
+
+**Every answerer is a worker:** an in-process peer that observes the conversation child doc and writes the answer into it (ADR-0025's observe → claim → stream → finish loop). A worker runs in exactly one of two **trust locations**, named by the agent's immutable bundle (ADR-0030):
+
+```txt
+managed agent  -> an Epicenter-hosted worker (the user chose Epicenter inference)
+home/daemon    -> the user's own box (a daemon; nothing leaves the house)
+browser        -> NEVER answers; writes user turns and renders the synced doc
+```
+
+**Blindness is per-agent, not global.** A managed agent's prompt and transcript flow to the Epicenter-hosted worker *because the user chose Epicenter's metered inference* — the cloud already sees that content today. A daemon agent's data never leaves the user's box. **BYOK is cloud-proxied:** the hosted worker uses the user's key per request, so even BYOK needs no browser answerer. The strong "my key never leaves my device" promise is served by running a daemon, not by the browser; a browser-local-BYOK answerer is a purely additive future option, not part of this decision.
+
+**The hosted worker is an on-demand Durable Object**, built from primitives the room DO already proves (`packages/server/src/room/`):
+
+- It **hibernates when idle** (zero duration cost — confirmed: a hibernating DO and its hibernating WebSockets incur no GB-s).
+- It is **woken by a doorbell** — the existing dispatch protocol (`dispatch_request` / `dispatch_inbound`) is the wake nudge — fired by the client that wrote a turn. The nudge is best-effort; the doc is the durable mailbox (ADR-0025), so a missed nudge delays an answer, never loses it (a periodic alarm backstops it).
+- On wake it **syncs the conversation child doc as a y-protocols peer** (the room DO already holds a live `Y.Doc` and runs y-protocols SYNC), runs the existing answer loop, streams parts into the doc (→ syncs to every device), and hibernates again.
+- **An approval pause costs nothing**: the worker writes the pending tool-call into the doc and hibernates until the approval write rings the doorbell again.
+
+The **same loop runs unchanged** on the user's daemon (Bun) and the hosted worker (DO), because `createRoomCore` and the child-doc worker are runtime-agnostic. The hosted worker is a separate **app-aware spoke**, never the app-blind anchor/room DO (ADR-0024/0035 preserved).
+
+## Consequences
+
+- **The deletion prize:** `attachChatBrowserAnswerer` and its wiring, the `owner: 'ephemeral' | 'durable'` fork (PR #2127), the browser engine walk + `browserEngines`, and the metered-SSE-token-passthrough to the browser. The `this-device` ephemeral agent **dissolves** into a managed (hosted-worker) agent; the Vocab catalog becomes two **durable** agents distinguished only by trust location: managed (Epicenter) and home daemon.
+- **Close-browser durability is free for every agent** — the worker keeps writing; the interactive/ambient distinction disappears.
+- **Cost is pennies per user per month:** DO duration is billed only during the generation wall-clock (~$0.00005 for a 30 s answer); idle and waiting-for-approval are free under hibernation. ADR-0033's "~$4/user-month idle residency" fear was about an always-on worker; on-demand hibernation eliminates it.
+- **The server-side Yjs peer returns**, but it is the daemon's existing loop on a DO host using `room/*` patterns, not a new primitive — and it is a separate spoke, so the anchor stays blind.
+- **PR #2127 is largely superseded** (owner ⊥ engine collapses to trust-location, which is already in the immutable bundle, ADR-0030). **PR #2128 (presence) parks** — it decorates liveness, never gates binding (the doc is a durable mailbox).
+- **The `/api/ai/chat` SSE endpoint survives** as the hosted worker's path to the provider and as a general metered inference API; it is no longer the browser's answering path.
+
+## Considered alternatives
+
+- **Keep ADR-0033 (the browser answers cloud conversations).** Rejected: it is the root of the answering-stack complexity and denies the close-browser durability the product wants. Durability-via-daemon alone forces every casual user onto a co-deployed box.
+- **An always-on hosted worker.** Rejected: the residency cost ADR-0033 feared. On-demand hibernation + the existing dispatch doorbell makes it pennies, with no permanent listener.
+- **Run the loop inside the room/anchor DO** (which already holds the `Y.Doc`). Rejected: it makes the app-blind anchor app-aware, breaking ADR-0024/0035. The worker is a distinct spoke that syncs the child doc.
+- **Browser-local BYOK (the key never leaves the device).** Deferred, not refused: cloud-proxied BYOK is chosen for the clean collapse; an in-process browser answerer for device-local keys is additive later and does not disturb this architecture.

--- a/docs/adr/0042-the-agent-loop-is-the-workers-over-the-doc-as-the-message-array.md
+++ b/docs/adr/0042-the-agent-loop-is-the-workers-over-the-doc-as-the-message-array.md
@@ -1,0 +1,43 @@
+# 0042. The agent loop is the worker's, over the doc as the message array
+
+- **Status:** Accepted (design; build deferred until a tool consumer exists)
+- **Date:** 2026-06-20
+- **Relates:** [ADR-0041](0041-every-answerer-is-a-worker-the-browser-never-answers.md) (the worker that owns the loop), [ADR-0033](0033-a-conversation-has-one-transport-and-two-triggers.md) (the engine stays a pure token source), [ADR-0025](0025-agent-conversations-are-durable-child-docs-driven-by-an-observing-worker.md) (approval is a durable doc record), [ADR-0021](0021-actions-are-the-only-surface-that-crosses-a-process-boundary.md) (tools are published actions), [ADR-0031](0031-collaboration-is-addressed-single-writer-regions-in-a-child-doc.md) (the single-writer region the approval is written into), [ADR-0036](0036-answer-bodies-are-native-parts-arrays-streamed-into-y-text.md) (the parts body the loop writes)
+
+## Context
+
+Today a `ChatStream` is single-shot text: `(messages, signal) => AsyncIterable<textChunk>`, drained once by `attachChatWorker`. Tools (workspace actions, ADR-0021) are the waiting seam: `AgentConfig.tools` is `[]`, and `chat-doc.ts` already models `tool-call` / `tool-result` parts ("Phase 1 writes only text"). The agentic tool loop and its approval flow need a home that does not contradict the rest of the system.
+
+Grounding the blessed frameworks (TanStack AI, Vercel AI SDK) surfaced the real constraint. Both run the multi-step loop (model → tool-call → execute → re-prompt) in a **request handler** — TanStack's server `chat()`, Vercel's `streamText`/`useChat` — with loop state in process or client memory. Epicenter's cloud is not a loop host (the relay/anchor is blind, ADR-0041/0033) and its approval must be durable and multi-device (ADR-0025), which an in-memory suspension cannot satisfy. But Vercel's own primitive states the escape: **the loop is a pure function of the messages array** — persist the messages (including tool-call/result parts) after each step and resume by re-calling with the saved messages; `stopWhen` halts the loop at an approval boundary.
+
+## Decision
+
+**The agent loop is a pure function of the message array, and the message array is the synced conversation child doc.** The **worker** owns the loop (the hosted or daemon worker of ADR-0041), generalizing the existing single-shot worker so there is **one answering path**: text-only is the zero-tool path (the loop runs once, no tool-calls).
+
+- **The engine stays a pure single model-invocation token source** (ADR-0033): `(messages, signal) => AsyncIterable<chunk>` where a chunk is a text-delta, a tool-call request, or a finish reason. One model call. It never executes a tool and never reads the doc.
+- **The worker drives the multi-step loop:** drain the engine → write text and tool-call parts into the doc → if the finish reason is `tool-calls`, run the tools, append tool-result parts, re-prompt with the augmented messages → repeat until a text finish. Tool execution lives in the worker, where the doc and the actions already are (ADR-0021).
+- **Tools are workspace actions via `tool-bridge`** (already built): list action keys on `AgentConfig.tools`; queries auto-run; mutations need approval.
+- **Approval is a durable doc record** (ADR-0025): the worker writes a `tool-call` with state `awaiting-approval` and **stops, releasing all memory** — so the pause survives a restart, a hibernation, or a different approving device. Any device writes the decision into a **client-owned single-writer region** (exactly the `cancelRequestedAt` pattern, ADR-0031); the assistant message stays worker-owned. The worker resumes by re-reading the doc. On a hibernating hosted worker (ADR-0041) the pause costs nothing.
+
+**Build is deferred until a real tool consumer exists.** Vocab has no actions and rides the unified path with `tools: []` for free, so it gains nothing user-visible from the loop. The first consumer is an app that has actions and wants durable, multi-device, approval-gated tools (opensidian / tab-manager), never Vocab. Recording the design now gives the `chat-doc.ts` tool-call parts a destination and fixes the contract the engine and the worker must speak.
+
+## Consequences
+
+- One answering path; single-shot is a special case of agentic, not a separate code path.
+- The engine seam stays narrow (a new engine implements one model call), so BYOK / local / metered all stay simple.
+- The CRDT-specific work is bounded to one thing: the approval as a single-writer region, a pattern already shipped for the cancel field.
+- `tool-bridge`'s in-memory TanStack approval (as used by tab-manager today) and this doc-mediated approval are different mechanisms; the consumer migration is the moment to converge them.
+
+## Open question (decided when F is built)
+
+The **loop engine** is left open and is engine-agnostic to this decision (the doc-as-message-store is the same either way):
+
+- **Hand-roll a thin loop over the existing TanStack adapters** in `@epicenter/ai-adapters` (no new framework; reuse provider tool-call normalization; own the small doc-coupled loop). Current lean.
+- **Vercel AI SDK `streamText` + `stopWhen`** in the worker (most blessed loop primitive; durable approval and resume-from-messages are first-class; cost: a second AI framework + a doc↔UIMessage boundary).
+- **Roll our own over raw provider SDKs** (zero framework impedance; cost: own per-provider tool-call streaming).
+
+## Considered alternatives
+
+- **The engine owns the loop** (model ↔ tool ↔ model inside the `ChatStream`). Rejected: it forces the engine to hold the actions and read the doc for approval, breaking the pure-token-source seam (ADR-0033); and an in-memory suspended generator cannot survive a restart or a cross-device approval (ADR-0025), so it collapses back into the worker-owned loop the moment approval must be durable.
+- **TanStack server `chat()` / a Vercel route as the loop host.** Rejected: the cloud is not a loop host (ADR-0041); the loop runs in the worker.
+- **Grow Vocab a tool to act as the tracer.** Rejected: it adds a table + action beyond the answering stack for a save that needs no daemon; the honest tracer is an app that already has actions.

--- a/specs/20260620T000000-vocab-answerer-collapse.md
+++ b/specs/20260620T000000-vocab-answerer-collapse.md
@@ -1,0 +1,263 @@
+# Vocab answerer collapse: rename, browser-never-answers, hosted worker
+
+Status: Draft. Date: 2026-06-20.
+
+The build plan for the answerer redesign settled in this design pass. The durable
+decisions live in ADRs; this spec is the dependency-ordered wave plan plus a
+self-contained handoff prompt per wave. Delete this spec when the waves land
+(the ADRs are the lasting record).
+
+## Decisions (the lasting record is the ADRs)
+
+- **ADR-0041** — every answerer is a worker; the **browser never answers**;
+  blindness is per-agent; **BYOK is cloud-proxied**; the managed answerer is an
+  on-demand hibernating Durable Object woken by the existing dispatch doorbell.
+- **ADR-0042** — the agent loop is the worker's, over the doc-as-message-array;
+  the engine stays a pure token source; durable doc-mediated approval. **Build
+  deferred** to a real tool consumer (not Vocab).
+- **ADR-0033** amended; **ADR-0025** amended (the ephemeral browser writer
+  dissolves); **ADR-0024** note (tension resolved toward the hosted-worker
+  quadrant). **ADR-0030** already settles model = agent (no model switcher) and
+  the managed/published vs user-authored catalog.
+
+## End state for Vocab
+
+- One app: a single Chinese vocab assistant. One model (`VOCAB_MODEL`), one
+  system prompt, `tools: []`.
+- Two **durable** agents in the catalog, distinguished by trust location:
+  - **Managed** (Epicenter-hosted worker, metered Gemini, cloud-proxied BYOK).
+  - **Home daemon** (`vocab-home`, the user's own box).
+- The browser writes user turns and renders the synced doc. It constructs no
+  engine and runs no answer loop.
+- Close the browser mid-answer → the worker keeps writing; resync catches up.
+
+## Wave plan (each is one standalone, reviewable PR, in order)
+
+| # | Wave | Depends on | Net |
+|---|---|---|---|
+| 1 | Rename zhongwen → vocab (incl. pre-release data ids) | — | mechanical, no behavior change |
+| 2 | Daemon ships live (`vocab-home`) | 1 | proves worker-answers-over-sync on the user's box |
+| 3 | Hosted managed worker (on-demand DO) | 1 | the managed answerer; the big build |
+| 4 | Browser → renderer-only (the collapse) | 2, 3 | deletion PR; supersedes #2127 |
+| 5 | F: agentic loop + doc approval (DEFERRED) | 4 + a tool consumer | not this milestone; ADR-0042 holds the design |
+
+Rename is first so nothing rebases over it. Wave 4 is safe only once both
+answerers (daemon + hosted) exist, so it follows 2 and 3.
+
+## PR / branch disposition
+
+- **#2127** (owner ⊥ engine): **superseded by wave 4.** The owner fork is deleted
+  there. Cherry-pick only the metered-engine single-homing (`epicenterMeteredEngine`,
+  the `@epicenter/zhongwen/engine` subpath) into the **worker** side in wave 3,
+  not the browser. Close #2127 once wave 4 lands.
+- **#2128** (presence slice 1): **parked.** Presence decorates liveness, never
+  gates binding (the doc is a durable mailbox). Revisit as a fast-follow after
+  wave 2, framed as the dead-mailbox warning ("you bound to your home daemon but
+  nothing is home"). Do not merge it into this stack.
+- `specs/zhongwen-conversation-deletion-refusal.md` — unrelated (deletion reclaim,
+  terminal "Refused" status). Pre-existing hygiene smell; handle in a separate
+  pass (convert to an ADR or delete). Wave 1 should rename its "zhongwen" mentions
+  or delete it; it is not load-bearing here.
+
+---
+
+## Wave 1 — Rename zhongwen → vocab
+
+**Goal.** A pure rename. `@epicenter/zhongwen` → `@epicenter/vocab` (package name,
+directory `apps/zhongwen` → `apps/vocab`, every import, `ZHONGWEN_*` constants →
+`VOCAB_*`, UI "Zhongwen" → "Vocab"). Because this is **pre-release**, also clean-
+break the two data identities: workspace id `epicenter-zhongwen` → `epicenter-vocab`
+and agent id `zhongwen-home` → `vocab-home`. The bilingual Chinese system prompt
+and `gemini-3.5-flash` model are unchanged.
+
+**Scope / files.**
+- `apps/zhongwen/` → `apps/vocab/`: `package.json` (`name`), `zhongwen.ts`
+  (`zhongwenWorkspace` id, `ZHONGWEN_*`, `THIS_DEVICE_AGENT_ID`, catalog),
+  `mount.ts`, `epicenter-engine.ts`, `epicenter.config.ts`, `zhongwen.browser.ts`,
+  `wrangler.jsonc` (`name`, the `zhongwen.epicenter.so` route → `vocab.epicenter.so`),
+  `src/lib/session.ts`, `src/routes/.../ConversationView.svelte`,
+  `ZhongwenSidebar.svelte` → `VocabSidebar.svelte`, the `@epicenter/zhongwen/engine`
+  subpath export.
+- Repo-wide consumers of `@epicenter/zhongwen` (grep the monorepo).
+- `agents.test.ts` and any test asserting ids.
+
+**Steps.**
+1. `git mv apps/zhongwen apps/vocab`; rename files; update `package.json` name +
+   exports map.
+2. Find/replace `zhongwen` → `vocab`, `Zhongwen` → `Vocab`, `ZHONGWEN_` →
+   `VOCAB_`, `epicenter-zhongwen` → `epicenter-vocab`, `zhongwen-home` →
+   `vocab-home`, `THIS_DEVICE_AGENT_ID` stays (`this-device` is already neutral —
+   though see wave 4, where it dissolves).
+3. Update the custom domain in `wrangler.jsonc`.
+4. Wipe dev rooms (manual: clear local IndexedDB + admin-wipe the DO room) so the
+   new `epicenter-vocab` room starts clean.
+5. Typecheck the workspace, run `apps/vocab` tests, biome.
+
+**Acceptance.** `bun run` typecheck clean repo-wide; vocab tests green; no
+remaining `zhongwen` string outside historical docs; app boots against the
+`epicenter-vocab` room.
+
+**Handoff prompt.**
+> Rename the `@epicenter/zhongwen` app to `@epicenter/vocab` in the worktree
+> `/Users/braden/Code/.worktrees/epicenter-row-childdocs`. This is pre-release, so
+> clean-break everything including data identities: `git mv apps/zhongwen apps/vocab`,
+> rename `@epicenter/zhongwen` → `@epicenter/vocab` (package name + the `/engine`
+> subpath), `ZHONGWEN_*` → `VOCAB_*`, the workspace id `epicenter-zhongwen` →
+> `epicenter-vocab`, the agent id `zhongwen-home` → `vocab-home`, the
+> `zhongwen.epicenter.so` route → `vocab.epicenter.so`, and all UI "Zhongwen" →
+> "Vocab" (rename `ZhongwenSidebar.svelte` → `VocabSidebar.svelte`). Keep the
+> Chinese system prompt and `gemini-3.5-flash` model exactly. Grep the whole
+> monorepo for `zhongwen`/`Zhongwen` and update every consumer. Do NOT change any
+> answering behavior — this is a pure rename. Read the writing-voice skill for UI
+> strings. Typecheck the repo, run the vocab app tests, run biome. One commit (or
+> a small handful of mechanical commits). This is wave 1 of
+> `specs/20260620T000000-vocab-answerer-collapse.md`.
+
+---
+
+## Wave 2 — Daemon ships live (`vocab-home`)
+
+**Goal.** Make `vocab-home` a real co-deployable daemon a user can run, bind a
+conversation to, close the browser, and have it answer over sync. The answer loop
+is the existing `attachChatWorker`; this wave is about making the deploy real and
+documented, not new answering machinery.
+
+**Scope / files.** `apps/vocab/mount.ts`, `apps/vocab/epicenter.config.ts`, the
+daemon entrypoint, deploy docs/README, the engine resolution
+(`resolveDaemonStream` → byok-key ?? cloud-proxied-metered, ADR-0038). Verify the
+child-doc observe loop hosts only `row.agent === 'vocab-home'` conversations.
+
+**Acceptance.** A documented path to run the daemon locally; binding a conversation
+to `vocab-home` and closing the browser yields an answer that appears on resync;
+the existence-is-the-claim guard prevents any double-answer with a watching tab
+(until wave 4 removes browser answering entirely).
+
+**Handoff prompt.**
+> In `apps/vocab` (worktree `/Users/braden/Code/.worktrees/epicenter-row-childdocs`,
+> after wave 1), make the `vocab-home` daemon a real, documented deliverable per
+> ADR-0024/0025/0041: a user co-deploys it, binds a conversation to `vocab-home`,
+> closes the browser, and it answers over sync. The answer loop is the existing
+> `attachChatWorker` (don't rewrite it). Confirm the child-doc observe loop hosts
+> only conversations where `row.agent === 'vocab-home'`, and that `resolveDaemonStream`
+> resolves byok-key ?? cloud-proxied-metered (ADR-0038). Write the co-deploy docs.
+> Verify close-browser durability end-to-end. This is wave 2 of
+> `specs/20260620T000000-vocab-answerer-collapse.md`.
+
+---
+
+## Wave 3 — Hosted managed worker (on-demand Durable Object)
+
+**Goal.** The Epicenter-hosted answerer for the **managed** agent: an on-demand DO
+that hibernates when idle, is woken by the existing dispatch doorbell when a turn
+is written, syncs the conversation child doc as a y-protocols peer, runs the same
+answer loop, streams parts into the doc, and hibernates again. BYOK is
+cloud-proxied (the worker uses the user's key per request). This is the largest
+wave but builds on primitives the room DO already proves.
+
+**Reuse (do not reinvent).** `packages/server/src/room/` is already a hibernating
+server-side Yjs peer: `createRoomCore` (runtime-agnostic, holds a live `Y.Doc`,
+y-protocols SYNC, dispatch + presence), the Cloudflare adapter
+(`durable-object.ts`: `acceptWebSocket`, `getWebSockets`, alarms,
+`setWebSocketAutoResponse`), and the DO-SQLite update log. The **dispatch protocol**
+(`dispatch_request`/`dispatch_inbound`) is the doorbell. The answer loop is the
+daemon's `attachChatWorker`. `keepAlive`/`keepAliveWhile` (Cloudflare `Agent`
+class pattern) prevents idle eviction during a streaming response.
+
+**Scope / files.** A new hosted-worker DO (its own class + wrangler binding),
+the cloud-proxied BYOK engine (the metered/BYOK `ChatStream` built worker-side,
+re-homing #2127's `epicenterMeteredEngine` here), the doorbell wake endpoint, the
+child-doc sync peer, the engine resolution (ADR-0038), `apps/api` wiring
+(`apps/api/worker/index.ts`, billing remains hosted-only). Keep the worker a
+separate spoke — never put answer logic in the room/anchor DO (ADR-0035).
+
+**Acceptance.** A conversation bound to the managed agent is answered server-side
+with no browser open; idle/approval-pause incurs no DO duration (hibernated);
+generation bills only the stream wall-clock; billing/Autumn still gates the
+metered path; a missed doorbell still gets answered (alarm backstop / next sync).
+
+**Handoff prompt.**
+> Build the Epicenter-hosted managed worker for Vocab per ADR-0041 (worktree
+> `/Users/braden/Code/.worktrees/epicenter-row-childdocs`, after waves 1–2). It is
+> an on-demand Durable Object that hibernates when idle, is woken by the existing
+> dispatch doorbell (`dispatch_request`/`dispatch_inbound` in
+> `packages/server/src/room/core.ts`) when a managed-agent turn is written, syncs
+> the conversation child doc as a y-protocols peer, runs the existing
+> `attachChatWorker` answer loop, streams parts into the doc, and hibernates again
+> (free across approval pauses). Reuse the room DO's hibernation patterns
+> (`packages/server/src/room/backends/cloudflare/durable-object.ts`:
+> `acceptWebSocket`, `getWebSockets`, alarms) and use `keepAlive`/`keepAliveWhile`
+> during streaming so a long generation isn't evicted. The engine is cloud-proxied:
+> the worker uses the metered house key (and BYOK keys, server-side) — re-home
+> #2127's `epicenterMeteredEngine` worker-side. Keep this a SEPARATE app-aware
+> spoke; never add answer logic to the room/anchor DO (ADR-0035). Preserve the
+> Autumn billing gate on the metered path (hosted-only, `apps/api/worker/billing`).
+> Ground DO behavior against `cloudflare/cloudflare-docs` via DeepWiki before
+> relying on memory. This is wave 3 of
+> `specs/20260620T000000-vocab-answerer-collapse.md`.
+
+---
+
+## Wave 4 — Browser becomes renderer-only (the collapse)
+
+**Goal.** The deletion PR. The browser stops answering. Now that the managed
+(wave 3) and daemon (wave 2) workers both answer, delete the browser answerer and
+the owner fork.
+
+**Scope / deletions.**
+- `apps/vocab/.../ConversationView.svelte`: remove the `browserEngines`,
+  `resolveEngine`, the `answer`/`answersHere`/owner branch, and the `{ answer }`
+  passed to `bindConversation`. The view opens the doc and renders; it writes user
+  turns via `convo.send`.
+- Remove the `owner: 'ephemeral' | 'durable'` field from `AgentConfig` and the
+  catalog; both agents are durable, keyed by trust location. The `this-device`
+  ephemeral agent dissolves into the **Managed** agent (Epicenter-hosted).
+- Delete `attachChatBrowserAnswerer` usage; if no consumer remains, delete it from
+  `packages/workspace/src/ai/` (and its export + test).
+- Remove the browser-side `Engine`/`resolveEngine`/`epicenterMeteredEngine`
+  surface from the app (engines are worker-only now).
+- Reshape the catalog/picker: Managed + Home daemon, both durable.
+- Close PR #2127 as superseded.
+
+**Acceptance.** The browser never opens an answerer; every answer comes from a
+worker; closing the browser never stops an answer; one answering path remains; no
+dead `owner`/`Engine`/browser-answerer code; tests green. Run
+post-implementation-review + collapse-pass on the deletion.
+
+**Handoff prompt.**
+> Make the Vocab browser renderer-only per ADR-0041 (worktree
+> `/Users/braden/Code/.worktrees/epicenter-row-childdocs`, after waves 1–3). Delete
+> the browser answerer: in `ConversationView.svelte` remove `browserEngines`,
+> `resolveEngine`, the `answer`/`answersHere`/owner branch, and the `{ answer }`
+> arg to `bindConversation` (the view just opens + renders the doc and writes user
+> turns via `convo.send`). Remove the `owner: 'ephemeral' | 'durable'` field from
+> `AgentConfig` and the catalog — both agents are now durable, distinguished by
+> trust location; the `this-device` ephemeral agent dissolves into the Managed
+> (Epicenter-hosted) agent. Delete `attachChatBrowserAnswerer` and the browser-side
+> `Engine`/`resolveEngine`/`epicenterMeteredEngine` surface if no consumer remains
+> (check exports + tests). Reshape the picker to Managed + Home daemon. Verify
+> closing the browser mid-answer no longer stops the answer. Run
+> post-implementation-review and collapse-pass on the deletion. Close PR #2127 as
+> superseded by this wave. This is wave 4 of
+> `specs/20260620T000000-vocab-answerer-collapse.md`.
+
+---
+
+## Wave 5 — F: agentic loop + doc-mediated approval (DEFERRED)
+
+Not this milestone. The design is ADR-0042: the worker owns the loop over the
+doc-as-message-array; the engine stays a pure token source; approval is a durable
+single-writer doc region (the `cancelRequestedAt` pattern). Build only when a real
+tool consumer exists (opensidian / tab-manager, which have actions) — never Vocab,
+which has no tools and rides the unified path with `tools: []` for free. The
+loop-engine choice (hand-roll over the existing TanStack adapters vs Vercel
+`streamText` vs roll-your-own) is left open in ADR-0042 and decided at build time.
+
+## Open items carried forward
+
+- Loop engine for F (ADR-0042 open question). Lean: hand-roll over
+  `@epicenter/ai-adapters`'s existing TanStack adapters.
+- Presence (#2128) as the dead-mailbox warning, fast-follow after wave 2.
+- Browser-local BYOK (key never leaves the device) — additive future option, does
+  not disturb ADR-0041.
+- `specs/zhongwen-conversation-deletion-refusal.md` hygiene (convert to ADR or
+  delete) — separate pass.


### PR DESCRIPTION
Records the durable decisions from the Vocab (formerly zhongwen) answering-stack design pass. Design-only; the code lands in the waves of `specs/20260620T000000-vocab-answerer-collapse.md`.

- **ADR-0041** — every answerer is a worker; the **browser never answers**. The managed agent is answered by an on-demand, hibernating Epicenter-hosted Durable Object woken by the existing dispatch doorbell; the home agent by the user's daemon. Blindness is per-agent; BYOK is cloud-proxied. Reverses the browser-answers-cloud choice that rooted the stack's complexity, and gives close-browser durability for free. Grounded: the room DO is already a hibernating server-side Yjs peer with a dispatch doorbell; `createRoomCore` is runtime-agnostic.
- **ADR-0042** — the agent loop is the worker's, over the doc-as-message-array; the engine stays a pure token source; approval is a durable single-writer doc region. Build deferred to a real tool consumer (not Vocab).
- Amends **0033** (which in-process peer answers a managed conversation), **0025** (the ephemeral browser writer dissolves), **0024** (tension resolved toward the hosted-worker quadrant). Adds *trust location* / *answerer* to CONTEXT.md.
- Supersedes the direction of the merged #2127 (owner fork collapses to trust location) and parks #2128 (presence is a fast-follow, not a gate).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784580571&installation_id=128463665&pr_number=2134&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2134&signature=863095abc66bb95d5554cb1b4fcd4fa6d01570948dcfb0018757c179cc17c8b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->