### PR TITLE
feat(whispering): restyle and reshape the recording pill

### DIFF
--- a/apps/whispering/src-tauri/src/overlay.rs
+++ b/apps/whispering/src-tauri/src/overlay.rs
@@ -21,7 +21,7 @@ use tauri_nspanel::{tauri_panel, CollectionBehavior, PanelBuilder, PanelLevel, S
 // Must stay in sync with the JS window manager's `WINDOW_LABEL` and the pill's
 // size in `src/lib/recording-overlay/`.
 const WINDOW_LABEL: &str = "recording-overlay";
-const OVERLAY_WIDTH: f64 = 184.0;
+const OVERLAY_WIDTH: f64 = 224.0;
 const OVERLAY_HEIGHT: f64 = 40.0;
 
 tauri_panel! {

--- a/apps/whispering/src/lib/recording-overlay/RecordingPill.svelte
+++ b/apps/whispering/src/lib/recording-overlay/RecordingPill.svelte
@@ -185,38 +185,15 @@
 				{/each}
 			</div>
 
-			{#if !isManual}
-				<!-- The VAD pip is the previous utterance's transcribe spinner riding
-				     beside the live meter. It holds a fixed-width slot (the size-3.5 icon's
-				     width) for the whole session, full or empty, so the pill does not
-				     resize when the spinner appears or clears. Dimmed so it reads as
-				     secondary to the meter. No success or failure state: success is the
-				     landing text, failure goes to the notification and the recordings row.
-				     Empty at rest. -->
-				<div
-					class="flex w-[14px] flex-none items-center justify-center text-white/50"
-					title={vadPip === 'transcribing'
-						? 'Transcribing previous phrase'
-						: undefined}
-				>
-					{#if vadPip === 'transcribing'}
-						<LoaderCircleIcon class="size-3.5 animate-spin" />
-					{/if}
-				</div>
-			{/if}
-
+			<!-- Trailing cluster: a contextual slot, then stop as the constant right
+			     anchor. Manual and VAD share this skeleton (slot then stop), so the
+			     meter and the stop button land in the same place in both modes and only
+			     the slot's content differs. The slot is always the cancel button's
+			     width, so the cluster reads as balanced and the pill keeps a steady
+			     width as the slot's content changes. -->
 			<div class="flex items-center gap-1">
-				<!-- Stop is the primary action: a red chip so it reads as "stop recording". -->
-				<button
-					type="button"
-					class={cn(actionBase, 'bg-red-500/30 text-white hover:bg-red-500/50')}
-					aria-label={isManual ? 'Stop recording' : 'Stop listening'}
-					title={isManual ? 'Stop recording' : 'Stop listening'}
-					onclick={handleStop}
-				>
-					<SquareIcon class="size-3.5" />
-				</button>
 				{#if isManual}
+					<!-- Manual can discard the take, so the slot is the cancel button. -->
 					<button
 						type="button"
 						class={cn(actionBase, 'hover:bg-[#faa2ca]/20 hover:text-[#ffd2e4]')}
@@ -226,7 +203,38 @@
 					>
 						<XIcon class="size-4" />
 					</button>
+				{:else}
+					<!-- VAD has no per-utterance cancel, so the slot holds an indicator the
+					     same size as the cancel button: the previous phrase's transcribe
+					     spinner while one is running, otherwise a faint dot that reads as
+					     "armed and listening" while the meter sits flat through silence. No
+					     success or failure state: success is the landing text, failure goes
+					     to the notification and the recordings row. -->
+					<div
+						class="flex size-6 items-center justify-center text-white/50"
+						title={vadPip === 'transcribing'
+							? 'Transcribing previous phrase'
+							: undefined}
+					>
+						{#if vadPip === 'transcribing'}
+							<LoaderCircleIcon class="size-3.5 animate-spin" />
+						{:else}
+							<span class="size-1.5 rounded-full bg-white/40"></span>
+						{/if}
+					</div>
 				{/if}
+
+				<!-- Stop: the primary action and the constant right anchor. A red chip so
+				     it reads as "stop recording". -->
+				<button
+					type="button"
+					class={cn(actionBase, 'bg-red-500/30 text-white hover:bg-red-500/50')}
+					aria-label={isManual ? 'Stop recording' : 'Stop listening'}
+					title={isManual ? 'Stop recording' : 'Stop listening'}
+					onclick={handleStop}
+				>
+					<SquareIcon class="size-3.5" />
+				</button>
 			</div>
 		{:else if chip}
 			<!-- One chip block for every non-recording phase. A failure is glanceable

--- a/apps/whispering/src/lib/recording-overlay/RecordingPill.svelte
+++ b/apps/whispering/src/lib/recording-overlay/RecordingPill.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { cn } from '@epicenter/ui/utils';
 	import AudioLinesIcon from '@lucide/svelte/icons/audio-lines';
 	import CheckIcon from '@lucide/svelte/icons/check';
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
@@ -109,6 +110,13 @@
 		return MIN_BAR_PX + envelope * level * (MAX_BAR_PX - MIN_BAR_PX);
 	}
 
+	// Resting state is a filled chip, not a bare icon, so the controls read as
+	// buttons at a glance in the small pill. Each control composes its own tone over
+	// this shared base. Per-property durations: colors glide at 150ms, the press
+	// scale snaps at 100ms.
+	const actionBase =
+		'flex size-6 cursor-pointer items-center justify-center rounded-full bg-white/10 text-white/92 [transition:background-color_150ms_ease-out,color_150ms_ease-out,transform_100ms_ease-out] hover:scale-[1.08] active:scale-95';
+
 	function handleStop(event: MouseEvent) {
 		// Don't let a button click bubble to the pill's focus-main handler:
 		// stop/cancel should only stop/cancel, never reveal the main window.
@@ -130,15 +138,29 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 {#if status}
 	<div
-		class="overlay"
-		class:speaking={isSpeaking}
-		class:failed={chip?.tone === 'failed'}
-		class:revealable={Boolean(onReveal)}
+		class={cn(
+			// The pill hugs its content and is centered within its mount (the desktop
+			// overlay window centers it; the web host translates it to center), so each
+			// state is a snug chip with no dead space leaving the meter off-center. The
+			// mount centers a fixed 40px-tall, up-to-184px-wide pill; max-w-[184px] caps
+			// it to that window so a long failed reason ellipsizes rather than overflowing.
+			'box-border flex h-10 w-fit max-w-[184px] items-center gap-2 rounded-full px-2.5 text-white/92 shadow-[0_6px_20px_rgba(0,0,0,0.35)] backdrop-blur-[12px] select-none',
+			// Failed: a red chip so the failure reads at a glance, with the terse reason
+			// in the label. No action: detail and retry live on the recordings row.
+			chip?.tone === 'failed'
+				? 'border border-red-500/55 bg-[#3c1216]/92'
+				: 'border border-white/8 bg-[#0f0f11]/82',
+			// Clickable only where it can reveal the main window: desktop, where onReveal
+			// is wired. On web the app window is already in front, so onReveal is omitted
+			// and the body shows no pointer or tooltip (the action buttons stop
+			// propagation, so only the empty areas would have triggered it).
+			onReveal && 'cursor-pointer',
+		)}
 		title={onReveal ? 'Open Whispering' : undefined}
 		onclick={onReveal}
 	>
 		{#if status.phase === 'recording'}
-			<div class="icon">
+			<div class="flex items-center text-white/85">
 				{#if isManual}
 					<MicIcon class="size-4" />
 				{:else}
@@ -146,18 +168,33 @@
 				{/if}
 			</div>
 
-			<div class="bars" aria-hidden="true">
+			<div class="flex h-5 items-center gap-[3px]" aria-hidden="true">
 				{#each BAR_ENVELOPE as envelope, i (i)}
-					<span class="bar" style="height: {barHeight(envelope)}px"></span>
+					<!-- Height is set inline from the live mic level; the transition glides
+					     between samples (~20-30 Hz) so the meter looks continuous, and is
+					     dropped under reduced motion. Speech detected (VAD) tints the bar so
+					     the user sees it cross the threshold, on top of the height already
+					     reacting to loudness. -->
+					<span
+						class={cn(
+							'w-[3px] rounded-full bg-white/85 transition-[height] duration-[80ms] ease-linear motion-reduce:transition-none',
+							isSpeaking && 'bg-[#ffe5ee]',
+						)}
+						style="height: {barHeight(envelope)}px"
+					></span>
 				{/each}
 			</div>
 
 			{#if !isManual}
-				<!-- The VAD pip holds a fixed-width slot for the whole session, full or
-				     empty, so the pill does not resize when the previous phrase's
-				     spinner appears or clears. Empty at rest. -->
+				<!-- The VAD pip is the previous utterance's transcribe spinner riding
+				     beside the live meter. It holds a fixed-width slot (the size-3.5 icon's
+				     width) for the whole session, full or empty, so the pill does not
+				     resize when the spinner appears or clears. Dimmed so it reads as
+				     secondary to the meter. No success or failure state: success is the
+				     landing text, failure goes to the notification and the recordings row.
+				     Empty at rest. -->
 				<div
-					class="pip"
+					class="flex w-[14px] flex-none items-center justify-center text-white/50"
 					title={vadPip === 'transcribing'
 						? 'Transcribing previous phrase'
 						: undefined}
@@ -168,10 +205,11 @@
 				</div>
 			{/if}
 
-			<div class="actions">
+			<div class="flex items-center gap-1">
+				<!-- Stop is the primary action: a red chip so it reads as "stop recording". -->
 				<button
 					type="button"
-					class="action stop"
+					class={cn(actionBase, 'bg-red-500/28 text-white hover:bg-red-500/50')}
 					aria-label={isManual ? 'Stop recording' : 'Stop listening'}
 					title={isManual ? 'Stop recording' : 'Stop listening'}
 					onclick={handleStop}
@@ -181,7 +219,7 @@
 				{#if isManual}
 					<button
 						type="button"
-						class="action cancel"
+						class={cn(actionBase, 'hover:bg-[#faa2ca]/22 hover:text-[#ffd2e4]')}
 						aria-label="Cancel recording"
 						title="Cancel recording"
 						onclick={handleCancel}
@@ -196,184 +234,25 @@
 			     recordings row (ADR-0039). -->
 			{@const Icon = chip.Icon}
 			<div
-				class="icon"
-				class:tone-success={chip.tone === 'success'}
-				class:tone-degraded={chip.tone === 'degraded'}
-				class:tone-failed={chip.tone === 'failed'}
+				class={cn(
+					'flex items-center text-white/85',
+					// A clean delivery reads green; a reduced reach (clipboard/history)
+					// reads amber, "landed, but not where you asked" rather than a clean
+					// success; a failure reads red, paired with the red pill background.
+					chip.tone === 'success' && 'text-[#7ee2a8]',
+					chip.tone === 'degraded' && 'text-[#f5c97b]',
+					chip.tone === 'failed' && 'text-[#ffb4b4]',
+				)}
 			>
 				<Icon class="size-4 {chip.spin ? 'animate-spin' : ''}" />
 			</div>
-			<span class="label">{chip.label}</span>
+			<!-- The label takes only its text's width in the snug chip. Labels are
+			     closed, short tokens that fit the fixed-width pill; truncate's ellipsis
+			     is a safety net, not load-bearing truncation. The full failure detail
+			     lives in the OS notification and the recordings row, never here. -->
+			<span class="min-w-0 flex-1 truncate text-[13px] font-medium"
+				>{chip.label}</span
+			>
 		{/if}
 	</div>
 {/if}
-
-<style>
-	.overlay {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		/* The pill hugs its content and is centered within its mount (the desktop
-		   overlay window centers it; the web host translates it to center), so each
-		   state is a snug chip with no dead space to leave the meter looking
-		   off-center. The mount centers a fixed 40px-tall, up-to-184px-wide pill;
-		   `max-width` caps it to that window so a long failed reason ellipsizes
-		   rather than overflowing. */
-		width: fit-content;
-		max-width: 184px;
-		height: 40px;
-		padding: 0 10px;
-		box-sizing: border-box;
-		border-radius: 9999px;
-		background: rgba(15, 15, 17, 0.82);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-		box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
-		color: rgba(255, 255, 255, 0.92);
-		-webkit-backdrop-filter: blur(12px);
-		backdrop-filter: blur(12px);
-		user-select: none;
-		-webkit-user-select: none;
-	}
-
-	/* The body is clickable only where it can reveal the main window: desktop,
-	   where `onReveal` is wired. On web the app window is already in front, so
-	   `onReveal` is omitted and the body shows no pointer or tooltip (the action
-	   buttons stop propagation so only the empty areas would have triggered it). */
-	.overlay.revealable {
-		cursor: pointer;
-	}
-
-	/* Failed: a red chip so the failure reads at a glance, with the terse reason
-	   in the label. No action: detail and retry live on the recordings row. */
-	.overlay.failed {
-		background: rgba(60, 18, 22, 0.92);
-		border-color: rgba(239, 68, 68, 0.55);
-	}
-
-	.icon {
-		display: flex;
-		align-items: center;
-		color: rgba(255, 255, 255, 0.85);
-	}
-
-	/* A clean delivery: green. */
-	.icon.tone-success {
-		color: #7ee2a8;
-	}
-
-	/* A reduced reach (clipboard/history): amber, so the glance reads "landed, but
-	   not where you asked" rather than a clean success. */
-	.icon.tone-degraded {
-		color: #f5c97b;
-	}
-
-	/* A failure: red, paired with the red pill background below. */
-	.icon.tone-failed {
-		color: #ffb4b4;
-	}
-
-	/* The label takes only its text's width in the snug chip. Labels are closed,
-	   short tokens that fit the fixed-width pill; the ellipsis is a safety net, not
-	   a load-bearing truncation. The full failure detail lives in the OS
-	   notification and the recordings row, never here. */
-	.label {
-		flex: 1;
-		min-width: 0;
-		font-size: 13px;
-		font-weight: 500;
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
-	}
-
-	.bars {
-		display: flex;
-		align-items: center;
-		gap: 3px;
-		height: 20px;
-	}
-
-	.bar {
-		width: 3px;
-		border-radius: 9999px;
-		background: rgba(255, 255, 255, 0.85);
-		/* Height is set inline from the live mic level; the transition glides
-		   between samples (~20-30 Hz) so the meter looks continuous. */
-		transition: height 80ms linear;
-	}
-
-	/* Speech detected (VAD): tint the meter so the user sees it cross the
-	   threshold, on top of the height already reacting to loudness. */
-	.overlay.speaking .bar {
-		background: #ffe5ee;
-	}
-
-	/* The VAD pip: the previous utterance's transcribe spinner riding beside the
-	   live meter. Dimmed so it reads as secondary to the meter. No success or
-	   failure state: success is the landing text, failure goes to the notification
-	   and the recordings row. */
-	.pip {
-		/* A fixed-width slot (the size-3.5 icon's width) reserved for the whole VAD
-		   session, so the pill keeps a steady width as the pip toggles. */
-		flex: none;
-		width: 14px;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		color: rgba(255, 255, 255, 0.5);
-	}
-
-	.actions {
-		display: flex;
-		align-items: center;
-		gap: 4px;
-	}
-
-	/* Resting state is a filled chip, not a bare icon, so the controls read as
-	   buttons at a glance in the small pill. */
-	.action {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 24px;
-		height: 24px;
-		border: none;
-		border-radius: 9999px;
-		background: rgba(255, 255, 255, 0.1);
-		color: rgba(255, 255, 255, 0.92);
-		cursor: pointer;
-		transition:
-			background-color 150ms ease-out,
-			color 150ms ease-out,
-			transform 100ms ease-out;
-	}
-
-	.action:hover {
-		transform: scale(1.08);
-	}
-
-	.action:active {
-		transform: scale(0.95);
-	}
-
-	/* Stop is the primary action: a red chip so it reads as "stop recording". */
-	.action.stop {
-		background: rgba(239, 68, 68, 0.28);
-		color: #fff;
-	}
-
-	.action.stop:hover {
-		background: rgba(239, 68, 68, 0.5);
-	}
-
-	.action.cancel:hover {
-		background: rgba(250, 162, 202, 0.22);
-		color: #ffd2e4;
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-		.bar {
-			transition: none;
-		}
-	}
-</style>

--- a/apps/whispering/src/lib/recording-overlay/RecordingPill.svelte
+++ b/apps/whispering/src/lib/recording-overlay/RecordingPill.svelte
@@ -112,10 +112,10 @@
 
 	// Resting state is a filled chip, not a bare icon, so the controls read as
 	// buttons at a glance in the small pill. Each control composes its own tone over
-	// this shared base. Per-property durations: colors glide at 150ms, the press
-	// scale snaps at 100ms.
+	// this shared base, which carries the hover/press feedback: background and
+	// press-scale glide together at 150ms.
 	const actionBase =
-		'flex size-6 cursor-pointer items-center justify-center rounded-full bg-white/10 text-white/92 [transition:background-color_150ms_ease-out,color_150ms_ease-out,transform_100ms_ease-out] hover:scale-[1.08] active:scale-95';
+		'flex size-6 cursor-pointer items-center justify-center rounded-full bg-white/10 text-white/90 transition duration-150 ease-out hover:scale-[1.08] active:scale-95';
 
 	function handleStop(event: MouseEvent) {
 		// Don't let a button click bubble to the pill's focus-main handler:
@@ -144,12 +144,12 @@
 			// state is a snug chip with no dead space leaving the meter off-center. The
 			// mount centers a fixed 40px-tall, up-to-184px-wide pill; max-w-[184px] caps
 			// it to that window so a long failed reason ellipsizes rather than overflowing.
-			'box-border flex h-10 w-fit max-w-[184px] items-center gap-2 rounded-full px-2.5 text-white/92 shadow-[0_6px_20px_rgba(0,0,0,0.35)] backdrop-blur-[12px] select-none',
+			'box-border flex h-10 w-fit max-w-[184px] items-center gap-2 rounded-full px-2.5 text-white/90 shadow-[0_6px_20px_rgba(0,0,0,0.35)] backdrop-blur-md select-none',
 			// Failed: a red chip so the failure reads at a glance, with the terse reason
 			// in the label. No action: detail and retry live on the recordings row.
 			chip?.tone === 'failed'
-				? 'border border-red-500/55 bg-[#3c1216]/92'
-				: 'border border-white/8 bg-[#0f0f11]/82',
+				? 'border border-red-500/55 bg-[#3c1216]/90'
+				: 'border border-white/10 bg-[#0f0f11]/80',
 			// Clickable only where it can reveal the main window: desktop, where onReveal
 			// is wired. On web the app window is already in front, so onReveal is omitted
 			// and the body shows no pointer or tooltip (the action buttons stop
@@ -160,7 +160,7 @@
 		onclick={onReveal}
 	>
 		{#if status.phase === 'recording'}
-			<div class="flex items-center text-white/85">
+			<div class="flex items-center text-white/80">
 				{#if isManual}
 					<MicIcon class="size-4" />
 				{:else}
@@ -177,7 +177,7 @@
 					     reacting to loudness. -->
 					<span
 						class={cn(
-							'w-[3px] rounded-full bg-white/85 transition-[height] duration-[80ms] ease-linear motion-reduce:transition-none',
+							'w-[3px] rounded-full bg-white/80 transition-[height] duration-[80ms] ease-linear motion-reduce:transition-none',
 							isSpeaking && 'bg-[#ffe5ee]',
 						)}
 						style="height: {barHeight(envelope)}px"
@@ -209,7 +209,7 @@
 				<!-- Stop is the primary action: a red chip so it reads as "stop recording". -->
 				<button
 					type="button"
-					class={cn(actionBase, 'bg-red-500/28 text-white hover:bg-red-500/50')}
+					class={cn(actionBase, 'bg-red-500/30 text-white hover:bg-red-500/50')}
 					aria-label={isManual ? 'Stop recording' : 'Stop listening'}
 					title={isManual ? 'Stop recording' : 'Stop listening'}
 					onclick={handleStop}
@@ -219,7 +219,7 @@
 				{#if isManual}
 					<button
 						type="button"
-						class={cn(actionBase, 'hover:bg-[#faa2ca]/22 hover:text-[#ffd2e4]')}
+						class={cn(actionBase, 'hover:bg-[#faa2ca]/20 hover:text-[#ffd2e4]')}
 						aria-label="Cancel recording"
 						title="Cancel recording"
 						onclick={handleCancel}
@@ -235,7 +235,7 @@
 			{@const Icon = chip.Icon}
 			<div
 				class={cn(
-					'flex items-center text-white/85',
+					'flex items-center text-white/80',
 					// A clean delivery reads green; a reduced reach (clipboard/history)
 					// reads amber, "landed, but not where you asked" rather than a clean
 					// success; a failure reads red, paired with the red pill background.

--- a/apps/whispering/src/lib/recording-overlay/RecordingPill.svelte
+++ b/apps/whispering/src/lib/recording-overlay/RecordingPill.svelte
@@ -102,7 +102,9 @@
 
 	// Per-bar height envelope (taller in the middle) scaled by `level`. Reacting
 	// the same amplitude through a fixed shape reads as a meter, not a flat block.
-	const BAR_ENVELOPE = [0.5, 0.72, 0.9, 1, 0.9, 0.72, 0.5];
+	const BAR_ENVELOPE = [
+		0.35, 0.5, 0.68, 0.84, 0.95, 1, 0.95, 0.84, 0.68, 0.5, 0.35,
+	];
 	const MIN_BAR_PX = 3;
 	const MAX_BAR_PX = 18;
 
@@ -139,12 +141,18 @@
 {#if status}
 	<div
 		class={cn(
-			// The pill hugs its content and is centered within its mount (the desktop
-			// overlay window centers it; the web host translates it to center), so each
-			// state is a snug chip with no dead space leaving the meter off-center. The
-			// mount centers a fixed 40px-tall, up-to-184px-wide pill; max-w-[184px] caps
-			// it to that window so a long failed reason ellipsizes rather than overflowing.
-			'box-border flex h-10 w-fit max-w-[184px] items-center gap-2 rounded-full px-2.5 text-white/90 shadow-[0_6px_20px_rgba(0,0,0,0.35)] backdrop-blur-md select-none',
+			// 40px-tall pill, shared look. gap-2.5 spaces the chip icon from its label;
+			// in recording it is only the floor (justify-between distributes wider). The
+			// width differs by phase (next arg).
+			'box-border flex h-10 items-center gap-2.5 rounded-full px-2.5 text-white/90 shadow-[0_6px_20px_rgba(0,0,0,0.35)] backdrop-blur-md select-none',
+			// Recording is a wider bar: the mic pins the left edge and stop the right,
+			// with the meter spread between them (justify-between). The text chips hug
+			// their content, capped wide enough for the longest label ("Transcription
+			// failed") to show in full. The 224px cap is mirrored by the desktop overlay
+			// window (OVERLAY_WIDTH in overlay.rs / index.tauri.ts), which must stay in sync.
+			status.phase === 'recording'
+				? 'w-[208px] justify-between'
+				: 'w-fit max-w-[224px]',
 			// Failed: a red chip so the failure reads at a glance, with the terse reason
 			// in the label. No action: detail and retry live on the recordings row.
 			chip?.tone === 'failed'
@@ -205,21 +213,29 @@
 					</button>
 				{:else}
 					<!-- VAD has no per-utterance cancel, so the slot holds an indicator the
-					     same size as the cancel button: the previous phrase's transcribe
-					     spinner while one is running, otherwise a faint dot that reads as
-					     "armed and listening" while the meter sits flat through silence. No
-					     success or failure state: success is the landing text, failure goes
-					     to the notification and the recordings row. -->
+					     same size as the cancel button. While a previous phrase is still
+					     transcribing it is the spinner; otherwise it is the capture dot. The
+					     bars track raw mic level continuously, but whether VAD has actually
+					     latched onto speech is a separate fact (with a detection delay): the
+					     dot is dim while armed and lights up the instant capture begins, so
+					     the user can tell "being recorded now" from "just hearing sound". -->
 					<div
 						class="flex size-6 items-center justify-center text-white/50"
 						title={vadPip === 'transcribing'
 							? 'Transcribing previous phrase'
-							: undefined}
+							: isSpeaking
+								? 'Capturing speech'
+								: 'Listening'}
 					>
 						{#if vadPip === 'transcribing'}
 							<LoaderCircleIcon class="size-3.5 animate-spin" />
 						{:else}
-							<span class="size-1.5 rounded-full bg-white/40"></span>
+							<span
+								class={cn(
+									'size-2 rounded-full',
+									isSpeaking ? 'bg-pink-300' : 'bg-white/40',
+								)}
+							></span>
 						{/if}
 					</div>
 				{/if}
@@ -228,7 +244,7 @@
 				     it reads as "stop recording". -->
 				<button
 					type="button"
-					class={cn(actionBase, 'bg-red-500/30 text-white hover:bg-red-500/50')}
+					class={cn(actionBase, 'bg-red-500/60 text-white hover:bg-red-500/80')}
 					aria-label={isManual ? 'Stop recording' : 'Stop listening'}
 					title={isManual ? 'Stop recording' : 'Stop listening'}
 					onclick={handleStop}
@@ -258,9 +274,7 @@
 			     closed, short tokens that fit the fixed-width pill; truncate's ellipsis
 			     is a safety net, not load-bearing truncation. The full failure detail
 			     lives in the OS notification and the recordings row, never here. -->
-			<span class="min-w-0 flex-1 truncate text-[13px] font-medium"
-				>{chip.label}</span
-			>
+			<span class="min-w-0 truncate text-[13px] font-medium">{chip.label}</span>
 		{/if}
 	</div>
 {/if}

--- a/apps/whispering/src/lib/recording-overlay/RecordingPillHost.svelte
+++ b/apps/whispering/src/lib/recording-overlay/RecordingPillHost.svelte
@@ -16,7 +16,9 @@
 </script>
 
 {#if !tauri && status}
-	<div class="pill-host">
+	<!-- Bottom-center, matching the desktop overlay's resting position
+	     (OVERLAY_BOTTOM_MARGIN). Above page content, below modals and toasts. -->
+	<div class="fixed bottom-[72px] left-1/2 z-50 -translate-x-1/2">
 		<RecordingPill
 			{status}
 			level={webPillLevel.level}
@@ -25,15 +27,3 @@
 		/>
 	</div>
 {/if}
-
-<style>
-	/* Bottom-center, matching the desktop overlay's resting position
-	   (OVERLAY_BOTTOM_MARGIN). Above page content, below modals and toasts. */
-	.pill-host {
-		position: fixed;
-		bottom: 72px;
-		left: 50%;
-		transform: translateX(-50%);
-		z-index: 50;
-	}
-</style>

--- a/apps/whispering/src/lib/recording-overlay/index.tauri.ts
+++ b/apps/whispering/src/lib/recording-overlay/index.tauri.ts
@@ -15,8 +15,9 @@ import {
 const log = createLogger('whispering/recording-overlay');
 
 const WINDOW_LABEL = 'recording-overlay';
-// Fixed size in logical pixels. Matches the pill drawn by the overlay route.
-const OVERLAY_WIDTH = 184;
+// Fixed size in logical pixels. The width is the pill's max width (the cap in
+// RecordingPill); the transparent window centers the narrower states inside it.
+const OVERLAY_WIDTH = 224;
 const OVERLAY_HEIGHT = 40;
 // Distance from the bottom edge of the monitor, in logical pixels.
 const OVERLAY_BOTTOM_MARGIN = 72;

--- a/apps/whispering/src/routes/recording-overlay/+page.svelte
+++ b/apps/whispering/src/routes/recording-overlay/+page.svelte
@@ -58,7 +58,10 @@
 	}
 </script>
 
-<div class="overlay-center">
+<!-- The pill hugs its content, so center it within the fixed overlay window (the
+     web host centers its own copy). A fixed full-window flex box centers the chip
+     regardless of how the layout nests the route. -->
+<div class="fixed inset-0 flex items-center justify-center">
 	<RecordingPill
 		{status}
 		{level}
@@ -69,12 +72,15 @@
 </div>
 
 <style>
-	/* These `:global` document rules belong to the overlay webview, not the pill:
-	   they are only ever loaded in the dedicated overlay Tauri window, which has
-	   its own document. The main app window never navigates here, so its document
-	   background is untouched. (The isolation comes from the separate webview
-	   document, not from Svelte's component scoping.) The shared `RecordingPill`
-	   keeps no document-level styles so it can also mount inside the app on web. */
+	/* The document-level resets below stay as `:global` CSS: a component cannot
+	   apply utilities to `html`/`body` or to the dev-injected inspector host, so
+	   these have no Tailwind equivalent. They belong to the overlay webview, not the
+	   pill: they are only ever loaded in the dedicated overlay Tauri window, which
+	   has its own document. The main app window never navigates here, so its
+	   document background is untouched. (The isolation comes from the separate
+	   webview document, not from Svelte's component scoping.) The shared
+	   `RecordingPill` keeps no document-level styles so it can also mount inside the
+	   app on web. */
 	:global(html),
 	:global(body) {
 		background: transparent !important;
@@ -84,17 +90,6 @@
 		   which makes the browser paint a dark canvas behind the pill in this
 		   transparent webview. Reset it so only the pill is visible. */
 		color-scheme: normal !important;
-	}
-
-	/* The pill hugs its content, so center it within the fixed overlay window (the
-	   web host centers its own copy). A fixed full-window flex box centers the chip
-	   regardless of how the layout nests the route. */
-	.overlay-center {
-		position: fixed;
-		inset: 0;
-		display: flex;
-		align-items: center;
-		justify-content: center;
 	}
 
 	/* The Svelte inspector toggle (svelte.config.js `showToggleButton: always`)


### PR DESCRIPTION
The recording-overlay pill was the app's odd one out: one of only a few `.svelte` files using a scoped `<style>` block, and the only place doing bespoke component-level CSS. This converts its ~200 lines of scoped CSS to Tailwind utilities so it styles like every other component, then uses that clean slate to reshape the layout.

The conversion also collapses a few special cases the CSS needed: `truncate` replaces the three-declaration ellipsis rule, `motion-reduce:transition-none` replaces the `prefers-reduced-motion` media query, and the `.overlay.speaking .bar` descendant combinator becomes a per-bar conditional. The only `<style>` left in the cluster is the overlay route's irreducible `:global` document resets (transparent `html`/`body`, and the `color-scheme` reset that defeats the dark app shell), which a component cannot express as utilities.

On that clean slate, the layout pass:

- Unifies the recording controls so manual and VAD share one skeleton (a contextual slot, then stop as the constant right anchor), instead of manual's stop-then-cancel cluster sitting opposite VAD's lone stop.
- Widens recording into a spread bar (mic at the left edge, stop at the right, the meter breathing between them) while the result chips hug their content, capped wide enough for "Copied to clipboard" and "Transcription failed" to show in full. The desktop overlay window grows to match the cap.
- Turns the VAD slot dot into a capture indicator. The bars track raw mic level continuously, but whether VAD has latched onto speech is a separate fact with a detection delay, so the dot stays dim while armed and turns pink the instant capture begins.

## Changelog
- The dictation pill is restyled and reshaped: a wider recording bar with evenly spaced controls, status labels that show in full, and a VAD dot that lights up only when speech is actually being captured.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784580705&installation_id=128463665&pr_number=2136&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2136&signature=8cfca4ca09a3ce3b57815dd5ee0d6f8dd386571a955bd83932369be0988b8c7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->