### PR TITLE
docs(adr): collapse the hosted worker to trusted-internal, house-key

### DIFF
--- a/docs/adr/0041-every-answerer-is-a-worker-the-browser-never-answers.md
+++ b/docs/adr/0041-every-answerer-is-a-worker-the-browser-never-answers.md
@@ -4,6 +4,7 @@
 - **Date:** 2026-06-20
 - **Refines:** [ADR-0033](0033-a-conversation-has-one-transport-and-two-triggers.md) (keeps the doc-as-transport doctrine; revises which in-process peer answers a managed conversation), [ADR-0024](0024-an-always-on-worker-runs-app-semantics-beside-the-app-blind-anchor.md) (resolves the latent contradiction toward the hosted-worker quadrant), [ADR-0025](0025-agent-conversations-are-durable-child-docs-driven-by-an-observing-worker.md) (the ephemeral browser writer dissolves)
 - **Relates:** [ADR-0030](0030-agents-are-immutable-capability-bundles.md) (trust location), [ADR-0035](0035-durable-storage-is-one-per-person-coordination-box.md) (workers are peer spokes, the anchor stays blind), [ADR-0021](0021-actions-are-the-only-surface-that-crosses-a-process-boundary.md), [ADR-0038](0038-a-daemon-answers-through-the-first-inference-backend-it-can-satisfy.md) (the engine the worker resolves)
+- **Refined (2026-06-20, same day):** the hosted worker is **trusted-internal infrastructure**, not an external client. It bills the room's `ownerId` directly via the in-process Autumn primitive (no user-impersonation credential, no HTTP loopback to `/api/ai/chat`) and reads/writes the conversation doc via the anchor's internal RPC (no remote y-protocols handshake). The first cut is **house-key only**; **cloud-proxied BYOK is deferred** until the server-side secret vault exists, so no user keys are stored server-side. The host shape (a doorbell-triggered worker vs a hibernating DO) follows F: text-only answers have no approval pause, so the simpler worker suffices until F's tool pauses arrive.
 
 ## Context
 
@@ -21,13 +22,13 @@ home/daemon    -> the user's own box (a daemon; nothing leaves the house)
 browser        -> NEVER answers; writes user turns and renders the synced doc
 ```
 
-**Blindness is per-agent, not global.** A managed agent's prompt and transcript flow to the Epicenter-hosted worker *because the user chose Epicenter's metered inference* — the cloud already sees that content today. A daemon agent's data never leaves the user's box. **BYOK is cloud-proxied:** the hosted worker uses the user's key per request, so even BYOK needs no browser answerer. The strong "my key never leaves my device" promise is served by running a daemon, not by the browser; a browser-local-BYOK answerer is a purely additive future option, not part of this decision.
+**Blindness is per-agent, not global.** A managed agent's prompt and transcript flow to the Epicenter-hosted worker *because the user chose Epicenter's metered inference* — the cloud already sees that content today. A daemon agent's data never leaves the user's box. **BYOK lives on the daemon, not the hosted worker.** The managed (hosted) path is **house-key only**; a user who wants their own key runs a daemon (their box, their key). Cloud-proxied BYOK (the hosted worker using the user's key) is deferred until the server-side secret vault exists, so the hosted worker stores no user keys. The strong "my key never leaves my device" promise is served by running a daemon, not by the browser; a browser-local-BYOK answerer is a purely additive future option, not part of this decision.
 
 **The hosted worker is an on-demand Durable Object**, built from primitives the room DO already proves (`packages/server/src/room/`):
 
 - It **hibernates when idle** (zero duration cost — confirmed: a hibernating DO and its hibernating WebSockets incur no GB-s).
 - It is **woken by a doorbell** — the existing dispatch protocol (`dispatch_request` / `dispatch_inbound`) is the wake nudge — fired by the client that wrote a turn. The nudge is best-effort; the doc is the durable mailbox (ADR-0025), so a missed nudge delays an answer, never loses it (a periodic alarm backstops it).
-- On wake it **syncs the conversation child doc as a y-protocols peer** (the room DO already holds a live `Y.Doc` and runs y-protocols SYNC), runs the existing answer loop, streams parts into the doc (→ syncs to every device), and hibernates again.
+- On wake it reads and writes the conversation child doc via the anchor's **internal RPC** (`getDoc` / `sync`) — it is co-located with the anchor that already holds the doc, so there is no remote y-protocols handshake — runs the existing answer loop, streams parts into the doc (→ syncs to every device), and goes idle again.
 - **An approval pause costs nothing**: the worker writes the pending tool-call into the doc and hibernates until the approval write rings the doorbell again.
 
 The **same loop runs unchanged** on the user's daemon (Bun) and the hosted worker (DO), because `createRoomCore` and the child-doc worker are runtime-agnostic. The hosted worker is a separate **app-aware spoke**, never the app-blind anchor/room DO (ADR-0024/0035 preserved).
@@ -37,13 +38,14 @@ The **same loop runs unchanged** on the user's daemon (Bun) and the hosted worke
 - **The deletion prize:** `attachChatBrowserAnswerer` and its wiring, the `owner: 'ephemeral' | 'durable'` fork (PR #2127), the browser engine walk + `browserEngines`, and the metered-SSE-token-passthrough to the browser. The `this-device` ephemeral agent **dissolves** into a managed (hosted-worker) agent; the Vocab catalog becomes two **durable** agents distinguished only by trust location: managed (Epicenter) and home daemon.
 - **Close-browser durability is free for every agent** — the worker keeps writing; the interactive/ambient distinction disappears.
 - **Cost is pennies per user per month:** DO duration is billed only during the generation wall-clock (~$0.00005 for a 30 s answer); idle and waiting-for-approval are free under hibernation. ADR-0033's "~$4/user-month idle residency" fear was about an always-on worker; on-demand hibernation eliminates it.
-- **The server-side Yjs peer returns**, but it is the daemon's existing loop on a DO host using `room/*` patterns, not a new primitive — and it is a separate spoke, so the anchor stays blind.
+- **The managed answer is written server-side again** (the path ADR-0033 deleted), but as the daemon's existing loop hosted by us with internal RPC access to the anchor's doc, billing `ownerId` — not a new primitive, and the anchor stays blind.
 - **PR #2127 is largely superseded** (owner ⊥ engine collapses to trust-location, which is already in the immutable bundle, ADR-0030). **PR #2128 (presence) parks** — it decorates liveness, never gates binding (the doc is a durable mailbox).
-- **The `/api/ai/chat` SSE endpoint survives** as the hosted worker's path to the provider and as a general metered inference API; it is no longer the browser's answering path.
+- **The `/api/ai/chat` SSE endpoint survives** as a general external metered inference API (browser, CLI, a BYOK daemon); the hosted worker calls the provider and the Autumn charge primitive **in-process** (billing `ownerId`), not through this endpoint. It is no longer the browser's answering path.
 
 ## Considered alternatives
 
 - **Keep ADR-0033 (the browser answers cloud conversations).** Rejected: it is the root of the answering-stack complexity and denies the close-browser durability the product wants. Durability-via-daemon alone forces every casual user onto a co-deployed box.
 - **An always-on hosted worker.** Rejected: the residency cost ADR-0033 feared. On-demand hibernation + the existing dispatch doorbell makes it pennies, with no permanent listener.
 - **Run the loop inside the room/anchor DO** (which already holds the `Y.Doc`). Rejected: it makes the app-blind anchor app-aware, breaking ADR-0024/0035. The worker is a distinct spoke that syncs the child doc.
-- **Browser-local BYOK (the key never leaves the device).** Deferred, not refused: cloud-proxied BYOK is chosen for the clean collapse; an in-process browser answerer for device-local keys is additive later and does not disturb this architecture.
+- **Cloud-proxied BYOK (the hosted worker uses the user's key).** Deferred, not refused: it needs server-side key storage (the secret vault), and for one-model Vocab the managed house key already covers "BYOK without a box" while the daemon covers "my own key." Additive once the vault exists.
+- **Browser-local BYOK (the key never leaves the device).** Also deferred; an in-process browser answerer for device-local keys is additive later and does not disturb this architecture.

--- a/specs/20260620T000000-vocab-answerer-collapse.md
+++ b/specs/20260620T000000-vocab-answerer-collapse.md
@@ -10,8 +10,10 @@ self-contained handoff prompt per wave. Delete this spec when the waves land
 ## Decisions (the lasting record is the ADRs)
 
 - **ADR-0041** — every answerer is a worker; the **browser never answers**;
-  blindness is per-agent; **BYOK is cloud-proxied**; the managed answerer is an
-  on-demand hibernating Durable Object woken by the existing dispatch doorbell.
+  blindness is per-agent. The managed answerer is **trusted-internal** Epicenter
+  infra (house-key Gemini, bills the room `ownerId` in-process, reads/writes the
+  doc via the anchor's RPC, woken by the existing dispatch doorbell). Cloud-proxied
+  BYOK is **deferred** (needs the secret vault).
 - **ADR-0042** — the agent loop is the worker's, over the doc-as-message-array;
   the engine stays a pure token source; durable doc-mediated approval. **Build
   deferred** to a real tool consumer (not Vocab).
@@ -25,7 +27,7 @@ self-contained handoff prompt per wave. Delete this spec when the waves land
 - One app: a single Chinese vocab assistant. One model (`VOCAB_MODEL`), one
   system prompt, `tools: []`.
 - Two **durable** agents in the catalog, distinguished by trust location:
-  - **Managed** (Epicenter-hosted worker, metered Gemini, cloud-proxied BYOK).
+  - **Managed** (Epicenter-hosted worker, house-key Gemini, billed to the room owner).
   - **Home daemon** (`vocab-home`, the user's own box).
 - The browser writes user turns and renders the synced doc. It constructs no
   engine and runs no answer loop.
@@ -46,10 +48,10 @@ answerers (daemon + hosted) exist, so it follows 2 and 3.
 
 ## PR / branch disposition
 
-- **#2127** (owner ⊥ engine): **superseded by wave 4.** The owner fork is deleted
-  there. Cherry-pick only the metered-engine single-homing (`epicenterMeteredEngine`,
-  the `@epicenter/zhongwen/engine` subpath) into the **worker** side in wave 3,
-  not the browser. Close #2127 once wave 4 lands.
+- **#2127** (owner ⊥ engine): **MERGED into main** (2026-06-20). Its `this-device`
+  rename, owner fork, and `epicenterMeteredEngine` / `@epicenter/vocab/engine` subpath
+  are now in main. Wave 4 deletes the owner fork + browser engine walk from main;
+  the engine code wave 3 needs is lifted from main, not cherry-picked from a PR.
 - **#2128** (presence slice 1): **parked.** Presence decorates liveness, never
   gates binding (the doc is a durable mailbox). Revisit as a fast-follow after
   wave 2, framed as the dead-mailbox warning ("you bound to your home daemon but
@@ -145,55 +147,60 @@ the existence-is-the-claim guard prevents any double-answer with a watching tab
 
 ---
 
-## Wave 3 — Hosted managed worker (on-demand Durable Object)
+## Wave 3 — Hosted managed worker (trusted-internal, house-key)
 
-**Goal.** The Epicenter-hosted answerer for the **managed** agent: an on-demand DO
-that hibernates when idle, is woken by the existing dispatch doorbell when a turn
-is written, syncs the conversation child doc as a y-protocols peer, runs the same
-answer loop, streams parts into the doc, and hibernates again. BYOK is
-cloud-proxied (the worker uses the user's key per request). This is the largest
-wave but builds on primitives the room DO already proves.
+**Goal.** The Epicenter-hosted answerer for the **managed** agent, as the daemon's
+answer loop hosted by us. It is **trusted-internal**: woken by the existing dispatch
+doorbell when a turn is written, it reads/writes the conversation doc via the
+anchor's internal RPC (co-located, no remote y-protocols handshake), runs the same
+`attachChatWorker` loop, streams parts into the doc, and bills the room's `ownerId`
+directly via the in-process Autumn primitive. **House-key Gemini only** — no
+user-impersonation credential, no HTTP loopback to `/api/ai/chat`, and no
+server-side key storage (cloud-proxied BYOK is deferred until the secret vault
+exists). Host shape: a doorbell-triggered worker suffices for text-only answers
+(no approval pause); the hibernating-DO upgrade arrives with F.
 
-**Reuse (do not reinvent).** `packages/server/src/room/` is already a hibernating
-server-side Yjs peer: `createRoomCore` (runtime-agnostic, holds a live `Y.Doc`,
-y-protocols SYNC, dispatch + presence), the Cloudflare adapter
-(`durable-object.ts`: `acceptWebSocket`, `getWebSockets`, alarms,
-`setWebSocketAutoResponse`), and the DO-SQLite update log. The **dispatch protocol**
-(`dispatch_request`/`dispatch_inbound`) is the doorbell. The answer loop is the
-daemon's `attachChatWorker`. `keepAlive`/`keepAliveWhile` (Cloudflare `Agent`
-class pattern) prevents idle eviction during a streaming response.
+**Reuse (do not reinvent).** `packages/server/src/room/` already holds the live
+`Y.Doc` and exposes `getDoc`/`sync` RPC + the `dispatch_request`/`dispatch_inbound`
+doorbell; `createRoomCore` is runtime-agnostic. The answer loop is the daemon's
+`attachChatWorker` (wave 2), reused verbatim. If a hibernating DO is chosen for the
+host, the room DO's hibernation patterns (`durable-object.ts`: `acceptWebSocket`,
+`getWebSockets`, alarms) and `keepAlive`/`keepAliveWhile` (Cloudflare `Agent` class)
+are the reference.
 
-**Scope / files.** A new hosted-worker DO (its own class + wrangler binding),
-the cloud-proxied BYOK engine (the metered/BYOK `ChatStream` built worker-side,
-re-homing #2127's `epicenterMeteredEngine` here), the doorbell wake endpoint, the
-child-doc sync peer, the engine resolution (ADR-0038), `apps/api` wiring
-(`apps/api/worker/index.ts`, billing remains hosted-only). Keep the worker a
-separate spoke — never put answer logic in the room/anchor DO (ADR-0035).
+**Scope / files.** The hosted-worker host (Worker or DO + wrangler binding), the
+house-key engine (the provider adapter from `@epicenter/ai-adapters`, built
+worker-side), the doorbell wake endpoint, anchor-RPC read/write of the conversation
+doc (`getDoc`/`sync`), and in-process Autumn billing keyed to the room's `ownerId`
+(`apps/api/worker/index.ts` + `apps/api/worker/billing`, hosted-only). Keep the
+worker a separate spoke — never put answer logic in the room/anchor DO (ADR-0035).
 
 **Acceptance.** A conversation bound to the managed agent is answered server-side
-with no browser open; idle/approval-pause incurs no DO duration (hibernated);
-generation bills only the stream wall-clock; billing/Autumn still gates the
-metered path; a missed doorbell still gets answered (alarm backstop / next sync).
+with no browser open and no daemon; the answer is billed to the room's `ownerId`
+via Autumn; a missed doorbell still gets answered (alarm backstop / next sync);
+the anchor never runs answer logic (stays blind).
 
-**Handoff prompt.**
+**Handoff prompt.** (PAIR with Braden on the host shape before building — this
+touches billing + the trust boundary.)
 > Build the Epicenter-hosted managed worker for Vocab per ADR-0041 (worktree
 > `/Users/braden/Code/.worktrees/epicenter-row-childdocs`, after waves 1–2). It is
-> an on-demand Durable Object that hibernates when idle, is woken by the existing
-> dispatch doorbell (`dispatch_request`/`dispatch_inbound` in
-> `packages/server/src/room/core.ts`) when a managed-agent turn is written, syncs
-> the conversation child doc as a y-protocols peer, runs the existing
-> `attachChatWorker` answer loop, streams parts into the doc, and hibernates again
-> (free across approval pauses). Reuse the room DO's hibernation patterns
-> (`packages/server/src/room/backends/cloudflare/durable-object.ts`:
-> `acceptWebSocket`, `getWebSockets`, alarms) and use `keepAlive`/`keepAliveWhile`
-> during streaming so a long generation isn't evicted. The engine is cloud-proxied:
-> the worker uses the metered house key (and BYOK keys, server-side) — re-home
-> #2127's `epicenterMeteredEngine` worker-side. Keep this a SEPARATE app-aware
-> spoke; never add answer logic to the room/anchor DO (ADR-0035). Preserve the
-> Autumn billing gate on the metered path (hosted-only, `apps/api/worker/billing`).
-> Ground DO behavior against `cloudflare/cloudflare-docs` via DeepWiki before
-> relying on memory. This is wave 3 of
-> `specs/20260620T000000-vocab-answerer-collapse.md`.
+> **trusted-internal infrastructure**, NOT an external client: do not mint a
+> user-impersonation credential, do not loop back to `/api/ai/chat`, do not store
+> user keys. It is woken by the existing dispatch doorbell
+> (`dispatch_request`/`dispatch_inbound` in `packages/server/src/room/core.ts`)
+> when a managed-agent turn is written; it reads/writes the conversation child doc
+> via the anchor's internal RPC (`getDoc`/`sync` — co-located, no remote
+> y-protocols handshake); it runs the daemon's existing `attachChatWorker` loop
+> (wave 2) verbatim with a **house-key Gemini** engine (provider adapter from
+> `@epicenter/ai-adapters`); and it bills the room's `ownerId` directly via the
+> in-process Autumn primitive (`apps/api/worker/billing`, hosted-only). Host shape:
+> a doorbell-triggered worker suffices (text-only answers have no approval pause);
+> the hibernating-DO upgrade (`acceptWebSocket`/`getWebSockets`/alarms +
+> `keepAlive`) arrives with F. Keep this a SEPARATE app-aware spoke; never add
+> answer logic to the room/anchor DO (ADR-0035). Cloud-proxied BYOK is DEFERRED
+> (needs the secret vault). Ground Cloudflare + Yjs behavior against
+> `cloudflare/cloudflare-docs` and `yjs/yjs` via DeepWiki before relying on memory.
+> This is wave 3 of `specs/20260620T000000-vocab-answerer-collapse.md`.
 
 ---
 


### PR DESCRIPTION
Refines ADR-0041 + the wave-3 plan after a greenfield grill (follows #2134/#2135).

The hosted managed worker was modeled as an external client (user-impersonation credential, HTTP loopback to `/api/ai/chat`, server-side BYOK key storage). It's **trusted-internal infrastructure** instead:

- bills the room's `ownerId` directly via the in-process Autumn primitive — no impersonation, no HTTP self-loopback;
- reads/writes the conversation doc via the anchor's internal RPC (`getDoc`/`sync`), co-located — no remote y-protocols handshake;
- **house-key Gemini only**; cloud-proxied BYOK deferred until the server-side secret vault exists (no user keys stored server-side);
- it's the daemon's `attachChatWorker` loop hosted by us; host shape (doorbell-triggered worker vs hibernating DO) follows F.

Also reconciles the #2127 disposition: it merged into main, so wave 4 deletes the owner fork from main rather than closing a PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784582119&installation_id=128463665&pr_number=2138&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2138&signature=3e23ceeb516333e5dd1d56909795bec136743139a92c107530e9cc451109576d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->