### PR TITLE
docs(vocab): ship the vocab-home home daemon (co-deploy guide)

### DIFF
--- a/apps/vocab/README.md
+++ b/apps/vocab/README.md
@@ -65,3 +65,61 @@ bun run build      # Production build
 bun run preview    # Preview production build
 bun run typecheck  # svelte-check
 ```
+
+## Run the home daemon (`vocab-home`)
+
+The home daemon is a long-lived process you run on your own box. Bind a conversation to it, close the browser, and it keeps answering over sync. It is the same answer loop the browser runs (`attachChatWorker`), just hosted somewhere that does not go away when you shut a tab.
+
+`apps/vocab` is itself an Epicenter root: `epicenter.config.ts` declares the mount and names the agent this daemon answers as (`vocab-home`). The `epicenter` binary and the daemon lifecycle (`epicenter daemon up`, `epicenter auth`, root discovery) are documented once in `packages/cli/README.md`; this section is the Vocab-specific wiring.
+
+### One time: log the machine in
+
+The daemon syncs and answers on your Epicenter account, so the machine needs a session.
+
+```sh
+epicenter auth login
+```
+
+This prints a URL. Sign in on the hosted portal, copy the one-time code from the success page, and paste it back into the terminal. The session is stored per API target under your platform user-data directory, so a local-dev login and a prod login coexist. Check it with `epicenter auth status`.
+
+A signed-out machine is still a valid daemon: it serves the local mount, but a conversation that needs the metered account stays unanswered until you log in.
+
+### Pick how the daemon answers
+
+The daemon resolves one inference backend per mount, in priority order (ADR-0038):
+
+1. **Local key (BYOK).** Set `GEMINI_API_KEY` (Vocab runs `gemini-3.5-flash`, a Gemini model). The daemon answers directly against Gemini with no cloud round-trip, billed to your key. This is the only backend that works offline or fully self-hosted, so it wins when present.
+2. **Metered Epicenter account.** Set `VOCAB_USE_METERED=1`. The daemon answers over the same `/api/ai/chat` stream the browser uses, billed to your Epicenter credits. Opt-in only: a signed-in daemon never spends credits unless you ask it to, the same way BYOK needs a key.
+3. **Neither.** The daemon hosts the conversation's sync but writes nothing. No placeholder, no half-answer; the turn waits for a configured answerer (a keyed daemon, or an open browser tab on your metered account). Starting a keyless, opt-out daemon is a supported state, not a misconfiguration: the doc is a durable mailbox.
+
+### Start it
+
+From the Vocab root (or pass `-C` to point at it):
+
+```sh
+GEMINI_API_KEY=... epicenter daemon up -C apps/vocab
+# or, to answer on your metered Epicenter account:
+VOCAB_USE_METERED=1 epicenter daemon up -C apps/vocab
+```
+
+The daemon runs in the foreground and prints sync and peer status to stderr. Backgrounding it is your job (a process manager, `nohup`, a systemd unit). It freezes its API target at boot; to retarget, `epicenter daemon down` then `epicenter daemon up` again.
+
+### Bind a conversation to it
+
+In the app, start a conversation with "Home daemon" as the agent ("New chat with → Home daemon"). The binding is set once at creation and never reassigned: to talk to a different agent you fork the conversation, so a transcript's history only ever reaches its one bound agent.
+
+The daemon's observe loop hosts exactly the conversations bound to `vocab-home` (`row.agent === 'vocab-home'`, ADR-0025) and ignores the rest. Once bound, you can close the browser: the daemon answers ambiently over sync, and the next time a device opens that conversation it catches up on resync. Claiming the turn is existence-based (`findUnansweredTurn`): the assistant message keyed to the turn's `generationId` is the claim, so a watching browser tab and the daemon never answer one turn twice.
+
+An unbound or offline daemon is fine. The picker lists "Home daemon" whether or not it is running, because the doc holds the turn until the daemon wakes. Nothing breaks if it is not home; the answer just waits.
+
+## Manually verify the daemon
+
+There is no automated end-to-end test for the cloud-plus-browser path, so this is the checklist to run by hand:
+
+1. `epicenter auth login`, then `epicenter auth status` shows your account and a verified session.
+2. Start the daemon with a backend, e.g. `GEMINI_API_KEY=... epicenter daemon up -C apps/vocab`. Confirm it prints `online (vocab)` and reaches `connected`.
+3. In the app, create a conversation with "Home daemon" as the agent.
+4. Send a turn. Confirm the assistant answer streams into the conversation, written by the daemon (the daemon's stderr shows activity; the browser made no HTTP kickoff for this conversation).
+5. Send another turn and immediately close the browser tab mid-answer. Reopen the app and the same conversation: the answer is complete (or still streaming and then finishes), caught up on resync. Closing the tab did not stop the answer.
+6. Stop the daemon (`Ctrl-C` or `epicenter daemon down -C apps/vocab`) and start it with no backend: unset `GEMINI_API_KEY` and leave `VOCAB_USE_METERED` off. It logs a warning that it has no inference backend and hosts sync without answering. Send a turn to a `vocab-home` conversation and confirm it stays unanswered. Restart with a backend and confirm the daemon then answers the waiting turn.
+7. (Until the browser stops answering in a later wave) With a watching browser tab open and the daemon running, send a turn and confirm exactly one assistant answer appears, never two. Existence-is-the-claim is what prevents the double-answer.


### PR DESCRIPTION
Wave 2 of `specs/20260620T000000-vocab-answerer-collapse.md`. The `vocab-home` daemon infrastructure already exists and was audited end-to-end (no code changes needed); this adds the co-deploy guide + manual verification checklist to `apps/vocab/README.md`.

**Audited path (works as intended, file:line in the audit):**
- Run flow: `epicenter auth login` (OOB OAuth 2.1 + PKCE machine login) → `epicenter daemon up -C apps/vocab` → `openEpicenterRoot` opens the mount. A signed-out machine is a valid state (hosts local mounts).
- Designation (ADR-0025): the observe loop hosts only conversations where `row.agent === 'vocab-home'`.
- Engine (ADR-0038): `GEMINI_API_KEY` (local, free) ?? `VOCAB_USE_METERED` (opt-in, metered via `/api/ai/chat`) ?? null (hosts sync, answers nothing).
- Single-answerer: existence-is-the-claim prevents a watching tab + the daemon double-answering.

**Notes for later:** the README "How it works" still describes the browser answering in-process — correct for current code; **wave 4** rewrites it when the browser stops answering.

Live cloud+browser e2e is a manual checklist (no automated harness for it); I did not run it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784582451&installation_id=128463665&pr_number=2139&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2139&signature=b7c5f0617b03d0be35d64c73a548bd101b52b62639380dba98eed1417cebad12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->