### PR TITLE
chore: pin bun install linker to isolated

### DIFF
--- a/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
@@ -266,7 +266,7 @@
 				</Item.Actions>
 			</Item.Root>
 		{:else if !value && customEntries.length === 0}
-			<Empty.Root class="py-8">
+			<Empty.Root>
 				<Empty.Media variant="icon">
 					<HardDriveDownload class="size-5" />
 				</Empty.Media>

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -2,10 +2,14 @@
 	import { Button } from '@epicenter/ui/button';
 	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { FileDropZone } from '@epicenter/ui/file-drop-zone';
+	import * as Item from '@epicenter/ui/item';
 	import * as Kbd from '@epicenter/ui/kbd';
 	import { Link } from '@epicenter/ui/link';
 	import * as SectionHeader from '@epicenter/ui/section-header';
 	import * as ToggleGroup from '@epicenter/ui/toggle-group';
+	import Cpu from '@lucide/svelte/icons/cpu';
+	import Heart from '@lucide/svelte/icons/heart';
+	import ShieldCheck from '@lucide/svelte/icons/shield-check';
 	import XIcon from '@lucide/svelte/icons/x';
 	import { createQuery } from '@tanstack/svelte-query';
 	import type { UnlistenFn } from '@tauri-apps/api/event';
@@ -179,10 +183,15 @@
 
 <svelte:head> <title>Whispering</title> </svelte:head>
 
-<div
-	class="flex flex-1 flex-col items-center justify-start gap-4 w-full max-w-lg mx-auto px-4 pt-6 pb-24 sm:justify-center sm:py-0"
->
-	<SectionHeader.Root class="flex flex-col items-center gap-3">
+{#snippet hero(layout: 'center' | 'split')}
+	<SectionHeader.Root
+		class={[
+			'flex flex-col gap-3',
+			layout === 'split'
+				? 'items-center text-center lg:items-start lg:text-left'
+				: 'items-center text-center',
+		]}
+	>
 		<div class="flex items-center gap-3">
 			<img src={studioMicrophone} alt="" class="size-12" />
 			<SectionHeader.Title
@@ -192,237 +201,292 @@
 				Whispering
 			</SectionHeader.Title>
 		</div>
-		<SectionHeader.Description class="text-center">
+		<SectionHeader.Description>
 			Press shortcut → speak → get text. Free and open source ❤️
 		</SectionHeader.Description>
 	</SectionHeader.Root>
+{/snippet}
 
-	<DictationCapabilityNotice />
-
+<div
+	class="flex flex-1 flex-col items-center justify-center w-full px-4 py-12 sm:py-16"
+>
 	{#if !transcriptionReadiness.isReady}
-		<div class="w-full space-y-3">
-			<div class="space-y-1">
-				<h2 class="text-base font-semibold">Set up transcription</h2>
-				<p class="text-sm text-muted-foreground">
-					{transcriptionReadiness.primaryIssue ??
-						'Choose how Whispering turns your speech into text.'}
-				</p>
+		<div class="w-full max-w-5xl space-y-6">
+			<DictationCapabilityNotice />
+			<div
+				class="grid items-start gap-8 lg:grid-cols-[1fr_minmax(420px,480px)] lg:gap-12"
+			>
+				<div
+					class="flex flex-col items-center gap-6 text-center lg:items-start lg:text-left"
+				>
+					{@render hero('split')}
+					<Item.Group class="w-full gap-1">
+						<Item.Root variant="muted">
+							<Item.Media variant="icon">
+								<ShieldCheck class="size-5" />
+							</Item.Media>
+							<Item.Content>
+								<Item.Title>Private and offline</Item.Title>
+								<Item.Description>
+									Audio is transcribed on your device and never uploaded.
+								</Item.Description>
+							</Item.Content>
+						</Item.Root>
+						<Item.Root variant="muted">
+							<Item.Media variant="icon">
+								<Cpu class="size-5" />
+							</Item.Media>
+							<Item.Content>
+								<Item.Title>Runs on this device</Item.Title>
+								<Item.Description>
+									No servers, no API keys, no monthly bill.
+								</Item.Description>
+							</Item.Content>
+						</Item.Root>
+						<Item.Root variant="muted">
+							<Item.Media variant="icon">
+								<Heart class="size-5" />
+							</Item.Media>
+							<Item.Content>
+								<Item.Title>Free and open source</Item.Title>
+								<Item.Description>
+									Yours to keep, audit, and extend.
+								</Item.Description>
+							</Item.Content>
+						</Item.Root>
+					</Item.Group>
+				</div>
+
+				<div class="w-full space-y-3">
+					<div class="space-y-1">
+						<h2 class="text-base font-semibold">Set up transcription</h2>
+						<p class="text-sm text-muted-foreground">
+							{transcriptionReadiness.primaryIssue ??
+								'Choose how Whispering turns your speech into text.'}
+						</p>
+					</div>
+					<TranscriptionRuntimeConfig
+						id="home-transcription-service"
+						label="Service"
+						showAdvanced={false}
+					/>
+				</div>
 			</div>
-			<TranscriptionRuntimeConfig
-				id="home-transcription-service"
-				label="Service"
-				showAdvanced={false}
-			/>
 		</div>
 	{:else}
-		<ToggleGroup.Root
-			type="single"
-			bind:value={() => captureSurface.current,
-				(surface) => {
-					if (!surface) return;
-					void selectCaptureSurface(surface as CaptureSurface);
-				}}
-			class="w-full"
-		>
-			{#each CAPTURE_SURFACE_OPTIONS as option}
-				{@const SurfaceIcon = CAPTURE_SURFACE_META[option.value].Icon}
-				<ToggleGroup.Item
-					value={option.value}
-					aria-label="Switch to {option.label.toLowerCase()}"
-				>
-					<SurfaceIcon class="size-4" />
-					<span class="hidden truncate sm:inline">{option.label}</span>
-				</ToggleGroup.Item>
-			{/each}
-		</ToggleGroup.Root>
+		<div class="flex w-full max-w-lg flex-col items-center gap-4">
+			{@render hero('center')}
 
-		<!--
-			The capture pipeline is each recording action's idle footer (the action
-			hides it while live), so it's defined inline per surface. Manual and VAD
-			differ only by their device selector; each owns a distinct one backed by a
-			different recorder config. The shared tail repeats, but that keeps each
-			surface's footer co-located with the branch that already chose it, rather
-			than re-deriving the surface inside a shared snippet.
-		-->
-		{#if captureSurface.current === 'manual'}
-			<div class="flex w-full flex-col items-center gap-3">
-				<ManualRecordingAction>
-					{#snippet pipeline()}
-						<CapturePipeline>
-							<ManualDeviceSelector
-								iconViewTransitionName={viewTransition.pipeline.device}
-							/>
-							<TranscriptionSelector
-								variant="pipeline"
-								iconViewTransitionName={viewTransition.pipeline.transcription}
-							/>
-							<TransformationSelector
-								iconViewTransitionName={transformationViewTransitionName}
-							/>
-							<CaptureBehaviorPopover />
-						</CapturePipeline>
-					{/snippet}
-				</ManualRecordingAction>
-				{#if manualRecorder.state === 'RECORDING'}
-					<Button
-						tooltip="Cancel recording and discard audio"
-						onclick={() => commandCallbacks.cancelRecording()}
-						variant="ghost-destructive"
-						size="sm"
+			<DictationCapabilityNotice />
+			<ToggleGroup.Root
+				type="single"
+				bind:value={() => captureSurface.current,
+					(surface) => {
+						if (!surface) return;
+						void selectCaptureSurface(surface as CaptureSurface);
+					}}
+				class="w-full"
+			>
+				{#each CAPTURE_SURFACE_OPTIONS as option}
+					{@const SurfaceIcon = CAPTURE_SURFACE_META[option.value].Icon}
+					<ToggleGroup.Item
+						value={option.value}
+						aria-label="Switch to {option.label.toLowerCase()}"
 					>
-						<XIcon class="size-4" />
-						Cancel
-					</Button>
-				{/if}
-			</div>
-		{:else if captureSurface.current === 'vad'}
-			<div class="flex w-full flex-col items-center gap-3">
-				<VadRecordingAction>
-					{#snippet pipeline()}
-						<CapturePipeline>
-							<VadDeviceSelector
-								iconViewTransitionName={viewTransition.pipeline.device}
-							/>
-							<TranscriptionSelector
-								variant="pipeline"
-								iconViewTransitionName={viewTransition.pipeline.transcription}
-							/>
-							<TransformationSelector
-								iconViewTransitionName={transformationViewTransitionName}
-							/>
-							<CaptureBehaviorPopover />
-						</CapturePipeline>
-					{/snippet}
-				</VadRecordingAction>
-			</div>
-		{:else if captureSurface.current === 'import'}
-			<div class="flex w-full flex-col items-center gap-4">
-				<FileDropZone
-					accept={IMPORT_ACCEPT}
-					maxFiles={MAX_IMPORT_FILES}
-					maxFileSize={MAX_IMPORT_FILE_SIZE}
-					onUpload={async (files) => {
-						if (files.length > 0) {
-							await importFiles({ files });
-						}
-					}}
-					onFileRejected={({ file, reason }) => {
-						report.error({
-							cause: PageError.FileRejected({
-								fileName: file.name,
-								reason,
-							}).error,
-							title: 'File rejected',
-						});
-					}}
-					class="h-32 sm:h-36 w-full"
-				/>
-				<CapturePipeline>
-					<TranscriptionSelector
-						variant="pipeline"
-						iconViewTransitionName={viewTransition.pipeline.transcription}
-					/>
-					<TransformationSelector
-						iconViewTransitionName={transformationViewTransitionName}
-					/>
-				</CapturePipeline>
-			</div>
-		{/if}
+						<SurfaceIcon class="size-4" />
+						<span class="hidden truncate sm:inline">{option.label}</span>
+					</ToggleGroup.Item>
+				{/each}
+			</ToggleGroup.Root>
 
-		{#if latestRecording}
-			<div class="flex w-full flex-col gap-2">
-				<TranscriptDialog
-					recordingId={latestRecording.id}
-					transcript={latestRecording.transcript}
-					rows={1}
-					disabled={!latestRecording.transcript.trim()}
-					onDelete={() => {
-						confirmationDialog.open({
-							title: 'Delete recording',
-							description: 'Are you sure you want to delete this recording?',
-							confirm: { text: 'Delete', variant: 'destructive' },
-							onConfirm: () => {
-								services.blobs.audio.revokeUrl(latestRecording.id);
-								recordings.delete(latestRecording.id);
-								report.success({
-									title: 'Deleted recording!',
-									description: 'Your recording has been deleted.',
-								});
-							},
-						});
-					}}
-				/>
-
-				{#if audioPlaybackUrlQuery.data}
-					<audio
-						style:view-transition-name={viewTransition.recording(
-							latestRecording.id,
-						).audio}
-						src={audioPlaybackUrlQuery.data}
-						controls
-						class="h-8 w-full"
-					></audio>
-				{/if}
-			</div>
-		{/if}
-
-		<div class="flex flex-col items-center gap-3">
+			<!--
+				The capture pipeline is each recording action's idle footer (the action
+				hides it while live), so it's defined inline per surface. Manual and VAD
+				differ only by their device selector; each owns a distinct one backed by a
+				different recorder config. The shared tail repeats, but that keeps each
+				surface's footer co-located with the branch that already chose it, rather
+				than re-deriving the surface inside a shared snippet.
+			-->
 			{#if captureSurface.current === 'manual'}
-				<p class="text-foreground/75 text-center text-sm">
-					{#if manualShortcutLabel}
-						Click the microphone to record{tauri ? ' here' : ''}, or press
-						<Link
-							tooltip="Configure the recording shortcut"
-							href="/settings/shortcuts"
+				<div class="flex w-full flex-col items-center gap-3">
+					<ManualRecordingAction>
+						{#snippet pipeline()}
+							<CapturePipeline>
+								<ManualDeviceSelector
+									iconViewTransitionName={viewTransition.pipeline.device}
+								/>
+								<TranscriptionSelector
+									variant="pipeline"
+									iconViewTransitionName={viewTransition.pipeline.transcription}
+								/>
+								<TransformationSelector
+									iconViewTransitionName={transformationViewTransitionName}
+								/>
+								<CaptureBehaviorPopover />
+							</CapturePipeline>
+						{/snippet}
+					</ManualRecordingAction>
+					{#if manualRecorder.state === 'RECORDING'}
+						<Button
+							tooltip="Cancel recording and discard audio"
+							onclick={() => commandCallbacks.cancelRecording()}
+							variant="ghost-destructive"
+							size="sm"
 						>
-							<Kbd.Root class={shortcutUnavailable ? 'opacity-50' : undefined}
-								>{manualShortcutLabel}</Kbd.Root>
-						</Link>
-						{tauri ? 'to record from anywhere.' : 'to record.'}
-					{:else if tauri}
-						Click the microphone to record, or
-						<Link tooltip="Set a global shortcut" href="/settings/shortcuts"
-							>set a global shortcut</Link>
-						to record from anywhere.
-					{:else}
-						Click the microphone to start recording.
+							<XIcon class="size-4" />
+							Cancel
+						</Button>
 					{/if}
-				</p>
+				</div>
 			{:else if captureSurface.current === 'vad'}
-				<p class="text-foreground/75 text-center text-sm">
-					{#if vadShortcutLabel}
-						Click the microphone to listen{tauri ? ' here' : ''}, or press
+				<div class="flex w-full flex-col items-center gap-3">
+					<VadRecordingAction>
+						{#snippet pipeline()}
+							<CapturePipeline>
+								<VadDeviceSelector
+									iconViewTransitionName={viewTransition.pipeline.device}
+								/>
+								<TranscriptionSelector
+									variant="pipeline"
+									iconViewTransitionName={viewTransition.pipeline.transcription}
+								/>
+								<TransformationSelector
+									iconViewTransitionName={transformationViewTransitionName}
+								/>
+								<CaptureBehaviorPopover />
+							</CapturePipeline>
+						{/snippet}
+					</VadRecordingAction>
+				</div>
+			{:else if captureSurface.current === 'import'}
+				<div class="flex w-full flex-col items-center gap-4">
+					<FileDropZone
+						accept={IMPORT_ACCEPT}
+						maxFiles={MAX_IMPORT_FILES}
+						maxFileSize={MAX_IMPORT_FILE_SIZE}
+						onUpload={async (files) => {
+							if (files.length > 0) {
+								await importFiles({ files });
+							}
+						}}
+						onFileRejected={({ file, reason }) => {
+							report.error({
+								cause: PageError.FileRejected({
+									fileName: file.name,
+									reason,
+								}).error,
+								title: 'File rejected',
+							});
+						}}
+						class="h-32 sm:h-36 w-full"
+					/>
+					<CapturePipeline>
+						<TranscriptionSelector
+							variant="pipeline"
+							iconViewTransitionName={viewTransition.pipeline.transcription}
+						/>
+						<TransformationSelector
+							iconViewTransitionName={transformationViewTransitionName}
+						/>
+					</CapturePipeline>
+				</div>
+			{/if}
+
+			{#if latestRecording}
+				<div class="flex w-full flex-col gap-2">
+					<TranscriptDialog
+						recordingId={latestRecording.id}
+						transcript={latestRecording.transcript}
+						rows={1}
+						disabled={!latestRecording.transcript.trim()}
+						onDelete={() => {
+							confirmationDialog.open({
+								title: 'Delete recording',
+								description: 'Are you sure you want to delete this recording?',
+								confirm: { text: 'Delete', variant: 'destructive' },
+								onConfirm: () => {
+									services.blobs.audio.revokeUrl(latestRecording.id);
+									recordings.delete(latestRecording.id);
+									report.success({
+										title: 'Deleted recording!',
+										description: 'Your recording has been deleted.',
+									});
+								},
+							});
+						}}
+					/>
+
+					{#if audioPlaybackUrlQuery.data}
+						<audio
+							style:view-transition-name={viewTransition.recording(
+								latestRecording.id,
+							).audio}
+							src={audioPlaybackUrlQuery.data}
+							controls
+							class="h-8 w-full"
+						></audio>
+					{/if}
+				</div>
+			{/if}
+
+			<div class="flex flex-col items-center gap-3">
+				{#if captureSurface.current === 'manual'}
+					<p class="text-foreground/75 text-center text-sm">
+						{#if manualShortcutLabel}
+							Click the microphone to record{tauri ? ' here' : ''}, or press
+							<Link
+								tooltip="Configure the recording shortcut"
+								href="/settings/shortcuts"
+							>
+								<Kbd.Root class={shortcutUnavailable ? 'opacity-50' : undefined}
+									>{manualShortcutLabel}</Kbd.Root>
+							</Link>
+							{tauri ? 'to record from anywhere.' : 'to record.'}
+						{:else if tauri}
+							Click the microphone to record, or
+							<Link tooltip="Set a global shortcut" href="/settings/shortcuts"
+								>set a global shortcut</Link>
+							to record from anywhere.
+						{:else}
+							Click the microphone to start recording.
+						{/if}
+					</p>
+				{:else if captureSurface.current === 'vad'}
+					<p class="text-foreground/75 text-center text-sm">
+						{#if vadShortcutLabel}
+							Click the microphone to listen{tauri ? ' here' : ''}, or press
+							<Link
+								tooltip="Configure the voice activation shortcut"
+								href="/settings/shortcuts"
+							>
+								<Kbd.Root class={shortcutUnavailable ? 'opacity-50' : undefined}
+									>{vadShortcutLabel}</Kbd.Root>
+							</Link>
+							{tauri ? 'to listen from anywhere.' : 'to listen.'}
+						{:else if tauri}
+							Click the microphone to start a voice activated session, or
+							<Link tooltip="Set a global shortcut" href="/settings/shortcuts"
+								>set a global shortcut</Link>
+							to listen from anywhere.
+						{:else}
+							Click the microphone to start a voice activated session.
+						{/if}
+					</p>
+				{/if}
+				<p class="text-muted-foreground text-center text-sm font-light">
+					{#if !tauri}
+						Tired of switching tabs?
 						<Link
-							tooltip="Configure the voice activation shortcut"
-							href="/settings/shortcuts"
+							tooltip="Get Whispering for desktop"
+							href="https://epicenter.so/whispering"
+							target="_blank"
+							rel="noopener noreferrer"
 						>
-							<Kbd.Root class={shortcutUnavailable ? 'opacity-50' : undefined}
-								>{vadShortcutLabel}</Kbd.Root>
+							Get the native desktop app
 						</Link>
-						{tauri ? 'to listen from anywhere.' : 'to listen.'}
-					{:else if tauri}
-						Click the microphone to start a voice activated session, or
-						<Link tooltip="Set a global shortcut" href="/settings/shortcuts"
-							>set a global shortcut</Link>
-						to listen from anywhere.
-					{:else}
-						Click the microphone to start a voice activated session.
 					{/if}
 				</p>
-			{/if}
-			<p class="text-muted-foreground text-center text-sm font-light">
-				{#if !tauri}
-					Tired of switching tabs?
-					<Link
-						tooltip="Get Whispering for desktop"
-						href="https://epicenter.so/whispering"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						Get the native desktop app
-					</Link>
-				{/if}
-			</p>
+			</div>
 		</div>
 	{/if}
 </div>

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,7 @@
+[install]
+# Pin the dependency linker so every machine and CI produce the same
+# node_modules layout, instead of leaving it to bun's default (which varies by
+# bun version, workspace setup, and lockfile configVersion). "isolated" is the
+# strict pnpm-style layout: a package can only import what it declares, so
+# phantom dependencies fail loudly instead of riding on accidental hoisting.
+linker = "isolated"


### PR DESCRIPTION

Add a root `bunfig.toml` pinning the bun install linker to `isolated` (pnpm-style).

The reason for this shape is:

bun's default linker varies by bun version, workspace setup, and the lockfile `configVersion`, so the `node_modules` layout was diverging across machines and could flip silently on a bun upgrade.

That already bit us. `onnxruntime-web` is a transitive dependency of `@ricky0123/vad-web`, not declared by whispering, so it is unreachable from the app root under an isolated tree. Whispering's vite config resolved it from the app root and threw `MODULE_NOT_FOUND` at config-eval time on an isolated machine while working fine on a hoisted one. The resolution path was fixed separately (resolve onnx through vad-web); this pins the layout so the hoisted-vs-isolated divergence stops happening across machines and CI.

`isolated` is the strict layout: a package can only import the dependencies it declares, so phantom dependencies fail loudly instead of riding on accidental hoisting.

A note for review:

This is repo-wide. The quality check on this PR exercises a full install and build under isolated. If another app was relying on a hoisted phantom dependency, it surfaces here rather than on `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784595449&installation_id=128463665&pr_number=2140&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2140&signature=6dc4da03763ec9f72e01d1dd71e1bb7d2d2a870a105f78f9e3c104ec421cca85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->