### PR TITLE
feat(whispering): home capability banner fires on issues only

### DIFF
--- a/apps/whispering/src/lib/components/DictationCapabilityNotice.svelte
+++ b/apps/whispering/src/lib/components/DictationCapabilityNotice.svelte
@@ -3,23 +3,27 @@
 	import * as Item from '@epicenter/ui/item';
 	import InfoIcon from '@lucide/svelte/icons/info';
 	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
-	import WandSparklesIcon from '@lucide/svelte/icons/wand-sparkles';
 	import { accessibilityGuide } from '$lib/components/MacosAccessibilityGuideDialog.svelte';
 	import { outputWritesToCursor } from '$lib/operations/delivery';
 	import { dictationCapability } from '$lib/state/dictation-capability.svelte';
-	import { recordings } from '$lib/state/recordings.svelte';
 
-	// One declarative view over the dictation capability Rust owns, in registers
-	// that differ in kind, not just wording. The untrusted case splits on whether
-	// the user has actually configured cursor paste (`outputWritesToCursor`):
-	//   - broken: a stale grant left the global tap dead. A real FAULT, so an amber
-	//     glyph, a `role="alert"`, and a primary action.
-	//   - untrusted + cursor paste configured: the paste the user asked for is
-	//     silently not firing. A soft fault: amber glyph and a primary action, but
-	//     no `role="alert"` (a steady recoverable state, not a change to announce).
-	//   - untrusted + cursor paste off (first grant): never granted, and nothing
-	//     configured needs it. An optional UPGRADE, not a wall, so the glyph is calm
-	//     and the action is a quiet outline button.
+	// A home banner that fires ONLY when something the user configured is broken,
+	// never as a feature pitch. The dictation capability Rust owns already encodes
+	// "is anything wrong": the global tap is held (`untrusted`/`broken`, the states
+	// `needsAccessibility` covers) only when some configured intent wants the macOS
+	// Accessibility grant (a hold-to-talk binding, paste at cursor, or a live
+	// capture); with nothing to grant for, the capability settles to
+	// `inactive`/`active` and this banner stays silent. Three registers, each a
+	// real problem with a fix:
+	//   - broken: a stale grant left the global tap dead. A previously-working
+	//     shortcut stopped firing, so it is a FAULT: amber glyph, `role="alert"`,
+	//     and a primary action.
+	//   - untrusted + paste at cursor configured: the paste the user asked for is
+	//     silently falling back to the clipboard. A soft fault: amber glyph and a
+	//     primary action, but no `role="alert"` (a steady recoverable state, not a
+	//     change to announce). The untrusted hold-to-talk gap (no cursor paste) is
+	//     surfaced at the shortcut recorder and the dimmed keycap, not here, so the
+	//     home banner stays about the non-obvious paste downgrade.
 	//   - unsupported (Wayland): a platform FACT, nothing to grant. An info glyph
 	//     pointing at the mic that still works; no action.
 	// All share one slim outlined `Item` (icon · message · trailing action) at the
@@ -27,33 +31,11 @@
 	// action carry the register. None is dismissable: each clears itself when the
 	// capability or the cursor toggle flips, and a quiet banner never needs hiding.
 	// The detailed steps live in the guide dialog the action opens. The branch order
-	// is load-bearing: `broken` is caught first, then the configured-paste fault
-	// before the plain upgrade pitch.
-	//
-	// The optional pitch waits for the first transcript: it is a pitch, not a
-	// problem, and "hold a key to talk" only means something once you have pressed
-	// once and watched a transcript land. The configured-paste fault does NOT wait,
-	// because turning cursor paste on is itself the signal that the pitch was
-	// already accepted, so the gap is worth surfacing immediately. Both are derived
-	// from state that already exists (recordings, settings), so neither costs a
-	// dismissal flag. Breakage and the Wayland limit are never gated: those are
-	// immediate.
-	const hasDictatedOnce = $derived(
-		recordings.sorted.some((r) => r.transcript.trim()),
-	);
-	// Cursor paste is configured but the grant isn't live, so the paste the user
-	// asked for is silently falling back to the clipboard. Not a stale grant (that
-	// is `isStale`), so it reads as a soft fault rather than the upgrade pitch.
+	// is load-bearing: `broken` is caught before the plain untrusted paste case.
 	const cursorPasteNotFiring = $derived(
 		dictationCapability.needsAccessibility &&
 			!dictationCapability.isStale &&
 			outputWritesToCursor(),
-	);
-	const isFirstGrant = $derived(
-		dictationCapability.needsAccessibility &&
-			!dictationCapability.isStale &&
-			!outputWritesToCursor() &&
-			hasDictatedOnce,
 	);
 </script>
 
@@ -89,27 +71,6 @@
 		</Item.Content>
 		<Item.Actions>
 			<Button size="sm" onclick={() => accessibilityGuide.open()}>
-				Show me how
-			</Button>
-		</Item.Actions>
-	</Item.Root>
-{:else if isFirstGrant}
-	<Item.Root variant="outline" size="sm" class="w-full">
-		<Item.Media>
-			<WandSparklesIcon class="size-4" aria-hidden="true" />
-		</Item.Media>
-		<Item.Content>
-			<Item.Title>Hold a key to talk, paste hands-free</Item.Title>
-			<Item.Description>
-				Your shortcut already copies transcripts to your clipboard.
-			</Item.Description>
-		</Item.Content>
-		<Item.Actions>
-			<Button
-				size="sm"
-				variant="outline"
-				onclick={() => accessibilityGuide.open()}
-			>
 				Show me how
 			</Button>
 		</Item.Actions>

--- a/apps/whispering/src/lib/components/DictationCapabilityNotice.svelte
+++ b/apps/whispering/src/lib/components/DictationCapabilityNotice.svelte
@@ -5,38 +5,54 @@
 	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 	import WandSparklesIcon from '@lucide/svelte/icons/wand-sparkles';
 	import { accessibilityGuide } from '$lib/components/MacosAccessibilityGuideDialog.svelte';
+	import { outputWritesToCursor } from '$lib/operations/delivery';
 	import { dictationCapability } from '$lib/state/dictation-capability.svelte';
 	import { recordings } from '$lib/state/recordings.svelte';
 
-	// One declarative view over the dictation capability Rust owns, in three
-	// registers that differ in kind, not just wording:
+	// One declarative view over the dictation capability Rust owns, in registers
+	// that differ in kind, not just wording. The untrusted case splits on whether
+	// the user has actually configured cursor paste (`outputWritesToCursor`):
 	//   - broken: a stale grant left the global tap dead. A real FAULT, so an amber
 	//     glyph, a `role="alert"`, and a primary action.
-	//   - untrusted (first grant): never granted. An optional UPGRADE, not a wall.
-	//     Dictation already works through the shortcut and clipboard, so the glyph
-	//     is calm and the action is a quiet outline button.
+	//   - untrusted + cursor paste configured: the paste the user asked for is
+	//     silently not firing. A soft fault: amber glyph and a primary action, but
+	//     no `role="alert"` (a steady recoverable state, not a change to announce).
+	//   - untrusted + cursor paste off (first grant): never granted, and nothing
+	//     configured needs it. An optional UPGRADE, not a wall, so the glyph is calm
+	//     and the action is a quiet outline button.
 	//   - unsupported (Wayland): a platform FACT, nothing to grant. An info glyph
 	//     pointing at the mic that still works; no action.
-	// All three share one slim outlined `Item` (icon · message · trailing action)
-	// at the same size, so backgrounds and padding stay uniform and only the glyph
-	// and the action carry the register. None is dismissable: each
-	// clears itself when the capability flips, and a quiet banner never needs
-	// hiding. The detailed steps live in the guide dialog the action opens. The
-	// branch order is load-bearing: `broken` is caught before the plain untrusted
-	// case (`needsAccessibility` covers both).
+	// All share one slim outlined `Item` (icon · message · trailing action) at the
+	// same size, so backgrounds and padding stay uniform and only the glyph and the
+	// action carry the register. None is dismissable: each clears itself when the
+	// capability or the cursor toggle flips, and a quiet banner never needs hiding.
+	// The detailed steps live in the guide dialog the action opens. The branch order
+	// is load-bearing: `broken` is caught first, then the configured-paste fault
+	// before the plain upgrade pitch.
 	//
-	// The optional pitch waits for the first transcript. It is a pitch, not a
+	// The optional pitch waits for the first transcript: it is a pitch, not a
 	// problem, and "hold a key to talk" only means something once you have pressed
-	// once and watched a transcript land. Holding it back keeps a brand-new home
-	// clean and lets the pitch arrive when it is finally relevant. Derived from the
-	// recordings that already exist, so it costs no dismissal flag. Breakage and
-	// the Wayland limit are never gated: those are immediate.
+	// once and watched a transcript land. The configured-paste fault does NOT wait,
+	// because turning cursor paste on is itself the signal that the pitch was
+	// already accepted, so the gap is worth surfacing immediately. Both are derived
+	// from state that already exists (recordings, settings), so neither costs a
+	// dismissal flag. Breakage and the Wayland limit are never gated: those are
+	// immediate.
 	const hasDictatedOnce = $derived(
 		recordings.sorted.some((r) => r.transcript.trim()),
+	);
+	// Cursor paste is configured but the grant isn't live, so the paste the user
+	// asked for is silently falling back to the clipboard. Not a stale grant (that
+	// is `isStale`), so it reads as a soft fault rather than the upgrade pitch.
+	const cursorPasteNotFiring = $derived(
+		dictationCapability.needsAccessibility &&
+			!dictationCapability.isStale &&
+			outputWritesToCursor(),
 	);
 	const isFirstGrant = $derived(
 		dictationCapability.needsAccessibility &&
 			!dictationCapability.isStale &&
+			!outputWritesToCursor() &&
 			hasDictatedOnce,
 	);
 </script>
@@ -51,6 +67,24 @@
 			<Item.Description>
 				Re-granting macOS Accessibility usually fixes it. Until then, transcripts
 				go to your clipboard.
+			</Item.Description>
+		</Item.Content>
+		<Item.Actions>
+			<Button size="sm" onclick={() => accessibilityGuide.open()}>
+				Show me how
+			</Button>
+		</Item.Actions>
+	</Item.Root>
+{:else if cursorPasteNotFiring}
+	<Item.Root variant="outline" size="sm" class="w-full">
+		<Item.Media>
+			<TriangleAlertIcon class="text-warning size-4" aria-hidden="true" />
+		</Item.Media>
+		<Item.Content>
+			<Item.Title>Paste at cursor needs macOS Accessibility</Item.Title>
+			<Item.Description>
+				You've turned on paste at cursor, but it isn't granted yet. Until you
+				grant it, transcripts go to your clipboard.
 			</Item.Description>
 		</Item.Content>
 		<Item.Actions>


### PR DESCRIPTION
The reason for this shape is:

The home dictation-capability notice had a register that showed a calm "Hold a key to talk, paste hands-free / Your shortcut already copies transcripts to your clipboard" pitch. It was an advertisement wearing a status banner's clothes: it appeared whenever Accessibility wasn't granted and you'd dictated once, regardless of whether you'd actually configured anything that needs the grant, and it confused even informed users.

Key realization: the dictation capability is only ever `untrusted`/`broken` when some configured intent wants the tap (`wants_tap() = bindings || auto_paste || capturing` in `keyboard/supervisor.rs`). With nothing needing the grant, it settles to `inactive`/`active` and the banner is silent. So the capability state itself already means "something you set up is broken" — there was never a need for a pitch register.

This change does the following:

The home banner now fires **only on real problems**, three registers:

- **`broken`** (stale grant, tap died) → fault: amber glyph, `role="alert"`, primary action. A previously-working shortcut stopped firing. Unchanged.
- **`untrusted` + paste-at-cursor configured** → soft fault: amber glyph, primary action, no `role="alert"` (a steady recoverable state). Names the gap and the fix; surfaces immediately rather than waiting for a first transcript, since enabling paste is itself the signal it's wanted. Keyed on the existing `outputWritesToCursor()`.
- **`unsupported`** (Wayland) → info, no action. Unchanged.

Deleted the calm first-grant pitch register and its `WandSparklesIcon` / `recordings` / `hasDictatedOnce` dependencies.

The composition lives in the view (capability × settings); the capability SSOT is unchanged, and no new state or dismissal flag is introduced.

## Trade-off

Brand-new users lose the home-screen nudge that paste-back exists. That discovery stays available on the **Paste at cursor** toggle in Output settings (the point where the decision is made), and the untrusted hold-to-talk-only gap keeps its existing surfaces (the shortcut recorder warning + the dimmed keycap). The home banner is now exclusively for "something you configured isn't working."

Surfaced while smoke-testing #2132 (independent branch off `main`; merge order doesn't matter).