### PR TITLE
refactor(whispering): collapse nullable-platform ceremony in settings

### DIFF
--- a/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
+++ b/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
@@ -307,99 +307,93 @@
 		</div>
 	{:else if settings.get('transcription.service') === 'whispercpp'}
 		<div class="space-y-4">
-			{#if tauri}
-				<LocalModelSelector
-					models={WHISPER_MODELS}
-					title="Whisper Model"
-					description="Download a pre-built model or add your own to the models folder. Models run locally for private, offline transcription."
-					bind:value={() => deviceConfig.get('transcription.whispercpp.model'),
-						(v) => deviceConfig.set('transcription.whispercpp.model', v)}
-				>
-					{#snippet footer()}
-						<Field.Description>
-							Pre-built models are downloaded from
-							<Link
-								href="https://huggingface.co/ggerganov/whisper.cpp"
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								Hugging Face
-							</Link>
-							into the models folder. Quantized models (q5_0, q8_0) offer
-							smaller sizes with minimal quality loss.
-						</Field.Description>
-					{/snippet}
-				</LocalModelSelector>
-			{/if}
+			<LocalModelSelector
+				models={WHISPER_MODELS}
+				title="Whisper Model"
+				description="Download a pre-built model or add your own to the models folder. Models run locally for private, offline transcription."
+				bind:value={() => deviceConfig.get('transcription.whispercpp.model'),
+					(v) => deviceConfig.set('transcription.whispercpp.model', v)}
+			>
+				{#snippet footer()}
+					<Field.Description>
+						Pre-built models are downloaded from
+						<Link
+							href="https://huggingface.co/ggerganov/whisper.cpp"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							Hugging Face
+						</Link>
+						into the models folder. Quantized models (q5_0, q8_0) offer
+						smaller sizes with minimal quality loss.
+					</Field.Description>
+				{/snippet}
+			</LocalModelSelector>
 		</div>
 	{:else if settings.get('transcription.service') === 'parakeet'}
 		<div class="space-y-4">
-			{#if tauri}
-				<LocalModelSelector
-					models={PARAKEET_MODELS}
-					title="Parakeet Model"
-					description="Parakeet is the recommended fast local model. It runs on this device, downloads once, and automatically detects supported spoken languages."
-					bind:value={() => deviceConfig.get('transcription.parakeet.model'),
-					(v) => deviceConfig.set('transcription.parakeet.model', v)}
-				>
-					{#snippet footer()}
-						<Field.Description>
-							Pre-built models are downloaded from
-							<Link
-								href="https://github.com/EpicenterHQ/epicenter/releases/tag/models/parakeet-tdt-0.6b-v3-int8"
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								GitHub releases
-							</Link>
-							into the models folder. Parakeet models from
-							<Link
-								href="https://github.com/NVIDIA/NeMo"
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								NVIDIA NeMo
-							</Link>
-							are directories containing ONNX files.
-						</Field.Description>
-					{/snippet}
-				</LocalModelSelector>
-			{/if}
+			<LocalModelSelector
+				models={PARAKEET_MODELS}
+				title="Parakeet Model"
+				description="Parakeet is the recommended fast local model. It runs on this device, downloads once, and automatically detects supported spoken languages."
+				bind:value={() => deviceConfig.get('transcription.parakeet.model'),
+				(v) => deviceConfig.set('transcription.parakeet.model', v)}
+			>
+				{#snippet footer()}
+					<Field.Description>
+						Pre-built models are downloaded from
+						<Link
+							href="https://github.com/EpicenterHQ/epicenter/releases/tag/models/parakeet-tdt-0.6b-v3-int8"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							GitHub releases
+						</Link>
+						into the models folder. Parakeet models from
+						<Link
+							href="https://github.com/NVIDIA/NeMo"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							NVIDIA NeMo
+						</Link>
+						are directories containing ONNX files.
+					</Field.Description>
+				{/snippet}
+			</LocalModelSelector>
 		</div>
 	{:else if settings.get('transcription.service') === 'moonshine'}
 		<div class="space-y-4">
-			{#if tauri}
-				<LocalModelSelector
-					models={MOONSHINE_MODELS}
-					title="Moonshine Model"
-					description="Moonshine is an efficient ONNX model by UsefulSensors. English-only with fast inference and small model sizes (~30 MB)."
-					bind:value={() => deviceConfig.get('transcription.moonshine.model'),
-					(v) => deviceConfig.set('transcription.moonshine.model', v)}
-				>
-					{#snippet footer()}
-						<Field.Description>
-							Pre-built models are downloaded from
-							<Link
-								href="https://huggingface.co/UsefulSensors/moonshine"
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								Hugging Face
-							</Link>
-							into the models folder. Your own Moonshine directory must be
-							named
-							<code class="rounded bg-muted px-1 py-0.5 font-mono"
-								>moonshine-&#123;variant&#125;-&#123;lang&#125;</code
-							>
-							(e.g.
-							<code class="rounded bg-muted px-1 py-0.5 font-mono"
-								>moonshine-tiny-en</code
-							>); the variant (tiny/base) tells Whispering the model
-							architecture.
-						</Field.Description>
-					{/snippet}
-				</LocalModelSelector>
-			{/if}
+			<LocalModelSelector
+				models={MOONSHINE_MODELS}
+				title="Moonshine Model"
+				description="Moonshine is an efficient ONNX model by UsefulSensors. English-only with fast inference and small model sizes (~30 MB)."
+				bind:value={() => deviceConfig.get('transcription.moonshine.model'),
+				(v) => deviceConfig.set('transcription.moonshine.model', v)}
+			>
+				{#snippet footer()}
+					<Field.Description>
+						Pre-built models are downloaded from
+						<Link
+							href="https://huggingface.co/UsefulSensors/moonshine"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							Hugging Face
+						</Link>
+						into the models folder. Your own Moonshine directory must be
+						named
+						<code class="rounded bg-muted px-1 py-0.5 font-mono"
+							>moonshine-&#123;variant&#125;-&#123;lang&#125;</code
+						>
+						(e.g.
+						<code class="rounded bg-muted px-1 py-0.5 font-mono"
+							>moonshine-tiny-en</code
+						>); the variant (tiny/base) tells Whispering the model
+						architecture.
+					</Field.Description>
+				{/snippet}
+			</LocalModelSelector>
 		</div>
 	{/if}
 

--- a/apps/whispering/src/lib/rpc/README.md
+++ b/apps/whispering/src/lib/rpc/README.md
@@ -112,7 +112,7 @@ Rules:
 - Define keys with `defineKeys` and export the key map beside the adapter that owns it.
 - Static key entries do not need `as const`; `defineKeys` preserves literal tuple types for them.
 - Key factories need `as const` when the literal positions matter, like `['audio', 'playbackUrl', id] as const`.
-- Keep keys in the owning module unless another layer must share the same fallback key, like web settings importing `autostartKeys` when Tauri is unavailable.
+- Keep keys in the owning module. Only lift them into a standalone file when a separate layer genuinely must reference the same key without importing the owning adapter (for example, a web fallback that cannot pull in a Tauri-only module).
 - Keep adapter-specific errors local unless another module needs to name that exact error union.
 - Inline small single-use input objects. Name an input type only when it is reused, exported, large enough to obscure the function, or carries domain meaning. Put named input types immediately before the adapter namespace that uses them.
 - If you export the exact return shape of a `create*` factory, derive it with `ReturnType<typeof createThing>` instead of duplicating the object shape.

--- a/apps/whispering/src/lib/tauri.tauri.ts
+++ b/apps/whispering/src/lib/tauri.tauri.ts
@@ -56,11 +56,11 @@ import { openPath as revealPath } from '@tauri-apps/plugin-opener';
 import { exit } from '@tauri-apps/plugin-process';
 import mime from 'mime';
 import { defineErrors, extractErrorMessage } from 'wellcrafted/error';
+import { defineKeys } from 'wellcrafted/query';
 import { Ok, tryAsync } from 'wellcrafted/result';
 import { goto } from '$app/navigation';
 import type { WhisperingRecordingState } from '$lib/constants/audio';
 import { defineMutation, defineQuery, queryClient } from '$lib/rpc/client';
-import { autostartKeys } from '$lib/tauri/autostart-keys';
 import type {
 	CommandBinding,
 	DictationCapability,
@@ -290,6 +290,12 @@ const AutostartError = defineErrors({
 // One canonical call shape per leaf; no `tauri.X.Y` vs `tauri.rpc.X.Y`
 // duplication.
 
+const autostartKeys = defineKeys({
+	isEnabled: ['autostart', 'isEnabled'],
+	enable: ['autostart', 'enable'],
+	disable: ['autostart', 'disable'],
+});
+
 const autostart = {
 	isEnabled: defineQuery({
 		queryKey: autostartKeys.isEnabled,
@@ -298,7 +304,10 @@ const autostart = {
 				try: () => isAutostartEnabled(),
 				catch: (error) => AutostartError.CheckFailed({ cause: error }),
 			}),
-		initialData: false,
+		// The OS login-item state can change outside the app (System Settings,
+		// another tool, the platform dropping the entry), so re-read on focus
+		// instead of trusting a stale cached value.
+		refetchOnWindowFocus: true,
 	}),
 	enable: defineMutation({
 		mutationKey: autostartKeys.enable,

--- a/apps/whispering/src/lib/tauri/autostart-keys.ts
+++ b/apps/whispering/src/lib/tauri/autostart-keys.ts
@@ -1,7 +1,0 @@
-import { defineKeys } from 'wellcrafted/query';
-
-export const autostartKeys = defineKeys({
-	isEnabled: ['autostart', 'isEnabled'],
-	enable: ['autostart', 'enable'],
-	disable: ['autostart', 'disable'],
-});

--- a/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
@@ -1,13 +1,10 @@
 <script lang="ts">
 	import * as Field from '@epicenter/ui/field';
-	import { Switch } from '@epicenter/ui/switch';
-	import { createMutation, createQuery } from '@tanstack/svelte-query';
 	import OutputDeliveryControls from '$lib/components/OutputDeliveryControls.svelte';
 	import { SettingSelect, SettingSwitch } from '$lib/components/settings';
-	import { report } from '$lib/report';
-	import { autostartKeys } from '$lib/tauri/autostart-keys';
 	import { tauri } from '#platform/tauri';
 	import { settings } from '$lib/state/settings.svelte';
+	import AutostartSwitch from './AutostartSwitch.svelte';
 
 	const retentionItems = [
 		{ value: 'keep-forever', label: 'Keep All Recordings' },
@@ -39,34 +36,6 @@
 		{ value: 100, label: '100 Recordings' },
 	];
 
-	// Autostart is Tauri-only; on web `tauri` is null and the query stays
-	// disabled (default value `false`).
-	const autostartQuery = createQuery(() =>
-		tauri
-			? tauri.autostart.isEnabled.options
-			: {
-					queryKey: autostartKeys.isEnabled,
-					queryFn: async () => false,
-					enabled: false,
-					initialData: false,
-				},
-	);
-	const enableAutostartMutation = createMutation(() =>
-		tauri
-			? tauri.autostart.enable.options
-			: {
-					mutationKey: autostartKeys.enable,
-					mutationFn: async () => undefined,
-				},
-	);
-	const disableAutostartMutation = createMutation(() =>
-		tauri
-			? tauri.autostart.disable.options
-			: {
-					mutationKey: autostartKeys.disable,
-					mutationFn: async () => undefined,
-				},
-	);
 </script>
 
 <svelte:head> <title>Settings - Whispering</title> </svelte:head>
@@ -120,32 +89,7 @@
 		{/if}
 
 		{#if tauri}
-			<Field.Field orientation="horizontal">
-				<Field.Content>
-					<Field.Label for="autostart">Launch on Startup</Field.Label>
-					<Field.Description>
-						Automatically open Whispering when you log in
-					</Field.Description>
-				</Field.Content>
-				<Switch
-					id="autostart"
-					checked={autostartQuery.data ?? false}
-					onCheckedChange={(checked) => {
-						if (checked) {
-							enableAutostartMutation.mutate(undefined, {
-								onError: (error) => report.error({ cause: error }),
-							});
-						} else {
-							disableAutostartMutation.mutate(undefined, {
-								onError: (error) => report.error({ cause: error }),
-							});
-						}
-					}}
-					disabled={autostartQuery.isPending ||
-						enableAutostartMutation.isPending ||
-						disableAutostartMutation.isPending}
-				/>
-			</Field.Field>
+			<AutostartSwitch autostart={tauri.autostart} />
 		{/if}
 	</Field.Group>
 </Field.Set>

--- a/apps/whispering/src/routes/(app)/(config)/settings/AutostartSwitch.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/AutostartSwitch.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import * as Field from '@epicenter/ui/field';
+	import { Switch } from '@epicenter/ui/switch';
+	import { createMutation, createQuery } from '@tanstack/svelte-query';
+	import { report } from '$lib/report';
+	import type { Tauri } from '#platform/tauri';
+
+	// The caller narrows `tauri` to non-null and passes just this namespace, so
+	// nothing here re-checks for the platform. The OS login-item registry is the
+	// source of truth; we read it rather than mirror it in a stored setting.
+	let { autostart }: { autostart: Tauri['autostart'] } = $props();
+
+	const isEnabledQuery = createQuery(() => autostart.isEnabled.options);
+	const enableMutation = createMutation(() => autostart.enable.options);
+	const disableMutation = createMutation(() => autostart.disable.options);
+</script>
+
+<Field.Field orientation="horizontal">
+	<Field.Content>
+		<Field.Label for="autostart">Launch on Startup</Field.Label>
+		<Field.Description>
+			Automatically open Whispering when you log in
+		</Field.Description>
+	</Field.Content>
+	<Switch
+		id="autostart"
+		checked={isEnabledQuery.data ?? false}
+		onCheckedChange={(checked) => {
+			if (checked) {
+				enableMutation.mutate(undefined, {
+					onError: (error) => report.error({ cause: error }),
+				});
+			} else {
+				disableMutation.mutate(undefined, {
+					onError: (error) => report.error({ cause: error }),
+				});
+			}
+		}}
+		disabled={isEnabledQuery.isPending ||
+			enableMutation.isPending ||
+			disableMutation.isPending}
+	/>
+</Field.Field>


### PR DESCRIPTION
Whispering exposes Tauri-only capabilities through a single nullable object, `tauri` (`Tauri | null`, `null` on web). Most consumers use it imperatively (`if (!tauri) return`), which is fine. But the Launch-on-Startup toggle consumed it *reactively*: its TanStack query/mutation `.options` came from `tauri.autostart.*`, and because `createQuery`/`createMutation` cannot take a null options object, the settings page had to fabricate no-op fallback hooks and `tauri ? real : stub` ternaries purely for the web branch. It was the only place in the app doing this.

**Old shape** (`settings/+page.svelte`):

```svelte
const autostartQuery = createQuery(() =>
  tauri
    ? tauri.autostart.isEnabled.options
    : { queryKey: autostartKeys.isEnabled, queryFn: async () => false, enabled: false },
);
// ...two more fallback mutations like this, then an inline {#if tauri} switch block
```

**New shape** narrows `tauri` once at the boundary and prop-injects the non-null namespace into a colocated child that does zero null handling:

```svelte
{#if tauri}
  <AutostartSwitch autostart={tauri.autostart} />
{/if}
```

```svelte
<!-- AutostartSwitch.svelte -->
let { autostart }: { autostart: Tauri['autostart'] } = $props();
const isEnabledQuery = createQuery(() => autostart.isEnabled.options); // non-null
```

The null is handled exactly once, where TypeScript already narrows it; nothing downstream re-checks. This deletes the fallback ceremony and the now-orphaned `autostart-keys.ts`, which existed only so the web fallback could name the query keys without importing a Tauri-only module. The keys move next to their sole consumer in `tauri.tauri.ts`.

### Decision: keep the mega-object

It is tempting to read this as "dissolve `#platform/tauri` into per-capability seams." We deliberately did not. For capabilities with no meaningful web behavior (`tray`, `fs`, `keyboard`), the atomic `Tauri | null` is the right model: a browser no-op stub would pretend the capability exists and silently swallow calls that are actually bugs. Autostart was simply mis-homed, since it is the one capability consumed reactively, so it earned a colocated component rather than a new seam.

### Behavior tweaks

Two small truth-alignment changes ride along, both consistent with the OS login-item registry being the single source of truth (Whispering intentionally stores no shadow setting):

- Drop `initialData: false`. The switch is already disabled while the query is pending, so there is no wrong-OFF flash to guard against.
- Add `refetchOnWindowFocus`, so a login-item change made outside the app (System Settings, another tool) is reflected when the window regains focus.

### Related dead-code removal

The whispercpp, parakeet, and moonshine branches of `TranscriptionRuntimeConfig` each wrapped their `LocalModelSelector` in `{#if tauri}`. An earlier branch in the same if-chain (`{#if isSelectedServiceUnavailable && selectedTranscriptionProvider}`) already matches the web case (a local service with `!tauri` is unavailable) and short-circuits, so the local-engine branches are only reachable when `tauri` is truthy. The guards were unreachable and are removed.

### Further reading

This is a concrete application of the prop-drilling lesson in [`tauri` is both the namespace and the platform check](https://github.com/EpicenterHQ/epicenter/blob/main/docs/articles/20260526T012526-tauri-is-both-the-namespace-and-the-platform-check.md), specifically its "Pushing the narrowing further: prop drilling" section: narrow `tauri` once at the boundary, then pass the non-null namespace down so nothing below re-checks. `AutostartSwitch` is now a second worked example of that move alongside `ShortcutTable`. See also [Two files, one import](https://github.com/EpicenterHQ/epicenter/blob/main/docs/articles/20260525T234034-two-files-one-import-build-time-platform-injection.md) on why runtime platform ternaries rot: "by the tenth service that does the same dance, you stop reading the conditional and start treating it as noise."