### PR TITLE
docs(adr): an agent answers where its capability lives

### DIFF
--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -245,7 +245,7 @@ const recording = {
 	// Pause system media playback while your voice is being captured, resume it
 	// after. Off by default (opt-in): the resume cannot keep its promise on macOS,
 	// where MediaRemote's Play is single-target so it can wake whatever app the OS
-	// last marked now-playing, not the app we actually paused (see ADR-0041). A
+	// last marked now-playing, not the app we actually paused (see ADR-0045). A
 	// convenience that can occasionally start unrelated media should be chosen, not
 	// sprung. Discoverable via the settings toggle's description and the home-row
 	// quick toggle, both of which explain it at the moment you turn it on. A

--- a/docs/adr/0041-every-answerer-is-a-worker-the-browser-never-answers.md
+++ b/docs/adr/0041-every-answerer-is-a-worker-the-browser-never-answers.md
@@ -1,7 +1,8 @@
 # 0041. Every answerer is a worker; the browser never answers
 
-- **Status:** Accepted
+- **Status:** Superseded
 - **Date:** 2026-06-20
+- **Superseded by:** [ADR-0043](0043-an-agent-answers-where-its-capability-lives.md) (an agent answers where its capability lives; the hosted managed worker is not built and the browser does answer the capability-free agent)
 - **Refines:** [ADR-0033](0033-a-conversation-has-one-transport-and-two-triggers.md) (keeps the doc-as-transport doctrine; revises which in-process peer answers a managed conversation), [ADR-0024](0024-an-always-on-worker-runs-app-semantics-beside-the-app-blind-anchor.md) (resolves the latent contradiction toward the hosted-worker quadrant), [ADR-0025](0025-agent-conversations-are-durable-child-docs-driven-by-an-observing-worker.md) (the ephemeral browser writer dissolves)
 - **Relates:** [ADR-0030](0030-agents-are-immutable-capability-bundles.md) (trust location), [ADR-0035](0035-durable-storage-is-one-per-person-coordination-box.md) (workers are peer spokes, the anchor stays blind), [ADR-0021](0021-actions-are-the-only-surface-that-crosses-a-process-boundary.md), [ADR-0038](0038-a-daemon-answers-through-the-first-inference-backend-it-can-satisfy.md) (the engine the worker resolves)
 - **Refined (2026-06-20, same day):** the hosted worker is **trusted-internal infrastructure**, not an external client. It bills the room's `ownerId` directly via the in-process Autumn primitive (no user-impersonation credential, no HTTP loopback to `/api/ai/chat`) and reads/writes the conversation doc via the anchor's internal RPC (no remote y-protocols handshake). The first cut is **house-key only**; **cloud-proxied BYOK is deferred** until the server-side secret vault exists, so no user keys are stored server-side. The host shape (a doorbell-triggered worker vs a hibernating DO) follows F: text-only answers have no approval pause, so the simpler worker suffices until F's tool pauses arrive.

--- a/docs/adr/0043-an-agent-answers-where-its-capability-lives.md
+++ b/docs/adr/0043-an-agent-answers-where-its-capability-lives.md
@@ -1,0 +1,43 @@
+# 0043. An agent answers where its capability lives
+
+- **Status:** Accepted
+- **Date:** 2026-06-20
+- **Supersedes:** [ADR-0041](0041-every-answerer-is-a-worker-the-browser-never-answers.md)
+- **Relates:** [ADR-0035](0035-durable-storage-is-one-per-person-coordination-box.md) (the blind box a worker syncs through), [ADR-0033](0033-a-conversation-has-one-transport-and-two-triggers.md) (the metered inference stream), [ADR-0042](0042-the-agent-loop-is-the-workers-over-the-doc-as-the-message-array.md) (the worker's agent loop), [ADR-0030](0030-agents-are-immutable-capability-bundles.md) (the capability bundle that names where an agent answers), [ADR-0036](0036-answer-bodies-are-native-parts-arrays-streamed-into-y-text.md) (the parts body every answer writes), [ADR-0038](0038-a-daemon-answers-through-the-first-inference-backend-it-can-satisfy.md) (the backend a worker resolves)
+
+## Context
+
+ADR-0041 deleted the browser answerer and committed the managed agent to an Epicenter-hosted, on-demand Durable Object, to win close-browser durability for a cloud conversation. A use-case pass against the two apps that actually motivate the answering stack showed that quadrant is a phantom. Vocab is stateless question-answering: a lost answer is re-asked at zero cost, so a client that calls metered inference and renders is already the correct and cheapest shape, with nothing to make durable. Local Books is the opposite: its worker reads a local SQLite mirror of your books, so it must run on the machine that holds the data; an Epicenter-hosted worker would mean uploading your books, the one thing a local-first books product exists to avoid. The hosted managed worker served neither app, and "the browser never answers" was the wrong general rule.
+
+## Decision
+
+**An agent answers where its capability lives, not in a fixed runtime.** Who answers follows the agent's immutable capability bundle (ADR-0030), and falls into exactly two cases:
+
+```txt
+capability-free agent (pure inference, e.g. Vocab)
+    -> answers in the CLIENT: the browser runs the shared answer core
+       (ADR-0036) fed by the metered /api/ai/chat stream (ADR-0033),
+       sinking parts into the conversation child doc.
+
+local-data / tool agent (e.g. Local Books)
+    -> answers on the DAEMON where its data and tools are; the answer
+       streams into the same synced conversation doc (ADR-0042's loop).
+```
+
+**Epicenter runs no per-user answering worker.** It is the blind coordination box (relay + anchor, ADR-0035) plus a metered, stateless inference stream (ADR-0033). The conversation substrate (table row to child doc to parts, ADR-0025/0036) and the one shared answer core stay; only the answer's *origin* differs. An always-on private worker that Epicenter hosts for you (a hosted daemon) is a paid premium, never the free default; a transient serverless answer-pass for the narrow "answer while I have zero devices online" cell is deferred until that cell is a real ask, not built now.
+
+This overturns the two ADR-0041 claims that depended on the phantom quadrant: "the browser never answers" (it does, for the capability-free agent) and "the managed answerer is an Epicenter-hosted on-demand Durable Object" (there is no hosted answering worker). What ADR-0041 got right carries forward: every answer is a worker writing into the doc, blindness is per-agent, the doc is the durable transport, and existence-is-the-claim is the only double-answer guard.
+
+## Consequences
+
+- **Wave 3 of `specs/20260620T000000-vocab-answerer-collapse.md` is not built.** The hosted Durable Object, the queue, the wake route, the internal-RPC child-doc connector, and the keepAlive / alarm machinery are deleted from the plan.
+- **Vocab is a client-side chat over the metered SSE endpoint** (`@tanstack/ai-svelte` `createChat` + `fetchServerSentEvents`), writing answer parts into the conversation child doc. The browser-answerer deletion ADR-0041 planned is reversed for capability-free agents; what is still deleted is the `owner` routing fork and the hosted-worker apparatus, not client answering.
+- **Local Books becomes the first real worker consumer and un-defers ADR-0042** (the agent loop): the daemon runs SQL locally and streams tool-call, tool-result, and text parts into the synced conversation. See `specs/20260620T180000-local-books-agent-over-sql.md`.
+- **Close-browser durability for stateless chat is a non-goal.** Durable async work belongs to the daemon, on-demand while you use that agent, with the anchor catching up a sleeping device. Epicenter never pays for a free always-on thinker.
+- **The economic floor is two blind things plus metered tokens:** the box never reads your data, the inference stream is pay-per-call with zero idle, and nothing per-user thinks-while-idle for free.
+
+## Considered alternatives
+
+- **Keep ADR-0041's hosted managed worker (Durable Object or queue).** Rejected: it serves a phantom cell. Vocab needs no worker; Local Books cannot use a hosted one without uploading the data its whole value is keeping local.
+- **One shared multi-tenant answer daemon.** Rejected as the default: a cross-tenant peer plus a per-user always-on cost, to answer what the client already answers for free.
+- **A transient serverless answer-pass as the default managed path.** Rejected for now: it is a cost optimization for one narrow cell (zero-box stateless chat, answered while you have no device online) that neither real app needs. Revisit only if that cell becomes a real product ask; the box and the metered stream already exist to host it cheaply then.

--- a/docs/adr/0044-tool-approval-is-a-per-conversation-policy.md
+++ b/docs/adr/0044-tool-approval-is-a-per-conversation-policy.md
@@ -1,0 +1,39 @@
+# 0044. Tool approval is a per-conversation policy, resolved per call
+
+- **Status:** Accepted (design; lands with the first tool consumer)
+- **Date:** 2026-06-20
+- **Relates:** [ADR-0042](0042-the-agent-loop-is-the-workers-over-the-doc-as-the-message-array.md) (the doc-mediated approval mechanism this policy drives), [ADR-0030](0030-agents-are-immutable-capability-bundles.md) (the agent the mode defaults from), [ADR-0021](0021-actions-are-the-only-surface-that-crosses-a-process-boundary.md) (tools are workspace actions), [ADR-0031](0031-collaboration-is-addressed-single-writer-regions-in-a-child-doc.md) (the single-writer region the decision is written into)
+
+## Context
+
+ADR-0042 made tool approval a durable doc record: the worker writes a tool-call in an awaiting-approval state and stops, any device writes the decision into a client-owned single-writer region, and the worker resumes by re-reading the doc. It left the decision rule as a sentence, "queries auto-run, mutations need approval." Local Books, the first consumer, needs more than that binary: read queries always auto-run, but a mutation (mark reviewed, add a note) wants a per-conversation choice between never (read-only), ask-each-time, and trust-and-run, and a "judge whether this mutation is safe" mode is clearly coming. A static `needsApproval` flag on each tool (TanStack AI's shape) cannot express a per-conversation mode or a later classifier, and it puts the choice on the wrong owner: the tool, not the conversation.
+
+## Decision
+
+**Whether a tool call needs approval is a policy resolved at the call site, not a static per-tool flag:**
+
+```txt
+resolveApproval(toolCall, ctx) -> 'auto' | 'ask' | 'deny'
+```
+
+The mode is a per-conversation setting, defaulted from the agent (ADR-0030). Three policies ship:
+
+```txt
+read-only   queries auto;  mutations deny    (the agent literally cannot write)
+ask         queries auto;  mutations ask     (doc-mediated approval, ADR-0042)   [default]
+auto        queries auto;  mutations auto     (run immediately, still audited)
+```
+
+The doc-mediated mechanism (ADR-0042) is unchanged underneath: the policy only decides whether a given call resolves to `auto` (run now), `ask` (write awaiting-approval, stop, wait for the doc), or `deny` (refuse and let the model continue). Even an `auto` mutation writes its tool-call and tool-result parts into the doc, so every action is auditable and replayable on every device. A **classifier policy** (judge each mutation, auto-approve the safe ones, escalate the risky ones to `ask`) is a future fourth policy that slots into the same seam without touching the mechanism. The dangerous all-auto policy ships first because it is the free case, the seam returning `auto`; the classifier is additive, never a precondition.
+
+## Consequences
+
+- One mechanism (ADR-0042), one seam, N policies: adding the classifier is purely additive, not a rework.
+- `read-only` is a real safety floor distinct from `ask`: the mutation tools are not offered to the model at all, so the worst a compromised prompt can do is read.
+- The mode is a conversation setting, not a per-tool rebuild; switching it mid-conversation is a policy swap, and an "approve all pending this turn" affordance is a batch over the same per-call decisions.
+- Audit is free: the doc holds every tool-call and tool-result part regardless of mode.
+
+## Considered alternatives
+
+- **A static `needsApproval` flag per tool (TanStack AI's default).** Rejected: it cannot express a per-conversation mode or a future classifier, and it owns the decision on the tool instead of the conversation.
+- **Ship the classifier first.** Rejected: it is a whole component (an LLM or rules judge). The seam plus the three trivial policies prove the shape now, and the classifier drops in later as one more policy.

--- a/docs/adr/0045-playback-pause-is-opt-in-because-resume-can-start-unrelated-media.md
+++ b/docs/adr/0045-playback-pause-is-opt-in-because-resume-can-start-unrelated-media.md
@@ -1,4 +1,4 @@
-# 0041. Playback pause ships opt-in because macOS resume can start unrelated media
+# 0045. Playback pause ships opt-in because macOS resume can start unrelated media
 
 - **Status:** Accepted
 - **Date:** 2026-06-20

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -84,8 +84,8 @@ Each option and the one reason it lost. Terse. This is not the spec.
 | [0014](0014-view-transitions-morph-a-re-expressed-glyph-not-its-container.md) | View transitions morph a re-expressed glyph, not its container | Accepted |
 | [0015](0015-the-brand-mark-has-one-canonical-source-every-other-form-is-generated.md) | The brand mark has one canonical source; every other form is generated | Proposed |
 | [0016](0016-prewarm-the-cold-model-load-and-refuse-the-rest-of-the-latency-menu.md) | Prewarm the cold model load and refuse the rest of the latency menu | Accepted |
-| [0017](0017-pause-system-media-playback-while-recording.md) | Pause system media playback while recording through one cross-platform controller | Accepted (VAD timing revised by 0027; default reaffirmed by 0041) |
-| [0018](0018-macos-resume-is-gated-on-a-coreaudio-output-read.md) | macOS resume is gated on a CoreAudio output read, not a MediaRemote read shim | Accepted (no-op consequence corrected by 0041) |
+| [0017](0017-pause-system-media-playback-while-recording.md) | Pause system media playback while recording through one cross-platform controller | Accepted (VAD timing revised by 0027; default reaffirmed by 0045) |
+| [0018](0018-macos-resume-is-gated-on-a-coreaudio-output-read.md) | macOS resume is gated on a CoreAudio output read, not a MediaRemote read shim | Accepted (no-op consequence corrected by 0045) |
 | [0019](0019-global-shortcuts-have-a-permission-free-floor-and-accessibility-is-an-opt-in-tier.md) | Global shortcuts have a permission-free floor; Accessibility is an opt-in tier | Accepted |
 | [0020](0020-macos-drives-its-keyboard-tap-with-an-owned-cgeventtap.md) | macOS drives its keyboard tap with an owned CGEventTap, not the rdev fork | Accepted |
 | [0021](0021-actions-are-the-only-surface-that-crosses-a-process-boundary.md) | Actions are the only surface that crosses a process boundary | Accepted |
@@ -108,6 +108,10 @@ Each option and the one reason it lost. Terse. This is not the spec.
 | [0038](0038-a-daemon-answers-through-the-first-inference-backend-it-can-satisfy.md) | A daemon answers through the first inference backend it can satisfy: byok, else opted-in metered, else host without answering | Accepted |
 | [0039](0039-dictation-feedback-is-a-projection-of-one-lifecycle-state.md) | Dictation feedback is a projection of one lifecycle state, not an event log | Accepted |
 | [0040](0040-a-cursor-write-that-cannot-paste-falls-back-to-the-clipboard-decided-from-the-grant.md) | A cursor write that cannot paste falls back to the clipboard, decided from the grant | Accepted |
-| [0041](0041-playback-pause-is-opt-in-because-resume-can-start-unrelated-media.md) | Playback pause ships opt-in because macOS resume can start unrelated media | Accepted |
+| [0041](0041-every-answerer-is-a-worker-the-browser-never-answers.md) | Every answerer is a worker; the browser never answers | Superseded by 0043 |
+| [0042](0042-the-agent-loop-is-the-workers-over-the-doc-as-the-message-array.md) | The agent loop is the worker's, over the doc as the message array | Accepted (design; build deferred) |
+| [0043](0043-an-agent-answers-where-its-capability-lives.md) | An agent answers where its capability lives (supersedes 0041 every-answerer) | Accepted |
+| [0044](0044-tool-approval-is-a-per-conversation-policy.md) | Tool approval is a per-conversation policy, resolved per call (auto / ask / deny) | Accepted (design) |
+| [0045](0045-playback-pause-is-opt-in-because-resume-can-start-unrelated-media.md) | Playback pause ships opt-in because macOS resume can start unrelated media | Accepted |
 
 When you add an ADR, add its row here.

--- a/specs/20260620T000000-vocab-answerer-collapse.md
+++ b/specs/20260620T000000-vocab-answerer-collapse.md
@@ -2,49 +2,61 @@
 
 Status: Draft. Date: 2026-06-20.
 
-The build plan for the answerer redesign settled in this design pass. The durable
-decisions live in ADRs; this spec is the dependency-ordered wave plan plus a
-self-contained handoff prompt per wave. Delete this spec when the waves land
-(the ADRs are the lasting record).
+> **Repointed 2026-06-20 by [ADR-0043](../docs/adr/0043-an-agent-answers-where-its-capability-lives.md).**
+> A use-case pass killed the hosted-worker premise: an agent answers where its
+> capability lives. Vocab is capability-free, so the **client answers** (a
+> client-side chat over the metered SSE stream); there is **no hosted managed
+> worker**. **Wave 3 is dropped**, **Wave 4 is rewritten** to the client-side
+> shape, and the agentic tool loop moves to its real consumer, Local Books
+> (`20260620T180000-local-books-agent-over-sql.md`). The sections below are
+> updated to match; Waves 1 and 2 already merged unchanged.
+
+The durable decisions live in ADRs; this spec is the dependency-ordered wave plan.
+Delete this spec when the waves land (the ADRs are the lasting record).
 
 ## Decisions (the lasting record is the ADRs)
 
-- **ADR-0041** — every answerer is a worker; the **browser never answers**;
-  blindness is per-agent. The managed answerer is **trusted-internal** Epicenter
-  infra (house-key Gemini, bills the room `ownerId` in-process, reads/writes the
-  doc via the anchor's RPC, woken by the existing dispatch doorbell). Cloud-proxied
-  BYOK is **deferred** (needs the secret vault).
+- **ADR-0043** (supersedes ADR-0041) — an agent answers where its capability
+  lives. A capability-free agent (Vocab) answers **in the client**; a local-data
+  agent (Local Books) answers on the **daemon** where the data is. Epicenter runs
+  **no per-user answering worker**: it is the blind box (relay + anchor) plus a
+  metered inference stream. The conversation substrate (table row to child doc to
+  parts) and the shared answer core stay; only the answer's origin differs.
+- **ADR-0044** — tool approval is a per-conversation policy (`auto` / `ask` /
+  `deny`), shipped as read-only / ask / auto, with a classifier deferred. Drives
+  ADR-0042's doc-mediated approval. Vocab has no tools and does not use it.
 - **ADR-0042** — the agent loop is the worker's, over the doc-as-message-array;
-  the engine stays a pure token source; durable doc-mediated approval. **Build
-  deferred** to a real tool consumer (not Vocab).
-- **ADR-0033** amended; **ADR-0025** amended (the ephemeral browser writer
-  dissolves); **ADR-0024** note (tension resolved toward the hosted-worker
-  quadrant). **ADR-0030** already settles model = agent (no model switcher) and
-  the managed/published vs user-authored catalog.
+  durable doc-mediated approval. Un-deferred by **Local Books**, not Vocab.
+- **ADR-0033 / ADR-0025 / ADR-0036 / ADR-0030** unchanged: the metered stream,
+  the conversation child doc, the parts body, and the immutable agent bundle.
 
 ## End state for Vocab
 
 - One app: a single Chinese vocab assistant. One model (`VOCAB_MODEL`), one
   system prompt, `tools: []`.
-- Two **durable** agents in the catalog, distinguished by trust location:
-  - **Managed** (Epicenter-hosted worker, house-key Gemini, billed to the room owner).
-  - **Home daemon** (`vocab-home`, the user's own box).
-- The browser writes user turns and renders the synced doc. It constructs no
-  engine and runs no answer loop.
-- Close the browser mid-answer → the worker keeps writing; resync catches up.
+- Two agents in the catalog, distinguished by where the answer is produced:
+  - **Client** (the capability-free default): the browser runs the shared answer
+    core fed by the metered `/api/ai/chat` SSE stream, sinking parts into the
+    conversation child doc. No hosted worker.
+  - **Home daemon** (`vocab-home`, the user's own box): same loop, different host.
+- The browser writes user turns, renders the synced doc, **and answers the client
+  agent** (a capability-free agent answers in the client, ADR-0043).
+- Close the browser mid-answer on the **client** agent → the answer stops; for a
+  one-shot vocab lookup this is a non-goal (re-ask costs nothing). The daemon agent
+  keeps writing because its worker is its own always-on box.
 
 ## Wave plan (each is one standalone, reviewable PR, in order)
 
 | # | Wave | Depends on | Net |
 |---|---|---|---|
-| 1 | Rename zhongwen → vocab (incl. pre-release data ids) | — | mechanical, no behavior change |
-| 2 | Daemon ships live (`vocab-home`) | 1 | proves worker-answers-over-sync on the user's box |
-| 3 | Hosted managed worker (on-demand DO) | 1 | the managed answerer; the big build |
-| 4 | Browser → renderer-only (the collapse) | 2, 3 | deletion PR; supersedes #2127 |
-| 5 | F: agentic loop + doc approval (DEFERRED) | 4 + a tool consumer | not this milestone; ADR-0042 holds the design |
+| 1 | Rename zhongwen → vocab (incl. pre-release data ids) | — | **merged**; mechanical, no behavior change |
+| 2 | Daemon ships live (`vocab-home`) | 1 | **merged**; proves worker-answers-over-sync on the user's box |
+| 3 | ~~Hosted managed worker (on-demand DO)~~ | — | **DROPPED by ADR-0043** (phantom cell; not built) |
+| 4 | Vocab client answers via metered SSE; drop the owner fork | 1, 2 | client-side chat over `/api/ai/chat`; the collapse |
+| 5 | Agentic loop + doc approval | a tool consumer | **moved to Local Books**, not Vocab; ADR-0042 / 0044 hold the design |
 
-Rename is first so nothing rebases over it. Wave 4 is safe only once both
-answerers (daemon + hosted) exist, so it follows 2 and 3.
+Rename was first so nothing rebased over it. Wave 4 no longer waits on a hosted
+worker (there is none): the client is the capability-free agent's answerer.
 
 ## PR / branch disposition
 
@@ -147,124 +159,88 @@ the existence-is-the-claim guard prevents any double-answer with a watching tab
 
 ---
 
-## Wave 3 — Hosted managed worker (trusted-internal, house-key)
+## Wave 3 — Hosted managed worker — DROPPED by ADR-0043
 
-**Goal.** The Epicenter-hosted answerer for the **managed** agent, as the daemon's
-answer loop hosted by us. It is **trusted-internal**: woken by the existing dispatch
-doorbell when a turn is written, it reads/writes the conversation doc via the
-anchor's internal RPC (co-located, no remote y-protocols handshake), runs the same
-`attachChatWorker` loop, streams parts into the doc, and bills the room's `ownerId`
-directly via the in-process Autumn primitive. **House-key Gemini only** — no
-user-impersonation credential, no HTTP loopback to `/api/ai/chat`, and no
-server-side key storage (cloud-proxied BYOK is deferred until the secret vault
-exists). Host shape: a doorbell-triggered worker suffices for text-only answers
-(no approval pause); the hibernating-DO upgrade arrives with F.
-
-**Reuse (do not reinvent).** `packages/server/src/room/` already holds the live
-`Y.Doc` and exposes `getDoc`/`sync` RPC + the `dispatch_request`/`dispatch_inbound`
-doorbell; `createRoomCore` is runtime-agnostic. The answer loop is the daemon's
-`attachChatWorker` (wave 2), reused verbatim. If a hibernating DO is chosen for the
-host, the room DO's hibernation patterns (`durable-object.ts`: `acceptWebSocket`,
-`getWebSockets`, alarms) and `keepAlive`/`keepAliveWhile` (Cloudflare `Agent` class)
-are the reference.
-
-**Scope / files.** The hosted-worker host (Worker or DO + wrangler binding), the
-house-key engine (the provider adapter from `@epicenter/ai-adapters`, built
-worker-side), the doorbell wake endpoint, anchor-RPC read/write of the conversation
-doc (`getDoc`/`sync`), and in-process Autumn billing keyed to the room's `ownerId`
-(`apps/api/worker/index.ts` + `apps/api/worker/billing`, hosted-only). Keep the
-worker a separate spoke — never put answer logic in the room/anchor DO (ADR-0035).
-
-**Acceptance.** A conversation bound to the managed agent is answered server-side
-with no browser open and no daemon; the answer is billed to the room's `ownerId`
-via Autumn; a missed doorbell still gets answered (alarm backstop / next sync);
-the anchor never runs answer logic (stays blind).
-
-**Handoff prompt.** (PAIR with Braden on the host shape before building — this
-touches billing + the trust boundary.)
-> Build the Epicenter-hosted managed worker for Vocab per ADR-0041 (worktree
-> `/Users/braden/Code/.worktrees/epicenter-row-childdocs`, after waves 1–2). It is
-> **trusted-internal infrastructure**, NOT an external client: do not mint a
-> user-impersonation credential, do not loop back to `/api/ai/chat`, do not store
-> user keys. It is woken by the existing dispatch doorbell
-> (`dispatch_request`/`dispatch_inbound` in `packages/server/src/room/core.ts`)
-> when a managed-agent turn is written; it reads/writes the conversation child doc
-> via the anchor's internal RPC (`getDoc`/`sync` — co-located, no remote
-> y-protocols handshake); it runs the daemon's existing `attachChatWorker` loop
-> (wave 2) verbatim with a **house-key Gemini** engine (provider adapter from
-> `@epicenter/ai-adapters`); and it bills the room's `ownerId` directly via the
-> in-process Autumn primitive (`apps/api/worker/billing`, hosted-only). Host shape:
-> a doorbell-triggered worker suffices (text-only answers have no approval pause);
-> the hibernating-DO upgrade (`acceptWebSocket`/`getWebSockets`/alarms +
-> `keepAlive`) arrives with F. Keep this a SEPARATE app-aware spoke; never add
-> answer logic to the room/anchor DO (ADR-0035). Cloud-proxied BYOK is DEFERRED
-> (needs the secret vault). Ground Cloudflare + Yjs behavior against
-> `cloudflare/cloudflare-docs` and `yjs/yjs` via DeepWiki before relying on memory.
-> This is wave 3 of `specs/20260620T000000-vocab-answerer-collapse.md`.
+This wave is not built. A use-case pass showed the Epicenter-hosted answerer
+serves a phantom cell: Vocab is capability-free, so the client is the correct and
+cheapest answerer (no durability to win), and the only other real app (Local Books)
+needs a worker that **must** run where its data lives, which a hosted worker cannot
+do without uploading the data. There is no hosted managed worker, no on-demand DO,
+no queue, no wake route, and no internal-RPC child-doc connector. The economic
+floor is the blind box (relay + anchor) plus the metered inference stream; nothing
+per-user thinks-while-idle for free. See ADR-0043.
 
 ---
 
-## Wave 4 — Browser becomes renderer-only (the collapse)
+## Wave 4 — Vocab client answers via metered SSE (the collapse)
 
-**Goal.** The deletion PR. The browser stops answering. Now that the managed
-(wave 3) and daemon (wave 2) workers both answer, delete the browser answerer and
-the owner fork.
+**Goal.** Vocab's capability-free agent answers **in the client** (ADR-0043): the
+browser runs the shared answer core fed by the metered `/api/ai/chat` SSE stream
+and sinks parts into the conversation child doc. This is the collapse, but the cut
+is the **owner routing fork and the hosted-worker scaffolding**, not client
+answering. The conversation substrate (table row to child doc to parts, ADR-0036)
+stays; `vocab-home` keeps answering on the user's box.
 
-**Scope / deletions.**
-- `apps/vocab/.../ConversationView.svelte`: remove the `browserEngines`,
-  `resolveEngine`, the `answer`/`answersHere`/owner branch, and the `{ answer }`
-  passed to `bindConversation`. The view opens the doc and renders; it writes user
-  turns via `convo.send`.
-- Remove the `owner: 'ephemeral' | 'durable'` field from `AgentConfig` and the
-  catalog; both agents are durable, keyed by trust location. The `this-device`
-  ephemeral agent dissolves into the **Managed** agent (Epicenter-hosted).
-- Delete `attachChatBrowserAnswerer` usage; if no consumer remains, delete it from
-  `packages/workspace/src/ai/` (and its export + test).
-- Remove the browser-side `Engine`/`resolveEngine`/`epicenterMeteredEngine`
-  surface from the app (engines are worker-only now).
-- Reshape the catalog/picker: Managed + Home daemon, both durable.
-- Close PR #2127 as superseded.
+**Scope / changes.**
+- `ConversationView.svelte`: keep the client answer path, but drop the
+  `owner: 'ephemeral' | 'durable'` routing fork and any "does the hosted worker
+  answer this?" branch. The two agents are **client** (capability-free, browser
+  answers) and **vocab-home** (daemon answers); the picker reflects that.
+- Use TanStack AI on the client (`@tanstack/ai-svelte` `createChat` +
+  `fetchServerSentEvents`) against `API_ROUTES.ai.chat.url(baseURL)` with
+  `createAiChatFetch(auth.fetch)`; body `{ model: VOCAB_MODEL, systemPrompts:
+  [VOCAB_SYSTEM_PROMPT], tools: [] }`. Sink the streamed parts into the
+  conversation child doc via the shared answer core (ADR-0036). `chat.stop()` on
+  unmount; render every `MessagePart` with an unknown-fallback.
+- Remove the `owner` field from `AgentConfig` and the catalog; agents are
+  distinguished by where the answer is produced (client vs daemon), not an owner
+  enum. Rename the `this-device` agent to the **client** agent.
+- Delete any hosted-worker scaffolding that landed (there is none if Wave 3 was
+  never built); keep `epicenterMeteredEngine` only if the daemon's metered arm
+  still uses it (ADR-0038), otherwise fold it into the client SSE path.
+- Close PR #2127 (its owner fork is removed here).
 
-**Acceptance.** The browser never opens an answerer; every answer comes from a
-worker; closing the browser never stops an answer; one answering path remains; no
-dead `owner`/`Engine`/browser-answerer code; tests green. Run
-post-implementation-review + collapse-pass on the deletion.
+**Acceptance.** The client answers the capability-free agent over metered SSE,
+writing parts into the synced doc; `vocab-home` answers its conversations on the
+user's box; no `owner` routing fork remains; one client answer path + one daemon
+answer path; tests green. Run post-implementation-review + collapse-pass.
 
 **Handoff prompt.**
-> Make the Vocab browser renderer-only per ADR-0041 (worktree
-> `/Users/braden/Code/.worktrees/epicenter-row-childdocs`, after waves 1–3). Delete
-> the browser answerer: in `ConversationView.svelte` remove `browserEngines`,
-> `resolveEngine`, the `answer`/`answersHere`/owner branch, and the `{ answer }`
-> arg to `bindConversation` (the view just opens + renders the doc and writes user
-> turns via `convo.send`). Remove the `owner: 'ephemeral' | 'durable'` field from
-> `AgentConfig` and the catalog — both agents are now durable, distinguished by
-> trust location; the `this-device` ephemeral agent dissolves into the Managed
-> (Epicenter-hosted) agent. Delete `attachChatBrowserAnswerer` and the browser-side
-> `Engine`/`resolveEngine`/`epicenterMeteredEngine` surface if no consumer remains
-> (check exports + tests). Reshape the picker to Managed + Home daemon. Verify
-> closing the browser mid-answer no longer stops the answer. Run
-> post-implementation-review and collapse-pass on the deletion. Close PR #2127 as
-> superseded by this wave. This is wave 4 of
+> Make Vocab's client agent answer in the browser over the metered SSE stream per
+> ADR-0043 (worktree `/Users/braden/Code/.worktrees/epicenter-row-childdocs`, after
+> waves 1–2; Wave 3 is dropped). Use `@tanstack/ai-svelte` `createChat` +
+> `fetchServerSentEvents` against `/api/ai/chat` with `createAiChatFetch(auth.fetch)`
+> and `{ model: VOCAB_MODEL, systemPrompts: [VOCAB_SYSTEM_PROMPT], tools: [] }`,
+> sinking parts into the conversation child doc via the shared answer core
+> (ADR-0036). Remove the `owner: 'ephemeral' | 'durable'` routing fork from
+> `AgentConfig` and the catalog; rename `this-device` to the **client** agent; the
+> two agents are client (browser answers) and `vocab-home` (daemon answers).
+> Keep `epicenterMeteredEngine` only if the daemon still needs it (ADR-0038).
+> `chat.stop()` on unmount; render every `MessagePart` with an unknown-fallback.
+> Close PR #2127. Run post-implementation-review + collapse-pass. Ground TanStack
+> AI behavior against `TanStack/ai` via DeepWiki. This is wave 4 of
 > `specs/20260620T000000-vocab-answerer-collapse.md`.
 
 ---
 
-## Wave 5 — F: agentic loop + doc-mediated approval (DEFERRED)
+## Wave 5 — Agentic loop + doc-mediated approval — moved to Local Books
 
-Not this milestone. The design is ADR-0042: the worker owns the loop over the
-doc-as-message-array; the engine stays a pure token source; approval is a durable
-single-writer doc region (the `cancelRequestedAt` pattern). Build only when a real
-tool consumer exists (opensidian / tab-manager, which have actions) — never Vocab,
-which has no tools and rides the unified path with `tools: []` for free. The
-loop-engine choice (hand-roll over the existing TanStack adapters vs Vercel
-`streamText` vs roll-your-own) is left open in ADR-0042 and decided at build time.
+Not Vocab's milestone, and no longer a vague "deferred F." The design is ADR-0042
+(the worker owns the loop over the doc-as-message-array; approval is a durable
+single-writer doc region, the `cancelRequestedAt` pattern) plus ADR-0044 (approval
+is a per-conversation policy: read-only / ask / auto, classifier deferred). Its
+real consumer is **Local Books** (`20260620T180000-local-books-agent-over-sql.md`),
+which has tools that bind a worker to the machine holding the data. Vocab has no
+tools and never drives this loop. The loop-engine choice (hand-roll over the
+TanStack adapters vs Vercel `streamText` vs roll-your-own) is decided at build time
+in the Local Books spec.
 
 ## Open items carried forward
 
-- Loop engine for F (ADR-0042 open question). Lean: hand-roll over
-  `@epicenter/ai-adapters`'s existing TanStack adapters.
+- Loop engine for the agentic loop (ADR-0042 open question), decided in the Local
+  Books spec. Lean: hand-roll over `@epicenter/ai-adapters`'s TanStack adapters.
 - Presence (#2128) as the dead-mailbox warning, fast-follow after wave 2.
-- Browser-local BYOK (key never leaves the device) — additive future option, does
-  not disturb ADR-0041.
+- Browser-local BYOK (key never leaves the device): additive future option, does
+  not disturb ADR-0043.
 - `specs/zhongwen-conversation-deletion-refusal.md` hygiene (convert to ADR or
   delete) — separate pass.

--- a/specs/20260620T180000-local-books-agent-over-sql.md
+++ b/specs/20260620T180000-local-books-agent-over-sql.md
@@ -1,0 +1,60 @@
+# Local Books: an agent over a local SQL mirror
+
+Status: Draft. Date: 2026-06-20.
+
+Local Books is the first real worker consumer (ADR-0043): a local-first product where an agent answers questions about your books by running SQL locally, over a synced conversation, and proposes mutations you approve from any device. It is the forcing function that un-defers the agent loop (ADR-0042) and exercises the approval policy seam (ADR-0044). Vocab proved the conversation substrate with zero tools; Local Books is the same substrate plus the tools that make a daemon necessary.
+
+## Why a daemon is necessary here (and not for Vocab)
+
+The justification for a worker is **capability locality**, not answering. Vocab's worker has no capability the client lacks (it is a stateless model call), so it answers in the client. Local Books' worker reads a local SQLite mirror of your books that lives on one machine: you ask from your phone, the data is on your desktop, so the agent must run on the desktop and stream the answer back through the box (ADR-0035) to your phone. A hosted worker is impossible by definition here: it would mean uploading the books, the one thing the product exists to avoid.
+
+## Locked product direction (mirror, not ledger)
+
+Settled in an earlier greenfield grill (not yet harvested onto `main`; harvest into `docs/adr/` when this lands):
+
+1. **Mirror plus overlay, not a ledger.** QuickBooks is the system of record; Local Books reflects and annotates, never authors.
+2. **SQLite, not Yjs, for the facts.** Facts are a re-pullable cache of remote truth, so a CRDT earns nothing. The conversation and the overlay (notes, review state) are the only Yjs-synced surfaces.
+3. **Faithful per-provider raw is canonical.** QuickBooks-only, concrete, no provider abstraction until provider #2 disagrees.
+4. **No Markdown in v1.** The read path is agent-over-SQL.
+5. **Append-only observations plus a local overlay keyed to the QuickBooks logical id.** Each sync appends; nothing updates or deletes a fact in place.
+6. **No write-back.** Append-only observation diffs give free change-tracking of your own books without competing with the accountant who owns the QuickBooks edits.
+
+## Shape
+
+```txt
+apps/local-books/                Epicenter root (app folder = root)
+  epicenter.config.ts            export default localBooks({ agentId: 'local-books' })
+  facts (NOT synced)             local SQLite mirror of QuickBooks:
+                                   observations  raw_payloads  sync_runs  overlay_*
+                                   + current_state / observation_diff views
+  conversation (synced)          conversations table -> child doc -> parts (ADR-0025/0036)
+
+daemon (runs where the data is, ADR-0043)
+  observes conversations bound to agent 'local-books' (designation, ADR-0025)
+  runs the agent loop (ADR-0042) over the synced conversation doc
+  tools = workspace actions via tool-bridge (ADR-0021):
+    READ   books_sql_query(sql)        approval policy -> auto
+    WRITE  mark_reviewed(ids)          approval policy -> read-only | ask | auto (ADR-0044)
+           add_note(qbId, note)
+  engine resolves a backend (ADR-0038); inference may be cloud-metered, data stays local
+  NEVER: bash, file I/O, write-SQL, a raw Y.Doc handle
+
+client (phone / browser)
+  opens the conversation child doc, renders parts (text, tool-call, tool-result)
+  writes user turns; approves pending mutations from any device
+  (writes the client-owned decision field, ADR-0042)
+```
+
+## Slices
+
+1. **QuickBooks OAuth read spike (sandbox).** Populate the SQLite mirror; observations append-only. Risk-first, proves the data path before any agent.
+2. **Agent-over-SQL daemon, read tools only.** `books_sql_query` auto-runs; phone asks, desktop answers over sync. This un-defers ADR-0042's loop at the zero-mutation path.
+3. **Write tools plus the approval policy seam (ADR-0044) over doc-mediated approval (ADR-0042).** `mark_reviewed` / `add_note`; ship `read-only` / `ask` / `auto`; classifier deferred.
+4. **Client UI.** Render the parts, approve pending mutations from any device, write user turns.
+
+## Open items
+
+- Placement confirmed: `apps/local-books` is its own root, reusing the CLI / relay / agent and the conversation workspace, not the books facts as Yjs.
+- Observation-table grain: one table plus `entity_type` plus `raw_json` plus extracted query columns (leaning), vs per-entity-type tables.
+- Bound transaction volume and which QuickBooks entities v1 mirrors.
+- Harvest the mirror-not-ledger and SQLite-not-Yjs decisions into `docs/adr/` on landing.


### PR DESCRIPTION
Vocab and Local Books showed that the Epicenter-hosted managed worker was answering a use case the product no longer needs. Vocab is capability-free, so the client is the cheapest and correct answerer; Local Books reads a local SQLite mirror, so its worker has to run where the books live. A hosted answerer would mean uploading the data the product exists to keep local.

## Agent Capability Locality

ADR-0043 supersedes ADR-0041's every-answerer model with one rule: an agent answers where its capability lives. Capability-free agents answer in the client. Local-data agents answer on the daemon. Epicenter remains the blind box, relay plus anchor, and the metered inference stream; it does not operate a per-user answering worker.

## Tool Approval Policy

ADR-0044 records tool approval as a per-conversation policy: `auto`, `ask`, or `deny`. It ships over ADR-0042's doc-mediated mechanism with read-only, ask, and auto paths first, leaving a classifier policy to slot into the same seam later.

## Spec Follow Through

The Vocab answerer spec drops the hosted-worker wave and rewrites the client path around TanStack AI over the metered SSE stream. The new Local Books agent-over-SQL spec becomes the real ADR-0042 consumer: read tools auto-run, write tools are gated by the ADR-0044 policy.

## Hygiene

The playback-pause ADR is renumbered from 0041 to 0045 so the every-answerer ADR keeps the lower number and ADR-0043 can supersede it cleanly. The ADR index and the one Whispering code reference move with the rename.