### PR TITLE
refactor(vocab): an agent answers where its capability lives

### DIFF
--- a/apps/vocab/epicenter-engine.ts
+++ b/apps/vocab/epicenter-engine.ts
@@ -1,7 +1,7 @@
 /**
- * The metered Epicenter engine: a vocab {@link Engine} that answers on the
+ * The metered Epicenter backend: a vocab {@link ChatStream} that answers on the
  * user's Epicenter account over the `/api/ai/chat` SSE stream (the Epicenter
- * provider, ADR-0033). Both peers that can power it (an open browser tab, a
+ * provider, ADR-0033). Both peers that answer with it (an open browser tab, a
  * signed-in daemon) build it the same way, so the wire shape (the AI-chat fetch
  * wrapper, the route, the `model` + `systemPrompts` body) is single-homed here
  * instead of duplicated at each call site.
@@ -17,26 +17,26 @@ import {
 	createEpicenterProviderChatStream,
 } from '@epicenter/client';
 import { API_ROUTES } from '@epicenter/constants/api-routes';
-import { type Engine, VOCAB_MODEL, VOCAB_SYSTEM_PROMPT } from './vocab.js';
+import type { ChatStream } from '@epicenter/workspace/ai';
+import { VOCAB_MODEL, VOCAB_SYSTEM_PROMPT } from './vocab.js';
 
 /**
- * Build the metered Epicenter {@link Engine} for one peer.
+ * Build the metered Epicenter {@link ChatStream} for one peer.
  *
  * @param sessionFetch the peer's authenticated fetch (the browser's `auth.fetch`,
  *   the daemon's `session.fetch`); wrapped here for the AI-chat route.
  * @param baseURL the Epicenter API origin the SSE route lives under.
  */
-export function epicenterMeteredEngine(
+export function epicenterMeteredChatStream(
 	sessionFetch: AuthFetch,
 	baseURL: string,
-): Engine {
-	return () =>
-		createEpicenterProviderChatStream({
-			fetch: createAiChatFetch(sessionFetch),
-			url: API_ROUTES.ai.chat.url(baseURL),
-			data: () => ({
-				model: VOCAB_MODEL,
-				systemPrompts: [VOCAB_SYSTEM_PROMPT],
-			}),
-		});
+): ChatStream {
+	return createEpicenterProviderChatStream({
+		fetch: createAiChatFetch(sessionFetch),
+		url: API_ROUTES.ai.chat.url(baseURL),
+		data: () => ({
+			model: VOCAB_MODEL,
+			systemPrompts: [VOCAB_SYSTEM_PROMPT],
+		}),
+	});
 }

--- a/apps/vocab/mount.ts
+++ b/apps/vocab/mount.ts
@@ -34,9 +34,9 @@
  * (`row.agent === selfAgentId`), so the factory supplies behavior alone. The
  * `agentId` option names which catalog agent this daemon answers as (a
  * `VOCAB_AGENTS` id like `vocab-home`); omit it and the daemon hosts
- * nothing, leaving every conversation to its bound agent. The browser answers
- * in-process only the conversations it claims (an `'ephemeral'`-owner agent), so
- * a single turn is never answered twice.
+ * nothing, leaving every conversation to its bound agent. The client tab answers
+ * in-process only the conversations bound to the client agent (ADR-0043), so a
+ * single turn is never answered twice.
  */
 
 import {

--- a/apps/vocab/mount.ts
+++ b/apps/vocab/mount.ts
@@ -49,14 +49,8 @@ import type { AgentId, MountWorkerContext } from '@epicenter/workspace';
 import { attachChatWorker, type ChatStream } from '@epicenter/workspace/ai';
 import { nodeMountRuntime } from '@epicenter/workspace/node';
 import { createLogger } from 'wellcrafted/logger';
-import { epicenterMeteredEngine } from './epicenter-engine.js';
-import {
-	type Engine,
-	resolveEngine,
-	VOCAB_MODEL,
-	VOCAB_SYSTEM_PROMPT,
-	vocabWorkspace,
-} from './vocab.js';
+import { epicenterMeteredChatStream } from './epicenter-engine.js';
+import { VOCAB_MODEL, VOCAB_SYSTEM_PROMPT, vocabWorkspace } from './vocab.js';
 
 const log = createLogger('vocab/mount');
 
@@ -102,24 +96,24 @@ export function vocab({ baseURL, agentId }: VocabMountOptions = {}) {
 }
 
 /**
- * The daemon's inference backend for this mount: the first engine its host can
- * power, ADR-0038's priority chain ({@link resolveEngine}) over the engines
- * below. This resolves only the *engine* (where tokens come from); *designation*
- * (which conversations are this daemon's) is the observe loop's job, which hosts
- * only the conversations bound to this daemon's agent (`row.agent === agentId`,
- * ADR-0025), so by here the turn is already its own.
+ * The daemon's inference backend for this mount: the first backend its host can
+ * satisfy, ADR-0038's priority chain expressed inline below. This resolves only
+ * the *engine* (where tokens come from); *designation* (which conversations are
+ * this daemon's) is the observe loop's job, which hosts only the conversations
+ * bound to this daemon's agent (`row.agent === agentId`, ADR-0025), so by here
+ * the turn is already its own.
  *
  *  - **byok**: a local provider key (`OPENAI_API_KEY` / `GEMINI_API_KEY`, the
  *    catalog picks which) answers free, with no cloud round-trip. The only path
  *    for an offline or self-hosted daemon, so it stays first.
  *  - **metered**: answer on the user's metered Epicenter account over the same
- *    `/api/ai/chat` SSE path the browser uses ({@link epicenterMeteredEngine}, the
- *    shared builder), authenticated with the `AuthedFetch` the daemon already
+ *    `/api/ai/chat` SSE path the browser uses ({@link epicenterMeteredChatStream},
+ *    the shared builder), authenticated with the `AuthedFetch` the daemon already
  *    syncs with. Opt-in only ({@link isMeteredEnabled}): spending credits is a
  *    deliberate choice, symmetric with BYOK needing a key, so a keyless signed-in
  *    daemon never silently bills the user.
  *
- * `null` (neither engine satisfiable) means host the conversation's sync but
+ * `null` (neither backend satisfiable) means host the conversation's sync but
  * answer nothing: the daemon writes no placeholder into a real, synced
  * conversation, and the turn stays unanswered for a configured answerer (a keyed
  * daemon, or an open browser tab on the metered account).
@@ -142,30 +136,31 @@ function resolveDaemonStream(
 	const { provider } = MODELS_BY_ID[VOCAB_MODEL];
 	const envVar = HOUSE_KEY_ENV_VAR[provider];
 
-	// The metered engine builds the same way for every peer; only the opt-in gate
-	// is the daemon's (a keyless signed-in daemon must not silently spend credits).
-	const metered = epicenterMeteredEngine(session.fetch, baseURL);
-	const engines: readonly Engine[] = [
-		() => {
-			const apiKey = process.env[envVar];
-			return apiKey
-				? chatStreamFromAdapter(createAdapterForModel(VOCAB_MODEL, apiKey), [
-						VOCAB_SYSTEM_PROMPT,
-					])
-				: null;
-		},
-		() => (isMeteredEnabled() ? metered() : null),
-	];
+	// First satisfiable backend wins (ADR-0038). BYOK first: a local key answers
+	// free and offline, the only path for an offline or self-hosted daemon.
+	const apiKey = process.env[envVar];
+	if (apiKey) {
+		return chatStreamFromAdapter(createAdapterForModel(VOCAB_MODEL, apiKey), [
+			VOCAB_SYSTEM_PROMPT,
+		]);
+	}
 
-	const stream = resolveEngine(engines);
-	if (agentId && !stream) {
+	// Else the metered account, opt-in only: a keyless signed-in daemon must not
+	// silently spend credits. The builder is shared with the browser; only this
+	// gate is the daemon's.
+	if (isMeteredEnabled()) {
+		return epicenterMeteredChatStream(session.fetch, baseURL);
+	}
+
+	// Neither satisfiable: host the conversation's sync but answer nothing.
+	if (agentId) {
 		log.warn(
 			new Error(
 				`The Vocab daemon has no inference backend: ${envVar} is unset and VOCAB_USE_METERED is off. It hosts conversation sync but does not answer. Set ${envVar} for local inference, or VOCAB_USE_METERED=1 to answer on your metered Epicenter account.`,
 			),
 		);
 	}
-	return stream;
+	return null;
 }
 
 /**

--- a/apps/vocab/src/agents.test.ts
+++ b/apps/vocab/src/agents.test.ts
@@ -13,13 +13,7 @@
 
 import { describe, expect, test } from 'bun:test';
 import { asAgentId } from '@epicenter/workspace';
-import type { ChatStream } from '@epicenter/workspace/ai';
-import {
-	CLIENT_AGENT_ID,
-	DEFAULT_AGENT_ID,
-	resolveEngine,
-	VOCAB_AGENTS,
-} from '../vocab.js';
+import { CLIENT_AGENT_ID, DEFAULT_AGENT_ID, VOCAB_AGENTS } from '../vocab.js';
 
 describe('agent catalog', () => {
 	test('the default agent is the client agent (no daemon required)', () => {
@@ -34,29 +28,5 @@ describe('agent catalog', () => {
 	test('every catalog id is unique (one entry per agent)', () => {
 		const ids = VOCAB_AGENTS.map((agent) => agent.id);
 		expect(new Set(ids).size).toBe(ids.length);
-	});
-});
-
-describe('resolveEngine', () => {
-	// The daemon walks its multi-engine priority chain through this (ADR-0038); the
-	// client has a single engine and calls it directly. Distinct sentinel streams
-	// so a test can assert *which* engine won.
-	const primary: ChatStream = async function* () {};
-	const fallback: ChatStream = async function* () {};
-
-	test('takes the first engine the host can power', () => {
-		expect(resolveEngine([() => primary, () => fallback])).toBe(primary);
-	});
-
-	test('falls through a null engine to the next in priority order', () => {
-		expect(resolveEngine([() => null, () => fallback])).toBe(fallback);
-	});
-
-	test('no satisfiable engine hosts without answering (null)', () => {
-		expect(resolveEngine([() => null, () => null])).toBeNull();
-	});
-
-	test('an empty engine list answers nothing', () => {
-		expect(resolveEngine([])).toBeNull();
 	});
 });

--- a/apps/vocab/src/agents.test.ts
+++ b/apps/vocab/src/agents.test.ts
@@ -1,41 +1,34 @@
 /**
- * The agent catalog's routing invariants (ADR-0025/0033).
+ * The agent catalog's routing invariants (ADR-0025/0043).
  *
- * The browser answers a conversation in-process (the Epicenter provider sourcing
- * tokens from `/api/ai/chat`) for, and only for, a bound agent the open tab owns
- * (`owner: 'ephemeral'`); a `'durable'`-owner agent is a resident daemon left to
- * answer ambiently over sync (`ConversationView` reads `agentConfig().owner`).
- * These tests pin the catalog data that fork reads, so flipping the cloud agent's
- * owner (which would silently strand it: the browser would stop answering and
- * defer to a daemon that isn't there) fails here instead of in the UI.
+ * An agent answers where its capability lives, and the bound agent id is what
+ * names that place: the client tab answers the capability-free
+ * {@link CLIENT_AGENT_ID} in-process (the Epicenter provider sourcing tokens from
+ * `/api/ai/chat`), while `vocab-home` is a resident daemon that answers its own
+ * conversations over sync (`ConversationView` compares `row.agent` to
+ * `CLIENT_AGENT_ID`). These tests pin the catalog data that routing reads, so
+ * renaming or dropping the client agent (which would silently strand the default
+ * "New Conversation" path) fails here instead of in the UI.
  */
 
 import { describe, expect, test } from 'bun:test';
 import { asAgentId } from '@epicenter/workspace';
 import type { ChatStream } from '@epicenter/workspace/ai';
 import {
-	agentConfig,
+	CLIENT_AGENT_ID,
 	DEFAULT_AGENT_ID,
 	resolveEngine,
-	THIS_DEVICE_AGENT_ID,
 	VOCAB_AGENTS,
 } from '../vocab.js';
 
 describe('agent catalog', () => {
-	test('the this-device agent is ephemeral-owned so the browser answers it in-process', () => {
-		expect(agentConfig(THIS_DEVICE_AGENT_ID)?.owner).toBe('ephemeral');
+	test('the default agent is the client agent (no daemon required)', () => {
+		expect(DEFAULT_AGENT_ID).toBe(CLIENT_AGENT_ID);
 	});
 
-	test('the default agent resolves to an ephemeral-owned agent (no daemon required)', () => {
-		expect(agentConfig(DEFAULT_AGENT_ID)?.owner).toBe('ephemeral');
-	});
-
-	test('the home daemon is durable-owned so the browser leaves it to sync', () => {
-		expect(agentConfig(asAgentId('vocab-home'))?.owner).toBe('durable');
-	});
-
-	test('an id no longer in the catalog resolves to undefined, never answered', () => {
-		expect(agentConfig(asAgentId('gone'))).toBeUndefined();
+	test('the catalog binds exactly the client tab and the home daemon', () => {
+		const ids = VOCAB_AGENTS.map((agent) => agent.id);
+		expect(ids).toEqual([CLIENT_AGENT_ID, asAgentId('vocab-home')]);
 	});
 
 	test('every catalog id is unique (one entry per agent)', () => {
@@ -45,7 +38,9 @@ describe('agent catalog', () => {
 });
 
 describe('resolveEngine', () => {
-	// Distinct sentinel streams so a test can assert *which* engine won.
+	// The daemon walks its multi-engine priority chain through this (ADR-0038); the
+	// client has a single engine and calls it directly. Distinct sentinel streams
+	// so a test can assert *which* engine won.
 	const primary: ChatStream = async function* () {};
 	const fallback: ChatStream = async function* () {};
 

--- a/apps/vocab/src/routes/(signed-in)/components/ConversationView.svelte
+++ b/apps/vocab/src/routes/(signed-in)/components/ConversationView.svelte
@@ -1,13 +1,12 @@
 <script module lang="ts">
 	import { APP_URLS } from '@epicenter/constants/vite';
-	import { epicenterMeteredEngine } from '@epicenter/vocab/engine';
+	import { epicenterMeteredChatStream } from '@epicenter/vocab/engine';
 	import { auth } from '$platform/auth';
 
 	// The client answers the capability-free agent over the metered `/api/ai/chat`
-	// SSE stream (ADR-0043). One engine, built once and shared across every mounted
-	// view; the daemon is the only peer that walks a multi-engine priority chain
-	// (ADR-0038), so the client just calls its single engine directly.
-	const clientEngine = epicenterMeteredEngine(auth.fetch, APP_URLS.API);
+	// SSE stream (ADR-0043). One backend, built once and shared across every
+	// mounted view; only the daemon walks a multi-backend priority chain (ADR-0038).
+	const clientStream = epicenterMeteredChatStream(auth.fetch, APP_URLS.API);
 </script>
 
 <script lang="ts">
@@ -43,9 +42,7 @@
 	// flips mid-conversation.
 	// svelte-ignore state_referenced_locally
 	const answer =
-		readRow()?.agent === CLIENT_AGENT_ID
-			? (clientEngine() ?? undefined)
-			: undefined;
+		readRow()?.agent === CLIENT_AGENT_ID ? clientStream : undefined;
 
 	// The component is keyed on conversationId, so it mounts fresh per
 	// conversation: open the transcript doc and bind it (the answerer, the clock,

--- a/apps/vocab/src/routes/(signed-in)/components/ConversationView.svelte
+++ b/apps/vocab/src/routes/(signed-in)/components/ConversationView.svelte
@@ -1,16 +1,13 @@
 <script module lang="ts">
 	import { APP_URLS } from '@epicenter/constants/vite';
-	import type { Engine } from '@epicenter/vocab';
 	import { epicenterMeteredEngine } from '@epicenter/vocab/engine';
 	import { auth } from '$platform/auth';
 
-	// The engines this tab can power, highest priority first. Today just the
-	// metered Epicenter account over the `/api/ai/chat` SSE stream; adding a
-	// local-key engine ahead of it is the whole of "engine unification" (the same
-	// list the daemon walks). Built once, shared across every mounted view.
-	const browserEngines: readonly Engine[] = [
-		epicenterMeteredEngine(auth.fetch, APP_URLS.API),
-	];
+	// The client answers the capability-free agent over the metered `/api/ai/chat`
+	// SSE stream (ADR-0043). One engine, built once and shared across every mounted
+	// view; the daemon is the only peer that walks a multi-engine priority chain
+	// (ADR-0038), so the client just calls its single engine directly.
+	const clientEngine = epicenterMeteredEngine(auth.fetch, APP_URLS.API);
 </script>
 
 <script lang="ts">
@@ -18,11 +15,7 @@
 	import { Button } from '@epicenter/ui/button';
 	import * as Chat from '@epicenter/ui/chat';
 	import { InstantString } from '@epicenter/workspace';
-	import {
-		agentConfig,
-		type ConversationId,
-		resolveEngine,
-	} from '@epicenter/vocab';
+	import { CLIENT_AGENT_ID, type ConversationId } from '@epicenter/vocab';
 	import { onDestroy } from 'svelte';
 	import { requireVocab } from '$lib/session';
 	import ChatInput from './ChatInput.svelte';
@@ -41,21 +34,18 @@
 		return vocab.tables.conversations.get(conversationId).data;
 	}
 
-	// Who answers this conversation? Two orthogonal questions (ADR-0033). First,
-	// designation: does this tab write the turn? A tab answers only the agents it
-	// owns (an `'ephemeral'` owner); a `'durable'` owner is a resident daemon that
-	// answers ambiently over sync, so the tab stays out (answering too would answer
-	// one turn twice). The bound agent is immutable, so this never flips
-	// mid-conversation. Then engine: which backend powers the answer
-	// (`resolveEngine`, ADR-0038). ADR-0033: a conversation is a synced doc only an
-	// in-process peer writes.
+	// Who answers this conversation? An agent answers where its capability lives
+	// (ADR-0043), and the bound agent id names that place. The client tab answers
+	// the capability-free CLIENT_AGENT_ID in-process, running the shared answer
+	// core (ADR-0036) over the metered SSE stream; every other agent (vocab-home)
+	// is a resident daemon that answers over sync, so the tab stays out (answering
+	// too would write one turn twice). The bound agent is immutable, so this never
+	// flips mid-conversation.
 	// svelte-ignore state_referenced_locally
-	const boundAgent = readRow()?.agent;
-	const answersHere =
-		boundAgent !== undefined && agentConfig(boundAgent)?.owner === 'ephemeral';
-	const answer = answersHere
-		? (resolveEngine(browserEngines) ?? undefined)
-		: undefined;
+	const answer =
+		readRow()?.agent === CLIENT_AGENT_ID
+			? (clientEngine() ?? undefined)
+			: undefined;
 
 	// The component is keyed on conversationId, so it mounts fresh per
 	// conversation: open the transcript doc and bind it (the answerer, the clock,

--- a/apps/vocab/vocab.ts
+++ b/apps/vocab/vocab.ts
@@ -28,10 +28,7 @@ import {
 	type Id,
 	type InferTableRow,
 } from '@epicenter/workspace';
-import {
-	attachChatConversation,
-	type ChatStream,
-} from '@epicenter/workspace/ai';
+import { attachChatConversation } from '@epicenter/workspace/ai';
 import { Type } from 'typebox';
 import type { Brand } from 'wellcrafted/brand';
 
@@ -70,9 +67,8 @@ export const CLIENT_AGENT_ID: AgentId = asAgentId('client');
 export type { AgentId };
 
 /**
- * One agent Vocab can bind a conversation to: its durable {@link AgentId},
- * a display `label` for the picker, the `model` it answers with, and the action
- * keys it may call as tools (ADR-0021; none yet).
+ * One agent Vocab can bind a conversation to: its durable {@link AgentId} and a
+ * display `label` for the picker.
  *
  * An agent answers where its capability lives (ADR-0043), and the agent's `id`
  * is what names that place: {@link CLIENT_AGENT_ID} is the capability-free agent
@@ -80,14 +76,17 @@ export type { AgentId };
  * the user co-deploys. There is no separate `owner` enum, because with these two
  * agents the identity already says where the answer is produced; the one peer
  * that answers a given turn is decided by the bound `id`, never a second field.
- * The engine each answerer uses (a local key, the user's metered account) is an
- * orthogonal sub-choice it resolves for itself (ADR-0038).
+ *
+ * The model and toolset are not per-agent here: Vocab runs one model
+ * ({@link VOCAB_MODEL}) with no tools, read as app constants by whichever peer
+ * answers. The two entries are the same capability-free agent in two places, so
+ * the catalog carries only what differs (id, label); the engine each answerer
+ * uses (a local key, the user's metered account) is an orthogonal sub-choice it
+ * resolves for itself (ADR-0038).
  */
 export type AgentConfig = {
 	readonly id: AgentId;
 	readonly label: string;
-	readonly model: ServableModel;
-	readonly tools: readonly string[];
 };
 
 /**
@@ -103,18 +102,8 @@ export type AgentConfig = {
  * conversation to it is what a later "co-deploy a live daemon" slice brings online.
  */
 export const VOCAB_AGENTS = [
-	{
-		id: CLIENT_AGENT_ID,
-		label: 'This device',
-		model: VOCAB_MODEL,
-		tools: [],
-	},
-	{
-		id: asAgentId('vocab-home'),
-		label: 'Home daemon',
-		model: VOCAB_MODEL,
-		tools: [],
-	},
+	{ id: CLIENT_AGENT_ID, label: 'This device' },
+	{ id: asAgentId('vocab-home'), label: 'Home daemon' },
 ] as const satisfies readonly AgentConfig[];
 
 /**
@@ -123,39 +112,6 @@ export const VOCAB_AGENTS = [
  * with no daemon required.
  */
 export const DEFAULT_AGENT_ID: AgentId = CLIENT_AGENT_ID;
-
-/**
- * One inference backend a peer can power, built lazily: it returns a
- * {@link ChatStream} when the host can satisfy it (a key is present, the account
- * is opted in) or `null` when it cannot, so {@link resolveEngine} can fall
- * through to the next engine in priority order (ADR-0038).
- */
-export type Engine = () => ChatStream | null;
-
-/**
- * The `ChatStream` to answer with, taken from the first engine this host can
- * power, or `null` when it can power none: host the conversation's sync, write
- * nothing, leave the turn for a configured answerer.
- *
- * This is only the *engine* half of answering, where tokens come from. The other
- * half, *designation* (is this turn mine to write?), is decided by the bound
- * agent id (ADR-0043), where each peer naturally decides it, never here: a
- * daemon's observe loop hosts only the conversations bound to its agent
- * (`row.agent === selfAgentId`, ADR-0025), so by the time it resolves an engine
- * the turn is already its own; a browser tab answers only the conversations bound
- * to {@link CLIENT_AGENT_ID}. The two halves are orthogonal (designation ⊥
- * engine, ADR-0033/0038), so they are not forced through one function: doing so
- * made the daemon's designation a tautology (it would only ever pass its own
- * agent). Today only the daemon walks more than one engine; the client has a
- * single engine and calls it directly.
- */
-export function resolveEngine(engines: readonly Engine[]): ChatStream | null {
-	for (const engine of engines) {
-		const stream = engine();
-		if (stream) return stream; // first engine this host can power
-	}
-	return null; // no engine here → host, don't answer
-}
 
 /**
  * The bilingual system prompt every Vocab answer is generated under. An app

--- a/apps/vocab/vocab.ts
+++ b/apps/vocab/vocab.ts
@@ -53,17 +53,17 @@ export const generateConversationId = (): ConversationId =>
 export const VOCAB_MODEL = 'gemini-3.5-flash' satisfies ServableModel;
 
 /**
- * The ephemeral agent's stable address (ADR-0025): the one the open browser tab
- * owns and answers in-process, sourcing tokens from the metered `/api/ai/chat`
- * stream via the Epicenter provider (ADR-0033). The id names the *owner* (the
- * device's tab, which is why the answer stops when you close it), not the engine
- * (the cloud credits the tokens are billed to): owner ⊥ engine. A new conversation
- * binds to this agent by default. The binding is immutable: to talk to a different
- * agent you fork the conversation, so a conversation's history only ever reaches
- * its one bound agent. An always-on daemon answers instead when a conversation is
- * bound to that daemon's agent id.
+ * The client agent's stable address (ADR-0025): the capability-free agent the
+ * open browser tab answers in the client (ADR-0043), running the shared answer
+ * core (ADR-0036) over the metered `/api/ai/chat` SSE stream (ADR-0033). The
+ * answer stops when you close the tab; for a one-shot vocab lookup that is a
+ * non-goal (re-asking costs nothing). A new conversation binds to this agent by
+ * default. The binding is immutable: to talk to a different agent you fork the
+ * conversation, so a conversation's history only ever reaches its one bound
+ * agent. The `vocab-home` daemon answers instead when a conversation is bound to
+ * its agent id, because that agent's capability (an always-on box) lives there.
  */
-export const THIS_DEVICE_AGENT_ID: AgentId = asAgentId('this-device');
+export const CLIENT_AGENT_ID: AgentId = asAgentId('client');
 
 // Re-export the agent address type so app UI binds against one import surface
 // (`@epicenter/vocab`) for the agent catalog and the ids it hands the picker.
@@ -71,26 +71,23 @@ export type { AgentId };
 
 /**
  * One agent Vocab can bind a conversation to: its durable {@link AgentId},
- * a display `label` for the picker, the `model` it answers with, the action keys
- * it may call as tools (ADR-0021; none yet), and the `owner` kind that writes its
- * conversations.
+ * a display `label` for the picker, the `model` it answers with, and the action
+ * keys it may call as tools (ADR-0021; none yet).
  *
- * `owner` is the routing fork the browser reads, and it names who writes the
- * transcript, not where tokens come from (ADR-0025). An `'ephemeral'` agent
- * (`this-device`) is owned by the open browser tab, which answers in-process
- * and stops when it closes. A `'durable'` agent is an always-on resident daemon,
- * which answers over sync and survives the tab closing, so the browser stays out
- * of the way (both answering would answer one turn twice, the D3 hazard). The
- * engine each writer uses (a local key, the user's metered account) is an
- * orthogonal sub-choice it resolves for itself (ADR-0038), never a property of
- * the owner. The catalog is the one place the owner fork is declared (ADR-0033).
+ * An agent answers where its capability lives (ADR-0043), and the agent's `id`
+ * is what names that place: {@link CLIENT_AGENT_ID} is the capability-free agent
+ * the open tab answers in the client, and `vocab-home` is the always-on daemon
+ * the user co-deploys. There is no separate `owner` enum, because with these two
+ * agents the identity already says where the answer is produced; the one peer
+ * that answers a given turn is decided by the bound `id`, never a second field.
+ * The engine each answerer uses (a local key, the user's metered account) is an
+ * orthogonal sub-choice it resolves for itself (ADR-0038).
  */
 export type AgentConfig = {
 	readonly id: AgentId;
 	readonly label: string;
 	readonly model: ServableModel;
 	readonly tools: readonly string[];
-	readonly owner: 'ephemeral' | 'durable';
 };
 
 /**
@@ -100,44 +97,32 @@ export type AgentConfig = {
  * daemon waits in the doc until that daemon wakes and answers. Presence only ever
  * decorates this list with a live/offline hint; it never gates what can be bound.
  *
- * The this-device agent is always available (the open tab answers it in-process
+ * The client agent is always available (the open tab answers it in the client
  * against the hosted inference stream, no daemon required). The home daemon is the
  * always-on worker a user co-deploys; binding a
  * conversation to it is what a later "co-deploy a live daemon" slice brings online.
  */
 export const VOCAB_AGENTS = [
 	{
-		id: THIS_DEVICE_AGENT_ID,
+		id: CLIENT_AGENT_ID,
 		label: 'This device',
 		model: VOCAB_MODEL,
 		tools: [],
-		owner: 'ephemeral',
 	},
 	{
 		id: asAgentId('vocab-home'),
 		label: 'Home daemon',
 		model: VOCAB_MODEL,
 		tools: [],
-		owner: 'durable',
 	},
 ] as const satisfies readonly AgentConfig[];
 
 /**
  * The agent a new conversation binds to when the user does not pick one: the
- * always-available this-device agent, so the fast "New Conversation" path answers
+ * always-available client agent, so the fast "New Conversation" path answers
  * with no daemon required.
  */
-export const DEFAULT_AGENT_ID: AgentId = THIS_DEVICE_AGENT_ID;
-
-/**
- * The catalog entry for a bound `agent`, or `undefined` for an id no longer in
- * the catalog (a conversation bound before the agent was removed). Callers read
- * `owner` to route: an `'ephemeral'` agent the browser answers in-process; a
- * `'durable'` agent is left to its resident daemon over sync.
- */
-export function agentConfig(id: AgentId): AgentConfig | undefined {
-	return VOCAB_AGENTS.find((agent) => agent.id === id);
-}
+export const DEFAULT_AGENT_ID: AgentId = CLIENT_AGENT_ID;
 
 /**
  * One inference backend a peer can power, built lazily: it returns a
@@ -153,14 +138,16 @@ export type Engine = () => ChatStream | null;
  * nothing, leave the turn for a configured answerer.
  *
  * This is only the *engine* half of answering, where tokens come from. The other
- * half, *designation* (is this turn mine to write?), is the owner fork and is
- * decided where each peer naturally decides it, never here: a daemon's observe
- * loop hosts only the conversations bound to its agent (`row.agent ===
- * selfAgentId`, ADR-0025), so by the time it resolves an engine the turn is
- * already its own; a browser tab reads the bound agent's `owner` kind before it
- * mounts an answerer at all. The two halves are orthogonal (owner ⊥ engine,
- * ADR-0033/0038), so they are not forced through one function: doing so made the
- * daemon's designation a tautology (it would only ever pass its own agent).
+ * half, *designation* (is this turn mine to write?), is decided by the bound
+ * agent id (ADR-0043), where each peer naturally decides it, never here: a
+ * daemon's observe loop hosts only the conversations bound to its agent
+ * (`row.agent === selfAgentId`, ADR-0025), so by the time it resolves an engine
+ * the turn is already its own; a browser tab answers only the conversations bound
+ * to {@link CLIENT_AGENT_ID}. The two halves are orthogonal (designation ⊥
+ * engine, ADR-0033/0038), so they are not forced through one function: doing so
+ * made the daemon's designation a tautology (it would only ever pass its own
+ * agent). Today only the daemon walks more than one engine; the client has a
+ * single engine and calls it directly.
  */
 export function resolveEngine(engines: readonly Engine[]): ChatStream | null {
 	for (const engine of engines) {
@@ -204,9 +191,9 @@ const conversationsTable = defineTable({
 	updatedAt: field.instant(),
 	/**
 	 * The agent this conversation is bound to (ADR-0025), set once at creation and
-	 * never reassigned. {@link THIS_DEVICE_AGENT_ID} routes to the browser answering
+	 * never reassigned. {@link CLIENT_AGENT_ID} routes to the client tab answering
 	 * in-process (the Epicenter provider); a daemon's agent id routes to that
-	 * always-on worker over sync, and the browser stays out. One immutable
+	 * always-on worker over sync, and the client stays out. One immutable
 	 * field is who was addressed and who answered, for every turn: the history
 	 * cannot disagree with itself, and the conversation's content only ever reaches
 	 * this one agent. Switching agents is a fork, not a write here.
@@ -223,8 +210,9 @@ export type Conversation = InferTableRow<typeof conversationsTable>;
  * The isomorphic Vocab workspace definition.
  *
  * Conversation transcripts are not rows: each `conversations.messages` handle
- * opens a synced child doc derived from the conversation id and streamed into
- * by the server generation worker.
+ * opens a synced child doc derived from the conversation id, streamed into by
+ * whichever peer answers the bound agent (the client tab or the `vocab-home`
+ * daemon, ADR-0036/0043).
  */
 export const vocabWorkspace = defineWorkspace({
 	id: 'epicenter-vocab',


### PR DESCRIPTION
The bound agent id already says where a Vocab turn is produced. Keeping a second `owner` enum made routing look configurable in two places, so this removes the duplicate routing state.

```txt
Before: AgentConfig.owner -> resolveEngine priority chain
After:  bound agent id    -> client or vocab-home daemon
```

`CLIENT_AGENT_ID` is answered in the browser over the metered `/api/ai/chat` stream. `vocab-home` is answered by the daemon over sync. The daemon's backend choice is now the two real branches it owns: BYOK when configured, opted-in metered otherwise, or no backend.

That removes the surfaces that existed only to support the owner fork: `AgentConfig.owner`, `agentConfig()`, `Engine`, `resolveEngine`, and the write-only `model` and `tools` fields on `AgentConfig`.

## Clean Break

Vocab was still pre-release, so stored agent identity breaks cleanly:

```txt
Before: this-device
After:  client
```

Dev rooms created before this rename need a wipe. No deployed user data is migrated.
