### PR TITLE
fix(vite-config): bridge the duplicate-vite Plugin type so svelte-check passes

### DIFF
--- a/packages/vite-config/src/index.ts
+++ b/packages/vite-config/src/index.ts
@@ -18,7 +18,12 @@ import { searchForWorkspaceRoot, type UserConfig } from 'vite';
  */
 export function workspaceAppViteConfig(app: { port: number }): UserConfig {
 	return {
-		plugins: [sveltekit(), tailwindcss()],
+		// A consuming app's `@sveltejs/kit` and this package can resolve different
+		// bun peer-variant copies of the same `vite` version (`vite@7.3.5` vs
+		// `vite@7.3.5+<hash>`), whose `Plugin` types are then nominally unrelated,
+		// so `svelte-check` rejects the array against this package's `UserConfig`.
+		// One vite runs at runtime; bridge the array to this package's plugin type.
+		plugins: [sveltekit(), tailwindcss()] as UserConfig['plugins'],
 		resolve: {
 			dedupe: ['yjs'],
 		},


### PR DESCRIPTION
The lockfile and root `overrides` already pin one `vite@7.3.5`, but bun materializes peer-variant copies on disk (`.bun/vite@7.3.5`, `vite@7.3.5+4ece0cffe9718641`, `vite@7.3.5+682e14911fb7da75`). A consuming app's `@sveltejs/kit` resolves the `+4ece` variant while `@epicenter/vite-config` resolves the plain one, so their `Plugin` / `PluginOption` types are nominally unrelated:

```
Type 'Promise<Plugin<any>[]>' is not assignable to type 'PluginOption'.
  ... Two different types with this name exist, but they are unrelated.
```

`svelte-check` hit this on `packages/vite-config/src/index.ts:21` in every workspace Svelte app. Only one vite runs at runtime, so the cast bridges the array to this package's own plugin type and type resolution lines up. `opensidian` and `vocab` both go from one error to zero.

This is separate from #2140 (which pins the bun linker to `isolated` for layout determinism): peer-variant copies persist under both linkers, so #2140 makes the layout deterministic without collapsing this particular type clash. This is the targeted fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784663300&installation_id=128463665&pr_number=2151&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2151&signature=2be4efece3dbc05c6f9af2439691de6018301dfd6f6156bf7910ba4a461188af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->