### PR TITLE
chore: pin bun install linker to isolated

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,7 @@
+[install]
+# Pin the dependency linker so every machine and CI produce the same
+# node_modules layout, instead of leaving it to bun's default (which varies by
+# bun version, workspace setup, and lockfile configVersion). "isolated" is the
+# strict pnpm-style layout: a package can only import what it declares, so
+# phantom dependencies fail loudly instead of riding on accidental hoisting.
+linker = "isolated"


### PR DESCRIPTION
Bun installs needed one deterministic `node_modules` shape. The default linker can vary by Bun version, workspace setup, and lockfile `configVersion`, so machines could silently disagree about whether phantom dependencies were reachable.

This adds a root `bunfig.toml` that pins the workspace to the isolated, pnpm-style linker. In that layout, a package can only import dependencies it declares, which makes undeclared imports fail loudly instead of riding on accidental hoisting.

That exact divergence already showed up in Whispering: `onnxruntime-web` is pulled in through `@ricky0123/vad-web`, not declared by the app, and config evaluation failed on an isolated install while passing on a hoisted one. The VAD resolution path was fixed separately; this PR makes the install layout consistent across local machines and CI.

The trade-off is repo-wide exposure. If another package still depends on a hoisted phantom dependency, this makes it surface immediately.