### PR TITLE
feat(local-books): expose the QuickBooks mirror as a dispatched read-only SQL tool

### DIFF
--- a/apps/local-books/AGENTS.md
+++ b/apps/local-books/AGENTS.md
@@ -29,7 +29,7 @@ Mode is chosen from stored state: `--full` / no cursor / cursor older than the C
 
 ## Config (env or `<data-dir>/config.json`)
 
-- `LOCAL_BOOKS_QB_CLIENT_ID` / `LOCAL_BOOKS_QB_CLIENT_SECRET` — your Intuit app keys (required for `auth`). The bare `QB_CLIENT_ID` / `QB_CLIENT_SECRET` names are also accepted, which is what Infisical injects: `infisical run --path=/apps/local-books -- bun run src/bin.ts auth`.
+- `QB_CLIENT_ID` / `QB_CLIENT_SECRET` — your Intuit app keys (required for `auth`). This is what Infisical injects at `/apps/local-books`, so the usual invocation is `infisical run --path=/apps/local-books -- bun run src/bin.ts auth`.
 - `LOCAL_BOOKS_QB_ENV` — `sandbox` (default) or `production`.
 - `LOCAL_BOOKS_DIR` / `--data-dir` — data directory override.
 - `LOCAL_BOOKS_KEYRING_FILE` — opt-in plaintext file token store (CI / headless boxes without a keyring daemon, and the test harness). Default is the OS keyring.

--- a/apps/local-books/AGENTS.md
+++ b/apps/local-books/AGENTS.md
@@ -35,6 +35,15 @@ Mode is chosen from stored state: `--full` / no cursor / cursor older than the C
 - `LOCAL_BOOKS_KEYRING_FILE` — opt-in plaintext file token store (CI / headless boxes without a keyring daemon, and the test harness). Default is the OS keyring.
 - Base-URL overrides (`LOCAL_BOOKS_QB_API_BASE`, `_TOKEN_URL`, `_AUTHORIZE_URL`) point the client at a mock server for tests.
 
+## Agent surface (ADR-0047)
+
+`books.ts` + `mount.ts` wrap the mirror as an Epicenter **data daemon**: it holds the SQLite and serves it as dispatched actions, but never runs inference. A client agent loop (`@epicenter/workspace/agent`) opens the same synced room and dispatches the tools; the financial data leaves the machine only as a tool result.
+
+- `src/agent/books-query.ts` — `books_sql_query`, a read-only SQL query (`query`, auto-approved). Enforced read-only by a `new Database(path, { readonly: true })` connection, not a string check; results are row-capped.
+- `src/agent/books-actions.ts` — `createBooksAgentActions({ dbPath })`, the served registry. The write tools (`mark_reviewed`, `add_note`) need an overlay table (parked in the spec) and land here next, gated by the synchronous approval pause.
+
+The CLI binary (`bin.ts` -> `cli.ts`) does not import this layer, so `bun build --compile` of the CLI stays lean.
+
 ## Testing
 
-`bun test` boots a mock QB server (`test/mock-qb-server.ts`) and drives the real command paths against it (seeded file keyring), so full pull, incremental CDC, cursor advance, and soft-delete are proven end-to-end without a live sandbox. The interactive browser hop of `auth` is the only piece a live sandbox is needed for.
+`bun test` boots a mock QB server (`test/mock-qb-server.ts`) and drives the real command paths against it (seeded file keyring), so full pull, incremental CDC, cursor advance, and soft-delete are proven end-to-end without a live sandbox. The interactive browser hop of `auth` is the only piece a live sandbox is needed for. The agent surface (`src/agent/`) is tested through the real dispatch catalog against a seeded mirror.

--- a/apps/local-books/README.md
+++ b/apps/local-books/README.md
@@ -19,8 +19,8 @@ You need an Intuit developer app (https://developer.intuit.com → your app → 
 Provide the keys by environment:
 
 ```sh
-export QB_CLIENT_ID=...        # or LOCAL_BOOKS_QB_CLIENT_ID
-export QB_CLIENT_SECRET=...    # or LOCAL_BOOKS_QB_CLIENT_SECRET
+export QB_CLIENT_ID=...
+export QB_CLIENT_SECRET=...
 ```
 
 In this monorepo the keys live in Infisical at `/apps/local-books`, so prefix any command:

--- a/apps/local-books/books.ts
+++ b/apps/local-books/books.ts
@@ -1,0 +1,54 @@
+/**
+ * Local Books agent workspace contract: the synced room the client agent loop
+ * (ADR-0047) and the Local Books data daemon share. The daemon advertises its
+ * read models as dispatched actions (see `mount.ts`); the client runs the loop
+ * here and dispatches them.
+ *
+ * Isomorphic: no `bun:sqlite`, no node APIs. The SQLite mirror is the daemon's
+ * private data, reached only as a tool result, never synced; this contract holds
+ * just the conversation transcripts.
+ */
+
+import { field } from '@epicenter/field';
+import {
+	attachKvStore,
+	defineActions,
+	defineTable,
+	defineWorkspace,
+	generateId,
+	type Id,
+	type InferTableRow,
+} from '@epicenter/workspace';
+import type { AgentMessage } from '@epicenter/workspace/agent';
+import type { Brand } from 'wellcrafted/brand';
+
+export type ConversationId = Id & Brand<'ConversationId'>;
+export const generateConversationId = (): ConversationId =>
+	generateId<ConversationId>();
+
+export type MessageId = Id & Brand<'MessageId'>;
+export const generateMessageId = (): MessageId => generateId<MessageId>();
+
+/**
+ * Conversations: each row's `messages` handle opens a synced child doc, a
+ * last-write-wins store of finished {@link AgentMessage} records (ADR-0047). The
+ * open client runs the loop and writes each finished message here; the live turn
+ * never enters the CRDT.
+ */
+const conversationsTable = defineTable({
+	id: field.string<ConversationId>(),
+	title: field.string(),
+	createdAt: field.instant(),
+	updatedAt: field.instant(),
+}).docs({ messages: (ydoc) => attachKvStore<AgentMessage>(ydoc) });
+export type Conversation = InferTableRow<typeof conversationsTable>;
+
+export const localBooksWorkspace = defineWorkspace({
+	id: 'epicenter-local-books',
+	name: 'local-books',
+	tables: {
+		conversations: conversationsTable,
+	},
+	kv: {},
+	actions: () => defineActions({}),
+});

--- a/apps/local-books/mount.ts
+++ b/apps/local-books/mount.ts
@@ -1,0 +1,39 @@
+/**
+ * The Local Books data daemon (ADR-0047): it holds the QuickBooks mirror and
+ * serves it as dispatched actions, but never runs inference. `localBooksMount()`
+ * returns the `Mount` an `epicenter.config.ts` default-exports; the daemon opens
+ * the same synced room the client loop drives and advertises `books_sql_query`
+ * over presence. A tool call dispatches here, runs against the local SQLite, and
+ * returns rows; the financial data leaves the machine only as that result.
+ *
+ * The mirror is the CLI's own `<dataDir>/<realmId>/books.db`. `local-books sync`
+ * keeps it current; this mount only reads it.
+ */
+
+import { nodeMountRuntime } from '@epicenter/workspace/node';
+import { localBooksWorkspace } from './books.ts';
+import { createBooksAgentActions } from './src/agent/books-actions.ts';
+import { dbPath } from './src/paths.ts';
+
+export type LocalBooksMountOptions = {
+	/** Base URL of the Epicenter cloud API used for sync. */
+	baseURL?: string;
+	/** Data directory holding `<realmId>/books.db` (the CLI's data dir). */
+	dataDir: string;
+	/** The QuickBooks company whose mirror this daemon serves. */
+	realmId: string;
+};
+
+export function localBooksMount({
+	baseURL,
+	dataDir,
+	realmId,
+}: LocalBooksMountOptions) {
+	return localBooksWorkspace.mount({
+		baseURL,
+		runtime: nodeMountRuntime(),
+		compose: () => ({
+			actions: createBooksAgentActions({ dbPath: dbPath(dataDir, realmId) }),
+		}),
+	});
+}

--- a/apps/local-books/package.json
+++ b/apps/local-books/package.json
@@ -22,6 +22,8 @@
 		"build:binary": "bun build --compile --outfile dist/local-books src/bin.ts"
 	},
 	"dependencies": {
+		"@epicenter/field": "workspace:*",
+		"@epicenter/workspace": "workspace:*",
 		"oauth4webapi": "catalog:",
 		"typebox": "catalog:",
 		"wellcrafted": "catalog:"

--- a/apps/local-books/src/agent/books-actions.ts
+++ b/apps/local-books/src/agent/books-actions.ts
@@ -1,0 +1,19 @@
+/**
+ * The action surface the Local Books daemon advertises to the client agent loop
+ * (ADR-0047). The daemon holds the QuickBooks mirror and runs these; the client
+ * dispatches them as tools.
+ *
+ * Today it is the read-only `books_sql_query`. The write tools the mirror needs
+ * an overlay table for (`mark_reviewed`, `add_note`) are the next increment;
+ * they land here beside the query, gated by the synchronous approval pause.
+ */
+
+import { defineActions } from '@epicenter/workspace';
+import { createBooksQueryAction } from './books-query.ts';
+
+/** Build the daemon's served actions over the mirror at `dbPath`. */
+export function createBooksAgentActions({ dbPath }: { dbPath: string }) {
+	return defineActions({
+		books_sql_query: createBooksQueryAction({ dbPath }),
+	});
+}

--- a/apps/local-books/src/agent/books-query.test.ts
+++ b/apps/local-books/src/agent/books-query.test.ts
@@ -1,0 +1,96 @@
+/**
+ * `books_sql_query` reached the way the client agent loop reaches it: as a
+ * dispatched action resolved through `createDispatchToolCatalog`. A seeded mirror
+ * stands in for a synced QuickBooks company. This proves the read-only path end
+ * to end (a tool call -> the catalog -> the SQLite mirror -> bounded rows); the
+ * loop that drives the catalog is proven in `@epicenter/workspace`'s loop tests.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+	createDispatchToolCatalog,
+	type DispatchSurface,
+} from '@epicenter/workspace/agent';
+import { Ok } from 'wellcrafted/result';
+import { openBooksDb } from '../db.ts';
+import { createBooksAgentActions } from './books-actions.ts';
+
+/** No peers: a books action resolves in-process; dispatch is never reached. */
+const LOCAL_ONLY: DispatchSurface = {
+	peers: { list: () => [] },
+	dispatch: () => Promise.resolve(Ok(null)),
+};
+
+/** Seed a mirror with two invoices (one soft-deleted); return its path. */
+function fixtureMirror() {
+	const dir = mkdtempSync(join(tmpdir(), 'local-books-'));
+	const path = join(dir, 'realm-1', 'books.db');
+	const db = openBooksDb(path, 'realm-1');
+	db.raw.exec(`
+		CREATE TABLE invoices (
+			id TEXT PRIMARY KEY, raw TEXT NOT NULL, updated_at TEXT,
+			synced_at TEXT NOT NULL, deleted INTEGER NOT NULL DEFAULT 0, total_amt REAL
+		);
+		INSERT INTO invoices (id, raw, synced_at, deleted, total_amt) VALUES
+			('i1', '{"Id":"i1"}', '2026-01-01', 0, 100.0),
+			('i2', '{"Id":"i2"}', '2026-01-01', 1, 50.0);
+	`);
+	db.close();
+	return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+function runQuery(dbPath: string, sql: string) {
+	const catalog = createDispatchToolCatalog(LOCAL_ONLY, {
+		localActions: createBooksAgentActions({ dbPath }),
+	});
+	return catalog.resolve(
+		{ toolCallId: 't1', toolName: 'books_sql_query', input: { sql } },
+		new AbortController().signal,
+	);
+}
+
+describe('books_sql_query as a dispatched action', () => {
+	test('the catalog advertises it as a query (auto-approved) tool', () => {
+		const catalog = createDispatchToolCatalog(LOCAL_ONLY, {
+			localActions: createBooksAgentActions({ dbPath: '/tmp/unused.db' }),
+		});
+		const def = catalog.definitions().find((d) => d.name === 'books_sql_query');
+		expect(def?.kind).toBe('query');
+	});
+
+	test('runs a read-only SELECT and returns the live rows, bounded', async () => {
+		const { path, cleanup } = fixtureMirror();
+		const outcome = await runQuery(
+			path,
+			'SELECT id, total_amt FROM invoices WHERE deleted = 0',
+		);
+		expect(outcome.isError).toBe(false);
+		expect(outcome.output).toMatchObject({ rowCount: 1, truncated: false });
+		expect((outcome.output as { rows: unknown[] }).rows).toEqual([
+			{ id: 'i1', total_amt: 100 },
+		]);
+		cleanup();
+	});
+
+	test('rejects a write: the read-only connection is the boundary', async () => {
+		const { path, cleanup } = fixtureMirror();
+		const outcome = await runQuery(
+			path,
+			"DELETE FROM invoices WHERE id = 'i1'",
+		);
+		expect(outcome.isError).toBe(true);
+		cleanup();
+	});
+
+	test('errors clearly when no mirror exists yet', async () => {
+		const outcome = await runQuery(
+			join(tmpdir(), 'local-books-absent', 'realm', 'books.db'),
+			'SELECT 1',
+		);
+		expect(outcome.isError).toBe(true);
+		expect(String(outcome.output)).toContain('No QuickBooks mirror');
+	});
+});

--- a/apps/local-books/src/agent/books-query.ts
+++ b/apps/local-books/src/agent/books-query.ts
@@ -1,0 +1,73 @@
+/**
+ * `books_sql_query`: the read-only SQL tool the agent reaches as a dispatched
+ * action (ADR-0047). The Local Books daemon holds the QuickBooks mirror (SQLite)
+ * and runs this action; the client agent loop dispatches it and feeds the rows
+ * back into the turn. The data leaves the machine only as a tool result, the
+ * egress ADR-0033 already accepts.
+ *
+ * It is a `query` (auto-approved): a read-only connection is the enforcement, not
+ * a string check. `new Database(path, { readonly: true })` makes SQLite reject
+ * any write statement, so the model cannot mutate the mirror through this tool
+ * even though it passes raw SQL. Results are row-capped so a broad query cannot
+ * flood the model's context.
+ */
+
+import { Database } from 'bun:sqlite';
+import { existsSync } from 'node:fs';
+import { defineQuery } from '@epicenter/workspace';
+import { Type } from 'typebox';
+import { defineErrors, extractErrorMessage } from 'wellcrafted/error';
+import { Ok } from 'wellcrafted/result';
+
+export const BooksQueryError = defineErrors({
+	NoMirror: ({ path }: { path: string }) => ({
+		message: `No QuickBooks mirror at ${path}. Run \`local-books sync\` first.`,
+	}),
+	QueryFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Read-only query failed (the mirror rejects writes): ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+});
+
+/** Cap returned rows so a broad query cannot flood the model's context. */
+const MAX_ROWS = 1000;
+
+/**
+ * Build the `books_sql_query` action over the mirror at `dbPath`. The handle is
+ * opened read-only per call (cheap, and it sidesteps holding a lock while sync
+ * writes), so the daemon can serve queries while `local-books sync` runs.
+ */
+export function createBooksQueryAction({ dbPath }: { dbPath: string }) {
+	return defineQuery({
+		title: 'Query the books',
+		description:
+			'Run a read-only SQL query against the local QuickBooks mirror (SQLite). ' +
+			'Tables: invoices, customers, items, payments, bills, vendors, accounts. ' +
+			'Each row has id, raw (verbatim QB JSON), updated_at, synced_at, ' +
+			'deleted, plus a few extracted scalar columns. Filter `deleted = 0` for ' +
+			'live rows. SELECT only; writes are rejected.',
+		input: Type.Object({
+			sql: Type.String({
+				description: 'A read-only SQL query (SELECT / WITH / PRAGMA).',
+			}),
+		}),
+		handler: ({ sql }) => {
+			if (!existsSync(dbPath))
+				return BooksQueryError.NoMirror({ path: dbPath });
+			const db = new Database(dbPath, { readonly: true });
+			try {
+				const rows = db.query(sql).all() as Record<string, unknown>[];
+				const truncated = rows.length > MAX_ROWS;
+				return Ok({
+					rows: truncated ? rows.slice(0, MAX_ROWS) : rows,
+					rowCount: rows.length,
+					truncated,
+				});
+			} catch (cause) {
+				return BooksQueryError.QueryFailed({ cause });
+			} finally {
+				db.close();
+			}
+		},
+	});
+}

--- a/apps/local-books/src/cli.ts
+++ b/apps/local-books/src/cli.ts
@@ -39,7 +39,7 @@ Options:
   -v, --version                Show version.
 
 Environment:
-  LOCAL_BOOKS_QB_CLIENT_ID / _SECRET   Intuit app credentials (required for auth).
+  QB_CLIENT_ID / QB_CLIENT_SECRET      Intuit app credentials (required for auth).
   LOCAL_BOOKS_DIR                       Data directory.
   LOCAL_BOOKS_KEYRING_FILE              Plaintext file token store instead of the OS keyring.
 `;

--- a/apps/local-books/src/commands/auth.ts
+++ b/apps/local-books/src/commands/auth.ts
@@ -19,8 +19,9 @@ export async function runAuth(args: ParsedArgs): Promise<number> {
 
 	if (!config.clientId || !config.clientSecret) {
 		console.error(
-			'Missing client credentials. Set LOCAL_BOOKS_QB_CLIENT_ID and LOCAL_BOOKS_QB_CLIENT_SECRET\n' +
-				'from your Intuit app (https://developer.intuit.com → your app → Keys & credentials).',
+			'Missing QuickBooks credentials. Set QB_CLIENT_ID and QB_CLIENT_SECRET\n' +
+				'(or run via `infisical run --path=/apps/local-books`) from your Intuit\n' +
+				'app (https://developer.intuit.com → your app → Keys & credentials).',
 		);
 		return 1;
 	}

--- a/apps/local-books/src/config.ts
+++ b/apps/local-books/src/config.ts
@@ -118,11 +118,10 @@ export function loadConfig(overrides: CliConfigOverrides = {}): AppConfig {
 	return {
 		dataDir,
 		environment,
-		// Accept the bare QB_* names (what Infisical injects at /apps/local-books)
-		// as well as the namespaced LOCAL_BOOKS_QB_* form.
-		clientId: env('LOCAL_BOOKS_QB_CLIENT_ID') ?? env('QB_CLIENT_ID') ?? null,
-		clientSecret:
-			env('LOCAL_BOOKS_QB_CLIENT_SECRET') ?? env('QB_CLIENT_SECRET') ?? null,
+		// The Intuit app keys are the bare QB_* names, what Infisical injects at
+		// /apps/local-books and the convention Intuit's own docs use.
+		clientId: env('QB_CLIENT_ID') ?? null,
+		clientSecret: env('QB_CLIENT_SECRET') ?? null,
 		redirectUri:
 			env('LOCAL_BOOKS_QB_REDIRECT_URI') ??
 			file.redirectUri ??

--- a/apps/local-books/src/oauth.ts
+++ b/apps/local-books/src/oauth.ts
@@ -24,7 +24,9 @@ import {
 export const OAuthError = defineErrors({
 	MissingCredentials: () => ({
 		message:
-			'Missing client credentials. Set LOCAL_BOOKS_QB_CLIENT_ID and LOCAL_BOOKS_QB_CLIENT_SECRET.',
+			'Missing QuickBooks credentials. Set QB_CLIENT_ID and QB_CLIENT_SECRET ' +
+			'(or run via `infisical run --path=/apps/local-books`) from your Intuit ' +
+			'app at https://developer.intuit.com.',
 	}),
 	AuthorizationDenied: ({
 		error,

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",
@@ -220,6 +219,8 @@
         "local-books": "./src/bin.ts",
       },
       "dependencies": {
+        "@epicenter/field": "workspace:*",
+        "@epicenter/workspace": "workspace:*",
         "oauth4webapi": "catalog:",
         "typebox": "catalog:",
         "wellcrafted": "catalog:",


### PR DESCRIPTION
First increment of the Local Books agent (ADR-0047), stacked on the now-merged agent-loop collapse and the Local Books CLI. It wraps the standalone QuickBooks-to-SQLite mirror as an Epicenter **data daemon**: the daemon holds the SQLite and serves it as dispatched actions, but never runs inference. A client agent loop dispatches the tools and feeds rows back into the turn; the financial data leaves the machine only as a tool result, the egress ADR-0033 already accepts.

## This PR: the read path

`books_sql_query` runs a read-only SQL query against the local mirror at `<dataDir>/<realmId>/books.db`.

```ts
// the daemon (mount.ts) serves it; the client loop dispatches it as a tool
const catalog = createDispatchToolCatalog(workspace.collaboration, {
  localActions: createBooksAgentActions({ dbPath }),
});
// books_sql_query -> { rows, rowCount, truncated }, over the 7 entity tables
```

**Read-only is enforced by the connection, not a string check:** `new Database(path, { readonly: true })` makes SQLite reject any write statement, so the auto-approved query tool cannot mutate the mirror even though it passes raw SQL. Results are row-capped so a broad query cannot flood the model's context.

- `src/agent/books-query.ts` — the `books_sql_query` action.
- `src/agent/books-actions.ts` — the served registry (the extension point for the write tools).
- `books.ts` — the synced room (conversation transcripts), isomorphic.
- `mount.ts` — the daemon serving the action over presence.

Tested through the real dispatch catalog against a seeded mirror: a SELECT returns live rows, a write is rejected, and an absent mirror errors clearly.

## Deferred (next increments)

- The write tools (`mark_reviewed`, `add_note`) need an overlay table the CLI spec parks; they land here next, gated by the synchronous approval pause.
- The async-job tier (ADR-0047's second tool tier: a dispatched action that acks and writes results into a synced doc over time).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784670356&installation_id=128463665&pr_number=2153&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2153&signature=79744deafba5f29d9161a3026de2eb6242a3a9e83598c912fab6f2f21f81eab4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Also: QuickBooks credentials are `QB_CLIENT_ID` / `QB_CLIENT_SECRET`

A second commit drops the redundant `LOCAL_BOOKS_QB_CLIENT_ID` / `LOCAL_BOOKS_QB_CLIENT_SECRET` form for the two Intuit app keys. The bare `QB_*` names are what Infisical injects at `/apps/local-books` and what Intuit's docs use; the prefixed variant added nothing and made the "missing credentials" error misleading (it pointed only at the prefixed names, not the `infisical --path` route). Every message (the command, the OAuth error, `--help`, the README, AGENTS.md) now points at `QB_CLIENT_ID` / `QB_CLIENT_SECRET`. The other `LOCAL_BOOKS_QB_*` tuning vars stay namespaced.
