### PR TITLE
docs(landing): add quick privacy and terms pages

### DIFF
--- a/apps/landing/src/pages/privacy.astro
+++ b/apps/landing/src/pages/privacy.astro
@@ -1,0 +1,86 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const lastUpdated = 'June 21, 2026';
+---
+
+<BaseLayout
+	title="Privacy Policy - Epicenter"
+	description="How Epicenter handles your data: local-first, stored on your device, never on our servers."
+>
+	<main class="mx-auto max-w-2xl px-6 py-16 leading-relaxed">
+		<a href="/" class="text-sm text-muted-foreground hover:underline">&larr; epicenter</a>
+		<h1 class="mt-6 text-3xl font-bold tracking-tight">Privacy Policy</h1>
+		<p class="mt-2 text-sm text-muted-foreground">Last updated: {lastUpdated}</p>
+
+		<section class="mt-8 space-y-4">
+			<p>
+				Epicenter builds local-first software. This policy covers the Epicenter
+				website (epicenter.so) and the Epicenter applications and command-line
+				tools, including local-books.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold">Your data stays on your device</h2>
+			<p>
+				Epicenter applications are designed so that your personal and financial
+				data lives on your own device, not on servers we operate. We do not
+				collect, store, sell, or transmit the contents of your data to ourselves
+				or to third parties. Because the data does not leave your machine, we
+				cannot see it.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold">Connected services</h2>
+			<p>
+				Some applications can connect to third-party services that you authorize,
+				such as QuickBooks Online. When you connect a service, the application
+				reads data from it using credentials you grant through that service's own
+				authorization flow, and stores a copy locally on your device. That data is
+				not sent to Epicenter.
+			</p>
+			<p>
+				Authorization tokens for connected services are stored in your operating
+				system's secure keyring (for example, the macOS Keychain), not on our
+				servers. You can revoke an application's access at any time from the
+				connected service's account settings (for QuickBooks Online, from your
+				Intuit account under Connected apps).
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold">Website analytics</h2>
+			<p>
+				The Epicenter website uses privacy-respecting analytics to understand
+				aggregate, anonymous usage (such as which pages are visited). This is
+				limited to the website and does not extend to the contents of any data
+				inside the applications.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold">Data security</h2>
+			<p>
+				Because your data is stored locally, its security is governed by your own
+				device. We recommend enabling full-disk encryption (such as FileVault on
+				macOS) and keeping your operating system and the application up to date.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold">Children's privacy</h2>
+			<p>
+				Epicenter is not directed at children under 13 and we do not knowingly
+				collect information from them.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold">Changes to this policy</h2>
+			<p>
+				We may update this policy from time to time. Material changes will be
+				reflected by the "Last updated" date above.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold">Contact</h2>
+			<p>
+				Questions about this policy? Reach us at
+				<a class="underline" href="mailto:hello@epicenter.so">hello@epicenter.so</a>
+				or open an issue at
+				<a class="underline" href="https://github.com/EpicenterHQ/epicenter"
+					>github.com/EpicenterHQ/epicenter</a
+				>.
+			</p>
+		</section>
+	</main>
+</BaseLayout>

--- a/apps/landing/src/pages/privacy.astro
+++ b/apps/landing/src/pages/privacy.astro
@@ -9,44 +9,55 @@ const lastUpdated = 'June 21, 2026';
 	description="Epicenter is local-first. Your data lives on your own machine, not on our servers."
 >
 	<main class="mx-auto max-w-2xl px-6 py-16 leading-relaxed">
-		<a href="/" class="text-sm text-muted-foreground hover:underline">&larr; epicenter</a>
+		<a href="/" class="text-sm text-muted-foreground hover:underline"
+			>&larr; epicenter</a
+		>
 		<h1 class="mt-6 text-3xl font-bold tracking-tight">Privacy</h1>
-		<p class="mt-2 text-sm text-muted-foreground">Last updated: {lastUpdated}</p>
+		<p class="mt-2 text-sm text-muted-foreground">
+			Last updated: {lastUpdated}
+		</p>
 
 		<section class="mt-8 space-y-5">
 			<p>
 				Epicenter is local-first. Your data lives on your own machine, as files
-				you own. There is no Epicenter server collecting, storing, or selling it.
-				We don't have your data, so we can't do anything with it.
+				you own. There is no Epicenter server collecting, storing, or selling
+				it. We don't have your data, so we can't do anything with it.
 			</p>
 
 			<p>
 				Epicenter is an open-source project, and some of its tools are personal
 				experiments the author runs on their own machine. local-books, for
 				example, is one of those experiments: it mirrors the author's own
-				QuickBooks company into a local SQLite database for personal use. It reads
-				that data onto the author's machine and sends nothing to Epicenter or
-				anyone else.
+				QuickBooks company into a local SQLite database for personal use. It
+				reads that data onto the author's machine and sends nothing to Epicenter
+				or anyone else.
 			</p>
 
 			<p>
-				<strong>Connected services.</strong> When a tool connects to a service you
-				authorize, it reads your data into local storage on your own device. Access
-				tokens are kept in your operating system's keyring, never on our servers,
-				and you can revoke a tool's access from that service whenever you want.
+				<strong>Connected services.</strong>
+				When a tool connects to a service you authorize, it reads your data into
+				local storage on your own device. Access tokens are kept in your
+				operating system's keyring, never on our servers, and you can revoke a
+				tool's access from that service whenever you want.
 			</p>
 
 			<p>
-				<strong>This website.</strong> epicenter.so uses privacy-respecting,
-				anonymous analytics to understand aggregate page visits. That is limited to
-				the website and never touches the contents of any tool.
+				<strong>This website.</strong>
+				epicenter.so uses privacy-respecting, anonymous analytics to understand
+				aggregate page visits. That is limited to the website and never touches
+				the contents of any tool.
 			</p>
 
 			<p>
-				<strong>Contact.</strong> Questions? Email
-				<a class="underline" href="mailto:hello@epicenter.so">hello@epicenter.so</a>
+				<strong>Contact.</strong>
+				Questions? Email
+				<a class="underline" href="mailto:hello@epicenter.so"
+					>hello@epicenter.so</a
+				>
 				or open an issue on
-				<a class="underline" href="https://github.com/EpicenterHQ/epicenter">GitHub</a>.
+				<a class="underline" href="https://github.com/EpicenterHQ/epicenter"
+					>GitHub</a
+				>.
 			</p>
 		</section>
 	</main>

--- a/apps/landing/src/pages/privacy.astro
+++ b/apps/landing/src/pages/privacy.astro
@@ -6,7 +6,7 @@ const lastUpdated = 'June 21, 2026';
 
 <BaseLayout
 	title="Privacy - Epicenter"
-	description="Epicenter is local-first. Your data lives on your own machine, not on our servers."
+	description="The short version: your data is yours, and it stays on your machine."
 >
 	<main class="mx-auto max-w-2xl px-6 py-16 leading-relaxed">
 		<a href="/" class="text-sm text-muted-foreground hover:underline"
@@ -19,42 +19,42 @@ const lastUpdated = 'June 21, 2026';
 
 		<section class="mt-8 space-y-5">
 			<p>
-				Epicenter is local-first. Your data lives on your own machine, as files
-				you own. There is no Epicenter server collecting, storing, or selling
-				it. We don't have your data, so we can't do anything with it.
+				The short version: your data is yours, and it stays on your machine.
 			</p>
 
 			<p>
-				Epicenter is an open-source project, and some of its tools are personal
-				experiments the author runs on their own machine. local-books, for
-				example, is one of those experiments: it mirrors the author's own
-				QuickBooks company into a local SQLite database for personal use. It
-				reads that data onto the author's machine and sends nothing to Epicenter
-				or anyone else.
+				Epicenter is local-first software, and I build it in the open. Your
+				files live on your own computer, not on a server I run. I don't collect
+				them, I don't store them, and I couldn't sell them if I tried, because I
+				never have them in the first place.
 			</p>
 
 			<p>
-				<strong>Connected services.</strong>
-				When a tool connects to a service you authorize, it reads your data into
-				local storage on your own device. Access tokens are kept in your
-				operating system's keyring, never on our servers, and you can revoke a
-				tool's access from that service whenever you want.
+				Some of these tools are personal experiments I run for myself.
+				local-books is one of them: I made it to keep a local copy of my own
+				QuickBooks books in a plain SQLite file on my own machine. It reads my
+				data onto my computer and sends nothing back to me or to anyone else. If
+				you run it, the same holds for you: your machine, your data.
 			</p>
 
 			<p>
-				<strong>This website.</strong>
-				epicenter.so uses privacy-respecting, anonymous analytics to understand
-				aggregate page visits. That is limited to the website and never touches
-				the contents of any tool.
+				When a tool connects to a service you sign into (like QuickBooks), it
+				reads your data onto your device and keeps the access token in your
+				operating system's keyring, never on a server. You can disconnect it
+				from that service anytime.
 			</p>
 
 			<p>
-				<strong>Contact.</strong>
-				Questions? Email
+				This website uses light, anonymous analytics so I can see which pages
+				get visited. That is the whole extent of it, and it only touches the
+				website, never anything inside the tools.
+			</p>
+
+			<p>
+				If you have questions, I would genuinely like to hear them:
 				<a class="underline" href="mailto:hello@epicenter.so"
 					>hello@epicenter.so</a
-				>
-				or open an issue on
+				>, or open an issue on
 				<a class="underline" href="https://github.com/EpicenterHQ/epicenter"
 					>GitHub</a
 				>.

--- a/apps/landing/src/pages/privacy.astro
+++ b/apps/landing/src/pages/privacy.astro
@@ -9,9 +9,13 @@ const lastUpdated = 'June 21, 2026';
 	description="How Epicenter handles your data: local-first, stored on your device, never on our servers."
 >
 	<main class="mx-auto max-w-2xl px-6 py-16 leading-relaxed">
-		<a href="/" class="text-sm text-muted-foreground hover:underline">&larr; epicenter</a>
+		<a href="/" class="text-sm text-muted-foreground hover:underline"
+			>&larr; epicenter</a
+		>
 		<h1 class="mt-6 text-3xl font-bold tracking-tight">Privacy Policy</h1>
-		<p class="mt-2 text-sm text-muted-foreground">Last updated: {lastUpdated}</p>
+		<p class="mt-2 text-sm text-muted-foreground">
+			Last updated: {lastUpdated}
+		</p>
 
 		<section class="mt-8 space-y-4">
 			<p>
@@ -31,11 +35,11 @@ const lastUpdated = 'June 21, 2026';
 
 			<h2 class="pt-4 text-xl font-semibold">Connected services</h2>
 			<p>
-				Some applications can connect to third-party services that you authorize,
-				such as QuickBooks Online. When you connect a service, the application
-				reads data from it using credentials you grant through that service's own
-				authorization flow, and stores a copy locally on your device. That data is
-				not sent to Epicenter.
+				Some applications can connect to third-party services that you
+				authorize, such as QuickBooks Online. When you connect a service, the
+				application reads data from it using credentials you grant through that
+				service's own authorization flow, and stores a copy locally on your
+				device. That data is not sent to Epicenter.
 			</p>
 			<p>
 				Authorization tokens for connected services are stored in your operating
@@ -55,9 +59,10 @@ const lastUpdated = 'June 21, 2026';
 
 			<h2 class="pt-4 text-xl font-semibold">Data security</h2>
 			<p>
-				Because your data is stored locally, its security is governed by your own
-				device. We recommend enabling full-disk encryption (such as FileVault on
-				macOS) and keeping your operating system and the application up to date.
+				Because your data is stored locally, its security is governed by your
+				own device. We recommend enabling full-disk encryption (such as
+				FileVault on macOS) and keeping your operating system and the
+				application up to date.
 			</p>
 
 			<h2 class="pt-4 text-xl font-semibold">Children's privacy</h2>
@@ -75,7 +80,9 @@ const lastUpdated = 'June 21, 2026';
 			<h2 class="pt-4 text-xl font-semibold">Contact</h2>
 			<p>
 				Questions about this policy? Reach us at
-				<a class="underline" href="mailto:hello@epicenter.so">hello@epicenter.so</a>
+				<a class="underline" href="mailto:hello@epicenter.so"
+					>hello@epicenter.so</a
+				>
 				or open an issue at
 				<a class="underline" href="https://github.com/EpicenterHQ/epicenter"
 					>github.com/EpicenterHQ/epicenter</a

--- a/apps/landing/src/pages/privacy.astro
+++ b/apps/landing/src/pages/privacy.astro
@@ -5,88 +5,48 @@ const lastUpdated = 'June 21, 2026';
 ---
 
 <BaseLayout
-	title="Privacy Policy - Epicenter"
-	description="How Epicenter handles your data: local-first, stored on your device, never on our servers."
+	title="Privacy - Epicenter"
+	description="Epicenter is local-first. Your data lives on your own machine, not on our servers."
 >
 	<main class="mx-auto max-w-2xl px-6 py-16 leading-relaxed">
-		<a href="/" class="text-sm text-muted-foreground hover:underline"
-			>&larr; epicenter</a
-		>
-		<h1 class="mt-6 text-3xl font-bold tracking-tight">Privacy Policy</h1>
-		<p class="mt-2 text-sm text-muted-foreground">
-			Last updated: {lastUpdated}
-		</p>
+		<a href="/" class="text-sm text-muted-foreground hover:underline">&larr; epicenter</a>
+		<h1 class="mt-6 text-3xl font-bold tracking-tight">Privacy</h1>
+		<p class="mt-2 text-sm text-muted-foreground">Last updated: {lastUpdated}</p>
 
-		<section class="mt-8 space-y-4">
+		<section class="mt-8 space-y-5">
 			<p>
-				Epicenter builds local-first software. This policy covers the Epicenter
-				website (epicenter.so) and the Epicenter applications and command-line
-				tools, including local-books.
+				Epicenter is local-first. Your data lives on your own machine, as files
+				you own. There is no Epicenter server collecting, storing, or selling it.
+				We don't have your data, so we can't do anything with it.
 			</p>
 
-			<h2 class="pt-4 text-xl font-semibold">Your data stays on your device</h2>
 			<p>
-				Epicenter applications are designed so that your personal and financial
-				data lives on your own device, not on servers we operate. We do not
-				collect, store, sell, or transmit the contents of your data to ourselves
-				or to third parties. Because the data does not leave your machine, we
-				cannot see it.
+				Epicenter is an open-source project, and some of its tools are personal
+				experiments the author runs on their own machine. local-books, for
+				example, is one of those experiments: it mirrors the author's own
+				QuickBooks company into a local SQLite database for personal use. It reads
+				that data onto the author's machine and sends nothing to Epicenter or
+				anyone else.
 			</p>
 
-			<h2 class="pt-4 text-xl font-semibold">Connected services</h2>
 			<p>
-				Some applications can connect to third-party services that you
-				authorize, such as QuickBooks Online. When you connect a service, the
-				application reads data from it using credentials you grant through that
-				service's own authorization flow, and stores a copy locally on your
-				device. That data is not sent to Epicenter.
-			</p>
-			<p>
-				Authorization tokens for connected services are stored in your operating
-				system's secure keyring (for example, the macOS Keychain), not on our
-				servers. You can revoke an application's access at any time from the
-				connected service's account settings (for QuickBooks Online, from your
-				Intuit account under Connected apps).
+				<strong>Connected services.</strong> When a tool connects to a service you
+				authorize, it reads your data into local storage on your own device. Access
+				tokens are kept in your operating system's keyring, never on our servers,
+				and you can revoke a tool's access from that service whenever you want.
 			</p>
 
-			<h2 class="pt-4 text-xl font-semibold">Website analytics</h2>
 			<p>
-				The Epicenter website uses privacy-respecting analytics to understand
-				aggregate, anonymous usage (such as which pages are visited). This is
-				limited to the website and does not extend to the contents of any data
-				inside the applications.
+				<strong>This website.</strong> epicenter.so uses privacy-respecting,
+				anonymous analytics to understand aggregate page visits. That is limited to
+				the website and never touches the contents of any tool.
 			</p>
 
-			<h2 class="pt-4 text-xl font-semibold">Data security</h2>
 			<p>
-				Because your data is stored locally, its security is governed by your
-				own device. We recommend enabling full-disk encryption (such as
-				FileVault on macOS) and keeping your operating system and the
-				application up to date.
-			</p>
-
-			<h2 class="pt-4 text-xl font-semibold">Children's privacy</h2>
-			<p>
-				Epicenter is not directed at children under 13 and we do not knowingly
-				collect information from them.
-			</p>
-
-			<h2 class="pt-4 text-xl font-semibold">Changes to this policy</h2>
-			<p>
-				We may update this policy from time to time. Material changes will be
-				reflected by the "Last updated" date above.
-			</p>
-
-			<h2 class="pt-4 text-xl font-semibold">Contact</h2>
-			<p>
-				Questions about this policy? Reach us at
-				<a class="underline" href="mailto:hello@epicenter.so"
-					>hello@epicenter.so</a
-				>
-				or open an issue at
-				<a class="underline" href="https://github.com/EpicenterHQ/epicenter"
-					>github.com/EpicenterHQ/epicenter</a
-				>.
+				<strong>Contact.</strong> Questions? Email
+				<a class="underline" href="mailto:hello@epicenter.so">hello@epicenter.so</a>
+				or open an issue on
+				<a class="underline" href="https://github.com/EpicenterHQ/epicenter">GitHub</a>.
 			</p>
 		</section>
 	</main>

--- a/apps/landing/src/pages/terms.astro
+++ b/apps/landing/src/pages/terms.astro
@@ -5,84 +5,44 @@ const lastUpdated = 'June 21, 2026';
 ---
 
 <BaseLayout
-	title="Terms of Service - Epicenter"
-	description="The terms for using Epicenter's open-source, local-first software."
+	title="Terms - Epicenter"
+	description="Epicenter is free, open-source, local-first software, provided as-is."
 >
 	<main class="mx-auto max-w-2xl px-6 py-16 leading-relaxed">
-		<a href="/" class="text-sm text-muted-foreground hover:underline"
-			>&larr; epicenter</a
-		>
-		<h1 class="mt-6 text-3xl font-bold tracking-tight">Terms of Service</h1>
-		<p class="mt-2 text-sm text-muted-foreground">
-			Last updated: {lastUpdated}
-		</p>
+		<a href="/" class="text-sm text-muted-foreground hover:underline">&larr; epicenter</a>
+		<h1 class="mt-6 text-3xl font-bold tracking-tight">Terms</h1>
+		<p class="mt-2 text-sm text-muted-foreground">Last updated: {lastUpdated}</p>
 
-		<section class="mt-8 space-y-4">
+		<section class="mt-8 space-y-5">
 			<p>
-				These terms govern your use of the Epicenter website and the Epicenter
-				applications and command-line tools (the "Software"). By using the
-				Software, you agree to these terms.
+				Epicenter is free, open-source software, licensed under AGPL-3.0. The
+				source is on
+				<a class="underline" href="https://github.com/EpicenterHQ/epicenter">GitHub</a>.
 			</p>
 
-			<h2 class="pt-4 text-xl font-semibold">License</h2>
 			<p>
-				The Software is open source, licensed under the GNU Affero General
-				Public License v3.0 (AGPL-3.0). The license text governs your rights to
-				use, modify, and distribute the Software. The source is available at
-				<a class="underline" href="https://github.com/EpicenterHQ/epicenter"
-					>github.com/EpicenterHQ/epicenter</a
-				>.
+				It is provided as-is, with no warranty of any kind. You use it at your own
+				risk, and you are responsible for your own data and for the credentials you
+				give it.
 			</p>
 
-			<h2 class="pt-4 text-xl font-semibold">Provided "as is"</h2>
 			<p>
-				The Software is provided "as is", without warranty of any kind, express
-				or implied, including but not limited to the warranties of
-				merchantability, fitness for a particular purpose, and non-infringement.
-				You use the Software at your own risk.
+				Some of these tools are personal experiments and may change or go away.
+				That is the point of local-first: your files stay yours regardless of what
+				happens to any app.
 			</p>
 
-			<h2 class="pt-4 text-xl font-semibold">Limitation of liability</h2>
 			<p>
-				To the maximum extent permitted by law, the authors and copyright
-				holders shall not be liable for any claim, damages, or other liability
-				arising from or in connection with the Software or its use.
+				If you connect a third-party service, you are also bound by that service's
+				terms. Epicenter is not affiliated with or endorsed by any service it can
+				connect to.
 			</p>
 
-			<h2 class="pt-4 text-xl font-semibold">Your responsibilities</h2>
 			<p>
-				You are responsible for the credentials you provide, the data you store
-				on your device, and your compliance with the terms of any third-party
-				services you connect. You are responsible for keeping your device and
-				credentials secure.
-			</p>
-
-			<h2 class="pt-4 text-xl font-semibold">
-				Third-party services and trademarks
-			</h2>
-			<p>
-				Epicenter is not affiliated with, endorsed by, or sponsored by Intuit
-				Inc. QuickBooks and QuickBooks Online are trademarks of Intuit Inc. Your
-				use of any connected third-party service is also subject to that
-				service's own terms.
-			</p>
-
-			<h2 class="pt-4 text-xl font-semibold">Changes to these terms</h2>
-			<p>
-				We may update these terms from time to time. Material changes will be
-				reflected by the "Last updated" date above.
-			</p>
-
-			<h2 class="pt-4 text-xl font-semibold">Contact</h2>
-			<p>
-				Questions about these terms? Reach us at
-				<a class="underline" href="mailto:hello@epicenter.so"
-					>hello@epicenter.so</a
-				>
-				or open an issue at
-				<a class="underline" href="https://github.com/EpicenterHQ/epicenter"
-					>github.com/EpicenterHQ/epicenter</a
-				>.
+				<strong>Contact.</strong> Questions? Email
+				<a class="underline" href="mailto:hello@epicenter.so">hello@epicenter.so</a>
+				or open an issue on
+				<a class="underline" href="https://github.com/EpicenterHQ/epicenter">GitHub</a>.
 			</p>
 		</section>
 	</main>

--- a/apps/landing/src/pages/terms.astro
+++ b/apps/landing/src/pages/terms.astro
@@ -9,9 +9,13 @@ const lastUpdated = 'June 21, 2026';
 	description="The terms for using Epicenter's open-source, local-first software."
 >
 	<main class="mx-auto max-w-2xl px-6 py-16 leading-relaxed">
-		<a href="/" class="text-sm text-muted-foreground hover:underline">&larr; epicenter</a>
+		<a href="/" class="text-sm text-muted-foreground hover:underline"
+			>&larr; epicenter</a
+		>
 		<h1 class="mt-6 text-3xl font-bold tracking-tight">Terms of Service</h1>
-		<p class="mt-2 text-sm text-muted-foreground">Last updated: {lastUpdated}</p>
+		<p class="mt-2 text-sm text-muted-foreground">
+			Last updated: {lastUpdated}
+		</p>
 
 		<section class="mt-8 space-y-4">
 			<p>
@@ -22,9 +26,9 @@ const lastUpdated = 'June 21, 2026';
 
 			<h2 class="pt-4 text-xl font-semibold">License</h2>
 			<p>
-				The Software is open source, licensed under the GNU Affero General Public
-				License v3.0 (AGPL-3.0). The license text governs your rights to use,
-				modify, and distribute the Software. The source is available at
+				The Software is open source, licensed under the GNU Affero General
+				Public License v3.0 (AGPL-3.0). The license text governs your rights to
+				use, modify, and distribute the Software. The source is available at
 				<a class="underline" href="https://github.com/EpicenterHQ/epicenter"
 					>github.com/EpicenterHQ/epicenter</a
 				>.
@@ -32,33 +36,35 @@ const lastUpdated = 'June 21, 2026';
 
 			<h2 class="pt-4 text-xl font-semibold">Provided "as is"</h2>
 			<p>
-				The Software is provided "as is", without warranty of any kind, express or
-				implied, including but not limited to the warranties of merchantability,
-				fitness for a particular purpose, and non-infringement. You use the
-				Software at your own risk.
+				The Software is provided "as is", without warranty of any kind, express
+				or implied, including but not limited to the warranties of
+				merchantability, fitness for a particular purpose, and non-infringement.
+				You use the Software at your own risk.
 			</p>
 
 			<h2 class="pt-4 text-xl font-semibold">Limitation of liability</h2>
 			<p>
-				To the maximum extent permitted by law, the authors and copyright holders
-				shall not be liable for any claim, damages, or other liability arising
-				from or in connection with the Software or its use.
+				To the maximum extent permitted by law, the authors and copyright
+				holders shall not be liable for any claim, damages, or other liability
+				arising from or in connection with the Software or its use.
 			</p>
 
 			<h2 class="pt-4 text-xl font-semibold">Your responsibilities</h2>
 			<p>
-				You are responsible for the credentials you provide, the data you store on
-				your device, and your compliance with the terms of any third-party
+				You are responsible for the credentials you provide, the data you store
+				on your device, and your compliance with the terms of any third-party
 				services you connect. You are responsible for keeping your device and
 				credentials secure.
 			</p>
 
-			<h2 class="pt-4 text-xl font-semibold">Third-party services and trademarks</h2>
+			<h2 class="pt-4 text-xl font-semibold">
+				Third-party services and trademarks
+			</h2>
 			<p>
-				Epicenter is not affiliated with, endorsed by, or sponsored by Intuit Inc.
-				QuickBooks and QuickBooks Online are trademarks of Intuit Inc. Your use of
-				any connected third-party service is also subject to that service's own
-				terms.
+				Epicenter is not affiliated with, endorsed by, or sponsored by Intuit
+				Inc. QuickBooks and QuickBooks Online are trademarks of Intuit Inc. Your
+				use of any connected third-party service is also subject to that
+				service's own terms.
 			</p>
 
 			<h2 class="pt-4 text-xl font-semibold">Changes to these terms</h2>
@@ -70,7 +76,9 @@ const lastUpdated = 'June 21, 2026';
 			<h2 class="pt-4 text-xl font-semibold">Contact</h2>
 			<p>
 				Questions about these terms? Reach us at
-				<a class="underline" href="mailto:hello@epicenter.so">hello@epicenter.so</a>
+				<a class="underline" href="mailto:hello@epicenter.so"
+					>hello@epicenter.so</a
+				>
 				or open an issue at
 				<a class="underline" href="https://github.com/EpicenterHQ/epicenter"
 					>github.com/EpicenterHQ/epicenter</a

--- a/apps/landing/src/pages/terms.astro
+++ b/apps/landing/src/pages/terms.astro
@@ -6,7 +6,7 @@ const lastUpdated = 'June 21, 2026';
 
 <BaseLayout
 	title="Terms - Epicenter"
-	description="Epicenter is free, open-source, local-first software, provided as-is."
+	description="Epicenter is free, open-source, local-first software, built in the open and provided as-is."
 >
 	<main class="mx-auto max-w-2xl px-6 py-16 leading-relaxed">
 		<a href="/" class="text-sm text-muted-foreground hover:underline"
@@ -19,38 +19,36 @@ const lastUpdated = 'June 21, 2026';
 
 		<section class="mt-8 space-y-5">
 			<p>
-				Epicenter is free, open-source software, licensed under AGPL-3.0. The
-				source is on
+				Epicenter is free and open source, under AGPL-3.0. The code is on
 				<a class="underline" href="https://github.com/EpicenterHQ/epicenter"
 					>GitHub</a
-				>.
+				>, and you are welcome to read it, run it, and change it.
 			</p>
 
 			<p>
-				It is provided as-is, with no warranty of any kind. You use it at your
-				own risk, and you are responsible for your own data and for the
-				credentials you give it.
+				It comes with no warranty. I build these tools with care, but I cannot
+				promise they are perfect, so you run them at your own risk, and your
+				data and your credentials are yours to look after.
 			</p>
 
 			<p>
-				Some of these tools are personal experiments and may change or go away.
-				That is the point of local-first: your files stay yours regardless of
-				what happens to any app.
+				Some of these are experiments, and they might change or go away. That is
+				part of the point of local-first: even if a tool disappears, your files
+				don't. They are plain SQLite and Markdown on your own disk, and they
+				stay yours.
 			</p>
 
 			<p>
-				If you connect a third-party service, you are also bound by that
-				service's terms. Epicenter is not affiliated with or endorsed by any
-				service it can connect to.
+				If you connect a service like QuickBooks, you are also agreeing to that
+				service's terms. Epicenter is not affiliated with or endorsed by the
+				services it can connect to.
 			</p>
 
 			<p>
-				<strong>Contact.</strong>
-				Questions? Email
+				Questions are welcome:
 				<a class="underline" href="mailto:hello@epicenter.so"
 					>hello@epicenter.so</a
-				>
-				or open an issue on
+				>, or open an issue on
 				<a class="underline" href="https://github.com/EpicenterHQ/epicenter"
 					>GitHub</a
 				>.

--- a/apps/landing/src/pages/terms.astro
+++ b/apps/landing/src/pages/terms.astro
@@ -9,40 +9,51 @@ const lastUpdated = 'June 21, 2026';
 	description="Epicenter is free, open-source, local-first software, provided as-is."
 >
 	<main class="mx-auto max-w-2xl px-6 py-16 leading-relaxed">
-		<a href="/" class="text-sm text-muted-foreground hover:underline">&larr; epicenter</a>
+		<a href="/" class="text-sm text-muted-foreground hover:underline"
+			>&larr; epicenter</a
+		>
 		<h1 class="mt-6 text-3xl font-bold tracking-tight">Terms</h1>
-		<p class="mt-2 text-sm text-muted-foreground">Last updated: {lastUpdated}</p>
+		<p class="mt-2 text-sm text-muted-foreground">
+			Last updated: {lastUpdated}
+		</p>
 
 		<section class="mt-8 space-y-5">
 			<p>
 				Epicenter is free, open-source software, licensed under AGPL-3.0. The
 				source is on
-				<a class="underline" href="https://github.com/EpicenterHQ/epicenter">GitHub</a>.
+				<a class="underline" href="https://github.com/EpicenterHQ/epicenter"
+					>GitHub</a
+				>.
 			</p>
 
 			<p>
-				It is provided as-is, with no warranty of any kind. You use it at your own
-				risk, and you are responsible for your own data and for the credentials you
-				give it.
+				It is provided as-is, with no warranty of any kind. You use it at your
+				own risk, and you are responsible for your own data and for the
+				credentials you give it.
 			</p>
 
 			<p>
 				Some of these tools are personal experiments and may change or go away.
-				That is the point of local-first: your files stay yours regardless of what
-				happens to any app.
+				That is the point of local-first: your files stay yours regardless of
+				what happens to any app.
 			</p>
 
 			<p>
-				If you connect a third-party service, you are also bound by that service's
-				terms. Epicenter is not affiliated with or endorsed by any service it can
-				connect to.
+				If you connect a third-party service, you are also bound by that
+				service's terms. Epicenter is not affiliated with or endorsed by any
+				service it can connect to.
 			</p>
 
 			<p>
-				<strong>Contact.</strong> Questions? Email
-				<a class="underline" href="mailto:hello@epicenter.so">hello@epicenter.so</a>
+				<strong>Contact.</strong>
+				Questions? Email
+				<a class="underline" href="mailto:hello@epicenter.so"
+					>hello@epicenter.so</a
+				>
 				or open an issue on
-				<a class="underline" href="https://github.com/EpicenterHQ/epicenter">GitHub</a>.
+				<a class="underline" href="https://github.com/EpicenterHQ/epicenter"
+					>GitHub</a
+				>.
 			</p>
 		</section>
 	</main>

--- a/apps/landing/src/pages/terms.astro
+++ b/apps/landing/src/pages/terms.astro
@@ -1,0 +1,81 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const lastUpdated = 'June 21, 2026';
+---
+
+<BaseLayout
+	title="Terms of Service - Epicenter"
+	description="The terms for using Epicenter's open-source, local-first software."
+>
+	<main class="mx-auto max-w-2xl px-6 py-16 leading-relaxed">
+		<a href="/" class="text-sm text-muted-foreground hover:underline">&larr; epicenter</a>
+		<h1 class="mt-6 text-3xl font-bold tracking-tight">Terms of Service</h1>
+		<p class="mt-2 text-sm text-muted-foreground">Last updated: {lastUpdated}</p>
+
+		<section class="mt-8 space-y-4">
+			<p>
+				These terms govern your use of the Epicenter website and the Epicenter
+				applications and command-line tools (the "Software"). By using the
+				Software, you agree to these terms.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold">License</h2>
+			<p>
+				The Software is open source, licensed under the GNU Affero General Public
+				License v3.0 (AGPL-3.0). The license text governs your rights to use,
+				modify, and distribute the Software. The source is available at
+				<a class="underline" href="https://github.com/EpicenterHQ/epicenter"
+					>github.com/EpicenterHQ/epicenter</a
+				>.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold">Provided "as is"</h2>
+			<p>
+				The Software is provided "as is", without warranty of any kind, express or
+				implied, including but not limited to the warranties of merchantability,
+				fitness for a particular purpose, and non-infringement. You use the
+				Software at your own risk.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold">Limitation of liability</h2>
+			<p>
+				To the maximum extent permitted by law, the authors and copyright holders
+				shall not be liable for any claim, damages, or other liability arising
+				from or in connection with the Software or its use.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold">Your responsibilities</h2>
+			<p>
+				You are responsible for the credentials you provide, the data you store on
+				your device, and your compliance with the terms of any third-party
+				services you connect. You are responsible for keeping your device and
+				credentials secure.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold">Third-party services and trademarks</h2>
+			<p>
+				Epicenter is not affiliated with, endorsed by, or sponsored by Intuit Inc.
+				QuickBooks and QuickBooks Online are trademarks of Intuit Inc. Your use of
+				any connected third-party service is also subject to that service's own
+				terms.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold">Changes to these terms</h2>
+			<p>
+				We may update these terms from time to time. Material changes will be
+				reflected by the "Last updated" date above.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold">Contact</h2>
+			<p>
+				Questions about these terms? Reach us at
+				<a class="underline" href="mailto:hello@epicenter.so">hello@epicenter.so</a>
+				or open an issue at
+				<a class="underline" href="https://github.com/EpicenterHQ/epicenter"
+					>github.com/EpicenterHQ/epicenter</a
+				>.
+			</p>
+		</section>
+	</main>
+</BaseLayout>


### PR DESCRIPTION
I wanted to run a quick experiment: keep a local copy of my own QuickBooks books on my machine (that's `apps/local-books`). To set it up, Intuit's production app needs a privacy policy and a terms URL, so I added these quick placeholder `/privacy` and `/terms` pages for epicenter.so, mainly so I have real links to point the form at.

They're written in the first person and kept simple. The gist: Epicenter is local-first, your data stays on your machine, and I never have it.