### PR TITLE
refactor(vite-config): drop the inert duplicate-vite Plugin cast

### DIFF
--- a/apps/api/ui/vite.config.ts
+++ b/apps/api/ui/vite.config.ts
@@ -1,7 +1,7 @@
 import { APPS } from '@epicenter/constants/apps';
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
-import { defineConfig, type PluginOption } from 'vite';
+import { defineConfig } from 'vite';
 
 // Dashboard is same-origin with API: in prod, served as static assets from
 // `api.epicenter.so/dashboard`; in dev, the proxy below routes /api and /auth
@@ -9,10 +9,7 @@ import { defineConfig, type PluginOption } from 'vite';
 const DASHBOARD_DEV_PORT = 5178;
 
 export default defineConfig({
-	// Each workspace has its own physical vite install (same version), so the
-	// plugins' `Plugin` type is nominally distinct from this config's
-	// `PluginOption`. Cast until the installs dedupe to one vite.
-	plugins: [sveltekit(), tailwindcss()] as PluginOption[],
+	plugins: [sveltekit(), tailwindcss()],
 	server: {
 		port: DASHBOARD_DEV_PORT,
 		strictPort: true,

--- a/apps/matter/vite.config.ts
+++ b/apps/matter/vite.config.ts
@@ -1,14 +1,11 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
-import { defineConfig, type PluginOption } from 'vite';
+import { defineConfig } from 'vite';
 
 // Matter is desktop-only (Tauri). There is no browser build to branch on, so the
 // app imports `@tauri-apps/*` directly; develop with `bun run tauri dev`.
 export default defineConfig({
-	// Each workspace has its own physical vite install (same version), so the
-	// plugins' `Plugin` type is nominally distinct from this config's
-	// `PluginOption`. Cast until the installs dedupe to one vite.
-	plugins: [sveltekit(), tailwindcss()] as PluginOption[],
+	plugins: [sveltekit(), tailwindcss()],
 	clearScreen: false,
 	server: {
 		// Tauri's devUrl points here; the port must be fixed.

--- a/apps/skills/vite.config.ts
+++ b/apps/skills/vite.config.ts
@@ -1,12 +1,9 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
-import { defineConfig, type PluginOption } from 'vite';
+import { defineConfig } from 'vite';
 
 export default defineConfig({
-	// Each workspace has its own physical vite install (same version), so the
-	// plugins' `Plugin` type is nominally distinct from this config's
-	// `PluginOption`. Cast until the installs dedupe to one vite.
-	plugins: [sveltekit(), tailwindcss()] as PluginOption[],
+	plugins: [sveltekit(), tailwindcss()],
 	resolve: {
 		dedupe: ['yjs'],
 	},

--- a/packages/vite-config/src/index.ts
+++ b/packages/vite-config/src/index.ts
@@ -18,12 +18,14 @@ import { searchForWorkspaceRoot, type UserConfig } from 'vite';
  */
 export function workspaceAppViteConfig(app: { port: number }): UserConfig {
 	return {
-		// A consuming app's `@sveltejs/kit` and this package can resolve different
-		// bun peer-variant copies of the same `vite` version (`vite@7.3.5` vs
-		// `vite@7.3.5+<hash>`), whose `Plugin` types are then nominally unrelated,
-		// so `svelte-check` rejects the array against this package's `UserConfig`.
-		// One vite runs at runtime; bridge the array to this package's plugin type.
-		plugins: [sveltekit(), tailwindcss()] as UserConfig['plugins'],
+		// No cast: the isolated install resolves a single `vite` peer-variant that
+		// every package (this one, the app, @sveltejs/kit, @tailwindcss/vite)
+		// symlinks to, so the plugins' `Plugin` type matches this `UserConfig`. If
+		// CI ever reports `Two different types with this name exist, but they are
+		// unrelated` on this line again, bun re-split `vite` into peer-variants
+		// (`vite@7.3.5+<hashA>` vs `+<hashB>`); restore `as UserConfig['plugins']`
+		// here, the one place every workspace app's plugins come from.
+		plugins: [sveltekit(), tailwindcss()],
 		resolve: {
 			dedupe: ['yjs'],
 		},


### PR DESCRIPTION

Removes the `as UserConfig['plugins']` / `as PluginOption[]` cast from the shared `workspaceAppConfig` helper and the three standalone configs (matter, api/ui, skills). Net −7 lines, no behavior change.

The reason for this shape is:

#2151 added the cast to bridge two physically distinct `vite` peer-variant copies (`vite@7.3.5+4ece…` vs `+682e…`), whose `Plugin` types are nominally unrelated. That state no longer exists.

On current `main`'s isolated install, bun resolves a **single** `vite` peer-variant (`vite@7.3.5+9df36cbd11bbdf29`) that every package symlinks to: the apps, `@sveltejs/kit`, `@tailwindcss/vite`, and `@epicenter/vite-config` alike. One physical `vite` means one `Plugin` type, so the plugin array already satisfies `UserConfig['plugins']` and the cast is dead weight. The two hashes #2151 saw are gone from the lockfile (regenerated since).

## Proof

`svelte-check` passes with **0 errors** across all nine vite-config consumers (fuji, honeycrisp, opensidian, matter, vocab, whispering, todos, skills, api/ui) and `tsc` on the package itself.

## Fragility, recorded in the comment

bun computes the peer-variant count at install time (it is not pinned in the lockfile), so a future graph or bun-version change could re-split `vite` and bring the clash back. The helper comment now says exactly that and points at the one place to restore the cast if `Two different types with this name exist, but they are unrelated` reappears in CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784675574&installation_id=128463665&pr_number=2156&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2156&signature=ad59be64dab5fa6ec093224fd3cd1f6f9fe278926e5cacbd81723ba4df5bd527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->