### PR TITLE
fix(workspace): keep agent loop render/persist in lockstep; record the two-loop rule (ADR-0048)

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -38,20 +38,28 @@ shapes, see `docs/adr/`.
   through `ws.tables.X.docs.field.open(rowId)`. The workspace owns guid derivation.
 - **Worker**: running behavior that observes workspace state and writes results
   back. Workers may be local (every node runs them) or agent-bound (one
-  configured agent answers). A conversation answer is written by the peer the
-  bound agent designates (ADR-0043): the client tab itself for a capability-free
-  agent, the agent's daemon for a local-data agent.
+  configured agent answers). A conversation is answered by the client agent loop
+  in the open tab, for every agent (ADR-0047); the daemon contributes data and
+  side effects as dispatched actions (tools), never by running the loop.
 - **Agent**: the durable address a row or conversation binds to (an immutable
   id). An agent names who should answer; the peer that answers as it is the
   client tab or a daemon, set by the agent's **trust location** (ADR-0030/0043).
-- **Trust location**: where an agent answers, and therefore where its data goes
-  (ADR-0043). **Client** = the open browser tab answers in-process over
-  Epicenter's metered inference stream (a capability-free agent; Epicenter meters
-  tokens but runs no answering worker). **Home daemon** = the user's own always-on
-  box answers (nothing leaves the house). Blindness is per-agent, not global.
-- **Answerer**: an in-process peer that observes a conversation child doc and
-  writes the reply into it. The client tab (capability-free agent) or a daemon
-  (local-data agent); never the cloud relay/anchor, which stays blind (ADR-0043).
+- **Trust location**: where an agent's data and tools live, and therefore where
+  its side effects run (ADR-0030, ADR-0047). The reasoning loop always runs in
+  the client over Epicenter's metered inference stream; what varies is the
+  agent's capability. A **capability-free** agent (Vocab) has no tools. A
+  **local-data** agent (Local Books) keeps its data and action handlers on the
+  user's own always-on daemon, which the client loop reaches by dispatching
+  actions; data leaves the daemon only as a tool result. Epicenter meters tokens
+  but runs no answering worker. Blindness is per-agent, not global.
+- **Conversation loop**: the client-side loop that answers every conversation,
+  streams the live turn into a snapshot the UI renders, and persists finished
+  messages as records (ADR-0047). It replaces the older doc-observing *answerer*
+  (a daemon that wrote the reply into the doc), which ADR-0047 removed. Two
+  implementations exist, chosen by transcript reach (ADR-0048): a transcript that
+  syncs across a person's peers uses the workspace loop (`createConversation`,
+  finished messages in a Yjs child doc); a deliberately device-local transcript
+  uses TanStack `createChat` (tab-manager, IndexedDB).
 - **Materializer**: a local, addressless worker that projects workspace data into
   another store (markdown, sqlite).
 - **`attach*` vs `create*`**: `attach*` are side-effectful primitives that register

--- a/docs/adr/0048-a-conversations-loop-is-chosen-by-whether-its-transcript-syncs.md
+++ b/docs/adr/0048-a-conversations-loop-is-chosen-by-whether-its-transcript-syncs.md
@@ -1,0 +1,27 @@
+# 0048. A conversation's loop is chosen by whether its transcript syncs across peers
+
+- **Status:** Accepted
+- **Date:** 2026-06-21
+- **Relates:** [ADR-0047](0047-the-agent-loop-runs-in-the-client-and-tools-are-dispatched-actions.md) (the client loop and its LWW-records persistence), [ADR-0046](0046-a-capability-free-agent-persists-finished-messages-not-live-doc-streams.md) (the persisted-record shape both loops share), [ADR-0033](0033-a-conversation-has-one-transport-and-two-triggers.md) (the blind cloud that rules out a server tool loop)
+
+## Context
+
+The monorepo runs two agent chat loops, and a new chat surface has to pick one. The workspace loop (`createConversation`, `packages/workspace/src/agent/loop.ts`) runs the multi-step loop in the client, persists each finished message into a synced Yjs child doc keyed by id, and reaches tools by dispatching actions to peers (ADR-0047), so the loop never runs on a server. tab-manager runs a separate loop on TanStack's `createChat` over device-local IndexedDB, for plain-text streaming. Without a stated rule the split looks accidental, and the next surface either rebuilds one loop on the other's substrate or forks a third. The two are not redundant: they differ on whether the transcript is shared across a person's devices and whether tools must be orchestrated client-side against a blind cloud.
+
+## Decision
+
+**Choose the loop by transcript reach. A conversation whose transcript must sync across a person's peers, or that needs client-orchestrated tools against a blind cloud, uses the workspace client loop (`createConversation`); a conversation that is deliberately device-local and text-only uses TanStack `createChat`.**
+
+The workspace loop's render state is a snapshot: the persisted transcript re-read from the Yjs store plus the live in-memory turn, so a remote message that syncs in from another device merges on the next read. TanStack's `ChatClient` is not ruled out by message syncing as such, it can be driven from an external store (`setMessagesManually`, `onMessagesChange`). It is ruled out as our synced-conversation host by its tool loop, which runs on a `chat()` server that sees tool names, arguments, and results, where ADR-0033 keeps the cloud a blind token pipe. A synced, tool-capable conversation therefore cannot use it. When a transcript is meant to stay on one device and needs no client-orchestrated tools (tab-manager's per-browser history), `createChat` over IndexedDB is the lighter fit and carries no CRDT cost. Both loops persist the same finished-message record shape (ADR-0046), so a surface can move between them without reshaping its messages.
+
+## Consequences
+
+- A new chat surface has one question to answer, not an open design space: does this transcript follow the person across devices, or carry client tools? Either picks the workspace loop; a device-local, text-only surface picks `createChat`.
+- The two loops stay deliberately separate; neither is the "real" one to converge on. tab-manager keeps `createChat` rather than adopting the synced loop it does not need.
+- The shared record shape is load-bearing: it is what lets a device-local surface graduate to a synced one later without a migration of message bodies. Diverging the two part schemas would forfeit that and is a cost, not a convenience.
+- This says nothing about where reasoning runs or where tools live; ADR-0047 owns that. This is only about transcript persistence and reach.
+
+## Considered alternatives
+
+- **Adopt TanStack `ChatClient` for both loops (its client tools, `needsApproval`, and external-store sync).** Rejected: `ChatClient`'s client-tool flow runs the agent loop on a `chat()` server, which emits `tool-input-available` to the browser and receives the tool result back, so the server sees every tool and its data. That reverses ADR-0033's blind cloud and re-creates the server answering vertical ADR-0047 deleted. `ChatClient` can still front the blind cloud for plain-text streaming, which is exactly what tab-manager uses.
+- **Converge tab-manager onto the workspace loop.** Rejected: a device-local, text-only history needs neither a synced Yjs child doc nor dispatched tools, and `createChat` carries no CRDT cost. The shared record shape leaves the door open if that changes.

--- a/packages/workspace/src/agent/loop.test.ts
+++ b/packages/workspace/src/agent/loop.test.ts
@@ -3,7 +3,11 @@ import { EventType, type StreamChunk } from '@tanstack/ai';
 import * as Y from 'yjs';
 import { attachKvStore } from '../document/attach-kv-store.js';
 import { type AgentEngine, createConversation } from './loop.js';
-import { type AgentMessage, agentMessageText } from './message.js';
+import {
+	type AgentMessage,
+	agentMessageText,
+	isPersistableMessage,
+} from './message.js';
 import {
 	type AgentToolCall,
 	type Approval,
@@ -233,5 +237,63 @@ describe('createConversation', () => {
 		const messages = handle.snapshot().messages;
 		expect(messages.map((m) => m.role)).toEqual(['user']);
 		expect(handle.snapshot().isGenerating).toBe(false);
+	});
+
+	// Guards the snapshot/persistence coupling: the live render filter and the
+	// persistence filter must use one predicate, or a message could render
+	// mid-turn and then vanish on a clean finish. See `snapshot` in loop.ts.
+	test('every assistant message that renders live also persists', async () => {
+		const store = makeStore();
+		const engine: AgentEngine = () =>
+			streamOf([
+				chunk({
+					type: EventType.TEXT_MESSAGE_CONTENT,
+					delta: 'streamed',
+					messageId: 'a',
+				}),
+				chunk({ type: EventType.RUN_FINISHED, finishReason: 'stop' }),
+			]);
+
+		const handle = createConversation({
+			store,
+			engine,
+			generateId: idMinter(),
+		});
+
+		// Record every assistant id that ever appears in a live snapshot.
+		const renderedLive = new Set<string>();
+		const unsubscribe = handle.subscribe(() => {
+			if (!handle.snapshot().isGenerating) return;
+			for (const message of handle.snapshot().messages) {
+				if (message.role === 'assistant') renderedLive.add(message.id);
+			}
+		});
+
+		handle.send('hi');
+		await settle(handle);
+		unsubscribe();
+
+		const persisted = new Set(
+			[...store.entries()]
+				.map((entry) => entry.val)
+				.filter((message) => message.role === 'assistant')
+				.map((message) => message.id),
+		);
+		expect([...renderedLive].sort()).toEqual([...persisted].sort());
+		expect(persisted.size).toBe(1);
+	});
+
+	// The discriminator the shared predicate closes: a message can hold parts yet
+	// not be persistable (an empty text part). `parts.length > 0` would render it
+	// live; `isPersistableMessage` (used by both filters) drops it consistently.
+	test('a parts-bearing but empty message is not persistable', () => {
+		const message: AgentMessage = {
+			id: 'm1',
+			role: 'assistant',
+			createdAt: 0,
+			parts: [{ type: 'text', text: '' }],
+		};
+		expect(message.parts.length).toBeGreaterThan(0);
+		expect(isPersistableMessage(message)).toBe(false);
 	});
 });

--- a/packages/workspace/src/agent/loop.ts
+++ b/packages/workspace/src/agent/loop.ts
@@ -122,7 +122,12 @@ export function createConversation(
 		for (const listener of listeners) listener();
 	}
 
-	/** The durable transcript, chronologically ordered. */
+	/**
+	 * The durable transcript, chronologically ordered. It is a flat, linear list
+	 * by design: branching and edit history are a product tier built above the
+	 * loop, not a missing primitive (ADR-0047 considered and deferred them, as
+	 * TanStack's own flat `UIMessage[]` does). Deferred indefinitely.
+	 */
 	function readAll(): AgentMessage[] {
 		return [...store.entries()]
 			.map((entry) => entry.val)
@@ -142,7 +147,14 @@ export function createConversation(
 	let controller: AbortController | null = null;
 
 	function snapshot(): ConversationSnapshot {
-		const live = (turn ?? []).filter((message) => message.parts.length > 0);
+		// One predicate decides both what renders live and what persists: a
+		// message the UI shows mid-turn is exactly a message a clean finish
+		// keeps. They must not drift, or a message would render then vanish on
+		// finish. `parts.length > 0` happens to agree today only because
+		// `appendText` never opens an empty text part; a future non-persistable
+		// part type (a reasoning marker, say) would break that. Sharing
+		// `isPersistableMessage` keeps the two in lockstep by construction.
+		const live = (turn ?? []).filter(isPersistableMessage);
 		return {
 			messages: live.length > 0 ? [...persisted, ...live] : persisted,
 			isThinking: turn !== null && live.length === 0,

--- a/packages/workspace/src/agent/message.ts
+++ b/packages/workspace/src/agent/message.ts
@@ -9,6 +9,11 @@
  * tool-result parts. The shapes mirror TanStack AI's message parts but stay a
  * plain, JSON-stable record (no streaming state, no Yjs), so a finished message
  * round-trips through the LWW store unchanged.
+ *
+ * The id is globally unique, so each key is written exactly once and the LWW
+ * store's conflict resolution never fires. We use the store for its by-id,
+ * idempotent writes and to share one substrate with the table layer, not for
+ * its last-write-wins semantics.
  */
 import type { ModelMessage, ToolCall } from '@tanstack/ai';
 import type { JsonValue } from 'wellcrafted/json';


### PR DESCRIPTION
The agent loop had two predicates for the same lifecycle question. Live conversation snapshots rendered a mid-turn message when `parts.length > 0`, while persistence kept finished messages with `isPersistableMessage`. Those agree today only because `appendText` never opens an empty text part; a future non-persistable part could render during the turn and then disappear after a clean finish.

The live snapshot now uses `isPersistableMessage` too, so render and persistence cannot drift. The tests pin that invariant at the loop boundary instead of relying on the current text-part implementation detail.

ADR-0048 records the loop-selection rule that was still tribal knowledge after ADR-0047: synced transcripts and client-orchestrated tools use the workspace client loop, while device-local text-only chat can use TanStack `createChat`. `ChatClient` is not the synced host because its tool loop runs on a `chat()` server, which would move answering back into the cloud path ADR-0033 ruled out.

CONTEXT.md now matches that model: a conversation is answered by the client loop, the daemon provides data through dispatched actions, and the old doc-observing Answerer term is gone. The nearby comments also record two invariants the loop depends on: transcripts are linear by design, and LWW message keys are write-once because message ids are globally unique.
