### PR TITLE
docs: inference is its own box; the contract is OpenAI-compatible (ADR-0049/0050 + spec)

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -38,20 +38,28 @@ shapes, see `docs/adr/`.
   through `ws.tables.X.docs.field.open(rowId)`. The workspace owns guid derivation.
 - **Worker**: running behavior that observes workspace state and writes results
   back. Workers may be local (every node runs them) or agent-bound (one
-  configured agent answers). A conversation answer is written by the peer the
-  bound agent designates (ADR-0043): the client tab itself for a capability-free
-  agent, the agent's daemon for a local-data agent.
+  configured agent answers). A conversation is answered by the client agent loop
+  in the open tab, for every agent (ADR-0047); the daemon contributes data and
+  side effects as dispatched actions (tools), never by running the loop.
 - **Agent**: the durable address a row or conversation binds to (an immutable
   id). An agent names who should answer; the peer that answers as it is the
   client tab or a daemon, set by the agent's **trust location** (ADR-0030/0043).
-- **Trust location**: where an agent answers, and therefore where its data goes
-  (ADR-0043). **Client** = the open browser tab answers in-process over
-  Epicenter's metered inference stream (a capability-free agent; Epicenter meters
-  tokens but runs no answering worker). **Home daemon** = the user's own always-on
-  box answers (nothing leaves the house). Blindness is per-agent, not global.
-- **Answerer**: an in-process peer that observes a conversation child doc and
-  writes the reply into it. The client tab (capability-free agent) or a daemon
-  (local-data agent); never the cloud relay/anchor, which stays blind (ADR-0043).
+- **Trust location**: where an agent's data and tools live, and therefore where
+  its side effects run (ADR-0030, ADR-0047). The reasoning loop always runs in
+  the client over Epicenter's metered inference stream; what varies is the
+  agent's capability. A **capability-free** agent (Vocab) has no tools. A
+  **local-data** agent (Local Books) keeps its data and action handlers on the
+  user's own always-on daemon, which the client loop reaches by dispatching
+  actions; data leaves the daemon only as a tool result. Epicenter meters tokens
+  but runs no answering worker. Blindness is per-agent, not global.
+- **Conversation loop**: the client-side loop that answers every conversation,
+  streams the live turn into a snapshot the UI renders, and persists finished
+  messages as records (ADR-0047). It replaces the older doc-observing *answerer*
+  (a daemon that wrote the reply into the doc), which ADR-0047 removed. Two
+  implementations exist, chosen by transcript reach (ADR-0048): a transcript that
+  syncs across a person's peers uses the workspace loop (`createConversation`,
+  finished messages in a Yjs child doc); a deliberately device-local transcript
+  uses TanStack `createChat` (tab-manager, IndexedDB).
 - **Materializer**: a local, addressless worker that projects workspace data into
   another store (markdown, sqlite).
 - **`attach*` vs `create*`**: `attach*` are side-effectful primitives that register

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -16,6 +16,21 @@ shapes, see `docs/adr/`.
   plaintext.
 - **Trusted relay**: the server reads workspace plaintext. Zero-knowledge was
   evaluated and rejected; the encryption layer was removed (see `docs/adr/`).
+- **Node roles**: four distinct roles, separable even when one machine plays
+  several (ADR-0049): *client* runs the agent loop and binds the others;
+  *inference server* turns a prompt into tokens; *daemon* holds data and runs
+  dispatched tools but never infers; *relay/anchor* is content-blind coordination
+  and never infers.
+- **Inference server**: the only node role that infers (ADR-0049). One stateless
+  turn per request: given a prompt plus a tool catalog it streams tokens, returns
+  the model's tool calls, and stops, leaving the client loop to execute them
+  (ADR-0047). It sees the prompt and tools as accepted egress to the model
+  (ADR-0033), so it is *not* content-blind, unlike the relay, but it owns no loop,
+  tool, or transcript. The wire is OpenAI-compatible (ADR-0050), so the box is
+  swappable by base URL: Epicenter's metered gateway (house key, billed), a
+  self-hosted gateway (your key or a local model), or any third-party
+  OpenAI-compatible endpoint. A BYOK key is handed to an inference server, never
+  to a daemon.
 - **Deployable vs library**: one library, `packages/server`, consumed by two
   deployables: `apps/api` (hosted personal cloud) and `apps/self-host` (the
   community shared-wiki reference, not Epicenter-operated).
@@ -46,12 +61,13 @@ shapes, see `docs/adr/`.
   client tab or a daemon, set by the agent's **trust location** (ADR-0030/0043).
 - **Trust location**: where an agent's data and tools live, and therefore where
   its side effects run (ADR-0030, ADR-0047). The reasoning loop always runs in
-  the client over Epicenter's metered inference stream; what varies is the
+  the client, which drives an inference server (ADR-0049); what varies is the
   agent's capability. A **capability-free** agent (Vocab) has no tools. A
   **local-data** agent (Local Books) keeps its data and action handlers on the
   user's own always-on daemon, which the client loop reaches by dispatching
-  actions; data leaves the daemon only as a tool result. Epicenter meters tokens
-  but runs no answering worker. Blindness is per-agent, not global.
+  actions; data leaves the daemon only as a tool result. The relay is
+  content-blind; the inference server is a stateless turn that sees the prompt as
+  accepted egress (not content-blind). Trust is per-agent, not global.
 - **Conversation loop**: the client-side loop that answers every conversation,
   streams the live turn into a snapshot the UI renders, and persists finished
   messages as records (ADR-0047). It replaces the older doc-observing *answerer*

--- a/docs/adr/0048-a-conversations-loop-is-chosen-by-whether-its-transcript-syncs.md
+++ b/docs/adr/0048-a-conversations-loop-is-chosen-by-whether-its-transcript-syncs.md
@@ -1,0 +1,27 @@
+# 0048. A conversation's loop is chosen by whether its transcript syncs across peers
+
+- **Status:** Accepted
+- **Date:** 2026-06-21
+- **Relates:** [ADR-0047](0047-the-agent-loop-runs-in-the-client-and-tools-are-dispatched-actions.md) (the client loop and its LWW-records persistence), [ADR-0046](0046-a-capability-free-agent-persists-finished-messages-not-live-doc-streams.md) (the persisted-record shape both loops share), [ADR-0033](0033-a-conversation-has-one-transport-and-two-triggers.md) (the blind cloud that rules out a server tool loop)
+
+## Context
+
+The monorepo runs two agent chat loops, and a new chat surface has to pick one. The workspace loop (`createConversation`, `packages/workspace/src/agent/loop.ts`) runs the multi-step loop in the client, persists each finished message into a synced Yjs child doc keyed by id, and reaches tools by dispatching actions to peers (ADR-0047), so the loop never runs on a server. tab-manager runs a separate loop on TanStack's `createChat` over device-local IndexedDB, for plain-text streaming. Without a stated rule the split looks accidental, and the next surface either rebuilds one loop on the other's substrate or forks a third. The two are not redundant: they differ on whether the transcript is shared across a person's devices and whether tools must be orchestrated client-side against a blind cloud.
+
+## Decision
+
+**Choose the loop by transcript reach. A conversation whose transcript must sync across a person's peers, or that needs client-orchestrated tools against a blind cloud, uses the workspace client loop (`createConversation`); a conversation that is deliberately device-local and text-only uses TanStack `createChat`.**
+
+The workspace loop's render state is a snapshot: the persisted transcript re-read from the Yjs store plus the live in-memory turn, so a remote message that syncs in from another device merges on the next read. TanStack's `ChatClient` is not ruled out by message syncing as such, it can be driven from an external store (`setMessagesManually`, `onMessagesChange`). It is ruled out as our synced-conversation host by its tool loop, which runs on a `chat()` server that sees tool names, arguments, and results, where ADR-0033 keeps the cloud a blind token pipe. A synced, tool-capable conversation therefore cannot use it. When a transcript is meant to stay on one device and needs no client-orchestrated tools (tab-manager's per-browser history), `createChat` over IndexedDB is the lighter fit and carries no CRDT cost. Both loops persist the same finished-message record shape (ADR-0046), so a surface can move between them without reshaping its messages.
+
+## Consequences
+
+- A new chat surface has one question to answer, not an open design space: does this transcript follow the person across devices, or carry client tools? Either picks the workspace loop; a device-local, text-only surface picks `createChat`.
+- The two loops stay deliberately separate; neither is the "real" one to converge on. tab-manager keeps `createChat` rather than adopting the synced loop it does not need.
+- The shared record shape is load-bearing: it is what lets a device-local surface graduate to a synced one later without a migration of message bodies. Diverging the two part schemas would forfeit that and is a cost, not a convenience.
+- This says nothing about where reasoning runs or where tools live; ADR-0047 owns that. This is only about transcript persistence and reach.
+
+## Considered alternatives
+
+- **Adopt TanStack `ChatClient` for both loops (its client tools, `needsApproval`, and external-store sync).** Rejected: `ChatClient`'s client-tool flow runs the agent loop on a `chat()` server, which emits `tool-input-available` to the browser and receives the tool result back, so the server sees every tool and its data. That reverses ADR-0033's blind cloud and re-creates the server answering vertical ADR-0047 deleted. `ChatClient` can still front the blind cloud for plain-text streaming, which is exactly what tab-manager uses.
+- **Converge tab-manager onto the workspace loop.** Rejected: a device-local, text-only history needs neither a synced Yjs child doc nor dispatched tools, and `createChat` carries no CRDT cost. The shared record shape leaves the door open if that changes.

--- a/docs/adr/0049-inference-is-its-own-box-the-daemon-never-infers.md
+++ b/docs/adr/0049-inference-is-its-own-box-the-daemon-never-infers.md
@@ -1,0 +1,34 @@
+# 0049. Inference is its own box; the daemon never infers; the client loop talks to a swappable inference server
+
+- **Status:** Proposed
+- **Date:** 2026-06-21
+- **Supersedes:** [ADR-0038](0038-a-daemon-answers-through-the-first-inference-backend-it-can-satisfy.md) (the daemon no longer resolves a `ChatStream` or answers; inference leaves the daemon entirely)
+- **Relates:** [ADR-0047](0047-the-agent-loop-runs-in-the-client-and-tools-are-dispatched-actions.md) (the client owns the loop; the daemon provides data as dispatched actions), [ADR-0033](0033-a-conversation-has-one-transport-and-two-triggers.md) (the metered inference stream this names a box), [ADR-0021](0021-actions-are-the-only-surface-that-crosses-a-process-boundary.md) (tools are dispatched actions), [ADR-0030](0030-agents-are-immutable-capability-bundles.md) (an agent's model and tools), [ADR-0035](0035-durable-storage-is-one-per-person-coordination-box.md) (the relay stays content-blind), [ADR-0050](0050-the-inference-contract-is-openai-compatible.md) (the wire this box speaks)
+
+## Context
+
+ADR-0047 put the agent loop in the client and made the daemon a data-and-tools provider that "never runs inference." But [ADR-0038](0038-a-daemon-answers-through-the-first-inference-backend-it-can-satisfy.md) still has the daemon resolve a `ChatStream` (`byok ?? metered ?? null`) and answer, and the code still carries that arm: `chatStreamFromAdapter` in `packages/ai-adapters/src/index.ts` and the daemon's `resolveChatStream`. Both live consumers already answer through the metered client path instead (`packages/client/src/epicenter-provider.ts`, used by `apps/vocab/epicenter-engine.ts` and opensidian), so the daemon-inference arm is a pre-0047 leftover that contradicts the merged decision. Separately, "blind cloud" became overloaded: the **relay** (ADR-0035) is genuinely content-blind, but the **metered inference stream** (ADR-0033) forwards the prompt and tool definitions to the provider (`epicenter-provider.ts:190-195`) and is not content-blind at all. The two are different things wearing one word.
+
+## Decision
+
+**Inference is its own node role, an *inference server*: a box whose only job is to turn a prompt plus a tool catalog into a token stream. It is the only role that infers. The daemon never infers; it holds data and runs dispatched actions ([ADR-0021](0021-actions-are-the-only-surface-that-crosses-a-process-boundary.md)). The client agent loop ([ADR-0047](0047-the-agent-loop-runs-in-the-client-and-tools-are-dispatched-actions.md)) talks to one inference server, chosen by configuration, and is the swap point.**
+
+- **Four roles, each doing one thing.** *Client* runs the loop and binds the others. *Inference server* turns messages+tools into tokens (one stateless turn per request; it returns the model's tool calls and stops, the client executes them). *Daemon* holds data and runs actions; never infers. *Relay/anchor* is content-blind coordination ([ADR-0035](0035-durable-storage-is-one-per-person-coordination-box.md)); never infers. One physical machine may play several roles, but the roles are distinct.
+- **The inference server is swappable by configuration**, not a compile-time import. The loop's `AgentEngine` (`packages/workspace/src/agent/loop.ts`) is already a client of a single inference contract; pointing it at a different base URL points it at a different inference server. Epicenter hosts a metered one; a user can self-host one (their key, or a local model); a user can point at a third-party one.
+- **"BYOK" is a key handed to an inference server, never to a daemon.** A BYOK key lives on the box that infers (Epicenter's gateway when passed through, or a self-hosted/local server), used for that request and unmetered. The daemon never holds a provider key for inference.
+- **"Blind" is retired as a single word.** The relay is *content-blind*. The inference server is a *stateless inference turn*: it sees the prompt and tools as accepted egress to the model ([ADR-0033](0033-a-conversation-has-one-transport-and-two-triggers.md), [ADR-0047](0047-the-agent-loop-runs-in-the-client-and-tools-are-dispatched-actions.md)'s "the data leaves only as a tool result"), but owns no loop, executes no tool, and keeps no transcript.
+
+What carries forward from ADR-0038: the three inference *flavors* (metered house key, BYOK key, local model) survive, but as flavors of an **inference server**, not as a daemon's `??` chain. The "no placeholder" and "spending credits is a deliberate opt-in" principles survive as properties of the metered inference server.
+
+## Consequences
+
+- The daemon-inference arm is deleted: `chatStreamFromAdapter`, the daemon `resolveChatStream`/answerer, and the daemon-BYOK concept go. The metered client path (`epicenter-provider.ts`) and the server route (`packages/server/src/routes/ai.ts`) stay as the inference server's two halves.
+- Self-hosting and local models become first-class: any box that speaks the inference contract is an inference server, so "run my own" and "point at Ollama" are configuration, not new code (see [ADR-0050](0050-the-inference-contract-is-openai-compatible.md)).
+- This reaffirms ADR-0047's foreclosure of an agent that reasons with no client open: if a scheduled or autonomous agent becomes a real need, it reopens a *server-run loop* explicitly; it does not reopen daemon inference.
+- The vocabulary is honest: a future reader cannot mistake the metered stream for content-blind, because the box is named for what it does (a stateless inference turn), not for a privacy property it does not have.
+
+## Considered alternatives
+
+- **Keep ADR-0038's daemon `ChatStream` chain.** Rejected: it contradicts ADR-0047 ("the daemon never runs inference") and conflates a data box with an inference box. The arm is already unused by both live consumers.
+- **Fold inference into the daemon for self-hosting (BYOK on the daemon).** Rejected: it puts a provider key and an inference runtime on the data box, re-tangling two roles. A self-hosted *inference server* is the clean home for a self-hosted key or local model; the daemon stays data-only.
+- **Keep one word, "blind cloud," as an umbrella.** Rejected: it is the exact trap that misled this design pass (a prior session, an external review, and a draft ADR all assumed the inference path was content-blind). Naming each property kills the trap.

--- a/docs/adr/0050-the-inference-contract-is-openai-compatible.md
+++ b/docs/adr/0050-the-inference-contract-is-openai-compatible.md
@@ -1,0 +1,36 @@
+# 0050. The inference contract is OpenAI-compatible Chat Completions; Epicenter's backend is one swappable gateway
+
+- **Status:** Proposed
+- **Date:** 2026-06-21
+- **Supersedes:** [ADR-0037](0037-adapter-construction-is-a-shared-leaf-package-keyed-on-the-model-catalog.md) (the SDK-adapter leaf is no longer the inference seam; the wire is OpenAI-compatible, not AG-UI via a TanStack adapter)
+- **Relates:** [ADR-0049](0049-inference-is-its-own-box-the-daemon-never-infers.md) (the inference-server box this contract defines), [ADR-0033](0033-a-conversation-has-one-transport-and-two-triggers.md) (refines its inference transport), [ADR-0047](0047-the-agent-loop-runs-in-the-client-and-tools-are-dispatched-actions.md) (the client loop that consumes one model turn), [ADR-0044](0044-tool-approval-is-a-per-conversation-policy.md) (approval stays client-side, unaffected by the wire)
+
+## Context
+
+The inference server ([ADR-0049](0049-inference-is-its-own-box-the-daemon-never-infers.md)) needs one wire. Today it is bespoke: the client engine (`packages/client/src/epicenter-provider.ts`) hand-parses an AG-UI `StreamChunk` SSE stream that the server produces with TanStack AI's `chat()` and `toServerSentEventsResponse()` (`packages/server/src/routes/ai.ts:147-155`), and provider normalization lives in TanStack adapters keyed on the model catalog ([ADR-0037](0037-adapter-construction-is-a-shared-leaf-package-keyed-on-the-model-catalog.md), `packages/ai-adapters/src/index.ts`). That contract is Epicenter's alone, so swapping the backend means writing an adapter for every alternative. The product goal is the opposite: the backend should swap from Epicenter to a self-hosted box or any third party with ease ([ADR-0049](0049-inference-is-its-own-box-the-daemon-never-infers.md)). The provider needs are narrow (OpenAI and Gemini, both with OpenAI-compatible endpoints) and the feature ceiling is text plus tool calls; reasoning traces, prompt caching, and citations are explicitly deferred. For a local-first product, the OpenAI Chat Completions API is the de-facto contract every local runner (Ollama, llama.cpp, LM Studio, vLLM) and aggregator (OpenRouter) already speaks.
+
+## Decision
+
+**The inference contract is the OpenAI-compatible Chat Completions API (`POST /v1/chat/completions`, streamed). Epicenter's backend becomes one OpenAI-compatible gateway among many interchangeable inference servers, and the client agent loop's engine is a provider-agnostic OpenAI-compatible client swapped by base URL. TanStack AI is dropped from the inference path.**
+
+- **One contract, end to end.** Client → inference server speaks Chat Completions; the server's tool-call-and-stop behavior (`finish_reason: "tool_calls"`) *is* the "return the calls, the client executes" model ([ADR-0047](0047-the-agent-loop-runs-in-the-client-and-tools-are-dispatched-actions.md)) with no adaptation. The server never executes a tool.
+- **The client engine parses OpenAI SSE deltas** (text deltas plus index-correlated `tool_call` deltas) into the loop's own small chunk type. The loop (`packages/workspace/src/agent/loop.ts`) and message record (`packages/workspace/src/agent/message.ts`) drop their `@tanstack/ai` types (`EventType`, `StreamChunk`, `ModelMessage`, `ToolCall`) for a local equivalent, decoupling the loop from any SDK.
+- **Epicenter's gateway owns provider normalization, invisibly.** OpenAI is passthrough; Gemini is reached through its OpenAI-compatible endpoint or a thin server-side translator. With two providers that both have OpenAI-compatible paths, this needs no third-party gateway (LiteLLM/OpenRouter) and no TanStack adapter; the gateway adds auth, credit metering (from the `usage` field), house-key injection, and BYOK passthrough ([ADR-0049](0049-inference-is-its-own-box-the-daemon-never-infers.md)).
+- **The base URL is the swap point.** Default is Epicenter's gateway; a user may point the engine at a self-hosted gateway, a local Ollama/vLLM, or OpenRouter. No per-backend code.
+- **Future feature openness rides an extension slot.** When reasoning traces, prompt caching, or citations matter, they ride a `provider_specific_fields`-style extension (the same escape hatch LiteLLM uses), not a contract change.
+
+## Consequences
+
+- `@tanstack/ai` leaves the inference path on both ends; the AG-UI `StreamChunk` parser and the server's `chat()` usage are deleted, and the SDK-adapter leaf of [ADR-0037](0037-adapter-construction-is-a-shared-leaf-package-keyed-on-the-model-catalog.md) dissolves (the model-catalog/provider-routing fact, if still needed, lives in the gateway).
+- Swapping inference backends is configuration, delivering [ADR-0049](0049-inference-is-its-own-box-the-daemon-never-infers.md)'s swappability for free; self-hosting and local models are first-class.
+- We own the OpenAI-SSE tool-call reducer on the client (index-correlated delta accumulation). This is a maintenance cost, but against a stable, ubiquitous format with many reference implementations, not a bespoke one.
+- The contract is lowest-common-denominator: provider-specific behavior leaks. Streamed tool calls are **not** uniform across providers (Anthropic accumulates partial-JSON arg deltas; Gemini embeds thought signatures in tool-call IDs; index correlation varies), so any non-OpenAI-native provider must be normalized at the gateway. This is contained to Epicenter's gateway; the client stays pure. **Open risk to spike before committing Gemini: verify Google's OpenAI-compatible endpoint streams tool calls faithfully, or have the gateway own a thin Gemini→OpenAI translator.**
+- App-level errors are encoded in the OpenAI error shape: `InsufficientCredits` as HTTP 402 with an `error.code`, `Unauthorized` as 401; a mid-stream failure as an error chunk. This is thinner than the typed AG-UI `RUN_ERROR.code` it replaces, so the gateway defines a small, documented error convention.
+- tab-manager's separate TanStack `createChat` loop ([ADR-0048](0048-a-conversations-loop-is-chosen-by-whether-its-transcript-syncs.md)) is device-local and out of scope; it may converge on this engine later but is not forced to.
+
+## Considered alternatives
+
+- **Keep the bespoke AG-UI contract + TanStack adapters ([ADR-0037](0037-adapter-construction-is-a-shared-leaf-package-keyed-on-the-model-catalog.md)).** Rejected: swapping backends then needs a per-backend adapter, defeating the product goal; and TanStack's value (provider normalization) is small here, only two providers, both OpenAI-compatible.
+- **Adopt a third-party gateway (LiteLLM / OpenRouter) as the normalizer now.** Deferred, not rejected: unnecessary for two OpenAI-compatible providers, but the contract makes either a drop-in upstream if the provider set grows exotic.
+- **Point the client directly at raw provider APIs (no gateway).** Rejected for the hosted path: it forfeits metering, auth, and house-key custody. It remains available as the self-hosted/local case precisely because the contract is OpenAI-compatible.
+- **Keep TanStack only on the server to normalize providers, OpenAI-compatible only to the client.** Rejected: it keeps the SDK dependency and a translation layer for a job two compat endpoints already do; the gateway's thin normalization is simpler.

--- a/packages/workspace/src/agent/loop.test.ts
+++ b/packages/workspace/src/agent/loop.test.ts
@@ -3,7 +3,11 @@ import { EventType, type StreamChunk } from '@tanstack/ai';
 import * as Y from 'yjs';
 import { attachKvStore } from '../document/attach-kv-store.js';
 import { type AgentEngine, createConversation } from './loop.js';
-import { type AgentMessage, agentMessageText } from './message.js';
+import {
+	type AgentMessage,
+	agentMessageText,
+	isPersistableMessage,
+} from './message.js';
 import {
 	type AgentToolCall,
 	type Approval,
@@ -233,5 +237,63 @@ describe('createConversation', () => {
 		const messages = handle.snapshot().messages;
 		expect(messages.map((m) => m.role)).toEqual(['user']);
 		expect(handle.snapshot().isGenerating).toBe(false);
+	});
+
+	// Guards the snapshot/persistence coupling: the live render filter and the
+	// persistence filter must use one predicate, or a message could render
+	// mid-turn and then vanish on a clean finish. See `snapshot` in loop.ts.
+	test('every assistant message that renders live also persists', async () => {
+		const store = makeStore();
+		const engine: AgentEngine = () =>
+			streamOf([
+				chunk({
+					type: EventType.TEXT_MESSAGE_CONTENT,
+					delta: 'streamed',
+					messageId: 'a',
+				}),
+				chunk({ type: EventType.RUN_FINISHED, finishReason: 'stop' }),
+			]);
+
+		const handle = createConversation({
+			store,
+			engine,
+			generateId: idMinter(),
+		});
+
+		// Record every assistant id that ever appears in a live snapshot.
+		const renderedLive = new Set<string>();
+		const unsubscribe = handle.subscribe(() => {
+			if (!handle.snapshot().isGenerating) return;
+			for (const message of handle.snapshot().messages) {
+				if (message.role === 'assistant') renderedLive.add(message.id);
+			}
+		});
+
+		handle.send('hi');
+		await settle(handle);
+		unsubscribe();
+
+		const persisted = new Set(
+			[...store.entries()]
+				.map((entry) => entry.val)
+				.filter((message) => message.role === 'assistant')
+				.map((message) => message.id),
+		);
+		expect([...renderedLive].sort()).toEqual([...persisted].sort());
+		expect(persisted.size).toBe(1);
+	});
+
+	// The discriminator the shared predicate closes: a message can hold parts yet
+	// not be persistable (an empty text part). `parts.length > 0` would render it
+	// live; `isPersistableMessage` (used by both filters) drops it consistently.
+	test('a parts-bearing but empty message is not persistable', () => {
+		const message: AgentMessage = {
+			id: 'm1',
+			role: 'assistant',
+			createdAt: 0,
+			parts: [{ type: 'text', text: '' }],
+		};
+		expect(message.parts.length).toBeGreaterThan(0);
+		expect(isPersistableMessage(message)).toBe(false);
 	});
 });

--- a/packages/workspace/src/agent/loop.ts
+++ b/packages/workspace/src/agent/loop.ts
@@ -122,7 +122,12 @@ export function createConversation(
 		for (const listener of listeners) listener();
 	}
 
-	/** The durable transcript, chronologically ordered. */
+	/**
+	 * The durable transcript, chronologically ordered. It is a flat, linear list
+	 * by design: branching and edit history are a product tier built above the
+	 * loop, not a missing primitive (ADR-0047 considered and deferred them, as
+	 * TanStack's own flat `UIMessage[]` does). Deferred indefinitely.
+	 */
 	function readAll(): AgentMessage[] {
 		return [...store.entries()]
 			.map((entry) => entry.val)
@@ -142,7 +147,14 @@ export function createConversation(
 	let controller: AbortController | null = null;
 
 	function snapshot(): ConversationSnapshot {
-		const live = (turn ?? []).filter((message) => message.parts.length > 0);
+		// One predicate decides both what renders live and what persists: a
+		// message the UI shows mid-turn is exactly a message a clean finish
+		// keeps. They must not drift, or a message would render then vanish on
+		// finish. `parts.length > 0` happens to agree today only because
+		// `appendText` never opens an empty text part; a future non-persistable
+		// part type (a reasoning marker, say) would break that. Sharing
+		// `isPersistableMessage` keeps the two in lockstep by construction.
+		const live = (turn ?? []).filter(isPersistableMessage);
 		return {
 			messages: live.length > 0 ? [...persisted, ...live] : persisted,
 			isThinking: turn !== null && live.length === 0,

--- a/packages/workspace/src/agent/message.ts
+++ b/packages/workspace/src/agent/message.ts
@@ -9,6 +9,11 @@
  * tool-result parts. The shapes mirror TanStack AI's message parts but stay a
  * plain, JSON-stable record (no streaming state, no Yjs), so a finished message
  * round-trips through the LWW store unchanged.
+ *
+ * The id is globally unique, so each key is written exactly once and the LWW
+ * store's conflict resolution never fires. We use the store for its by-id,
+ * idempotent writes and to share one substrate with the table layer, not for
+ * its last-write-wins semantics.
  */
 import type { ModelMessage, ToolCall } from '@tanstack/ai';
 import type { JsonValue } from 'wellcrafted/json';

--- a/specs/20260621T180000-inference-server-openai-compatible-collapse.md
+++ b/specs/20260621T180000-inference-server-openai-compatible-collapse.md
@@ -1,0 +1,97 @@
+# Inference server + OpenAI-compatible contract collapse
+
+- **Status:** Draft
+- **Date:** 2026-06-21
+- **Decisions:** [ADR-0049](../docs/adr/0049-inference-is-its-own-box-the-daemon-never-infers.md) (inference is its own box; the daemon never infers; the client loop talks to a swappable inference server), [ADR-0050](../docs/adr/0050-the-inference-contract-is-openai-compatible.md) (the inference contract is OpenAI-compatible Chat Completions; Epicenter's backend is one swappable gateway)
+- **Builds on:** [ADR-0047](../docs/adr/0047-the-agent-loop-runs-in-the-client-and-tools-are-dispatched-actions.md) (client loop, dispatched tools), [ADR-0048](../docs/adr/0048-a-conversations-loop-is-chosen-by-whether-its-transcript-syncs.md) (two-loop boundary)
+- **Supersedes on landing:** [ADR-0037](../docs/adr/0037-adapter-construction-is-a-shared-leaf-package-keyed-on-the-model-catalog.md), [ADR-0038](../docs/adr/0038-a-daemon-answers-through-the-first-inference-backend-it-can-satisfy.md)
+
+This is in-flight scaffolding. When the work lands: flip ADR-0049/0050 to `Accepted`, add reciprocal `Superseded by` headers to ADR-0037/0038, and delete this spec.
+
+## Goal
+
+Make inference a single, swappable box that speaks the OpenAI-compatible Chat Completions API, and remove the daemon-side inference arm. The client agent loop drives one inference server chosen by base URL: Epicenter's metered gateway, a self-hosted gateway, or any third-party OpenAI-compatible endpoint (Ollama, vLLM, OpenRouter). The daemon holds data and runs dispatched tools only; it never infers.
+
+The product driver is swappability: changing the inference backend should be configuration (`baseURL` + auth), not per-backend adapter code. That is free under an OpenAI-compatible contract and expensive under the current bespoke AG-UI contract.
+
+## Current state (what exists today)
+
+- **Client engine** (`packages/client/src/epicenter-provider.ts`): `createEpicenterAgentEngine` posts to `/api/ai/chat`, hand-parses an AG-UI `StreamChunk` SSE stream, forwards tool definitions (`:190-195`).
+- **Consumers:** `apps/vocab/epicenter-engine.ts` and opensidian's chat-state both use this metered engine. Both live consumers already answer through the server (no daemon inference).
+- **Server route** (`packages/server/src/routes/ai.ts:147-155`): runs TanStack `chat({ adapter, messages, tools })` + `toServerSentEventsResponse()`. Tools have no server `execute`, so `chat()` emits the tool calls and stops; the client loop executes them.
+- **Provider normalization** (`packages/ai-adapters/src/index.ts`): `createAdapterForModel` (TanStack openai/gemini adapters), `chatStreamFromAdapter` (the daemon BYOK arm, ADR-0038).
+- **Loop:** `packages/workspace/src/agent/loop.ts` + `message.ts` import `@tanstack/ai` types (`EventType`, `StreamChunk`, `ModelMessage`, `ToolCall`).
+- **Dead-on-paper:** the daemon inference arm (`chatStreamFromAdapter`, the daemon `resolveChatStream`) contradicts ADR-0047 and is unused by both live consumers.
+
+## Target state
+
+```
+CLIENT loop ──(OpenAI /v1/chat/completions, configurable baseURL + auth)──▶ inference server
+  parses OpenAI SSE deltas into its own small chunk type                    Epicenter gateway (auth + meter + BYOK passthrough; OpenAI passthru, Gemini normalized)
+  executes tool_calls -> local action or dispatched to a daemon             self-hosted gateway (your key or local model, unmetered)
+  no @tanstack/ai                                                           Ollama / vLLM / OpenRouter
+```
+
+Privacy gradient the box model gives users: **metered** (house key, Epicenter pays), then **BYOK-passthrough** (your key via Epicenter, unmetered, key seen in transit only), then **self-hosted/local** (key never touches Epicenter).
+
+## The contract
+
+OpenAI-compatible Chat Completions, streamed:
+- Request: `POST /v1/chat/completions` with `{ model, messages, tools?, stream: true, stream_options: { include_usage: true } }`.
+- Stream of `chat.completion.chunk` SSE: `choices[].delta.content` (text) and `choices[].delta.tool_calls[]` (index-correlated; `id`, `function.name`, `function.arguments` deltas). Terminal `finish_reason` of `tool_calls`, `stop`, etc. A final usage-bearing chunk when `include_usage` is set.
+- The server returns tool calls and stops; it never executes a tool.
+
+## Waves
+
+### Wave 0: decisions as docs (this PR)
+- ADR-0049, ADR-0050 (`Proposed`), CONTEXT glossary (Node roles, Inference server). Done in this branch.
+
+### Wave 1: Gemini-over-OpenAI-compatible spike (GATE)
+Verify Google's OpenAI-compatible endpoint (`/v1beta/openai/`) streams **tool calls** faithfully: index correlation, partial-argument accumulation, and that Gemini's thought-signature-in-tool-call-id behavior does not corrupt the OpenAI shape. Throwaway spike.
+- If faithful: gateway does passthrough to Google's compat endpoint.
+- If not: the gateway owns a thin Gemini-native to OpenAI-compatible stream translator (server-side; client unaffected).
+- Blocks committing Gemini only; OpenAI works regardless.
+
+### Wave 2: client OpenAI-compatible engine
+- New `AgentEngine` that speaks `/v1/chat/completions` SSE: build the request (messages to OpenAI messages incl. system role from `systemPrompts`; tools to OpenAI `tools`), parse text + index-correlated `tool_call` deltas, map `finish_reason`.
+- Define a small internal chunk/event type in `packages/workspace/src/agent` to replace `@tanstack/ai`'s `EventType`/`StreamChunk`/`ModelMessage`/`ToolCall` in `loop.ts` and `message.ts`. The loop's `runStep` reducer keeps its shape; only the event vocabulary becomes local.
+- Engine takes a configurable `baseURL` + auth header. Default points at the Epicenter gateway.
+- Coexist with the current AG-UI engine behind config until Wave 5.
+
+### Wave 3: Epicenter OpenAI-compatible gateway
+- `/v1/chat/completions` route: bearer auth, then credit check (Autumn) + house-key injection, OR **BYOK passthrough** (user key in `Authorization`, skip metering), then upstream OpenAI (passthrough) / Gemini (compat or translator per Wave 1), stream back, meter from `usage`.
+- App-error convention in OpenAI shape: `InsufficientCredits` as HTTP 402 + `error.code`; `Unauthorized` as 401; a mid-stream failure as an error chunk. Document it.
+- Billing stays hosted-only (`apps/api/worker/billing/`); the route lives in `packages/server` so a self-hosted deployable can mount it without billing.
+
+### Wave 4: swap config + self-host
+- Expose "inference server URL + auth" as client config (default Epicenter gateway; allow Ollama/OpenRouter/self-hosted URL).
+- Self-hostable gateway deployable = the gateway route minus billing (a thin wrapper over the `packages/server` AI sub-app).
+
+### Wave 5: delete the old path
+- Remove the AG-UI `createEpicenterAgentEngine` + its SSE-frame parser, the server's TanStack `chat()` usage, the daemon inference arm (`chatStreamFromAdapter`, daemon `resolveChatStream`), and `@tanstack/ai` from `packages/workspace` + `packages/client` + the `ai-adapters` inference path.
+- Flip ADR-0049/0050 to `Accepted`; add `Superseded by` to ADR-0037/0038; delete this spec.
+
+## Out of scope (do not touch)
+
+- **tab-manager** keeps its `@tanstack/ai-svelte` / `@tanstack/ai-client` device-local loop (ADR-0048). Do not remove its TanStack deps. It may converge on the new engine later, but is not forced to.
+- Advanced features (reasoning traces, prompt caching, citations). They ride a `provider_specific_fields`-style extension slot when needed; not now.
+- A third-party gateway (LiteLLM/OpenRouter) as the normalizer. Unnecessary for two OpenAI-compatible providers; the contract makes either a drop-in upstream later.
+
+## Open questions
+
+1. **Gemini streamed tool-call fidelity** (Wave 1 gate): passthrough vs thin translator.
+2. **Self-hosted gateway packaging**: a new `apps/inference-server` deployable, or a documented standalone mount of the `packages/server` AI sub-app? Decide in Wave 4.
+3. **Loop chunk type**: exact shape of the internal event type replacing `@tanstack/ai`'s; keep it minimal (text-delta, tool-call-start/args/end, run-error, run-finished).
+
+## Done criteria
+
+- The client loop drives inference over the OpenAI-compatible contract; `@tanstack/ai` is gone from the workspace + client inference path.
+- Changing the inference backend is configuration only (proven by pointing at a local Ollama).
+- The daemon runs no inference; `chatStreamFromAdapter` and the daemon answerer are deleted.
+- Metering still works (usage-based) on the Epicenter gateway; BYOK passthrough skips metering.
+- Build green; doc-hygiene clean; ADRs flipped and spec deleted.
+
+## Sequencing vs other work
+
+- **PR #2157** (agent-loop predicate fix + ADR-0048 + CONTEXT reconcile) lands first; this branch stacks on it because the CONTEXT edits build on #2157's reconcile. After #2157 merges, rebase this onto `main`.
+- Wave 1 (Gemini spike) is the first execution step and gates Gemini only.


### PR DESCRIPTION
This records the agent-loop boundary that exists today, then proposes the next inference boundary.

First, the workspace agent loop now uses the same predicate for live rendering and persistence. The old live snapshot used `parts.length > 0`, while persistence used `isPersistableMessage`; those agree today only because text parts are never opened empty. Routing both through `isPersistableMessage` keeps a future non-persistable part from rendering mid-turn and disappearing after a clean finish.

ADR-0048 records the current two-loop rule: synced transcripts and client-orchestrated tools use the workspace client loop, while device-local text-only chat can use TanStack `createChat`. CONTEXT.md now names the client conversation loop as the answering owner and removes the obsolete doc-observing Answerer vocabulary.

## Proposed Inference Boundary

ADR-0049 proposes inference as its own node role. The daemon keeps data and dispatched tools; it does not infer. The old word "blind" was carrying two meanings, so the docs now separate the content-blind relay from the inference server, which sees an accepted prompt for one stateless turn.

ADR-0050 proposes the OpenAI-compatible Chat Completions API as the inference contract. Epicenter's hosted backend becomes one swappable gateway, and the same contract can point at self-hosted deployments or third-party compatible backends without per-backend adapter code.

The spec records the wave-by-wave build plan that would move from the current AG-UI path to the proposed OpenAI-compatible box, with a Gemini compatibility spike as the gate before implementation.
