### PR TITLE
feat(local-books): production OAuth via HTTPS-tunnel redirect

### DIFF
--- a/apps/local-books/README.md
+++ b/apps/local-books/README.md
@@ -14,22 +14,70 @@ local-books status                            # token state + per-entity cursor,
 
 ## Setup
 
-You need an Intuit developer app (https://developer.intuit.com → your app → Keys & credentials). Use the **sandbox / development** keys to mirror a sandbox company. Register `http://localhost:8765/callback` as a redirect URI on the app.
+You need an Intuit developer app (https://developer.intuit.com → your app → Keys & credentials) with `http://localhost:8765/callback` registered as a redirect URI. Intuit issues two key sets, and they are not interchangeable:
 
-Provide the keys by environment:
+- **Development keys** connect sandbox companies only. Use them with `--env sandbox` (the default).
+- **Production keys** connect your real company. Use them with `--env production`. Intuit only issues these once the app has passed their production go-live assessment.
+
+Provide the keys as `QB_CLIENT_ID` / `QB_CLIENT_SECRET`:
 
 ```sh
 export QB_CLIENT_ID=...
 export QB_CLIENT_SECRET=...
 ```
 
-In this monorepo the keys live in Infisical at `/apps/local-books`, so prefix any command:
+In this monorepo the keys live in Infisical at `/apps/local-books`, split by Infisical environment: the `dev` environment holds the development keys, the `prod` environment holds the production keys. Pick the Infisical environment that matches the QuickBooks deployment you are targeting.
+
+### Mirror a sandbox company
 
 ```sh
 infisical run --path=/apps/local-books -- bun run src/bin.ts auth
 infisical run --path=/apps/local-books -- bun run src/bin.ts sync --entity Invoice --full
 infisical run --path=/apps/local-books -- bun run src/bin.ts status
 ```
+
+### Mirror your real company
+
+Two different `--env` flags are in play, and they are easy to confuse:
+
+- `infisical run --env=prod` selects the Infisical environment, which decides which key set is injected.
+- `bun run src/bin.ts ... --env production` selects the QuickBooks deployment, which decides which Intuit API the CLI calls.
+
+Both must say production, on every command. `auth` captures the `realmId` from the OAuth callback, so you never pass `--realm`; you just log into the real company in the browser.
+
+```sh
+infisical run --env=prod --path=/apps/local-books -- bun run src/bin.ts auth --env production
+infisical run --env=prod --path=/apps/local-books -- bun run src/bin.ts sync --env production --entity Invoice --full
+infisical run --env=prod --path=/apps/local-books -- bun run src/bin.ts status --env production
+```
+
+Those three invocations are wrapped as `:remote` scripts so you do not have to assemble the double-`--env` dance by hand (extra flags pass through to the end):
+
+```sh
+bun run auth:remote
+bun run sync:remote --entity Invoice --full
+bun run status:remote
+```
+
+#### Production needs an HTTPS tunnel for the one-time `auth`
+
+Intuit production rejects `http://localhost` redirect URIs (only Development accepts them), so the interactive `auth` hop needs a public HTTPS URL. This is only for `auth`: once tokens are in the keyring, every `sync` refreshes them and never touches the redirect URI again.
+
+1. Start a tunnel to the local callback port (`cloudflared` needs no account):
+   ```sh
+   cloudflared tunnel --url http://localhost:8765
+   ```
+   Copy the `https://<name>.trycloudflare.com` URL it prints.
+2. On the Intuit app's **Production** Redirect URIs, add exactly `https://<name>.trycloudflare.com/callback`.
+3. Run `auth` with the tunnel as the public redirect, pointing the local listener back at 8765:
+   ```sh
+   LOCAL_BOOKS_QB_REDIRECT_URI=https://<name>.trycloudflare.com/callback \
+   LOCAL_BOOKS_CALLBACK_PORT=8765 \
+     bun run auth:remote
+   ```
+   `LOCAL_BOOKS_CALLBACK_PORT` decouples the local listener from the portless tunnel host. After tokens land in the keyring, stop the tunnel; `sync:remote` and `status:remote` need nothing further.
+
+To avoid repeating `--env production` outside the scripts, set `LOCAL_BOOKS_QB_ENV=production` once, or write `{ "environment": "production" }` into `<data-dir>/config.json`.
 
 ## Where things live
 

--- a/apps/local-books/package.json
+++ b/apps/local-books/package.json
@@ -17,6 +17,9 @@
 	},
 	"scripts": {
 		"local-books": "bun run src/bin.ts",
+		"auth:remote": "infisical run --env=prod --path=/apps/local-books -- bun run src/bin.ts auth --env production",
+		"sync:remote": "infisical run --env=prod --path=/apps/local-books -- bun run src/bin.ts sync --env production",
+		"status:remote": "infisical run --env=prod --path=/apps/local-books -- bun run src/bin.ts status --env production",
 		"test": "bun test",
 		"typecheck": "tsc --noEmit",
 		"build:binary": "bun build --compile --outfile dist/local-books src/bin.ts"

--- a/apps/local-books/src/config.ts
+++ b/apps/local-books/src/config.ts
@@ -39,6 +39,12 @@ export type AppConfig = {
 	pageSize: number;
 	keyringFile: string | null;
 	realmOverride: string | null;
+	/**
+	 * Port the localhost OAuth callback server binds to. Defaults to the port in
+	 * `redirectUri`. Set it when `redirectUri` is a public HTTPS tunnel (no port),
+	 * as Intuit production requires: the tunnel forwards to this local port.
+	 */
+	callbackPort: number | null;
 };
 
 export type CliConfigOverrides = {
@@ -70,6 +76,7 @@ const ConfigFileSchema = Type.Object({
 	cdcSafeWindowDays: Type.Optional(Type.Number({ exclusiveMinimum: 0 })),
 	fullBackstopDays: Type.Optional(Type.Number({ exclusiveMinimum: 0 })),
 	pageSize: Type.Optional(Type.Number({ exclusiveMinimum: 0 })),
+	callbackPort: Type.Optional(Type.Number({ exclusiveMinimum: 0 })),
 });
 type ConfigFile = Static<typeof ConfigFileSchema>;
 
@@ -108,6 +115,7 @@ function resolveEntities(file: ConfigFile): string[] {
 export function loadConfig(overrides: CliConfigOverrides = {}): AppConfig {
 	const dataDir = resolveDataDir(overrides.dataDir);
 	const file = readConfigFile(dataDir);
+	const callbackPortEnv = env('LOCAL_BOOKS_CALLBACK_PORT');
 
 	const environment: QbEnvironment =
 		overrides.environment ??
@@ -140,5 +148,8 @@ export function loadConfig(overrides: CliConfigOverrides = {}): AppConfig {
 		pageSize: Math.min(file.pageSize ?? 1000, 1000),
 		keyringFile: env('LOCAL_BOOKS_KEYRING_FILE') ?? null,
 		realmOverride: overrides.realm ?? env('LOCAL_BOOKS_QB_REALM') ?? null,
+		callbackPort: callbackPortEnv
+			? Number(callbackPortEnv)
+			: (file.callbackPort ?? null),
 	};
 }

--- a/apps/local-books/src/oauth.ts
+++ b/apps/local-books/src/oauth.ts
@@ -220,7 +220,10 @@ export async function runAuthorizationFlow(
 	const codeVerifier = oauth.generateRandomCodeVerifier();
 	const codeChallenge = await oauth.calculatePKCECodeChallenge(codeVerifier);
 	const redirect = new URL(config.redirectUri);
-	const port = Number(redirect.port || '80');
+	// The public redirect host and the local listen port are decoupled: a public
+	// HTTPS tunnel (Intuit production requires one, since it rejects localhost)
+	// forwards to `callbackPort` here, which has no port of its own in the URL.
+	const port = config.callbackPort ?? Number(redirect.port || '80');
 	const timeoutMs = deps.timeoutMs ?? 5 * 60 * 1000;
 	const log = deps.log ?? (() => {});
 

--- a/apps/local-books/test/helpers.ts
+++ b/apps/local-books/test/helpers.ts
@@ -22,6 +22,7 @@ export function makeConfig(over: Partial<AppConfig> = {}): AppConfig {
 		pageSize: 1000,
 		keyringFile: null,
 		realmOverride: null,
+		callbackPort: null,
 		...over,
 	};
 }

--- a/apps/local-books/test/oauth.test.ts
+++ b/apps/local-books/test/oauth.test.ts
@@ -1,5 +1,9 @@
 import { afterAll, beforeAll, expect, test } from 'bun:test';
-import { completeAuthorization, refreshAccessToken } from '../src/oauth.ts';
+import {
+	completeAuthorization,
+	refreshAccessToken,
+	runAuthorizationFlow,
+} from '../src/oauth.ts';
 import type { TokenSet } from '../src/tokens.ts';
 import { makeConfig } from './helpers.ts';
 import { type MockQbServer, startMockQbServer } from './mock-qb-server.ts';
@@ -75,6 +79,37 @@ test('refresh exchange mints a new token set', async () => {
 	expect(error).toBeNull();
 	expect(data?.accessToken).not.toBe('old-access');
 	expect(server.hits.token).toBe(before + 1);
+});
+
+test('callbackPort decouples the local listener from a portless HTTPS redirect', async () => {
+	// Intuit production rejects localhost, so the redirect is a public HTTPS
+	// tunnel with no port; the tunnel forwards to callbackPort on this machine.
+	const PORT = 18765;
+	const config = makeConfig({
+		tokenUrl: server.tokenUrl,
+		realmOverride: server.realmId,
+		redirectUri: 'https://books.example.trycloudflare.com/callback',
+		callbackPort: PORT,
+	});
+	const { data, error } = await runAuthorizationFlow(config, {
+		now: () => NOW,
+		timeoutMs: 5000,
+		// Stand in for the browser: bounce the authorize request straight at the
+		// local callback server on PORT, the way the tunnel would.
+		openBrowser: (url) => {
+			const state = new URL(url).searchParams.get('state') ?? '';
+			const cb = new URL(`http://localhost:${PORT}/callback`);
+			cb.searchParams.set('code', 'auth-code');
+			cb.searchParams.set('state', state);
+			cb.searchParams.set('realmId', server.realmId);
+			// The server force-stops the instant it catches the callback, resetting
+			// this connection; that reset is expected, not a failure.
+			void fetch(cb).catch(() => {});
+		},
+	});
+	expect(error).toBeNull();
+	expect(data?.realmId).toBe(server.realmId);
+	expect(data?.accessToken).toStartWith('access-');
 });
 
 test('a missing client secret is reported, not thrown', async () => {


### PR DESCRIPTION
Production QuickBooks OAuth rejects `http://localhost` redirect URIs, so the one-time `auth` flow has to enter through a public HTTPS tunnel and forward back to the local callback server. A tunnel URL like `https://name.trycloudflare.com/callback` has no port, so the callback server can no longer derive its listen port from the redirect URI.

`local-books` now has an explicit `callbackPort` setting, available through `LOCAL_BOOKS_CALLBACK_PORT` or `config.json`. The OAuth server binds to that port first, then falls back to the redirect URI port, then to `80`. That keeps sandbox localhost auth working while making production auth work through a portless HTTPS tunnel.

The production scripts now wrap the repeated remote invocation shape:

```txt
bun run auth:remote
bun run sync:remote
bun run status:remote
```

Those scripts run through `infisical run --env=prod` and pin the QuickBooks deployment to production, so the Infisical environment and the QuickBooks environment no longer have to be assembled by hand. The README documents the sandbox and production split, the two `--env` meanings, and the tunnel flow.

The tunnel is only needed for the one-time OAuth grant. After tokens are in the keyring, sync refreshes them without touching the redirect URI.

## Changelog

- Add production QuickBooks OAuth support through HTTPS tunnel callbacks.
- Add `local-books` remote scripts for production auth, sync, and status commands.
