### PR TITLE
feat(local-books): mirror Purchase and Deposit transactions

### DIFF
--- a/apps/local-books/src/agent/books-query.ts
+++ b/apps/local-books/src/agent/books-query.ts
@@ -42,10 +42,11 @@ export function createBooksQueryAction({ dbPath }: { dbPath: string }) {
 		title: 'Query the books',
 		description:
 			'Run a read-only SQL query against the local QuickBooks mirror (SQLite). ' +
-			'Tables: invoices, customers, items, payments, bills, vendors, accounts. ' +
-			'Each row has id, raw (verbatim QB JSON), updated_at, synced_at, ' +
-			'deleted, plus a few extracted scalar columns. Filter `deleted = 0` for ' +
-			'live rows. SELECT only; writes are rejected.',
+			'Tables: invoices, customers, items, payments, bills, vendors, accounts, ' +
+			'purchases (expenses), deposits. Each row has id, raw (verbatim QB JSON), ' +
+			'updated_at, synced_at, deleted, plus a few extracted scalar columns; the ' +
+			"line-level category lives in raw (e.g. json_extract(raw, '$.Line')). " +
+			'Filter `deleted = 0` for live rows. SELECT only; writes are rejected.',
 		input: Type.Object({
 			sql: Type.String({
 				description: 'A read-only SQL query (SELECT / WITH / PRAGMA).',

--- a/apps/local-books/src/entities.ts
+++ b/apps/local-books/src/entities.ts
@@ -152,6 +152,33 @@ export const ENTITY_DEFS: Record<string, EntityDef> = {
 			col('active', 'INTEGER', bool('Active')),
 		],
 	},
+	// Money-out transactions (card/cash/check expenses, incl. posted bank-feed
+	// items). The category lives in Line[].AccountBasedExpenseLineDetail.AccountRef
+	// (1:N), so it stays in `raw`; the extracted columns are the header scalars
+	// worth grouping and joining on.
+	Purchase: {
+		name: 'Purchase',
+		table: 'purchases',
+		columns: [
+			col('txn_date', 'TEXT', text('TxnDate')),
+			col('total_amt', 'REAL', real('TotalAmt')),
+			col('payment_type', 'TEXT', text('PaymentType')),
+			col('account_ref', 'TEXT', text('AccountRef', 'name')),
+			col('payee', 'TEXT', text('EntityRef', 'name')),
+		],
+	},
+	// Money-in transactions (deposits, incl. posted bank-feed credits). The
+	// crediting category lives in Line[].DepositLineDetail.AccountRef (1:N) and
+	// stays in `raw`.
+	Deposit: {
+		name: 'Deposit',
+		table: 'deposits',
+		columns: [
+			col('txn_date', 'TEXT', text('TxnDate')),
+			col('total_amt', 'REAL', real('TotalAmt')),
+			col('deposit_to', 'TEXT', text('DepositToAccountRef', 'name')),
+		],
+	},
 };
 
 /** The default entities mirrored when config does not narrow the set. */

--- a/apps/local-books/test/entities.test.ts
+++ b/apps/local-books/test/entities.test.ts
@@ -1,0 +1,67 @@
+/**
+ * The Purchase/Deposit extractors, pinned against the real QuickBooks object
+ * shapes (header scalars only; the line-level category stays in `raw`). The
+ * second case guards the load-bearing invariant that a CDC delete stub
+ * (`Id` + `MetaData` only) extracts to nulls rather than throwing.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { entityDef, type QbObject } from '../src/entities.ts';
+
+function extract(name: string, raw: QbObject): Record<string, unknown> {
+	const def = entityDef(name);
+	return Object.fromEntries(def.columns.map((c) => [c.name, c.extract(raw)]));
+}
+
+describe('Purchase extractor', () => {
+	test('lifts the header scalars from a live-shaped object', () => {
+		const purchase: QbObject = {
+			Id: '855',
+			TxnDate: '2026-05-21',
+			TotalAmt: 200,
+			PaymentType: 'Cash',
+			AccountRef: { value: '11', name: 'Every Bank Account' },
+			EntityRef: { value: '112', name: 'Anthropic (Expense)', type: 'Vendor' },
+			Line: [{ AccountBasedExpenseLineDetail: { AccountRef: { name: 'IT Costs' } } }],
+		};
+		expect(extract('Purchase', purchase)).toEqual({
+			txn_date: '2026-05-21',
+			total_amt: 200,
+			payment_type: 'Cash',
+			account_ref: 'Every Bank Account',
+			payee: 'Anthropic (Expense)',
+		});
+	});
+
+	test('a CDC delete stub extracts to nulls, never throws', () => {
+		const stub: QbObject = {
+			Id: '855',
+			status: 'Deleted',
+			MetaData: { LastUpdatedTime: '2026-06-21T23:00:00-07:00' },
+		};
+		expect(extract('Purchase', stub)).toEqual({
+			txn_date: null,
+			total_amt: null,
+			payment_type: null,
+			account_ref: null,
+			payee: null,
+		});
+	});
+});
+
+describe('Deposit extractor', () => {
+	test('reads the deposit-to account from DepositToAccountRef', () => {
+		const deposit: QbObject = {
+			Id: '815',
+			TxnDate: '2026-02-05',
+			TotalAmt: 1500,
+			DepositToAccountRef: { value: '9', name: 'Arc Business account (2249)' },
+			Line: [{ DepositLineDetail: { AccountRef: { name: '40000 Revenue' } } }],
+		};
+		expect(extract('Deposit', deposit)).toEqual({
+			txn_date: '2026-02-05',
+			total_amt: 1500,
+			deposit_to: 'Arc Business account (2249)',
+		});
+	});
+});

--- a/apps/local-books/test/entities.test.ts
+++ b/apps/local-books/test/entities.test.ts
@@ -22,7 +22,9 @@ describe('Purchase extractor', () => {
 			PaymentType: 'Cash',
 			AccountRef: { value: '11', name: 'Every Bank Account' },
 			EntityRef: { value: '112', name: 'Anthropic (Expense)', type: 'Vendor' },
-			Line: [{ AccountBasedExpenseLineDetail: { AccountRef: { name: 'IT Costs' } } }],
+			Line: [
+				{ AccountBasedExpenseLineDetail: { AccountRef: { name: 'IT Costs' } } },
+			],
 		};
 		expect(extract('Purchase', purchase)).toEqual({
 			txn_date: '2026-05-21',


### PR DESCRIPTION
QuickBooks bank-feed rows are not queryable as expenses or deposits until they are posted. Once posted, they become `Purchase` and `Deposit` objects, and CDC was already reporting those changes, but the local mirror did not track either entity. Categorized expenses and deposits were being dropped at ingest.

This adds `Purchase` and `Deposit` to the mirrored entity set with the header fields worth grouping and joining on: transaction date, total amount, payment type, source or destination account, and payee where QuickBooks provides one. The line-level category stays in `raw` because `Line[].*LineDetail.AccountRef` is 1:N; callers can reach it with `json_extract(raw, '$.Line')` instead of pretending it is a scalar column.

```sql
SELECT txn_date, total_amt, json_extract(raw, '$.Line') AS lines
FROM purchases
WHERE deleted = 0;
```

The agent query tool now names `purchases` and `deposits` as queryable tables and points category questions at the raw line JSON. The extractor coverage uses real QuickBooks object shapes, including the CDC delete-stub case where nullable payloads must not crash the mirror.

## Changelog

- Mirror posted QuickBooks purchases and deposits so categorized bank-feed transactions are available in local-books.
