### PR TITLE
refactor(local-books): project extracted columns as SQLite generated columns

### DIFF
--- a/apps/local-books/src/db.ts
+++ b/apps/local-books/src/db.ts
@@ -1,7 +1,7 @@
 import { Database } from 'bun:sqlite';
 import { mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
-import type { ColumnValue, EntityDef } from './entities.ts';
+import type { EntityDef } from './entities.ts';
 
 /**
  * The local mirror: one SQLite file per company. Holds an entity table per QB
@@ -19,16 +19,13 @@ export type SyncStateRow = {
 	lastSyncedAt: string | null;
 };
 
-/** A live object to upsert; `columns` are in `def.columns` order. */
-export type UpsertRow = {
-	id: string;
-	raw: string;
-	updatedAt: string | null;
-	columns: ColumnValue[];
-};
-
-/** A CDC delete: flip `deleted`, preserve any existing blob. */
-export type DeleteRow = {
+/**
+ * One row destined for an entity table, keyed by QB `id`. The same shape feeds
+ * an upsert (store this blob) and a soft-delete (the blob is a stub, used only
+ * if the row is new); the destiny is the array it lands in, not the type. The
+ * extracted columns are generated from `raw`, so no row carries them.
+ */
+export type MirrorRow = {
 	id: string;
 	raw: string;
 	updatedAt: string | null;
@@ -48,6 +45,18 @@ const IDENT = /^[a-z_][a-z0-9_]*$/;
 function assertIdent(name: string): string {
 	if (!IDENT.test(name)) throw new Error(`Unsafe SQL identifier: ${name}`);
 	return name;
+}
+
+// Generated-column paths are inlined into the CREATE TABLE string literal, so
+// each QB field segment must be a bare identifier (no quotes, dots, or `$`).
+const PATH_SEGMENT = /^[A-Za-z_][A-Za-z0-9_]*$/;
+function jsonExtractPath(segments: string[]): string {
+	for (const seg of segments) {
+		if (!PATH_SEGMENT.test(seg)) {
+			throw new Error(`Unsafe JSON path segment: ${seg}`);
+		}
+	}
+	return `$.${segments.join('.')}`;
 }
 
 export type BooksDb = ReturnType<typeof openBooksDb>;
@@ -94,8 +103,14 @@ export function openBooksDb(path: string, realmId: string) {
 
 	function ensureEntityTable(def: EntityDef): void {
 		const table = assertIdent(def.table);
+		// Each extracted column is a VIRTUAL generated projection of `raw`, so the
+		// blob stays the single source of truth: no write-path extraction, and a
+		// missing field is `json_extract`'s null for free.
 		const extra = def.columns
-			.map((c) => `${assertIdent(c.name)} ${c.type}`)
+			.map(
+				(c) =>
+					`${assertIdent(c.name)} ${c.type} GENERATED ALWAYS AS (json_extract(raw, '${jsonExtractPath(c.path)}')) VIRTUAL`,
+			)
 			.join(',\n\t\t\t\t');
 		db.exec(`
 			CREATE TABLE IF NOT EXISTS ${table} (
@@ -112,27 +127,16 @@ export function openBooksDb(path: string, realmId: string) {
 	function upsertStmtFor(def: EntityDef) {
 		const cached = upsertStmts.get(def.table);
 		if (cached) return cached;
-		const cols = def.columns.map((c) => assertIdent(c.name));
-		const insertCols = [
-			'id',
-			'raw',
-			'updated_at',
-			'synced_at',
-			'deleted',
-			...cols,
-		];
-		const placeholders = ['?', '?', '?', '?', '0', ...cols.map(() => '?')];
-		const updates = [
-			'raw = excluded.raw',
-			'updated_at = excluded.updated_at',
-			'synced_at = excluded.synced_at',
-			'deleted = 0',
-			...cols.map((c) => `${c} = excluded.${c}`),
-		];
+		// The extracted columns are generated from `raw`, so the upsert writes only
+		// the blob and its bookkeeping; SQLite recomputes the projections.
 		const stmt = db.query(
-			`INSERT INTO ${assertIdent(def.table)} (${insertCols.join(', ')})
-			 VALUES (${placeholders.join(', ')})
-			 ON CONFLICT(id) DO UPDATE SET ${updates.join(', ')}`,
+			`INSERT INTO ${assertIdent(def.table)} (id, raw, updated_at, synced_at, deleted)
+			 VALUES (?, ?, ?, ?, 0)
+			 ON CONFLICT(id) DO UPDATE SET
+			   raw = excluded.raw,
+			   updated_at = excluded.updated_at,
+			   synced_at = excluded.synced_at,
+			   deleted = 0`,
 		);
 		upsertStmts.set(def.table, stmt);
 		return stmt;
@@ -141,8 +145,9 @@ export function openBooksDb(path: string, realmId: string) {
 	function deleteStmtFor(def: EntityDef) {
 		const cached = deleteStmts.get(def.table);
 		if (cached) return cached;
-		// On conflict, only flip the flag + timestamps: keep the existing blob and
-		// extracted columns, since a CDC delete payload is just a stub.
+		// On conflict, only flip the flag + timestamps: keep the existing blob,
+		// since a CDC delete payload is just a stub. The generated columns keep
+		// projecting that preserved blob, so the last-known scalars survive.
 		const stmt = db.query(
 			`INSERT INTO ${assertIdent(def.table)} (id, raw, updated_at, synced_at, deleted)
 			 VALUES (?, ?, ?, ?, 1)
@@ -194,8 +199,8 @@ export function openBooksDb(path: string, realmId: string) {
 				syncState,
 				syncedAt,
 			}: {
-				upserts: UpsertRow[];
-				deletes: DeleteRow[];
+				upserts: MirrorRow[];
+				deletes: MirrorRow[];
 				syncState: SyncStateRow;
 				syncedAt: string;
 			},
@@ -205,7 +210,7 @@ export function openBooksDb(path: string, realmId: string) {
 			const markDeleted = deleteStmtFor(def);
 			const tx = db.transaction(() => {
 				for (const row of upserts) {
-					upsert.run(row.id, row.raw, row.updatedAt, syncedAt, ...row.columns);
+					upsert.run(row.id, row.raw, row.updatedAt, syncedAt);
 				}
 				for (const row of deletes) {
 					markDeleted.run(row.id, row.raw, row.updatedAt, syncedAt);

--- a/apps/local-books/src/entities.ts
+++ b/apps/local-books/src/entities.ts
@@ -4,18 +4,25 @@
  * blob for indexing and joins. Everything else stays in `raw`, so a new QB
  * field needs no migration.
  *
- * The raw blob is canonical; extracted columns are a denormalized convenience.
- * On a CDC delete we only get a stub (Id + MetaData), so extractors must return
- * `null` for absent fields rather than throw.
+ * The raw blob is canonical; the extracted columns are pure projections of it.
+ * Each column is declared as a SQLite GENERATED column over `json_extract(raw,
+ * ...)` (see `db.ts`), so the registry is plain data: a JSON path and the column
+ * type SQLite coerces it to. There is no write-path extraction and no delete-stub
+ * special case: a missing field is `json_extract`'s `null` for free.
  */
 
 export type ColumnType = 'TEXT' | 'INTEGER' | 'REAL';
-export type ColumnValue = string | number | null;
 
-export type ExtractedColumn = {
+/**
+ * A scalar column projected from `raw`. `path` is the segment list into the QB
+ * object, e.g. `['CustomerRef', 'value']` becomes `json_extract(raw,
+ * '$.CustomerRef.value')`. `type` is the SQLite affinity: REAL for amounts,
+ * INTEGER for JSON booleans (`json_extract` yields 0/1), TEXT otherwise.
+ */
+export type GeneratedColumn = {
 	name: string;
 	type: ColumnType;
-	extract: (raw: QbObject) => ColumnValue;
+	path: string[];
 };
 
 export type EntityDef = {
@@ -23,7 +30,7 @@ export type EntityDef = {
 	name: string;
 	/** SQLite table name, e.g. `invoices`. */
 	table: string;
-	columns: ExtractedColumn[];
+	columns: GeneratedColumn[];
 };
 
 export type QbObject = Record<string, unknown> & {
@@ -32,124 +39,86 @@ export type QbObject = Record<string, unknown> & {
 	MetaData?: { LastUpdatedTime?: string; CreateTime?: string };
 };
 
-function path(raw: QbObject, ...keys: string[]): unknown {
-	let value: unknown = raw;
-	for (const key of keys) {
-		if (value === null || typeof value !== 'object') return undefined;
-		value = (value as Record<string, unknown>)[key];
-	}
-	return value;
-}
-
-function text(...keys: string[]): (raw: QbObject) => ColumnValue {
-	return (raw) => {
-		const value = path(raw, ...keys);
-		return typeof value === 'string' || typeof value === 'number'
-			? String(value)
-			: null;
-	};
-}
-
-function real(...keys: string[]): (raw: QbObject) => ColumnValue {
-	return (raw) => {
-		const value = path(raw, ...keys);
-		const num = typeof value === 'number' ? value : Number(value);
-		return Number.isFinite(num) ? num : null;
-	};
-}
-
-function bool(...keys: string[]): (raw: QbObject) => ColumnValue {
-	return (raw) => {
-		const value = path(raw, ...keys);
-		if (value === true) return 1;
-		if (value === false) return 0;
-		return null;
-	};
-}
-
+/** A column declaration: the SQLite name, its type, and the JSON path into `raw`. */
 function col(
 	name: string,
 	type: ColumnType,
-	extract: (raw: QbObject) => ColumnValue,
-): ExtractedColumn {
-	return { name, type, extract };
+	...path: string[]
+): GeneratedColumn {
+	return { name, type, path };
 }
+
+/** The registry, keyed by QB entity name; the key is the canonical name. */
+type EntitySource = Omit<EntityDef, 'name'>;
 
 /**
  * Default mirror set. Each is a CDC-supported QuickBooks transaction or
  * name-list entity. Extend or trim via `config.json` `entities`.
  */
-export const ENTITY_DEFS: Record<string, EntityDef> = {
+export const ENTITY_DEFS: Record<string, EntitySource> = {
 	Invoice: {
-		name: 'Invoice',
 		table: 'invoices',
 		columns: [
-			col('doc_number', 'TEXT', text('DocNumber')),
-			col('doc_date', 'TEXT', text('TxnDate')),
-			col('total_amt', 'REAL', real('TotalAmt')),
-			col('balance', 'REAL', real('Balance')),
-			col('customer_ref', 'TEXT', text('CustomerRef', 'value')),
+			col('doc_number', 'TEXT', 'DocNumber'),
+			col('doc_date', 'TEXT', 'TxnDate'),
+			col('total_amt', 'REAL', 'TotalAmt'),
+			col('balance', 'REAL', 'Balance'),
+			col('customer_ref', 'TEXT', 'CustomerRef', 'value'),
 		],
 	},
 	Customer: {
-		name: 'Customer',
 		table: 'customers',
 		columns: [
-			col('display_name', 'TEXT', text('DisplayName')),
-			col('company_name', 'TEXT', text('CompanyName')),
-			col('email', 'TEXT', text('PrimaryEmailAddr', 'Address')),
-			col('active', 'INTEGER', bool('Active')),
-			col('balance', 'REAL', real('Balance')),
+			col('display_name', 'TEXT', 'DisplayName'),
+			col('company_name', 'TEXT', 'CompanyName'),
+			col('email', 'TEXT', 'PrimaryEmailAddr', 'Address'),
+			col('active', 'INTEGER', 'Active'),
+			col('balance', 'REAL', 'Balance'),
 		],
 	},
 	Item: {
-		name: 'Item',
 		table: 'items',
 		columns: [
-			col('name', 'TEXT', text('Name')),
-			col('type', 'TEXT', text('Type')),
-			col('unit_price', 'REAL', real('UnitPrice')),
-			col('active', 'INTEGER', bool('Active')),
+			col('name', 'TEXT', 'Name'),
+			col('type', 'TEXT', 'Type'),
+			col('unit_price', 'REAL', 'UnitPrice'),
+			col('active', 'INTEGER', 'Active'),
 		],
 	},
 	Payment: {
-		name: 'Payment',
 		table: 'payments',
 		columns: [
-			col('txn_date', 'TEXT', text('TxnDate')),
-			col('total_amt', 'REAL', real('TotalAmt')),
-			col('customer_ref', 'TEXT', text('CustomerRef', 'value')),
+			col('txn_date', 'TEXT', 'TxnDate'),
+			col('total_amt', 'REAL', 'TotalAmt'),
+			col('customer_ref', 'TEXT', 'CustomerRef', 'value'),
 		],
 	},
 	Bill: {
-		name: 'Bill',
 		table: 'bills',
 		columns: [
-			col('doc_number', 'TEXT', text('DocNumber')),
-			col('txn_date', 'TEXT', text('TxnDate')),
-			col('total_amt', 'REAL', real('TotalAmt')),
-			col('balance', 'REAL', real('Balance')),
-			col('vendor_ref', 'TEXT', text('VendorRef', 'value')),
+			col('doc_number', 'TEXT', 'DocNumber'),
+			col('txn_date', 'TEXT', 'TxnDate'),
+			col('total_amt', 'REAL', 'TotalAmt'),
+			col('balance', 'REAL', 'Balance'),
+			col('vendor_ref', 'TEXT', 'VendorRef', 'value'),
 		],
 	},
 	Vendor: {
-		name: 'Vendor',
 		table: 'vendors',
 		columns: [
-			col('display_name', 'TEXT', text('DisplayName')),
-			col('company_name', 'TEXT', text('CompanyName')),
-			col('active', 'INTEGER', bool('Active')),
-			col('balance', 'REAL', real('Balance')),
+			col('display_name', 'TEXT', 'DisplayName'),
+			col('company_name', 'TEXT', 'CompanyName'),
+			col('active', 'INTEGER', 'Active'),
+			col('balance', 'REAL', 'Balance'),
 		],
 	},
 	Account: {
-		name: 'Account',
 		table: 'accounts',
 		columns: [
-			col('name', 'TEXT', text('Name')),
-			col('account_type', 'TEXT', text('AccountType')),
-			col('current_balance', 'REAL', real('CurrentBalance')),
-			col('active', 'INTEGER', bool('Active')),
+			col('name', 'TEXT', 'Name'),
+			col('account_type', 'TEXT', 'AccountType'),
+			col('current_balance', 'REAL', 'CurrentBalance'),
+			col('active', 'INTEGER', 'Active'),
 		],
 	},
 	// Money-out transactions (card/cash/check expenses, incl. posted bank-feed
@@ -157,26 +126,24 @@ export const ENTITY_DEFS: Record<string, EntityDef> = {
 	// (1:N), so it stays in `raw`; the extracted columns are the header scalars
 	// worth grouping and joining on.
 	Purchase: {
-		name: 'Purchase',
 		table: 'purchases',
 		columns: [
-			col('txn_date', 'TEXT', text('TxnDate')),
-			col('total_amt', 'REAL', real('TotalAmt')),
-			col('payment_type', 'TEXT', text('PaymentType')),
-			col('account_ref', 'TEXT', text('AccountRef', 'name')),
-			col('payee', 'TEXT', text('EntityRef', 'name')),
+			col('txn_date', 'TEXT', 'TxnDate'),
+			col('total_amt', 'REAL', 'TotalAmt'),
+			col('payment_type', 'TEXT', 'PaymentType'),
+			col('account_ref', 'TEXT', 'AccountRef', 'name'),
+			col('payee', 'TEXT', 'EntityRef', 'name'),
 		],
 	},
 	// Money-in transactions (deposits, incl. posted bank-feed credits). The
 	// crediting category lives in Line[].DepositLineDetail.AccountRef (1:N) and
 	// stays in `raw`.
 	Deposit: {
-		name: 'Deposit',
 		table: 'deposits',
 		columns: [
-			col('txn_date', 'TEXT', text('TxnDate')),
-			col('total_amt', 'REAL', real('TotalAmt')),
-			col('deposit_to', 'TEXT', text('DepositToAccountRef', 'name')),
+			col('txn_date', 'TEXT', 'TxnDate'),
+			col('total_amt', 'REAL', 'TotalAmt'),
+			col('deposit_to', 'TEXT', 'DepositToAccountRef', 'name'),
 		],
 	},
 };
@@ -189,13 +156,13 @@ export function isKnownEntity(name: string): boolean {
 }
 
 export function entityDef(name: string): EntityDef {
-	const def = ENTITY_DEFS[name];
-	if (!def) {
+	const source = ENTITY_DEFS[name];
+	if (!source) {
 		throw new Error(
 			`Unknown QuickBooks entity "${name}". Known entities: ${DEFAULT_ENTITIES.join(', ')}.`,
 		);
 	}
-	return def;
+	return { name, ...source };
 }
 
 /** A deleted CDC record carries `status: "Deleted"`; everything else is live. */

--- a/apps/local-books/src/sync.ts
+++ b/apps/local-books/src/sync.ts
@@ -1,6 +1,6 @@
 import { Ok, type Result } from 'wellcrafted/result';
 import type { AppConfig } from './config.ts';
-import type { BooksDb, DeleteRow, SyncStateRow, UpsertRow } from './db.ts';
+import type { BooksDb, MirrorRow, SyncStateRow } from './db.ts';
 import {
 	type EntityDef,
 	entityDef,
@@ -86,15 +86,12 @@ export type SyncDeps = {
 };
 
 /** Split a batch of QB objects into live upserts and soft-deletes. */
-function partition(
-	def: EntityDef,
-	objects: QbObject[],
-): {
-	upserts: UpsertRow[];
-	deletes: DeleteRow[];
+function partition(objects: QbObject[]): {
+	upserts: MirrorRow[];
+	deletes: MirrorRow[];
 } {
-	const upserts: UpsertRow[] = [];
-	const deletes: DeleteRow[] = [];
+	const upserts: MirrorRow[] = [];
+	const deletes: MirrorRow[] = [];
 	for (const obj of objects) {
 		const id = obj.Id != null ? String(obj.Id) : null;
 		if (!id) continue; // skip malformed objects with no Id
@@ -103,12 +100,7 @@ function partition(
 		if (isDeleted(obj)) {
 			deletes.push({ id, raw, updatedAt });
 		} else {
-			upserts.push({
-				id,
-				raw,
-				updatedAt,
-				columns: def.columns.map((c) => c.extract(obj)),
-			});
+			upserts.push({ id, raw, updatedAt });
 		}
 	}
 	return { upserts, deletes };
@@ -151,7 +143,7 @@ export async function syncEntity(
 		objects = changed.data.changes[def.name] ?? [];
 	}
 
-	const { upserts, deletes } = partition(def, objects);
+	const { upserts, deletes } = partition(objects);
 
 	const newState: SyncStateRow = {
 		entity: def.name,

--- a/apps/local-books/test/entities.test.ts
+++ b/apps/local-books/test/entities.test.ts
@@ -1,19 +1,47 @@
 /**
- * The Purchase/Deposit extractors, pinned against the real QuickBooks object
- * shapes (header scalars only; the line-level category stays in `raw`). The
- * second case guards the load-bearing invariant that a CDC delete stub
- * (`Id` + `MetaData` only) extracts to nulls rather than throwing.
+ * The Purchase/Deposit projections, pinned against the real QuickBooks object
+ * shapes. These are SQLite GENERATED columns over `json_extract(raw, ...)`, so
+ * the test inserts a raw blob and reads the columns back: it proves the JSON
+ * paths are right (header scalars only; the line-level category stays in `raw`)
+ * and that a sparse object projects to nulls rather than failing the insert.
  */
 
 import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import { type BooksDb, openBooksDb } from '../src/db.ts';
 import { entityDef, type QbObject } from '../src/entities.ts';
+import { tempDir } from './helpers.ts';
 
-function extract(name: string, raw: QbObject): Record<string, unknown> {
-	const def = entityDef(name);
-	return Object.fromEntries(def.columns.map((c) => [c.name, c.extract(raw)]));
+/** Open a throwaway mirror, upsert one object, return its projected columns. */
+function project(entity: string, raw: QbObject): Record<string, unknown> {
+	const def = entityDef(entity);
+	const tmp = tempDir();
+	let db: BooksDb | undefined;
+	try {
+		db = openBooksDb(join(tmp.dir, 'books.db'), 'realm-test');
+		const id = String(raw.Id);
+		db.applyEntitySync(def, {
+			upserts: [{ id, raw: JSON.stringify(raw), updatedAt: null }],
+			deletes: [],
+			syncState: {
+				entity,
+				cdcCursor: null,
+				lastFullPullAt: null,
+				lastSyncedAt: null,
+			},
+			syncedAt: '2026-06-21T00:00:00.000Z',
+		});
+		const cols = def.columns.map((c) => c.name).join(', ');
+		return db.raw
+			.query(`SELECT ${cols} FROM ${def.table} WHERE id = ?`)
+			.get(id) as Record<string, unknown>;
+	} finally {
+		db?.close();
+		tmp.cleanup();
+	}
 }
 
-describe('Purchase extractor', () => {
+describe('Purchase projection', () => {
 	test('lifts the header scalars from a live-shaped object', () => {
 		const purchase: QbObject = {
 			Id: '855',
@@ -26,7 +54,7 @@ describe('Purchase extractor', () => {
 				{ AccountBasedExpenseLineDetail: { AccountRef: { name: 'IT Costs' } } },
 			],
 		};
-		expect(extract('Purchase', purchase)).toEqual({
+		expect(project('Purchase', purchase)).toEqual({
 			txn_date: '2026-05-21',
 			total_amt: 200,
 			payment_type: 'Cash',
@@ -35,13 +63,9 @@ describe('Purchase extractor', () => {
 		});
 	});
 
-	test('a CDC delete stub extracts to nulls, never throws', () => {
-		const stub: QbObject = {
-			Id: '855',
-			status: 'Deleted',
-			MetaData: { LastUpdatedTime: '2026-06-21T23:00:00-07:00' },
-		};
-		expect(extract('Purchase', stub)).toEqual({
+	test('a sparse object (missing fields) projects to nulls', () => {
+		const sparse: QbObject = { Id: '855' };
+		expect(project('Purchase', sparse)).toEqual({
 			txn_date: null,
 			total_amt: null,
 			payment_type: null,
@@ -51,7 +75,7 @@ describe('Purchase extractor', () => {
 	});
 });
 
-describe('Deposit extractor', () => {
+describe('Deposit projection', () => {
 	test('reads the deposit-to account from DepositToAccountRef', () => {
 		const deposit: QbObject = {
 			Id: '815',
@@ -60,7 +84,7 @@ describe('Deposit extractor', () => {
 			DepositToAccountRef: { value: '9', name: 'Arc Business account (2249)' },
 			Line: [{ DepositLineDetail: { AccountRef: { name: '40000 Revenue' } } }],
 		};
-		expect(extract('Deposit', deposit)).toEqual({
+		expect(project('Deposit', deposit)).toEqual({
 			txn_date: '2026-02-05',
 			total_amt: 1500,
 			deposit_to: 'Arc Business account (2249)',


### PR DESCRIPTION
The raw QuickBooks blob is the canonical fact for each mirrored object. The scalar columns are projections, but the old write path treated them like second facts by extracting values in TypeScript and threading them into the upsert beside `raw`.

SQLite generated columns make the ownership honest:

```sql
total_amt REAL GENERATED ALWAYS AS (json_extract(raw, '$.TotalAmt')) VIRTUAL
payee     TEXT GENERATED ALWAYS AS (json_extract(raw, '$.EntityRef.name')) VIRTUAL
```

`EntityDef` collapses to plain table metadata: table name, column name, type, and JSON path. The `path` / `text` / `real` / `bool` / `col` extraction DSL disappears, and the upsert writes only `id`, `raw`, and `updated_at`.

## Projection Ownership

`json_extract` returns `null` for missing paths, so the old delete-stub null-safety rule no longer needs its own TypeScript invariant. Soft deletes preserve `raw`, and generated columns keep projecting the last-known blob.

`UpsertRow` and `DeleteRow` were structurally identical after column extraction moved into SQLite, so they merge into `MirrorRow`. `EntityDef.name` is derived from the registry key, while `table` stays explicit to avoid pretending pluralization is a rule.

The mirror is a cache. QuickBooks owns authoritative history, so this schema change costs one re-pull and does not break a durable data contract.
