### PR TITLE
refactor(local-books): drop the write-only realmId from the mirror

### DIFF
--- a/apps/local-books/src/agent/books-query.test.ts
+++ b/apps/local-books/src/agent/books-query.test.ts
@@ -28,7 +28,7 @@ const LOCAL_ONLY: DispatchSurface = {
 function fixtureMirror() {
 	const dir = mkdtempSync(join(tmpdir(), 'local-books-'));
 	const path = join(dir, 'realm-1', 'books.db');
-	const db = openBooksDb(path, 'realm-1');
+	const db = openBooksDb(path);
 	db.raw.exec(`
 		CREATE TABLE invoices (
 			id TEXT PRIMARY KEY, raw TEXT NOT NULL, updated_at TEXT,

--- a/apps/local-books/src/commands/status.ts
+++ b/apps/local-books/src/commands/status.ts
@@ -43,7 +43,7 @@ export async function runStatus(args: ParsedArgs): Promise<number> {
 		return 0;
 	}
 
-	const db = openBooksDb(path, realmId);
+	const db = openBooksDb(path);
 	console.log(`Schema:       v${db.getMeta('schema_version')}`);
 	console.log('');
 	console.log(

--- a/apps/local-books/src/commands/sync.ts
+++ b/apps/local-books/src/commands/sync.ts
@@ -67,7 +67,7 @@ export async function runSync(args: ParsedArgs): Promise<number> {
 		deps: oauthDeps,
 	});
 	const client = createQbClient({ config, realmId, tokens, log });
-	const db = openBooksDb(dbPath(config.dataDir, realmId), realmId);
+	const db = openBooksDb(dbPath(config.dataDir, realmId));
 	const deps: SyncDeps = { db, client, config, now, log };
 
 	// Looping mode: keep the mirror fresh until interrupted.

--- a/apps/local-books/src/db.ts
+++ b/apps/local-books/src/db.ts
@@ -8,6 +8,9 @@ import type { EntityDef } from './entities.ts';
  * type plus `_sync_state` (the per-entity CDC cursor) and `_meta`. The cursor is
  * written in the same transaction as the rows it accounts for, so ingest and
  * cursor-advance are atomic and crash-safe (see the spec's atomicity argument).
+ *
+ * The realm owns its identity through the path (`<dataDir>/<realmId>/books.db`),
+ * not a stored column, so the db need not know which company it holds.
  */
 
 export const SCHEMA_VERSION = '1';
@@ -61,7 +64,7 @@ function jsonExtractPath(segments: string[]): string {
 
 export type BooksDb = ReturnType<typeof openBooksDb>;
 
-export function openBooksDb(path: string, realmId: string) {
+export function openBooksDb(path: string) {
 	mkdirSync(dirname(path), { recursive: true });
 	const db = new Database(path, { create: true });
 	db.exec('PRAGMA journal_mode = WAL;');
@@ -85,7 +88,6 @@ export function openBooksDb(path: string, realmId: string) {
 		`SELECT value FROM _meta WHERE key = ?`,
 	);
 
-	setMetaStmt.run('realmId', realmId);
 	setMetaStmt.run('schema_version', SCHEMA_VERSION);
 
 	// Prepared-statement caches, keyed by table.

--- a/apps/local-books/test/entities.test.ts
+++ b/apps/local-books/test/entities.test.ts
@@ -18,7 +18,7 @@ function project(entity: string, raw: QbObject): Record<string, unknown> {
 	const tmp = tempDir();
 	let db: BooksDb | undefined;
 	try {
-		db = openBooksDb(join(tmp.dir, 'books.db'), 'realm-test');
+		db = openBooksDb(join(tmp.dir, 'books.db'));
 		const id = String(raw.Id);
 		db.applyEntitySync(def, {
 			upserts: [{ id, raw: JSON.stringify(raw), updatedAt: null }],

--- a/apps/local-books/test/sync.test.ts
+++ b/apps/local-books/test/sync.test.ts
@@ -46,7 +46,7 @@ function setup(configOver: Partial<AppConfig> = {}) {
 		sleep: async () => {},
 	});
 	const tmp = tempDir();
-	const db = openBooksDb(join(tmp.dir, 'books.db'), server.realmId);
+	const db = openBooksDb(join(tmp.dir, 'books.db'));
 
 	const teardown = () => {
 		db.close();
@@ -91,7 +91,6 @@ test('full pull seeds the mirror with valid JSON and a populated cursor', async 
 	const state = ctx.db.readSyncState('Invoice');
 	expect(state?.cdcCursor).toBe(data!.cursorAfter);
 	expect(state?.lastFullPullAt).toBe(data!.cursorAfter);
-	expect(ctx.db.getMeta('realmId')).toBe(ctx.server.realmId);
 
 	ctx.teardown();
 });


### PR DESCRIPTION
`openBooksDb(path, realmId)` carried the company identity twice. The path already includes the realm (`<dataDir>/<realmId>/books.db`), and the extra `realmId` parameter only stamped `_meta.realmId`, which no production code read back.

This deletes the write-only identity path:

```ts
// Before
openBooksDb(dbPath(config.dataDir, realmId), realmId);

// After
openBooksDb(dbPath(config.dataDir, realmId));
```

The database path is now the single owner of which company the mirror belongs to. `_meta` keeps `schema_version`, because that one is the migration anchor when a future schema needs to decide between migrate and rebuild.

The rejected alternative was to make `_meta.realmId` load-bearing by validating it against the path on open. That would defend only against a manual file move in a re-pullable personal cache, so it does not earn a second durable identity.
