### PR TITLE
feat(workspace): bound the agent loop with a max-step guard

### DIFF
--- a/.changeset/agent-loop-max-step-guard.md
+++ b/.changeset/agent-loop-max-step-guard.md
@@ -1,0 +1,5 @@
+---
+'@epicenter/workspace': minor
+---
+
+Bound the client agent loop's multi-step tool cycle with a runaway backstop (`MAX_STEPS = 50`). A turn that keeps re-issuing tool calls without ever giving a final answer now fails with a `MaxStepsExceeded` code instead of looping forever, which matters when a misbehaving backend or a transcript that spans backends keeps requesting tools. Well-behaved turns are unaffected.

--- a/packages/workspace/src/agent/loop.test.ts
+++ b/packages/workspace/src/agent/loop.test.ts
@@ -128,6 +128,43 @@ describe('createConversation', () => {
 		expect(agentMessageText(messages[2]!)).toBe('It is noon.');
 	});
 
+	test('a runaway tool loop is bounded by the max-step guard', async () => {
+		const store = makeStore();
+		let calls = 0;
+		// An engine that never finishes: every step asks for the same tool again.
+		const engine: AgentEngine = () => {
+			calls += 1;
+			return streamOf([
+				{
+					type: 'tool-call',
+					toolCallId: `t${calls}`,
+					toolName: 'loop',
+					input: {},
+				},
+			]);
+		};
+		const tools: ToolCatalog = {
+			definitions: () => [{ name: 'loop', kind: 'query' }],
+			resolve: async () => ({ output: 'again', isError: false }),
+		};
+
+		const handle = createConversation({
+			store,
+			engine,
+			tools,
+			generateId: idMinter(),
+		});
+		handle.send('go');
+		await settle(handle);
+
+		expect(handle.snapshot().isGenerating).toBe(false);
+		expect(handle.snapshot().error?.code).toBe('MaxStepsExceeded');
+		// The loop stopped at the cap (one engine call per step) rather than
+		// spinning forever, and the unfinished turn persisted nothing.
+		expect(calls).toBe(50);
+		expect([...store.entries()].map((e) => e.val.role)).toEqual(['user']);
+	});
+
 	test('an asked mutation that is declined records a denial, never resolves', async () => {
 		const store = makeStore();
 		let stepCount = 0;

--- a/packages/workspace/src/agent/loop.ts
+++ b/packages/workspace/src/agent/loop.ts
@@ -87,6 +87,16 @@ const DENY_GATED_MUTATIONS: Approval = {
 	request: async () => false,
 };
 
+/**
+ * A turn's multi-step tool loop is bounded by this runaway backstop, not a product
+ * limit. Each step is one model call that either finishes (text, no tools) or asks
+ * for tools and re-prompts; the loop never reads a provider finish reason, so a
+ * misbehaving backend, or a transcript that spans backends (ADR-0053), could
+ * otherwise re-issue tool calls forever. A well-behaved turn converges far below
+ * this.
+ */
+const MAX_STEPS = 50;
+
 export function createConversation(
 	options: ConversationOptions,
 ): ConversationHandle {
@@ -237,7 +247,15 @@ export function createConversation(
 		notify();
 
 		let failure: ConversationError | undefined;
+		let steps = 0;
 		while (!signal.aborted) {
+			if (steps++ >= MAX_STEPS) {
+				failure = {
+					message: `Stopped after ${MAX_STEPS} steps without a final answer.`,
+					code: 'MaxStepsExceeded',
+				};
+				break;
+			}
 			const assistant: AgentMessage = {
 				id: generateId(),
 				role: 'assistant',

--- a/packages/workspace/src/agent/loop.ts
+++ b/packages/workspace/src/agent/loop.ts
@@ -271,7 +271,10 @@ export function createConversation(
 				failure = step.failure;
 				break;
 			}
-			if (step.calls.length === 0) break; // a text finish ends the turn
+
+			// No tool calls means the model gave its final answer; the turn is done.
+			const isFinalAnswer = step.calls.length === 0;
+			if (isFinalAnswer) break;
 
 			await runTools(assistant, step.calls, signal);
 		}


### PR DESCRIPTION
The client agent loop runs a turn as a multi-step cycle: each step is one model call that either finishes with text or requests tools and re-prompts with their results. The loop never reads a provider finish reason, so a misbehaving backend, or a transcript that spans backends, could re-issue tool calls forever.

This adds a runaway backstop: a turn is bounded to `MAX_STEPS = 50` model calls. Past that, the turn fails with a `MaxStepsExceeded` code and the UI surfaces it like any other turn error. This is a safety bound, not a product limit; a well-behaved turn converges far below it.

The text-finish exit is also named `isFinalAnswer`, so the loop's two exit paths now read directly: a clean final answer, or the step ceiling.

## Changelog

- Prevent AI turns from running indefinitely when a backend repeatedly asks for tools.
