### PR TITLE
refactor: destructure params in the signature, collapse up.ts monitor

### DIFF
--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -224,9 +224,7 @@ export const upCommand = cmd({
 		} else {
 			const entry = handle.opened.entry;
 			logSyncStatus(`online (${entry.mount})`);
-			printPeersSnapshot(entry);
-			subscribePeers(entry, options.quiet);
-			subscribeSyncStatus(entry);
+			monitorMount(entry, { quiet: options.quiet });
 		}
 
 		const onSignal = () => {
@@ -243,55 +241,54 @@ export const upCommand = cmd({
 	},
 });
 
-function printPeersSnapshot(entry: StartedMount): void {
-	const collaboration = entry.runtime.collaboration;
+/**
+ * Reports one mount's live collaboration over stderr: an initial peer
+ * snapshot, then subscriptions for peer join/leave and sync status changes.
+ * No-op when the mount has no collaboration channel. These three always run
+ * together as one unit, so they share a single guard and `mount` binding.
+ */
+function monitorMount(
+	{ mount, runtime }: StartedMount,
+	{ quiet }: { quiet: boolean },
+): void {
+	const collaboration = runtime.collaboration;
 	if (!collaboration) return;
+
+	// Initial peer snapshot.
 	const peers = collaboration.peers.list();
 	if (peers.length === 0) {
-		process.stderr.write(`${entry.mount}: no peers connected\n`);
-		return;
+		process.stderr.write(`${mount}: no peers connected\n`);
+	} else {
+		for (const peer of peers) {
+			process.stderr.write(`${mount}: peer ${peer.nodeId}\n`);
+		}
 	}
-	for (const peer of peers) {
-		process.stderr.write(`${entry.mount}: peer ${peer.nodeId}\n`);
-	}
-}
 
-function subscribePeers(entry: StartedMount, quiet: boolean): void {
-	const collaboration = entry.runtime.collaboration;
-	if (!collaboration) return;
-	const snapshot = () =>
-		new Set(collaboration.peers.list().map((peer) => peer.nodeId));
-	let prev = snapshot();
+	// Peer join/leave.
+	let prev = new Set(peers.map((peer) => peer.nodeId));
 	collaboration.peers.subscribe(() => {
-		const next = snapshot();
+		const next = new Set(collaboration.peers.list().map((peer) => peer.nodeId));
 		for (const nodeId of next) {
-			if (!prev.has(nodeId)) {
-				if (!quiet) {
-					process.stderr.write(`${entry.mount}: ${nodeId} joined\n`);
-				}
+			if (!prev.has(nodeId) && !quiet) {
+				process.stderr.write(`${mount}: ${nodeId} joined\n`);
 			}
 		}
 		for (const nodeId of prev) {
-			if (!next.has(nodeId)) {
-				if (!quiet) {
-					process.stderr.write(`${entry.mount}: ${nodeId} left\n`);
-				}
+			if (!next.has(nodeId) && !quiet) {
+				process.stderr.write(`${mount}: ${nodeId} left\n`);
 			}
 		}
 		prev = next;
 	});
-}
 
-function subscribeSyncStatus(entry: StartedMount): void {
-	const collaboration = entry.runtime.collaboration;
-	if (!collaboration) return;
+	// Sync status.
 	collaboration.onStatusChange((status) => {
 		if (status.phase === 'connecting') {
-			logSyncStatus(`${entry.mount}: connecting (retry ${status.retries})`);
+			logSyncStatus(`${mount}: connecting (retry ${status.retries})`);
 		} else if (status.phase === 'connected') {
-			logSyncStatus(`${entry.mount}: connected`);
+			logSyncStatus(`${mount}: connected`);
 		} else if (status.phase === 'offline') {
-			logSyncStatus(`${entry.mount}: offline`);
+			logSyncStatus(`${mount}: offline`);
 		}
 	});
 }

--- a/packages/server/src/routes/assets.ts
+++ b/packages/server/src/routes/assets.ts
@@ -133,8 +133,7 @@ function sanitizeFilename(name: string): string {
 		.slice(0, 255);
 }
 
-function createAssetsApp(opts: { ownership: OwnershipRule }): Hono<Env> {
-	const { ownership } = opts;
+function createAssetsApp({ ownership }: { ownership: OwnershipRule }): Hono<Env> {
 	return (
 		new Hono<Env>()
 			// POST upload (authed).

--- a/packages/server/src/routes/assets.ts
+++ b/packages/server/src/routes/assets.ts
@@ -133,7 +133,11 @@ function sanitizeFilename(name: string): string {
 		.slice(0, 255);
 }
 
-function createAssetsApp({ ownership }: { ownership: OwnershipRule }): Hono<Env> {
+function createAssetsApp({
+	ownership,
+}: {
+	ownership: OwnershipRule;
+}): Hono<Env> {
 	return (
 		new Hono<Env>()
 			// POST upload (authed).

--- a/packages/workspace/src/agent/dispatch-catalog.ts
+++ b/packages/workspace/src/agent/dispatch-catalog.ts
@@ -53,10 +53,8 @@ export type DispatchToolCatalogOptions = {
  */
 export function createDispatchToolCatalog(
 	surface: DispatchSurface,
-	options: DispatchToolCatalogOptions = {},
+	{ localActions = {}, selfNodeId }: DispatchToolCatalogOptions = {},
 ): ToolCatalog {
-	const { localActions = {}, selfNodeId } = options;
-
 	function definitions(): AgentToolDefinition[] {
 		const byName = new Map<string, AgentToolDefinition>();
 		for (const [name, action] of Object.entries(localActions)) {

--- a/packages/workspace/src/daemon/mount-runtime.ts
+++ b/packages/workspace/src/daemon/mount-runtime.ts
@@ -107,11 +107,10 @@ export function attachMountSqlite<
 	TTables extends TablesRecord,
 	TFts extends FtsConfig<TTables> | undefined = undefined,
 >(
-	scope: MountComposeScope,
+	{ ctx, registerDrain }: MountComposeScope,
 	workspace: MaterializerInput<TTables>,
 	options?: SqliteMountOptions<TTables, TFts>,
 ): ReturnType<typeof attachBunSqliteMaterializer<TTables, TFts>> {
-	const { ctx, registerDrain } = scope;
 	const materializer = attachBunSqliteMaterializer<TTables, TFts>(workspace, {
 		filePath: sqlitePath(ctx.epicenterRoot, workspace.ydoc.guid),
 		fts: options?.fts,
@@ -132,11 +131,10 @@ export function attachMountSqlite<
  * passes only the per-table export config and git policy.
  */
 export function attachMountMarkdown<TTables extends TablesRecord>(
-	scope: MountComposeScope,
+	{ ctx, registerDrain }: MountComposeScope,
 	workspace: MaterializerInput<TTables>,
 	{ tables, git }: MarkdownMountOptions<TTables>,
 ): MarkdownExport {
-	const { ctx, registerDrain } = scope;
 	const markdown = attachMarkdownExport<TTables>(workspace, {
 		dir: ctx.epicenterRoot,
 		tables,

--- a/packages/workspace/src/document/materializer/markdown/export.ts
+++ b/packages/workspace/src/document/materializer/markdown/export.ts
@@ -491,7 +491,14 @@ async function writeMarkdownFile(
  * filesystem write failure (ENOSPC, EACCES) is NOT swallowed: it propagates, so
  * the initial flush rejects and the observer's outer catch surfaces it.
  */
-async function materializeTable(opts: {
+async function materializeTable({
+	table,
+	directory,
+	render,
+	fileState,
+	track,
+	log,
+}: {
 	table: AnyTable;
 	directory: string;
 	render: RenderRow;
@@ -500,8 +507,6 @@ async function materializeTable(opts: {
 	track: (work: Promise<void>) => void;
 	log: Logger;
 }): Promise<() => void> {
-	const { table, directory, render, fileState, track, log } = opts;
-
 	await claimGeneratedDirectory(directory);
 
 	// Write one valid row to disk, shared by the initial flush and the observer.
@@ -576,14 +581,19 @@ async function materializeTable(opts: {
  * then sweep existing `.md` files and write the rendered set. Updates `fileState`
  * so the live observer stays consistent.
  */
-async function rebuildTable(opts: {
+async function rebuildTable({
+	table,
+	directory,
+	render,
+	fileState,
+	log,
+}: {
 	table: AnyTable;
 	directory: string;
 	render: RenderRow;
 	fileState: FileState;
 	log: Logger;
 }): Promise<{ deleted: number; written: number }> {
-	const { table, directory, render, fileState, log } = opts;
 	let deleted = 0;
 	let written = 0;
 	await claimGeneratedDirectory(directory);


### PR DESCRIPTION
This keeps the factory-function and destructuring cleanup narrow. The only behavior-shaped change is in `epicenter up`: the peer snapshot, peer join/leave subscription, and sync status subscription now run through one `monitorMount` helper because they are always registered together for the same started mount.

`monitorMount` resolves `runtime.collaboration` once, returns early for mounts without a collaboration channel, and keeps the `mount` binding next to every stderr line it labels. Peer and sync reporting behavior stays the same; the guard and setup now live in the same unit they describe.

The rest is mechanical. Helpers that accepted an object only to destructure it as the first statement now destructure in the signature, so each function declares the fields it consumes at the boundary. That covers the mount materializers, dispatch tool catalog, assets app factory, and markdown export rebuild/materialization helpers without changing their call sites or runtime behavior.
