### PR TITLE
refactor(whispering): collapse record button onto one controller

### DIFF
--- a/apps/whispering/src/routes/(app)/_components/ManualRecordingAction.svelte
+++ b/apps/whispering/src/routes/(app)/_components/ManualRecordingAction.svelte
@@ -1,14 +1,7 @@
 <script lang="ts">
-	import { createMutation } from '@tanstack/svelte-query';
 	import type { Snippet } from 'svelte';
-	import { MANUAL_RECORDING_BUTTON } from '$lib/constants/audio';
-	import {
-		startManualRecording,
-		stopManualRecording,
-	} from '$lib/operations/recording';
-	import { manualRecorder } from '$lib/state/manual-recorder.svelte';
-	import { getRecordingShortcutLabel } from '$lib/utils/recording-shortcut';
 	import { viewTransition } from '$lib/utils/viewTransitions';
+	import { createManualRecordingController } from './manual-recording-controller.svelte';
 	import RecordingActionCard from './RecordingActionCard.svelte';
 
 	let {
@@ -17,59 +10,11 @@
 		pipeline: Snippet;
 	} = $props();
 
-	// Manual stop and start are separate mutations on purpose: stopManualRecording
-	// awaits the full transcription pipeline, so its pending window outlives the
-	// RECORDING state (the recorder resets to IDLE the moment the mic stops, while
-	// transcription is still running). Deriving direction from manualRecorder.state
-	// alone would mislabel that post-stop window as "starting". VAD can use a single
-	// toggle because its pipeline runs in a separate speech-end callback, not in stop.
-	const startMutation = createMutation(() => ({
-		mutationFn: startManualRecording,
-	}));
-	const stopMutation = createMutation(() => ({
-		mutationFn: stopManualRecording,
-	}));
-
-	const isStarting = $derived(startMutation.isPending);
-	const isStopping = $derived(stopMutation.isPending);
-	const isPending = $derived(isStarting || isStopping);
-	const isRecording = $derived(manualRecorder.state === 'RECORDING');
-	const shortcutLabel = $derived(getRecordingShortcutLabel('manual'));
-	const button = $derived(MANUAL_RECORDING_BUTTON[manualRecorder.state]);
-	const label = $derived(button.label);
-	const idleDescription = $derived(
-		shortcutLabel ? 'Click or press shortcut' : 'Click to record',
-	);
-	const description = $derived.by(() => {
-		if (isStarting) return 'Opening microphone input';
-		if (isStopping) return 'Stopping recording';
-		if (isRecording) return 'Click again to stop';
-		return idleDescription;
-	});
-	const tooltip = $derived.by(() => {
-		if (isStarting) return 'Preparing recording controls';
-		if (isStopping) return 'Stopping recording';
-		return label;
-	});
-
-	function handleClick() {
-		if (isRecording) {
-			stopMutation.mutate();
-		} else {
-			startMutation.mutate();
-		}
-	}
+	const rec = createManualRecordingController();
 </script>
 
 <RecordingActionCard
-	active={isRecording}
-	{description}
-	footer={isRecording ? undefined : pipeline}
-	icon={button.Icon}
+	controller={rec}
+	footer={pipeline}
 	iconViewTransitionName={viewTransition.recordingMode('manual')}
-	{label}
-	pending={isPending}
-	{shortcutLabel}
-	{tooltip}
-	onclick={handleClick}
 />

--- a/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
+++ b/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
@@ -3,28 +3,20 @@
 	import * as Kbd from '@epicenter/ui/kbd';
 	import { Spinner } from '@epicenter/ui/spinner';
 	import { cn } from '@epicenter/ui/utils';
-	import type { Component, Snippet } from 'svelte';
+	import type { Snippet } from 'svelte';
 	import { dictationCapability } from '$lib/state/dictation-capability.svelte';
+	import type { RecordingActionController } from './recording-action-controller';
 
-	// The caller owns its own state machine, so it picks which icon to show
-	// and hands us one `icon`. We only decide presentation: a spinner while
-	// pending, and the destructive "filled" treatment while `active`.
+	// The controller owns the state machine and every derived label/icon. The card
+	// only decides presentation: a spinner while pending, the destructive "filled"
+	// treatment while active, and a footer shown only at rest.
 	let {
-		active = false,
-		description,
+		controller,
 		footer,
-		icon: Icon,
 		iconViewTransitionName,
-		label,
-		onclick,
-		pending = false,
-		shortcutLabel,
-		tooltip,
 	}: {
-		active?: boolean;
-		description: string;
+		controller: RecordingActionController;
 		footer?: Snippet;
-		icon: Component<{ class?: string }>;
 		/**
 		 * When set, names the action glyph for a cross-page view transition while
 		 * the card is at rest. Suppressed automatically while `active`, because the
@@ -33,67 +25,71 @@
 		 * the card owns the at-rest gate.
 		 */
 		iconViewTransitionName?: string;
-		label: string;
-		onclick: () => void;
-		pending?: boolean;
-		shortcutLabel?: string;
-		tooltip: string;
 	} = $props();
 
 	const accessibleLabel = $derived(
-		shortcutLabel ? `${label} (${shortcutLabel})` : label,
+		controller.shortcutLabel
+			? `${controller.label} (${controller.shortcutLabel})`
+			: controller.label,
 	);
 </script>
 
 <div
 	class={cn(
 		'w-full overflow-hidden rounded-lg border border-border/70 bg-card/60 text-foreground shadow-sm ring-1 ring-foreground/5 transition-[background-color,border-color,box-shadow,color] duration-200 hover:border-primary/55 hover:bg-card/75 hover:shadow-md hover:ring-primary/25',
-		active &&
+		controller.active &&
 			'border-destructive/45 bg-card/70 hover:border-destructive/60 hover:bg-destructive/10 hover:ring-destructive/25',
 	)}
 >
 	<Button
 		aria-label={accessibleLabel}
-		aria-pressed={active}
-		aria-busy={pending}
-		{tooltip}
-		disabled={pending}
-		{onclick}
+		aria-pressed={controller.active}
+		aria-busy={controller.pending}
+		tooltip={controller.tooltip}
+		disabled={controller.pending}
+		onclick={controller.toggle}
 		variant="ghost"
 		class={cn(
 			'min-h-24 w-full justify-start gap-3 rounded-none bg-transparent px-3.5 py-3.5 text-left hover:bg-card/70 sm:gap-4 sm:px-4',
-			pending && 'cursor-wait',
+			controller.pending && 'cursor-wait',
 		)}
 	>
 		<span
 			aria-hidden="true"
 			class={cn(
 				'flex size-14 shrink-0 items-center justify-center rounded-md border border-border/70 bg-background/70 text-foreground shadow-inner transition-colors duration-200 sm:size-16',
-				active && 'border-destructive/45 bg-destructive/10 text-destructive',
+				controller.active &&
+					'border-destructive/45 bg-destructive/10 text-destructive',
 			)}
 		>
-			{#if pending}
+			{#if controller.pending}
 				<Spinner class="size-7" />
 			{:else}
+				{@const Icon = controller.icon}
 				<span
 					class="inline-flex"
-					style:view-transition-name={active ? undefined : iconViewTransitionName}
+					style:view-transition-name={controller.active
+						? undefined
+						: iconViewTransitionName}
 				>
 					<Icon
-						class={cn('size-7', active && 'size-6 fill-current stroke-[1.75]')}
+						class={cn(
+							'size-7',
+							controller.active && 'size-6 fill-current stroke-[1.75]',
+						)}
 					/>
 				</span>
 			{/if}
 		</span>
 		<span class="flex min-w-0 flex-1 flex-col gap-1">
 			<span class="truncate text-base font-semibold leading-none sm:text-lg">
-				{label}
+				{controller.label}
 			</span>
 			<span class="truncate text-xs font-medium text-muted-foreground sm:text-sm">
-				{description}
+				{controller.description}
 			</span>
 		</span>
-		{#if shortcutLabel}
+		{#if controller.shortcutLabel}
 			<!-- On desktop the shortcut is the global rdev tap, which only fires when
 			the capability is active. Keep showing the key but dim it whenever the tap
 			can't fire (macOS Accessibility ungranted or stale, or Linux Wayland),
@@ -104,12 +100,12 @@
 					dictationCapability.isUnavailable && 'opacity-50',
 				)}
 			>
-				{shortcutLabel}
+				{controller.shortcutLabel}
 			</Kbd.Root>
 		{/if}
 	</Button>
 
-	{#if footer}
+	{#if footer && !controller.active}
 		<div class="border-t border-border/60 bg-background/20 px-3 py-2">
 			{@render footer()}
 		</div>

--- a/apps/whispering/src/routes/(app)/_components/VadRecordingAction.svelte
+++ b/apps/whispering/src/routes/(app)/_components/VadRecordingAction.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
-	import { createMutation } from '@tanstack/svelte-query';
 	import type { Snippet } from 'svelte';
-	import { VAD_RECORDING_BUTTON } from '$lib/constants/audio';
-	import { toggleVadRecording } from '$lib/operations/recording';
-	import { vadRecorder } from '$lib/state/vad-recorder.svelte';
-	import { getRecordingShortcutLabel } from '$lib/utils/recording-shortcut';
 	import { viewTransition } from '$lib/utils/viewTransitions';
+	import { createVadRecordingController } from './vad-recording-controller.svelte';
 	import RecordingActionCard from './RecordingActionCard.svelte';
 
 	let {
@@ -14,37 +10,11 @@
 		pipeline: Snippet;
 	} = $props();
 
-	const toggleMutation = createMutation(() => ({
-		mutationFn: toggleVadRecording,
-	}));
-
-	const isListening = $derived(vadRecorder.state !== 'IDLE');
-	const isSpeechDetected = $derived(vadRecorder.state === 'SPEECH_DETECTED');
-	const button = $derived(VAD_RECORDING_BUTTON[vadRecorder.state]);
-	const shortcutLabel = $derived(getRecordingShortcutLabel('vad'));
-	const label = $derived(button.label);
-	const description = $derived.by(() => {
-		if (toggleMutation.isPending) return 'Updating voice activation';
-		if (isSpeechDetected) return 'Speech detected';
-		if (isListening) return 'Listening for speech';
-		return 'Listen for speech';
-	});
-	const tooltip = $derived.by(() => {
-		if (toggleMutation.isPending) return 'Updating voice activated session';
-		if (isListening) return 'Stop voice activated session';
-		return 'Start voice activated session';
-	});
+	const rec = createVadRecordingController();
 </script>
 
 <RecordingActionCard
-	active={isListening}
-	{description}
-	footer={isListening ? undefined : pipeline}
-	icon={button.Icon}
+	controller={rec}
+	footer={pipeline}
 	iconViewTransitionName={viewTransition.recordingMode('vad')}
-	{label}
-	pending={toggleMutation.isPending}
-	{shortcutLabel}
-	{tooltip}
-	onclick={() => toggleMutation.mutate()}
 />

--- a/apps/whispering/src/routes/(app)/_components/manual-recording-controller.svelte.ts
+++ b/apps/whispering/src/routes/(app)/_components/manual-recording-controller.svelte.ts
@@ -1,0 +1,88 @@
+import { createMutation } from '@tanstack/svelte-query';
+import { MANUAL_RECORDING_BUTTON } from '$lib/constants/audio';
+import {
+	startManualRecording,
+	stopManualRecording,
+} from '$lib/operations/recording';
+import { manualRecorder } from '$lib/state/manual-recorder.svelte';
+import { getRecordingShortcutLabel } from '$lib/utils/recording-shortcut';
+
+/**
+ * The shared manual-record button behavior: the start/stop mutations plus every
+ * prop a `RecordingActionCard` needs, all derived from the one `manualRecorder`
+ * state machine. The home recorder and the first-run "try it" step both call
+ * this so the button looks and behaves identically, instead of each
+ * re-implementing the wiring (and, in the wizard's case, faking the states).
+ *
+ * Start and stop are separate mutations on purpose: `stopManualRecording` awaits
+ * the full transcription pipeline, so its pending window outlives the RECORDING
+ * state (the recorder resets to IDLE the moment the mic stops, while
+ * transcription is still running). Deriving direction from `manualRecorder.state`
+ * alone would mislabel that post-stop window as "starting".
+ *
+ * Call from a component's init: it creates TanStack mutations, which need the
+ * component query-client context.
+ */
+export function createManualRecordingController() {
+	const startMutation = createMutation(() => ({
+		mutationFn: startManualRecording,
+	}));
+	const stopMutation = createMutation(() => ({
+		mutationFn: stopManualRecording,
+	}));
+
+	const isStarting = $derived(startMutation.isPending);
+	const isStopping = $derived(stopMutation.isPending);
+	const isRecording = $derived(manualRecorder.state === 'RECORDING');
+	const button = $derived(MANUAL_RECORDING_BUTTON[manualRecorder.state]);
+	const shortcutLabel = $derived(getRecordingShortcutLabel('manual'));
+
+	const description = $derived.by(() => {
+		if (isStarting) return 'Opening microphone input';
+		if (isStopping) return 'Stopping recording';
+		if (isRecording) return 'Click again to stop';
+		return shortcutLabel ? 'Click or press shortcut' : 'Click to record';
+	});
+	const tooltip = $derived.by(() => {
+		if (isStarting) return 'Preparing recording controls';
+		if (isStopping) return 'Stopping recording';
+		return button.label;
+	});
+
+	return {
+		/** Recording right now: drives the card's destructive "filled" treatment. */
+		get active() {
+			return isRecording;
+		},
+		/** Mid start or mid stop: drives the card's spinner. */
+		get pending() {
+			return isStarting || isStopping;
+		},
+		get isRecording() {
+			return isRecording;
+		},
+		/** True once a stop has fully resolved, i.e. transcription is done. */
+		get justRecorded() {
+			return stopMutation.isSuccess;
+		},
+		get icon() {
+			return button.Icon;
+		},
+		get label() {
+			return button.label;
+		},
+		get description() {
+			return description;
+		},
+		get tooltip() {
+			return tooltip;
+		},
+		get shortcutLabel() {
+			return shortcutLabel;
+		},
+		toggle() {
+			if (isRecording) stopMutation.mutate();
+			else startMutation.mutate();
+		},
+	};
+}

--- a/apps/whispering/src/routes/(app)/_components/recording-action-controller.ts
+++ b/apps/whispering/src/routes/(app)/_components/recording-action-controller.ts
@@ -1,0 +1,25 @@
+import type { Component } from 'svelte';
+
+/**
+ * What a `RecordingActionCard` needs from a recorder: its live state, the
+ * presentation derived from that state, and a single toggle. Both
+ * `createManualRecordingController` and `createVadRecordingController` satisfy
+ * this structurally, so the card takes one `controller` prop instead of the
+ * same eight-prop mapping spelled out at every call site.
+ *
+ * This is a shared contract (two factories implement it), so it is declared
+ * explicitly here rather than derived from either factory's return type.
+ */
+export type RecordingActionController = {
+	/** Capturing right now: drives the card's destructive "filled" treatment. */
+	readonly active: boolean;
+	/** Mid start or stop: drives the card's spinner. */
+	readonly pending: boolean;
+	readonly icon: Component<{ class?: string }>;
+	readonly label: string;
+	readonly description: string;
+	readonly tooltip: string;
+	readonly shortcutLabel: string;
+	/** Start when idle, stop when active. */
+	toggle(): void;
+};

--- a/apps/whispering/src/routes/(app)/_components/vad-recording-controller.svelte.ts
+++ b/apps/whispering/src/routes/(app)/_components/vad-recording-controller.svelte.ts
@@ -1,0 +1,64 @@
+import { createMutation } from '@tanstack/svelte-query';
+import { VAD_RECORDING_BUTTON } from '$lib/constants/audio';
+import { toggleVadRecording } from '$lib/operations/recording';
+import { vadRecorder } from '$lib/state/vad-recorder.svelte';
+import { getRecordingShortcutLabel } from '$lib/utils/recording-shortcut';
+
+/**
+ * The voice-activated record button behavior, in the same shape as
+ * `createManualRecordingController` so both feed `RecordingActionCard` through
+ * one `controller` prop. VAD is a single toggle (its capture pipeline runs in a
+ * separate speech-end callback, not in stop), so there is one mutation here, not
+ * a start/stop pair.
+ *
+ * Call from a component's init: it creates a TanStack mutation.
+ */
+export function createVadRecordingController() {
+	const toggleMutation = createMutation(() => ({
+		mutationFn: toggleVadRecording,
+	}));
+
+	const isListening = $derived(vadRecorder.state !== 'IDLE');
+	const isSpeechDetected = $derived(vadRecorder.state === 'SPEECH_DETECTED');
+	const button = $derived(VAD_RECORDING_BUTTON[vadRecorder.state]);
+	const shortcutLabel = $derived(getRecordingShortcutLabel('vad'));
+
+	const description = $derived.by(() => {
+		if (toggleMutation.isPending) return 'Updating voice activation';
+		if (isSpeechDetected) return 'Speech detected';
+		if (isListening) return 'Listening for speech';
+		return 'Listen for speech';
+	});
+	const tooltip = $derived.by(() => {
+		if (toggleMutation.isPending) return 'Updating voice activated session';
+		if (isListening) return 'Stop voice activated session';
+		return 'Start voice activated session';
+	});
+
+	return {
+		get active() {
+			return isListening;
+		},
+		get pending() {
+			return toggleMutation.isPending;
+		},
+		get icon() {
+			return button.Icon;
+		},
+		get label() {
+			return button.label;
+		},
+		get description() {
+			return description;
+		},
+		get tooltip() {
+			return tooltip;
+		},
+		get shortcutLabel() {
+			return shortcutLabel;
+		},
+		toggle() {
+			toggleMutation.mutate();
+		},
+	};
+}


### PR DESCRIPTION
Recording actions now hand `RecordingActionCard` one controller instead of re-deriving the same active, pending, icon, label, description, tooltip, shortcut, and click wiring at each call site.

`createManualRecordingController` and `createVadRecordingController` own the mutations and derived presentation for their modes. `ManualRecordingAction` and `VadRecordingAction` still expose the same `{ pipeline }` contract; internally they construct the controller and pass it through.

The card also owns the shared "hide footer while active" rule, which keeps the visual behavior attached to the component that renders it.
