### PR TITLE
refactor(whispering): extract RecordingResult component

### DIFF
--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -7,14 +7,12 @@
 	import * as SectionHeader from '@epicenter/ui/section-header';
 	import * as ToggleGroup from '@epicenter/ui/toggle-group';
 	import XIcon from '@lucide/svelte/icons/x';
-	import { createQuery } from '@tanstack/svelte-query';
 	import type { UnlistenFn } from '@tauri-apps/api/event';
 	import { onDestroy, onMount } from 'svelte';
 	import { defineErrors, extractErrorMessage } from 'wellcrafted/error';
 	import { tryAsync } from 'wellcrafted/result';
 	import { commandRunners } from '$lib/commands';
 	import DictationCapabilityNotice from '$lib/components/DictationCapabilityNotice.svelte';
-	import TranscriptDialog from '$lib/components/copyable/TranscriptDialog.svelte';
 	import {
 		TranscriptionRuntimeConfig,
 		TranscriptionSelector,
@@ -37,7 +35,6 @@
 	import { importFiles } from '$lib/operations/import';
 	import { selectCaptureSurface } from '$lib/operations/recording';
 	import { report } from '$lib/report';
-	import { rpc } from '$lib/rpc';
 	import { services } from '$lib/services';
 	import { getTranscriptionReadiness } from '$lib/settings/transcription-validation';
 	import { captureSurface } from '$lib/state/capture-surface.svelte';
@@ -52,6 +49,7 @@
 	import CaptureBehaviorPopover from './_components/CaptureBehaviorPopover.svelte';
 	import CapturePipeline from './_components/CapturePipeline.svelte';
 	import ManualRecordingAction from './_components/ManualRecordingAction.svelte';
+	import RecordingResult from './_components/RecordingResult.svelte';
 	import VadRecordingAction from './_components/VadRecordingAction.svelte';
 
 	const latestRecording = $derived(recordings.sorted[0]);
@@ -96,11 +94,6 @@
 			reason,
 		}),
 	});
-
-	const audioPlaybackUrlQuery = createQuery(() => ({
-		...rpc.audio.getPlaybackUrl(() => latestRecording?.id ?? '').options,
-		enabled: !!latestRecording?.id,
-	}));
 
 	let unlistenDragDrop: UnlistenFn | undefined;
 
@@ -171,9 +164,6 @@
 
 	onDestroy(() => {
 		unlistenDragDrop?.();
-		if (latestRecording?.id) {
-			services.blobs.audio.revokeUrl(latestRecording.id);
-		}
 	});
 </script>
 
@@ -330,40 +320,26 @@
 		{/if}
 
 		{#if latestRecording}
-			<div class="flex w-full flex-col gap-2">
-				<TranscriptDialog
-					recordingId={latestRecording.id}
-					transcript={latestRecording.transcript}
-					rows={1}
-					disabled={!latestRecording.transcript.trim()}
-					onDelete={() => {
-						confirmationDialog.open({
-							title: 'Delete recording',
-							description: 'Are you sure you want to delete this recording?',
-							confirm: { text: 'Delete', variant: 'destructive' },
-							onConfirm: () => {
-								services.blobs.audio.revokeUrl(latestRecording.id);
-								recordings.delete(latestRecording.id);
-								report.success({
-									title: 'Deleted recording!',
-									description: 'Your recording has been deleted.',
-								});
-							},
-						});
-					}}
-				/>
-
-				{#if audioPlaybackUrlQuery.data}
-					<audio
-						style:view-transition-name={viewTransition.recording(
-							latestRecording.id,
-						).audio}
-						src={audioPlaybackUrlQuery.data}
-						controls
-						class="h-8 w-full"
-					></audio>
-				{/if}
-			</div>
+			<RecordingResult
+				recordingId={latestRecording.id}
+				transcript={latestRecording.transcript}
+				rows={1}
+				onDelete={() => {
+					confirmationDialog.open({
+						title: 'Delete recording',
+						description: 'Are you sure you want to delete this recording?',
+						confirm: { text: 'Delete', variant: 'destructive' },
+						onConfirm: () => {
+							services.blobs.audio.revokeUrl(latestRecording.id);
+							recordings.delete(latestRecording.id);
+							report.success({
+								title: 'Deleted recording!',
+								description: 'Your recording has been deleted.',
+							});
+						},
+					});
+				}}
+			/>
 		{/if}
 
 		<div class="flex flex-col items-center gap-3">

--- a/apps/whispering/src/routes/(app)/_components/RecordingResult.svelte
+++ b/apps/whispering/src/routes/(app)/_components/RecordingResult.svelte
@@ -1,0 +1,57 @@
+<!--
+	The result of a finished recording: a copyable, expandable transcript preview
+	and a player for the captured audio. The home recorder and the first-run "try
+	it" step both render this, so the two cannot drift.
+
+	The audio renders whenever the clip exists, independent of the transcript, so a
+	silent or not-yet-transcribed recording still plays back. The playback URL is
+	owned here: the blob store caches it per id, and it is revoked on teardown.
+-->
+<script lang="ts">
+	import { createQuery } from '@tanstack/svelte-query';
+	import { onDestroy } from 'svelte';
+	import TranscriptDialog from '$lib/components/copyable/TranscriptDialog.svelte';
+	import { rpc } from '$lib/rpc';
+	import { services } from '$lib/services';
+	import { viewTransition } from '$lib/utils/viewTransitions';
+
+	let {
+		recordingId,
+		transcript,
+		rows = 1,
+		onDelete,
+	}: {
+		recordingId: string;
+		transcript: string;
+		/** Visible rows of the transcript preview before it scrolls/expands. */
+		rows?: number;
+		/** When provided, the transcript dialog shows a delete action. */
+		onDelete?: () => void;
+	} = $props();
+
+	const audioQuery = createQuery(() => ({
+		...rpc.audio.getPlaybackUrl(() => recordingId).options,
+		enabled: !!recordingId,
+	}));
+	onDestroy(() => {
+		if (recordingId) services.blobs.audio.revokeUrl(recordingId);
+	});
+</script>
+
+<div class="flex w-full flex-col gap-2">
+	<TranscriptDialog
+		{recordingId}
+		{transcript}
+		{rows}
+		disabled={!transcript.trim()}
+		{onDelete}
+	/>
+	{#if audioQuery.data}
+		<audio
+			style:view-transition-name={viewTransition.recording(recordingId).audio}
+			src={audioQuery.data}
+			controls
+			class="h-8 w-full"
+		></audio>
+	{/if}
+</div>


### PR DESCRIPTION
The finished recording result is now a `RecordingResult` component instead of page-local transcript and playback plumbing inside the home route.

`RecordingResult` owns the transcript dialog, audio playback element, playback URL query, and teardown revoke for the rendered result. The home page keeps the capture surface, delete confirmation, drag-drop, shortcuts, and manual / VAD / import flows where they already live.

The extraction gives the first-dictation flow and the main recorder one result surface to share, so playback and transcript presentation cannot drift between them.
