### PR TITLE
refactor: require optional params and split conflated option bags

### DIFF
--- a/apps/api/ui/src/lib/billing/queries.ts
+++ b/apps/api/ui/src/lib/billing/queries.ts
@@ -48,7 +48,7 @@ export const billing = {
 
 	topUp: defineMutation({
 		mutationKey: billingKeys.topUp,
-		mutationFn: (successUrl?: string) =>
+		mutationFn: (successUrl: string) =>
 			billingApi.checkoutTopUp({ successUrl }),
 	}),
 

--- a/apps/api/worker/billing/service.ts
+++ b/apps/api/worker/billing/service.ts
@@ -443,7 +443,7 @@ export function createBillingService(
 	 */
 	function reserveAiCreditsWithLock(input: {
 		credits: number;
-		properties?: Record<string, unknown>;
+		properties: Record<string, unknown>;
 	}): Promise<Result<LockedCheck, BillingError>> {
 		const lockId = crypto.randomUUID();
 		return tryAutumn(async () => {
@@ -456,7 +456,7 @@ export function createBillingService(
 					enabled: true,
 					expiresAt: Date.now() + LOCK_TTL_MS,
 				},
-				...(input.properties ? { properties: input.properties } : {}),
+				properties: input.properties,
 			});
 
 			return {

--- a/apps/fuji/src/lib/components/TagInput.svelte
+++ b/apps/fuji/src/lib/components/TagInput.svelte
@@ -9,7 +9,7 @@
 		onRemove,
 	}: {
 		values: string[];
-		placeholder?: string;
+		placeholder: string;
 		onAdd: (value: string) => void;
 		onRemove: (value: string) => void;
 	} = $props();

--- a/apps/fuji/src/routes/(signed-in)/components/EntryBodyEditor.svelte
+++ b/apps/fuji/src/routes/(signed-in)/components/EntryBodyEditor.svelte
@@ -30,7 +30,7 @@
 		onWordCountChange,
 	}: {
 		entryId: EntryId;
-		onWordCountChange?: (count: number) => void;
+		onWordCountChange: (count: number) => void;
 	} = $props();
 
 	const fuji = requireFuji();
@@ -48,7 +48,7 @@
 			if (nextCount === previousCount) return;
 
 			previousCount = nextCount;
-			onChange?.(nextCount);
+			onChange(nextCount);
 		}
 
 		return new Plugin({

--- a/apps/honeycrisp/src/lib/editor/Editor.svelte
+++ b/apps/honeycrisp/src/lib/editor/Editor.svelte
@@ -234,7 +234,7 @@
 		onContentChange,
 	}: {
 		yxmlfragment: Y.XmlFragment;
-		onContentChange?: (content: {
+		onContentChange: (content: {
 			title: string;
 			preview: string;
 			wordCount: number;
@@ -354,7 +354,7 @@
 				const newState = currentView.state.apply(tr);
 				currentView.updateState(newState);
 				updateActiveFormats(newState);
-				if (tr.docChanged && onContentChange) {
+				if (tr.docChanged) {
 					onContentChange(extractTitleAndPreview(newState.doc));
 				}
 			},
@@ -364,9 +364,7 @@
 		updateActiveFormats(currentView.state);
 
 		// Fire initial content extraction
-		if (onContentChange) {
-			onContentChange(extractTitleAndPreview(currentView.state.doc));
-		}
+		onContentChange(extractTitleAndPreview(currentView.state.doc));
 
 		return () => {
 			currentView.destroy();

--- a/apps/honeycrisp/src/routes/(signed-in)/state/notes.svelte.ts
+++ b/apps/honeycrisp/src/routes/(signed-in)/state/notes.svelte.ts
@@ -16,7 +16,7 @@
  * {#each honeycrisp.state.notes.all as note (note.id)}
  *   <p>{note.title}</p>
  * {/each}
- * <button onclick={() => honeycrisp.state.notes.create()}>New Note</button>
+ * <button onclick={() => honeycrisp.state.notes.create(null)}>New Note</button>
  * ```
  */
 
@@ -101,11 +101,11 @@ export function createNotes({
 		 * app.state.view.selectNote(id);
 		 * ```
 		 */
-		create(folderId?: FolderId | null) {
+		create(folderId: FolderId | null) {
 			const id = generateNoteId();
 			honeycrisp.tables.notes.set({
 				id,
-				folderId: folderId ?? null,
+				folderId,
 				title: '',
 				preview: '',
 				pinned: false,

--- a/apps/local-books/src/commands/auth.ts
+++ b/apps/local-books/src/commands/auth.ts
@@ -2,7 +2,7 @@ import type { ParsedArgs } from '../cli.ts';
 import { recordCompany } from '../companies.ts';
 import { loadConfig } from '../config.ts';
 import { createKeyring } from '../keyring.ts';
-import { type OAuthDeps, runAuthorizationFlow } from '../oauth.ts';
+import { runAuthorizationFlow } from '../oauth.ts';
 import { storeToken } from '../token-manager.ts';
 import { formatRelative } from './context.ts';
 
@@ -27,13 +27,12 @@ export async function runAuth(args: ParsedArgs): Promise<number> {
 	}
 
 	const keyring = createKeyring(config);
-	const deps: OAuthDeps = {
-		now: () => Date.now(),
-		log: (m) => console.error(m),
-	};
 
 	console.error(`Authenticating against QuickBooks (${config.environment})...`);
-	const { data: token, error } = await runAuthorizationFlow(config, deps);
+	const { data: token, error } = await runAuthorizationFlow(config, {
+		now: () => Date.now(),
+		log: (m) => console.error(m),
+	});
 	if (error) {
 		console.error(`auth failed: ${error.message}`);
 		return 1;

--- a/apps/local-books/src/commands/sync.ts
+++ b/apps/local-books/src/commands/sync.ts
@@ -2,7 +2,6 @@ import ms from 'ms';
 import type { ParsedArgs } from '../cli.ts';
 import { openBooksDb } from '../db.ts';
 import { DEFAULT_ENTITIES, isKnownEntity } from '../entities.ts';
-import type { OAuthDeps } from '../oauth.ts';
 import { dbPath } from '../paths.ts';
 import { createQbClient } from '../qb-client.ts';
 import {
@@ -59,13 +58,7 @@ export async function runSync(args: ParsedArgs): Promise<number> {
 
 	const now = () => Date.now();
 	const log = (m: string) => console.error(m);
-	const oauthDeps: OAuthDeps = { now, log };
-	const tokens = createTokenManager({
-		config,
-		keyring,
-		token,
-		deps: oauthDeps,
-	});
+	const tokens = createTokenManager({ config, keyring, token, now });
 	const client = createQbClient({ config, realmId, tokens, log });
 	const db = openBooksDb(dbPath(config.dataDir, realmId));
 	const deps: SyncDeps = { db, client, config, now, log };

--- a/apps/local-books/src/oauth.ts
+++ b/apps/local-books/src/oauth.ts
@@ -56,7 +56,6 @@ export type OAuthError = InferErrors<typeof OAuthError>;
 
 export type OAuthDeps = {
 	now: () => number;
-	fetchImpl?: typeof fetch;
 	openBrowser?: (url: string) => void;
 	log?: (message: string) => void;
 	/** Callback wait budget; defaults to 5 minutes. */
@@ -74,12 +73,11 @@ function authServer(config: AppConfig): oauth.AuthorizationServer {
 	};
 }
 
-/** Allow http for the mock token endpoint in tests; inject a fetch when given. */
-function httpOptions(config: AppConfig, deps: OAuthDeps) {
+/** Allow http for the mock token endpoint in tests. */
+function httpOptions(config: AppConfig) {
 	return {
 		[oauth.allowInsecureRequests]:
 			new URL(config.tokenUrl).protocol === 'http:',
-		...(deps.fetchImpl ? { [oauth.customFetch]: deps.fetchImpl } : {}),
 	};
 }
 
@@ -99,7 +97,7 @@ export async function refreshAccessToken(
 			client,
 			oauth.ClientSecretBasic(config.clientSecret),
 			token.refreshToken,
-			httpOptions(config, deps),
+			httpOptions(config),
 		);
 		const grant = await oauth.processRefreshTokenResponse(as, client, response);
 		// Rotation: QuickBooks may omit refresh_token when the old one stays valid.
@@ -151,7 +149,7 @@ export async function completeAuthorization(
 			params,
 			config.redirectUri,
 			codeVerifier ?? oauth.nopkce,
-			httpOptions(config, deps),
+			httpOptions(config),
 		);
 		const grant = await oauth.processAuthorizationCodeResponse(
 			as,

--- a/apps/local-books/src/oauth.ts
+++ b/apps/local-books/src/oauth.ts
@@ -54,7 +54,13 @@ export const OAuthError = defineErrors({
 });
 export type OAuthError = InferErrors<typeof OAuthError>;
 
-export type OAuthDeps = {
+/**
+ * Boundaries the interactive {@link runAuthorizationFlow} needs beyond the
+ * clock: a browser opener and a callback-wait budget. The non-interactive grant
+ * exchanges ({@link refreshAccessToken}, {@link completeAuthorization}) need only
+ * the clock, so they take a bare `now` rather than this bag.
+ */
+export type AuthorizationFlowOptions = {
 	now: () => number;
 	openBrowser?: (url: string) => void;
 	log?: (message: string) => void;
@@ -84,7 +90,7 @@ function httpOptions(config: AppConfig) {
 export async function refreshAccessToken(
 	config: AppConfig,
 	token: TokenSet,
-	deps: OAuthDeps,
+	now: () => number,
 ): GrantResult {
 	if (!config.clientId || !config.clientSecret) {
 		return OAuthError.MissingCredentials();
@@ -104,7 +110,7 @@ export async function refreshAccessToken(
 		return tokenSetFromGrant(grant, {
 			realmId: token.realmId,
 			environment: config.environment,
-			now: deps.now(),
+			now: now(),
 			fallbackRefreshToken: token.refreshToken,
 		});
 	} catch (cause) {
@@ -126,7 +132,7 @@ export async function completeAuthorization(
 		state,
 		codeVerifier,
 	}: { callbackUrl: URL; state: string; codeVerifier?: string },
-	deps: OAuthDeps,
+	now: () => number,
 ): GrantResult {
 	if (!config.clientId || !config.clientSecret) {
 		return OAuthError.MissingCredentials();
@@ -159,7 +165,7 @@ export async function completeAuthorization(
 		return tokenSetFromGrant(grant, {
 			realmId,
 			environment: config.environment,
-			now: deps.now(),
+			now: now(),
 		});
 	} catch (cause) {
 		if (cause instanceof oauth.AuthorizationResponseError) {
@@ -208,7 +214,7 @@ function defaultOpenBrowser(url: string): void {
  */
 export async function runAuthorizationFlow(
 	config: AppConfig,
-	deps: OAuthDeps,
+	options: AuthorizationFlowOptions,
 ): GrantResult {
 	if (!config.clientId || !config.clientSecret) {
 		return OAuthError.MissingCredentials();
@@ -222,8 +228,8 @@ export async function runAuthorizationFlow(
 	// HTTPS tunnel (Intuit production requires one, since it rejects localhost)
 	// forwards to `callbackPort` here, which has no port of its own in the URL.
 	const port = config.callbackPort ?? Number(redirect.port || '80');
-	const timeoutMs = deps.timeoutMs ?? 5 * 60 * 1000;
-	const log = deps.log ?? (() => {});
+	const timeoutMs = options.timeoutMs ?? 5 * 60 * 1000;
+	const log = options.log ?? (() => {});
 
 	const { promise: callback, resolve } = Promise.withResolvers<URL | null>();
 	const server = Bun.serve({
@@ -244,7 +250,7 @@ export async function runAuthorizationFlow(
 	const authorizeUrl = buildAuthorizeUrl(config, { state, codeChallenge });
 	log('Opening your browser to authorize QuickBooks access...');
 	log(`If it does not open, visit:\n  ${authorizeUrl}`);
-	(deps.openBrowser ?? defaultOpenBrowser)(authorizeUrl);
+	(options.openBrowser ?? defaultOpenBrowser)(authorizeUrl);
 
 	const timeout = new Promise<URL | null>((resolveTimeout) => {
 		setTimeout(() => resolveTimeout(null), timeoutMs);
@@ -256,6 +262,6 @@ export async function runAuthorizationFlow(
 	return completeAuthorization(
 		config,
 		{ callbackUrl, state, codeVerifier },
-		deps,
+		options.now,
 	);
 }

--- a/apps/local-books/src/qb-client.ts
+++ b/apps/local-books/src/qb-client.ts
@@ -65,14 +65,13 @@ export type QbClientDeps = {
 	config: AppConfig;
 	realmId: string;
 	tokens: TokenManager;
-	fetchImpl?: typeof fetch;
-	sleep?: (ms: number) => Promise<void>;
 	log?: (message: string) => void;
-	/** Retry budget for 429 / 5xx / transient network errors. */
-	maxRetries?: number;
-	/** Wait applied on 429 when the response has no Retry-After. */
-	throttleWaitMs?: number;
 };
+
+/** Retry budget for 429 / 5xx / transient network errors. */
+const MAX_RETRIES = 5;
+/** Wait applied on 429 when the response has no Retry-After. QuickBooks asks ~60s. */
+const THROTTLE_WAIT_MS = 60_000;
 
 function retryAfterMs(response: Response): number | null {
 	const header = response.headers.get('retry-after');
@@ -81,18 +80,15 @@ function retryAfterMs(response: Response): number | null {
 	return Number.isFinite(seconds) ? seconds * 1000 : null;
 }
 
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
 export function createQbClient(deps: QbClientDeps): QbClient {
 	const { config, realmId, tokens } = deps;
-	const fetchImpl = deps.fetchImpl ?? fetch;
-	const sleep =
-		deps.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
 	const log = deps.log ?? (() => {});
-	const maxRetries = deps.maxRetries ?? 5;
-	const throttleWaitMs = deps.throttleWaitMs ?? 60_000;
 	const pageSize = config.pageSize;
 
 	const backoffMs = (attempt: number) =>
-		Math.min(throttleWaitMs, 500 * 2 ** attempt);
+		Math.min(THROTTLE_WAIT_MS, 500 * 2 ** attempt);
 
 	async function request(
 		path: string,
@@ -112,14 +108,14 @@ export function createQbClient(deps: QbClientDeps): QbClient {
 
 			let response: Response;
 			try {
-				response = await fetchImpl(url.toString(), {
+				response = await fetch(url.toString(), {
 					headers: {
 						Authorization: `Bearer ${token.data}`,
 						Accept: 'application/json',
 					},
 				});
 			} catch (cause) {
-				if (attempt < maxRetries) {
+				if (attempt < MAX_RETRIES) {
 					attempt += 1;
 					await sleep(backoffMs(attempt));
 					continue;
@@ -145,19 +141,19 @@ export function createQbClient(deps: QbClientDeps): QbClient {
 			}
 
 			if (response.status === 429) {
-				if (attempt >= maxRetries)
+				if (attempt >= MAX_RETRIES)
 					return QbApiError.Throttled({ retries: attempt });
 				attempt += 1;
-				const wait = retryAfterMs(response) ?? throttleWaitMs;
+				const wait = retryAfterMs(response) ?? THROTTLE_WAIT_MS;
 				log(
-					`QuickBooks throttled (429); waiting ${wait}ms before retry ${attempt}/${maxRetries}.`,
+					`QuickBooks throttled (429); waiting ${wait}ms before retry ${attempt}/${MAX_RETRIES}.`,
 				);
 				await sleep(wait);
 				continue;
 			}
 
 			if (response.status >= 500) {
-				if (attempt >= maxRetries) {
+				if (attempt >= MAX_RETRIES) {
 					const body = await response.text().catch(() => '');
 					return QbApiError.Http({ status: response.status, body });
 				}

--- a/apps/local-books/src/sync.ts
+++ b/apps/local-books/src/sync.ts
@@ -208,7 +208,7 @@ export type SyncLoopOptions = {
 	/** Aborting the signal stops the loop after the current pass or sleep. */
 	signal: AbortSignal;
 	/** Called after each pass with its outcome and 1-based pass number. */
-	onPass?: (outcome: SyncAllOutcome, pass: number) => void;
+	onPass: (outcome: SyncAllOutcome, pass: number) => void;
 };
 
 /**
@@ -246,7 +246,7 @@ export async function runSyncLoop(
 			entities: opts.entities,
 		});
 		pass += 1;
-		opts.onPass?.(outcome, pass);
+		opts.onPass(outcome, pass);
 		if (opts.signal.aborted) break;
 		await interruptibleSleep(opts.intervalMs, opts.signal);
 	}

--- a/apps/local-books/src/token-manager.ts
+++ b/apps/local-books/src/token-manager.ts
@@ -93,8 +93,7 @@ export function createTokenManager({
 	return {
 		current: () => current,
 		async getValidAccessToken() {
-			if (!isAccessTokenExpired(current, now()))
-				return Ok(current.accessToken);
+			if (!isAccessTokenExpired(current, now())) return Ok(current.accessToken);
 			return refresh();
 		},
 		forceRefresh: refresh,

--- a/apps/local-books/src/token-manager.ts
+++ b/apps/local-books/src/token-manager.ts
@@ -3,7 +3,7 @@ import { Value } from 'typebox/value';
 import { Ok, type Result } from 'wellcrafted/result';
 import type { AppConfig } from './config.ts';
 import type { Keyring } from './keyring.ts';
-import { type OAuthDeps, OAuthError, refreshAccessToken } from './oauth.ts';
+import { OAuthError, refreshAccessToken } from './oauth.ts';
 import type { TokenGrantError } from './tokens.ts';
 import {
 	isAccessTokenExpired,
@@ -66,23 +66,23 @@ export function createTokenManager({
 	config,
 	keyring,
 	token,
-	deps,
+	now,
 }: {
 	config: AppConfig;
 	keyring: Keyring;
 	token: TokenSet;
-	deps: OAuthDeps;
+	now: () => number;
 }): TokenManager {
 	let current = token;
 
 	async function refresh(): Promise<Result<string, TokenError>> {
-		if (isRefreshTokenExpired(current, deps.now())) {
+		if (isRefreshTokenExpired(current, now())) {
 			return OAuthError.ReauthRequired({ reason: 'refresh token expired' });
 		}
 		const { data: refreshed, error } = await refreshAccessToken(
 			config,
 			current,
-			deps,
+			now,
 		);
 		if (error) return { data: null, error };
 		current = refreshed;
@@ -93,7 +93,7 @@ export function createTokenManager({
 	return {
 		current: () => current,
 		async getValidAccessToken() {
-			if (!isAccessTokenExpired(current, deps.now()))
+			if (!isAccessTokenExpired(current, now()))
 				return Ok(current.accessToken);
 			return refresh();
 		},

--- a/apps/local-books/test/oauth.test.ts
+++ b/apps/local-books/test/oauth.test.ts
@@ -34,7 +34,7 @@ test('authorization-code exchange yields a token set', async () => {
 	const { data, error } = await completeAuthorization(
 		config,
 		{ callbackUrl: callback('s1'), state: 's1' },
-		{ now: () => NOW },
+		() => NOW,
 	);
 	expect(error).toBeNull();
 	expect(data?.realmId).toBe(server.realmId);
@@ -52,7 +52,7 @@ test('a forged callback (state mismatch) is rejected, not exchanged', async () =
 	const { error } = await completeAuthorization(
 		config,
 		{ callbackUrl: callback('attacker-state'), state: 'expected-state' },
-		{ now: () => NOW },
+		() => NOW,
 	);
 	expect(error).not.toBeNull();
 	expect(server.hits.token).toBe(before); // never reached the token endpoint
@@ -73,9 +73,7 @@ test('refresh exchange mints a new token set', async () => {
 		refreshTokenExpiresAt: new Date(NOW + 8726400 * 1000).toISOString(),
 		obtainedAt: new Date(NOW).toISOString(),
 	};
-	const { data, error } = await refreshAccessToken(config, token, {
-		now: () => NOW,
-	});
+	const { data, error } = await refreshAccessToken(config, token, () => NOW);
 	expect(error).toBeNull();
 	expect(data?.accessToken).not.toBe('old-access');
 	expect(server.hits.token).toBe(before + 1);
@@ -117,7 +115,7 @@ test('a missing client secret is reported, not thrown', async () => {
 	const { error } = await completeAuthorization(
 		config,
 		{ callbackUrl: callback('s2'), state: 's2' },
-		{ now: () => NOW },
+		() => NOW,
 	);
 	expect(error?.name).toBe('MissingCredentials');
 });

--- a/apps/local-books/test/sync.test.ts
+++ b/apps/local-books/test/sync.test.ts
@@ -39,12 +39,7 @@ function setup(configOver: Partial<AppConfig> = {}) {
 		now: clock,
 	}).data as TokenSet;
 	const tokens = createTokenManager({ config, keyring, token, deps: { now } });
-	const client = createQbClient({
-		config,
-		realmId: server.realmId,
-		tokens,
-		sleep: async () => {},
-	});
+	const client = createQbClient({ config, realmId: server.realmId, tokens });
 	const tmp = tempDir();
 	const db = openBooksDb(join(tmp.dir, 'books.db'));
 
@@ -222,12 +217,7 @@ test('a 401 triggers a transparent refresh, retries, and persists the new token'
 		token: stale,
 		deps: { now },
 	});
-	const client = createQbClient({
-		config,
-		realmId: server.realmId,
-		tokens,
-		sleep: async () => {},
-	});
+	const client = createQbClient({ config, realmId: server.realmId, tokens });
 	server.put('Invoice', makeInvoice('1'));
 
 	const { data, error } = await client.queryAll('Invoice');

--- a/apps/local-books/test/sync.test.ts
+++ b/apps/local-books/test/sync.test.ts
@@ -38,7 +38,7 @@ function setup(configOver: Partial<AppConfig> = {}) {
 		environment: 'sandbox',
 		now: clock,
 	}).data as TokenSet;
-	const tokens = createTokenManager({ config, keyring, token, deps: { now } });
+	const tokens = createTokenManager({ config, keyring, token, now });
 	const client = createQbClient({ config, realmId: server.realmId, tokens });
 	const tmp = tempDir();
 	const db = openBooksDb(join(tmp.dir, 'books.db'));
@@ -211,12 +211,7 @@ test('a 401 triggers a transparent refresh, retries, and persists the new token'
 	await storeToken(keyring, stale);
 	server.rejectAccessToken('stale-access');
 
-	const tokens = createTokenManager({
-		config,
-		keyring,
-		token: stale,
-		deps: { now },
-	});
+	const tokens = createTokenManager({ config, keyring, token: stale, now });
 	const client = createQbClient({ config, realmId: server.realmId, tokens });
 	server.put('Invoice', makeInvoice('1'));
 

--- a/apps/matter/src/lib/components/ModeledCell.svelte
+++ b/apps/matter/src/lib/components/ModeledCell.svelte
@@ -10,7 +10,7 @@
 		cell,
 		save,
 		clear,
-		mode = 'grid',
+		mode,
 	}: {
 		cell: Cell;
 		save: SaveField;
@@ -21,9 +21,8 @@
 		 * first, so the clear affordance stays quiet (dimmed) at rest and brightens on
 		 * hover or keyboard focus. `detail` is the editing row in the row dialog:
 		 * editing comes first, so the clear affordance is shown at full strength.
-		 * Defaults to the quieter `grid`.
 		 */
-		mode?: 'grid' | 'detail';
+		mode: 'grid' | 'detail';
 	} = $props();
 
 	// Kind dispatch is gated behind VALIDITY: an INVALID value is out of every

--- a/apps/opensidian/src/lib/components/editor/CodeMirrorEditor.svelte
+++ b/apps/opensidian/src/lib/components/editor/CodeMirrorEditor.svelte
@@ -15,12 +15,12 @@
 
 	let {
 		ytext,
-		filename = 'untitled.md',
-		extensions: extraExtensions = [],
+		filename,
+		extensions: extraExtensions,
 	}: {
 		ytext: Y.Text;
-		filename?: string;
-		extensions?: Extension[];
+		filename: string;
+		extensions: Extension[];
 	} = $props();
 
 	const opensidian = requireOpensidian();

--- a/apps/opensidian/src/lib/components/editor/extensions/link-decorations.ts
+++ b/apps/opensidian/src/lib/components/editor/extensions/link-decorations.ts
@@ -30,11 +30,11 @@ type LinkDecorationConfig = {
 	/** Called when a decorated epicenter link is clicked. */
 	onNavigate: (ref: EpicenterLink) => void;
 	/**
-	 * Optional title resolver for epicenter links.
+	 * Title resolver for epicenter links.
 	 *
-	 * When provided and it returns a non-null value, the widget displays the
-	 * resolved title instead of the stored markdown display text. This is useful
-	 * when the target entity can be renamed after the link was inserted.
+	 * When it returns a non-null value, the widget displays the resolved title
+	 * instead of the stored markdown display text. This is useful when the target
+	 * entity can be renamed after the link was inserted.
 	 *
 	 * @example
 	 * ```typescript
@@ -44,7 +44,7 @@ type LinkDecorationConfig = {
 	 * }
 	 * ```
 	 */
-	resolveTitle?: (ref: EpicenterLink) => string | null;
+	resolveTitle: (ref: EpicenterLink) => string | null;
 };
 
 /**
@@ -78,7 +78,7 @@ class EpicenterLinkWidget extends WidgetType {
 
 	override toDOM(): HTMLElement {
 		const span = document.createElement('span');
-		const resolvedTitle = this.config.resolveTitle?.(this.ref);
+		const resolvedTitle = this.config.resolveTitle(this.ref);
 		span.textContent = resolvedTitle ?? this.displayText;
 		span.className = 'cm-epicenter-link';
 		span.style.cssText =

--- a/apps/opensidian/src/lib/components/search/SearchResultGroup.svelte
+++ b/apps/opensidian/src/lib/components/search/SearchResultGroup.svelte
@@ -2,7 +2,6 @@
 	import { asFileId } from '@epicenter/filesystem';
 	import { Badge } from '@epicenter/ui/badge';
 	import * as Collapsible from '@epicenter/ui/collapsible';
-	import { cn } from '@epicenter/ui/utils';
 	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
 	import FileTextIcon from '@lucide/svelte/icons/file-text';
 	import { requireOpensidian } from '$lib/session';
@@ -17,8 +16,11 @@
 		defaultOpen: boolean;
 	} = $props();
 
-	// svelte-ignore state_referenced_locally - `defaultOpen` is an uncontrolled default: seed the open state once, then let the user own it via the trigger (a later re-search changing matchCount must not clobber their toggle).
-	let open = $state(defaultOpen);
+	// svelte-ignore state_referenced_locally - snapshot the matchCount heuristic once as the
+	// collapsible's initial open state. `loadMore` raises matchCount on persisted groups (keyed
+	// by fileId), so a reactive `open={defaultOpen}` would collapse a group the user had expanded.
+	// bits-ui owns the live open/closed state from here; the chevron rotates off its data-state.
+	const initialOpen = defaultOpen;
 
 	/**
 	 * Strip all HTML tags except <mark> for safe snippet rendering.
@@ -38,15 +40,12 @@
 	);
 </script>
 
-<Collapsible.Root bind:open>
+<Collapsible.Root open={initialOpen}>
 	<Collapsible.Trigger
 		class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-accent/50"
 	>
 		<ChevronRightIcon
-			class={cn(
-				'size-4 shrink-0 text-muted-foreground transition-transform',
-				open && 'rotate-90',
-			)}
+			class="size-4 shrink-0 text-muted-foreground transition-transform [[data-state=open]>&]:rotate-90"
 		/>
 		<FileTextIcon class="size-4 shrink-0 text-muted-foreground" />
 		<span class="truncate font-medium">{group.fileName}</span>

--- a/apps/opensidian/src/lib/components/search/SearchResultGroup.svelte
+++ b/apps/opensidian/src/lib/components/search/SearchResultGroup.svelte
@@ -11,10 +11,10 @@
 	const opensidian = requireOpensidian();
 	let {
 		group,
-		defaultOpen = true,
+		defaultOpen,
 	}: {
 		group: FileGroup;
-		defaultOpen?: boolean;
+		defaultOpen: boolean;
 	} = $props();
 
 	let open = $derived(defaultOpen);

--- a/apps/opensidian/src/lib/components/search/SearchResultGroup.svelte
+++ b/apps/opensidian/src/lib/components/search/SearchResultGroup.svelte
@@ -17,7 +17,8 @@
 		defaultOpen: boolean;
 	} = $props();
 
-	let open = $derived(defaultOpen);
+	// svelte-ignore state_referenced_locally - `defaultOpen` is an uncontrolled default: seed the open state once, then let the user own it via the trigger (a later re-search changing matchCount must not clobber their toggle).
+	let open = $state(defaultOpen);
 
 	/**
 	 * Strip all HTML tags except <mark> for safe snippet rendering.

--- a/apps/opensidian/src/lib/components/tree/InlineNameInput.svelte
+++ b/apps/opensidian/src/lib/components/tree/InlineNameInput.svelte
@@ -4,12 +4,12 @@
 
 	let {
 		defaultValue = '',
-		icon = 'file',
+		icon,
 		onConfirm,
 		onCancel,
 	}: {
 		defaultValue?: string;
-		icon?: 'file' | 'folder';
+		icon: 'file' | 'folder';
 		onConfirm: (name: string) => void;
 		onCancel: () => void;
 	} = $props();

--- a/apps/tab-manager/src/lib/components/CollapsibleSection.svelte
+++ b/apps/tab-manager/src/lib/components/CollapsibleSection.svelte
@@ -13,7 +13,7 @@
 		label: string;
 		icon?: Snippet;
 		children: Snippet;
-		contentClass?: string;
+		contentClass: string;
 	} = $props();
 </script>
 
@@ -31,10 +31,7 @@
 	</Collapsible.Trigger>
 	<Collapsible.Content>
 		<div
-			class={cn(
-				'mt-1 rounded-md p-2 text-xs',
-				contentClass ?? 'bg-muted/30 text-muted-foreground',
-			)}
+			class={cn('mt-1 rounded-md p-2 text-xs', contentClass)}
 		>
 			{@render children()}
 		</div>

--- a/apps/vocab/scripts/loop-repro.ts
+++ b/apps/vocab/scripts/loop-repro.ts
@@ -105,7 +105,6 @@ async function main(): Promise<void> {
 		store: inMemoryStore(),
 		engine,
 		generateId: () => `m${nextId++}`,
-		now: () => nextId,
 	});
 
 	for (const userText of ['Hello!', 'Test', "What's your name?"]) {

--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -76,7 +76,8 @@
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"bindings:tauri": "cargo test --manifest-path src-tauri/Cargo.toml export_types",
-		"typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && svelte-check --tsconfig ./tsconfig.tauri.json",
+		"typecheck:tauri": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.tauri.json",
 		"typecheck:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"tauri": "tauri",
 		"deploy": "wrangler deploy"

--- a/apps/whispering/src/lib/services/recorder/index.browser.ts
+++ b/apps/whispering/src/lib/services/recorder/index.browser.ts
@@ -12,6 +12,7 @@ import { categorizeBrowserStreamError } from './categorize-error';
 import type {
 	NavigatorRecordingParams,
 	RecorderService,
+	RecordingCallbacks,
 	RecordingSession,
 } from './types';
 import { RecorderError } from './types';
@@ -126,12 +127,10 @@ function createNavigatorRecorder() {
 			return Ok(devices);
 		},
 
-		startRecording: async ({
-			selectedDeviceId,
-			recordingId,
-			bitrateKbps,
-			onLevel,
-		}: NavigatorRecordingParams) => {
+		startRecording: async (
+			{ selectedDeviceId, recordingId, bitrateKbps }: NavigatorRecordingParams,
+			{ onLevel }: RecordingCallbacks,
+		) => {
 			const { data: streamResult, error: acquireStreamError } =
 				await getRecordingStream({ selectedDeviceId });
 			if (acquireStreamError) {

--- a/apps/whispering/src/lib/services/recorder/index.browser.ts
+++ b/apps/whispering/src/lib/services/recorder/index.browser.ts
@@ -32,7 +32,7 @@ function createNavigatorRecorder() {
 		mediaRecorder: MediaRecorder;
 		recordedChunks: Blob[];
 		startedAtMs: number;
-		stopLevelMeter: (() => void) | null;
+		stopLevelMeter: () => void;
 	}) {
 		const {
 			recordingId,
@@ -56,7 +56,7 @@ function createNavigatorRecorder() {
 		};
 
 		const teardown = () => {
-			stopLevelMeter?.();
+			stopLevelMeter();
 			cleanupRecordingStream(stream);
 			notify('IDLE');
 		};
@@ -168,9 +168,7 @@ function createNavigatorRecorder() {
 
 			// Tap the same stream for the pill's meter. Independent of the
 			// MediaRecorder (both can read one stream), torn down with the session.
-			const stopLevelMeter = onLevel
-				? startMicLevelMeter(stream, onLevel)
-				: null;
+			const stopLevelMeter = startMicLevelMeter(stream, onLevel);
 
 			const session = buildSession({
 				recordingId,

--- a/apps/whispering/src/lib/services/recorder/index.browser.ts
+++ b/apps/whispering/src/lib/services/recorder/index.browser.ts
@@ -183,8 +183,8 @@ function createNavigatorRecorder() {
 	} satisfies RecorderService<NavigatorRecordingParams>;
 }
 
-export const ManualRecorderLive =
-	createNavigatorRecorder() satisfies RecorderService<NavigatorRecordingParams>;
+export const ManualRecorderLive: RecorderService<NavigatorRecordingParams> =
+	createNavigatorRecorder();
 
 /**
  * Tap a live MediaStream and report raw mic loudness (RMS) each animation frame,

--- a/apps/whispering/src/lib/services/recorder/index.tauri.ts
+++ b/apps/whispering/src/lib/services/recorder/index.tauri.ts
@@ -229,6 +229,10 @@ function createCpalRecorder() {
 
 		enumerateDevices,
 
+		// Takes only params, no RecordingCallbacks: CPAL drives the pill meter
+		// from Rust straight to the overlay window, so it has no use for the
+		// caller's `onLevel` sink. A narrower function still satisfies the
+		// RecorderService contract.
 		startRecording: async ({
 			selectedDeviceId,
 			recordingId,

--- a/apps/whispering/src/lib/services/recorder/index.tauri.ts
+++ b/apps/whispering/src/lib/services/recorder/index.tauri.ts
@@ -229,10 +229,12 @@ function createCpalRecorder() {
 
 		enumerateDevices,
 
-		// Takes only params, no RecordingCallbacks: CPAL drives the pill meter
-		// from Rust straight to the overlay window, so it has no use for the
-		// caller's `onLevel` sink. A narrower function still satisfies the
-		// RecorderService contract.
+		// Takes only `params`, no callbacks: CPAL drives the pill meter from Rust
+		// straight to the overlay window, so it never reads the caller's
+		// `onLevel` sink. A params-only function still satisfies the
+		// RecorderService contract (a narrower function is assignable to a wider
+		// one), and callers reach it through the `RecorderService` contract type
+		// the export below publishes, so they still pass both arguments.
 		startRecording: async ({
 			selectedDeviceId,
 			recordingId,
@@ -312,5 +314,5 @@ function createCpalRecorder() {
 	} satisfies RecorderService<CpalRecordingParams>;
 }
 
-export const ManualRecorderLive =
-	createCpalRecorder() satisfies RecorderService<CpalRecordingParams>;
+export const ManualRecorderLive: RecorderService<CpalRecordingParams> =
+	createCpalRecorder();

--- a/apps/whispering/src/lib/services/recorder/types.ts
+++ b/apps/whispering/src/lib/services/recorder/types.ts
@@ -154,16 +154,33 @@ export const RecorderError = defineErrors({
 export type RecorderError = InferErrors<typeof RecorderError>;
 
 /**
- * Base parameters shared across manual recorder implementations.
+ * Settings-derived parameters shared across manual recorder implementations.
+ *
+ * This is config resolved from persisted settings (device, encoding). Live
+ * caller callbacks are not config and travel separately in
+ * {@link RecordingCallbacks}.
  */
 type BaseRecordingParams = {
 	selectedDeviceId: DeviceIdentifier | null;
 	recordingId: string;
+};
+
+/**
+ * Live callbacks supplied by the caller at the moment of starting, kept
+ * separate from the settings-derived {@link CpalRecordingParams} /
+ * {@link NavigatorRecordingParams} config because a callback is not a persisted
+ * setting. They are passed alongside the resolved params, never merged into
+ * them.
+ */
+export type RecordingCallbacks = {
 	/**
 	 * Sink for live mic loudness (raw RMS, ~0 silent to ~0.3 loud speech),
 	 * called continuously while recording so the pill can draw a meter.
-	 * The navigator recorder taps its MediaStream to drive this; the CPAL recorder
-	 * ignores it because Rust emits the level straight to the overlay window.
+	 *
+	 * The navigator recorder taps its MediaStream to drive this. The CPAL
+	 * recorder reaches the same meter another way (Rust emits the level straight
+	 * to the overlay window), so its `startRecording` simply does not accept
+	 * callbacks.
 	 */
 	onLevel: (level: number) => void;
 };
@@ -266,8 +283,15 @@ export type RecorderService<RecordingParams extends BaseRecordingParams> = {
 	 * Start a new recording session, returning the RecordingSession handle along
 	 * with the device acquisition outcome. The caller holds the RecordingSession
 	 * and uses its `stop`/`cancel`/`subscribe` for the rest of the session.
+	 *
+	 * `params` is settings-derived config; `callbacks` are the caller's live
+	 * sinks. An implementation that satisfies the meter another way (CPAL via the
+	 * overlay) may take only `params` and ignore the callbacks.
 	 */
-	startRecording(params: RecordingParams): Promise<
+	startRecording(
+		params: RecordingParams,
+		callbacks: RecordingCallbacks,
+	): Promise<
 		Result<
 			{
 				session: RecordingSession;

--- a/apps/whispering/src/lib/services/recorder/types.ts
+++ b/apps/whispering/src/lib/services/recorder/types.ts
@@ -160,12 +160,12 @@ type BaseRecordingParams = {
 	selectedDeviceId: DeviceIdentifier | null;
 	recordingId: string;
 	/**
-	 * Optional sink for live mic loudness (raw RMS, ~0 silent to ~0.3 loud
-	 * speech), called continuously while recording so the pill can draw a meter.
+	 * Sink for live mic loudness (raw RMS, ~0 silent to ~0.3 loud speech),
+	 * called continuously while recording so the pill can draw a meter.
 	 * The navigator recorder taps its MediaStream to drive this; the CPAL recorder
 	 * ignores it because Rust emits the level straight to the overlay window.
 	 */
-	onLevel?: (level: number) => void;
+	onLevel: (level: number) => void;
 };
 
 /**

--- a/apps/whispering/src/lib/state/manual-recorder-config.browser.ts
+++ b/apps/whispering/src/lib/state/manual-recorder-config.browser.ts
@@ -28,8 +28,12 @@ export const manualRecorderConfig = {
 	 *
 	 * The recorder service stays params-in and does not read Svelte state; this
 	 * config boundary performs that app-level read immediately before starting.
+	 * `onLevel` is the caller's live-meter sink, merged in at the start call, not
+	 * a persisted setting this boundary resolves.
 	 */
-	resolveStartParams(recordingId: string): NavigatorRecordingParams {
+	resolveStartParams(
+		recordingId: string,
+	): Omit<NavigatorRecordingParams, 'onLevel'> {
 		const deviceId = this.deviceId;
 		return {
 			recordingId,

--- a/apps/whispering/src/lib/state/manual-recorder-config.browser.ts
+++ b/apps/whispering/src/lib/state/manual-recorder-config.browser.ts
@@ -28,12 +28,10 @@ export const manualRecorderConfig = {
 	 *
 	 * The recorder service stays params-in and does not read Svelte state; this
 	 * config boundary performs that app-level read immediately before starting.
-	 * `onLevel` is the caller's live-meter sink, merged in at the start call, not
-	 * a persisted setting this boundary resolves.
+	 * Only settings-derived config lives here; live callbacks (the meter sink)
+	 * are passed separately to `startRecording`.
 	 */
-	resolveStartParams(
-		recordingId: string,
-	): Omit<NavigatorRecordingParams, 'onLevel'> {
+	resolveStartParams(recordingId: string): NavigatorRecordingParams {
 		const deviceId = this.deviceId;
 		return {
 			recordingId,

--- a/apps/whispering/src/lib/state/manual-recorder-config.tauri.ts
+++ b/apps/whispering/src/lib/state/manual-recorder-config.tauri.ts
@@ -28,10 +28,10 @@ export const manualRecorderConfig = {
 	 *
 	 * The recorder service stays params-in and does not read Svelte state; this
 	 * config boundary performs that app-level read immediately before starting.
-	 * `onLevel` is the caller's live-meter sink, merged in at the start call, not
-	 * a persisted setting this boundary resolves.
+	 * Only settings-derived config lives here; live callbacks (the meter sink)
+	 * are passed separately to `startRecording`.
 	 */
-	resolveStartParams(recordingId: string): Omit<CpalRecordingParams, 'onLevel'> {
+	resolveStartParams(recordingId: string): CpalRecordingParams {
 		const deviceId = this.deviceId;
 		return {
 			recordingId,

--- a/apps/whispering/src/lib/state/manual-recorder-config.tauri.ts
+++ b/apps/whispering/src/lib/state/manual-recorder-config.tauri.ts
@@ -28,8 +28,10 @@ export const manualRecorderConfig = {
 	 *
 	 * The recorder service stays params-in and does not read Svelte state; this
 	 * config boundary performs that app-level read immediately before starting.
+	 * `onLevel` is the caller's live-meter sink, merged in at the start call, not
+	 * a persisted setting this boundary resolves.
 	 */
-	resolveStartParams(recordingId: string): CpalRecordingParams {
+	resolveStartParams(recordingId: string): Omit<CpalRecordingParams, 'onLevel'> {
 		const deviceId = this.deviceId;
 		return {
 			recordingId,

--- a/apps/whispering/src/lib/state/manual-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/manual-recorder.svelte.ts
@@ -143,7 +143,7 @@ function createManualRecorder() {
 				const recordingId = nanoid();
 				const params = manualRecorderConfig.resolveStartParams(recordingId);
 				const { data, error: startRecordingError } =
-					await ManualRecorderLive.startRecording({ ...params, onLevel });
+					await ManualRecorderLive.startRecording(params, { onLevel });
 
 				if (startRecordingError) return Err(startRecordingError);
 

--- a/apps/whispering/src/lib/state/manual-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/manual-recorder.svelte.ts
@@ -8,6 +8,7 @@ import type { WhisperingRecordingState } from '$lib/constants/audio';
 import { defineQuery } from '$lib/rpc/client';
 import type {
 	RecorderError,
+	RecordingCallbacks,
 	RecordingSession,
 } from '$lib/services/recorder/types';
 
@@ -131,7 +132,7 @@ function createManualRecorder() {
 			},
 		}),
 
-		async startRecording({ onLevel }: { onLevel: (level: number) => void }) {
+		async startRecording(callbacks: RecordingCallbacks) {
 			if (_starting) return ManualRecorderError.AlreadyRecording();
 			_starting = true;
 			try {
@@ -143,7 +144,7 @@ function createManualRecorder() {
 				const recordingId = nanoid();
 				const params = manualRecorderConfig.resolveStartParams(recordingId);
 				const { data, error: startRecordingError } =
-					await ManualRecorderLive.startRecording(params, { onLevel });
+					await ManualRecorderLive.startRecording(params, callbacks);
 
 				if (startRecordingError) return Err(startRecordingError);
 

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -390,12 +390,12 @@ const shortcuts = {
 } as const;
 
 type CreateWhisperingOptions = {
-	defaultTranscriptionService?: TranscriptionServiceId;
+	defaultTranscriptionService: TranscriptionServiceId;
 };
 
 export function createWhispering({
-	defaultTranscriptionService = 'parakeet',
-}: CreateWhisperingOptions = {}) {
+	defaultTranscriptionService,
+}: CreateWhisperingOptions) {
 	/**
 	 * Whispering KV schemas: ~40 entries for synced preferences. Defined locally
 	 * so the raw schema map is not a module-level export. Callers reach the

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/create-chord-recorder.ts
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/create-chord-recorder.ts
@@ -22,7 +22,7 @@ const CAPTURE_WINDOW_MS = 300; // Time to wait for additional keys in a combinat
  * try again without re-opening. The owner calls `stop()` once a capture is
  * accepted. Escape is left to bubble; the session owner cancels.
  *
- * `onProgress` (optional) fires on every keydown with the combo accumulated so
+ * `onProgress` fires on every keydown with the combo accumulated so
  * far, before the gesture completes. The recorder owns capture; the owner owns
  * meaning, so the owner reads this partial to preview the reach a binding would
  * earn ("hold a modifier and it reaches everywhere") live, as the user holds.
@@ -32,7 +32,7 @@ export function createChordRecorder({
 	onProgress,
 }: {
 	onCapture: (binding: KeyBinding) => void;
-	onProgress?: (binding: KeyBinding) => void;
+	onProgress: (binding: KeyBinding) => void;
 }) {
 	// Internal control-flow guard only (the owner tracks its own session state), so
 	// a plain bool, not reactive.
@@ -93,7 +93,7 @@ export function createChordRecorder({
 		const key = domCodeToKey(e.code);
 		if (key) capturedKey = key;
 
-		onProgress?.({
+		onProgress({
 			modifiers: [...capturedModifiers],
 			keys: capturedKey ? [capturedKey] : [],
 		});

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/create-tap-recorder.ts
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/create-tap-recorder.ts
@@ -30,7 +30,7 @@ export function createTapRecorder({
 }: {
 	keyboard: CaptureKeyboard;
 	onCapture: (binding: KeyBinding) => void;
-	onProgress?: (binding: KeyBinding) => void;
+	onProgress: (binding: KeyBinding) => void;
 }) {
 	// Accumulated across the gesture: every modifier and key ever held, so a combo
 	// built up over several presses commits whole when the last key releases.
@@ -63,7 +63,7 @@ export function createTapRecorder({
 					reset();
 					onCapture(accumulated);
 				} else {
-					onProgress?.(accumulated);
+					onProgress(accumulated);
 				}
 			})
 			.then((fn) => {

--- a/apps/whispering/tsconfig.tauri.json
+++ b/apps/whispering/tsconfig.tauri.json
@@ -1,0 +1,11 @@
+{
+	// Typechecks the `#platform/*` tauri condition. `tsconfig.json` resolves the
+	// default (browser) impls, so the desktop platform files and the call sites
+	// that wire them are only checked when the resolver is flipped to `tauri`.
+	// `bun run typecheck` runs both configs; use `typecheck:tauri` for this one
+	// in isolation.
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"customConditions": ["tauri"]
+	}
+}

--- a/packages/auth/src/node/oob-launcher.ts
+++ b/packages/auth/src/node/oob-launcher.ts
@@ -101,10 +101,6 @@ type CreateOobOAuthLauncherConfig = {
 	 */
 	fetch?: AuthFetch;
 	/**
-	 * Crypto implementation used for PKCE verifier and challenge generation.
-	 */
-	crypto?: Crypto;
-	/**
 	 * Clock used to convert `expires_in` into the persisted grant refresh hint.
 	 */
 	now?: () => number;
@@ -128,16 +124,15 @@ export function createOobOAuthLauncher({
 	readCode = defaultReadCode,
 	print = (line) => process.stdout.write(`${line}\n`),
 	fetch = globalThis.fetch.bind(globalThis),
-	crypto = globalThis.crypto,
 	now = Date.now,
 }: CreateOobOAuthLauncherConfig) {
 	return {
 		async startSignIn(): Promise<Result<OAuthLaunchResult, OobLauncherError>> {
 			const verifierBytes = new Uint8Array(32);
-			crypto.getRandomValues(verifierBytes);
+			globalThis.crypto.getRandomValues(verifierBytes);
 			const codeVerifier = base64UrlEncode(verifierBytes);
 			const challengeBytes = new Uint8Array(
-				await crypto.subtle.digest(
+				await globalThis.crypto.subtle.digest(
 					'SHA-256',
 					new TextEncoder().encode(codeVerifier),
 				),

--- a/packages/svelte-utils/src/persisted-map.svelte.ts
+++ b/packages/svelte-utils/src/persisted-map.svelte.ts
@@ -97,12 +97,7 @@ export function defineEntry<TSchema extends StandardSchemaV1>(
  */
 export function createPersistedMap<
 	TDefs extends Record<string, PersistedMapDefinition<StandardSchemaV1>>,
->({
-	prefix,
-	definitions,
-	onError,
-	onUpdateError,
-}: PersistedMapOptions<TDefs>) {
+>({ prefix, definitions, onError, onUpdateError }: PersistedMapOptions<TDefs>) {
 	// Object.keys() returns string[] by design; safe here because we define the object ourselves.
 	const definitionKeys = Object.keys(definitions) as (string & keyof TDefs)[];
 

--- a/packages/svelte-utils/src/persisted-map.svelte.ts
+++ b/packages/svelte-utils/src/persisted-map.svelte.ts
@@ -23,16 +23,6 @@ type PersistedMapOptions<
 	/** Per-key schema and default value definitions. */
 	definitions: TDefs;
 	/**
-	 * The Web Storage instance to use.
-	 * @default window.localStorage
-	 */
-	storage?: Storage;
-	/**
-	 * Whether to sync state across tabs via the `storage` event.
-	 * @default true
-	 */
-	syncTabs?: boolean;
-	/**
 	 * Called when a value read from storage fails to parse or validate.
 	 * Fire-and-forget. `defaultValue` is used as the fallback regardless.
 	 */
@@ -110,8 +100,6 @@ export function createPersistedMap<
 >({
 	prefix,
 	definitions,
-	storage: storageApi = window.localStorage,
-	syncTabs = true,
 	onError,
 	onUpdateError,
 }: PersistedMapOptions<TDefs>) {
@@ -180,7 +168,7 @@ export function createPersistedMap<
 	}
 
 	function readKey(key: string & keyof TDefs) {
-		return parseRawValue(key, storageApi.getItem(storageKey(key)));
+		return parseRawValue(key, window.localStorage.getItem(storageKey(key)));
 	}
 
 	// Typed as `unknown` because a single map holds heterogeneous values for all key types.
@@ -192,14 +180,12 @@ export function createPersistedMap<
 
 	// Cross-tab sync: ONE listener for all keys, filtered by prefix.
 	// Listeners are never removed: this function assumes singleton/module-scope usage.
-	if (syncTabs) {
-		window.addEventListener('storage', (e) => {
-			if (!e.key?.startsWith(prefix)) return;
-			const key = e.key.slice(prefix.length);
-			if (!isDefinitionKey(key)) return;
-			map.set(key, parseRawValue(key, e.newValue));
-		});
-	}
+	window.addEventListener('storage', (e) => {
+		if (!e.key?.startsWith(prefix)) return;
+		const key = e.key.slice(prefix.length);
+		if (!isDefinitionKey(key)) return;
+		map.set(key, parseRawValue(key, e.newValue));
+	});
 
 	// Same-tab sync: ONE listener for all keys.
 	window.addEventListener('focus', () => {
@@ -219,7 +205,7 @@ export function createPersistedMap<
 			value: InferDefinitionValue<TDefs[TKey]>,
 		) {
 			try {
-				storageApi.setItem(storageKey(key), JSON.stringify(value));
+				window.localStorage.setItem(storageKey(key), JSON.stringify(value));
 			} catch (error) {
 				onUpdateError?.(key, error);
 			}

--- a/packages/svelte-utils/src/persisted-map.svelte.ts
+++ b/packages/svelte-utils/src/persisted-map.svelte.ts
@@ -180,6 +180,9 @@ export function createPersistedMap<
 
 	// Cross-tab sync: ONE listener for all keys, filtered by prefix.
 	// Listeners are never removed: this function assumes singleton/module-scope usage.
+	// localStorage is hardcoded (not a `storage` option) because this `storage`
+	// event is a localStorage-only mechanism; sessionStorage would silently lose
+	// cross-tab sync. See createPersistedState for the full rationale.
 	window.addEventListener('storage', (e) => {
 		if (!e.key?.startsWith(prefix)) return;
 		const key = e.key.slice(prefix.length);

--- a/packages/svelte-utils/src/persisted-state.svelte.ts
+++ b/packages/svelte-utils/src/persisted-state.svelte.ts
@@ -53,16 +53,6 @@ type PersistedStateOptions<TSchema extends StandardSchemaV1> = {
 	 */
 	defaultValue: NoInfer<StandardSchemaV1.InferOutput<TSchema>>;
 	/**
-	 * The Web Storage instance to use.
-	 * @default window.localStorage
-	 */
-	storage?: Storage;
-	/**
-	 * Whether to sync state across tabs via the `storage` event.
-	 * @default true
-	 */
-	syncTabs?: boolean;
-	/**
 	 * Called when a value read from storage fails to parse or validate.
 	 * Fire-and-forget. `defaultValue` is used as the fallback regardless.
 	 */
@@ -102,8 +92,6 @@ export function createPersistedState<TSchema extends StandardSchemaV1>({
 	key,
 	schema,
 	defaultValue,
-	storage: storageApi = window.localStorage,
-	syncTabs = true,
 	onError,
 	onUpdateError,
 }: PersistedStateOptions<TSchema>) {
@@ -151,7 +139,7 @@ export function createPersistedState<TSchema extends StandardSchemaV1>({
 	}
 
 	function readFromStorage() {
-		return parseRawValue(storageApi.getItem(key));
+		return parseRawValue(window.localStorage.getItem(key));
 	}
 
 	let value = $state(readFromStorage());
@@ -173,14 +161,13 @@ export function createPersistedState<TSchema extends StandardSchemaV1>({
 		if (disposed) return;
 		setValue(nextValue);
 		try {
-			storageApi.setItem(key, JSON.stringify(nextValue));
+			window.localStorage.setItem(key, JSON.stringify(nextValue));
 		} catch (error) {
 			onUpdateError?.(error);
 		}
 	}
 
 	// Cross-tab sync: `storage` event fires when ANOTHER tab writes to localStorage.
-	// sessionStorage doesn't fire cross-tab events, so enabling this is harmless.
 	const handleStorage = (e: StorageEvent) => {
 		if (disposed) return;
 		if (e.key !== key) return;
@@ -192,9 +179,7 @@ export function createPersistedState<TSchema extends StandardSchemaV1>({
 		setValue(readFromStorage());
 	};
 
-	if (syncTabs) {
-		window.addEventListener('storage', handleStorage);
-	}
+	window.addEventListener('storage', handleStorage);
 
 	// Same-tab sync: catches DevTools edits and writes from other libraries.
 	window.addEventListener('focus', handleFocus);
@@ -246,9 +231,7 @@ export function createPersistedState<TSchema extends StandardSchemaV1>({
 		[Symbol.dispose]() {
 			if (disposed) return;
 			disposed = true;
-			if (syncTabs) {
-				window.removeEventListener('storage', handleStorage);
-			}
+			window.removeEventListener('storage', handleStorage);
 			window.removeEventListener('focus', handleFocus);
 			listeners.clear();
 		},

--- a/packages/svelte-utils/src/persisted-state.svelte.ts
+++ b/packages/svelte-utils/src/persisted-state.svelte.ts
@@ -167,7 +167,12 @@ export function createPersistedState<TSchema extends StandardSchemaV1>({
 		}
 	}
 
-	// Cross-tab sync: `storage` event fires when ANOTHER tab writes to localStorage.
+	// Cross-tab sync: the `storage` event fires when ANOTHER tab writes to
+	// localStorage. This is why the backend is hardcoded to localStorage and not a
+	// `storage: Storage` option: sessionStorage is per-tab and never fires this
+	// event, so a sessionStorage-backed instance's headline feature (cross-tab
+	// sync) would silently no-op. Per-tab ephemeral state wants a separate
+	// primitive, not a swapped backend on this one.
 	const handleStorage = (e: StorageEvent) => {
 		if (disposed) return;
 		if (e.key !== key) return;

--- a/packages/workspace/src/agent/loop.ts
+++ b/packages/workspace/src/agent/loop.ts
@@ -110,8 +110,6 @@ export type ConversationOptions = {
 	approval?: Approval;
 	/** Mint a message id. */
 	generateId: () => string;
-	/** Clock, injectable for tests. */
-	now?: () => number;
 };
 
 /** When no approval is wired, a gated mutation is denied rather than run. */
@@ -139,7 +137,6 @@ export function createConversation(
 		tools = NO_TOOLS,
 		approval = DENY_GATED_MUTATIONS,
 		generateId,
-		now = Date.now,
 	} = options;
 
 	const listeners = new Set<() => void>();
@@ -324,7 +321,7 @@ export function createConversation(
 			const assistant: AgentMessage = {
 				id: generateId(),
 				role: 'assistant',
-				createdAt: now(),
+				createdAt: Date.now(),
 				parts: [],
 			};
 			turn.push(assistant);
@@ -382,7 +379,7 @@ export function createConversation(
 			store.set(id, {
 				id,
 				role: 'user',
-				createdAt: now(),
+				createdAt: Date.now(),
 				parts: [{ type: 'text', text }],
 			});
 			void runTurn();

--- a/packages/workspace/src/document/internal/sync-supervisor.ts
+++ b/packages/workspace/src/document/internal/sync-supervisor.ts
@@ -113,7 +113,7 @@ type SyncSupervisorConfig = {
 	 * text frames itself; downstream code (e.g. dispatch_inbound
 	 * handlers) receives the raw string.
 	 */
-	onTextFrame?: (text: string) => void;
+	onTextFrame: (text: string) => void;
 };
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -348,7 +348,7 @@ export function createSyncSupervisor(
 		ws.onmessage = (event: MessageEvent) => {
 			liveness.touch();
 			if (typeof event.data === 'string') {
-				config.onTextFrame?.(event.data);
+				config.onTextFrame(event.data);
 				return;
 			}
 


### PR DESCRIPTION
Optional parameters were being used as politeness, not as truth. A parameter that every caller passes forces dead guards and defaults that can never run, and it makes the boundary less honest than the call graph.

This pass tightens optional parameters only when the diff proves no supported caller omits them. Published package boundaries and real public omissions keep their optionality.

The real shape change is the recorder config split. `onLevel` is a live callback, not settings-derived recording config, and CPAL never reads it because desktop levels go straight to the overlay. The boundary now separates config from live callbacks:

```ts
// Before: live callback inside resolved config
startRecording(params: RecordingParams): Promise<unknown>;

// After: config and live callbacks are separate concerns
startRecording(
	params: RecordingParams,
	callbacks: RecordingCallbacks,
): Promise<unknown>;
```

That deletes the `Omit<..., "onLevel">` carve-outs and lets CPAL's implementation accept only the config it actually uses while the exported manual-recorder contract still shows the two-argument shape.

Two smaller corrections come from the same pass. Local Books OAuth now distinguishes the interactive authorization options from non-interactive grant exchange clocks. opensidian search groups seed `defaultOpen` once instead of deriving open state reactively, so loading more results cannot collapse a group the user expanded.
