### PR TITLE
feat(whispering): surface both shortcut tiers in the recording hint

### DIFF
--- a/apps/whispering/src/lib/utils/recording-shortcut.ts
+++ b/apps/whispering/src/lib/utils/recording-shortcut.ts
@@ -2,14 +2,12 @@ import { os } from '#platform/os';
 import { systemShortcuts } from '#platform/system-shortcuts';
 import type { Command } from '$lib/commands';
 import { focusedShortcuts } from '$lib/platform/focused-shortcuts';
+import type { Shortcuts } from '$lib/platform/types';
 import { keyBindingToLabel } from '$lib/utils/key-binding';
 
 /**
- * The single backend the recording-key hint reads. The hint shows one label, so
- * it cannot use the reach router (which exposes both slots). On desktop the
- * system (global) key is the one that fires from anywhere, so it leads; web has
- * only the focused backend. The flat settings list (a later phase) shows both
- * slots through the router; this single-label hint keeps the simple selection.
+ * The backend the one-label helper reads: the system (global) key leads on desktop
+ * because it fires from anywhere; web has only the focused backend.
  */
 const primaryShortcuts = systemShortcuts ?? focusedShortcuts;
 
@@ -31,19 +29,54 @@ const RECORDING_SHORTCUT_PREFERENCE = {
 export type RecordingShortcutMode = keyof typeof RECORDING_SHORTCUT_PREFERENCE;
 
 /**
- * The display label for the shortcut that actually starts this recording mode on
- * this platform, resolved through the primary shortcut backend.
- *
- * Reading a single command (`toggleManualRecording`) rendered an empty key on a
- * fresh desktop install, where the toggle ships unbound and push-to-talk (Fn) is
- * the gesture that works. Routing through the preference list shows the bound
- * gesture instead. Returns `''` when nothing in the list is bound; callers hide
- * the hint and fall back to "click".
+ * The label for the bound gesture this mode starts in one store, picked by walking
+ * the preference list (the first bound command wins). Reading a single command
+ * (`toggleManualRecording`) rendered an empty key where the toggle ships unbound
+ * and another gesture is the live one; the list shows the bound gesture instead.
+ * Returns `''` when nothing in the list is bound. `keyBindingToLabel` formats the
+ * physical binding.
  */
-export function getRecordingShortcutLabel(mode: RecordingShortcutMode): string {
+function shortcutLabelFor(
+	store: Shortcuts,
+	mode: RecordingShortcutMode,
+): string {
 	for (const commandId of RECORDING_SHORTCUT_PREFERENCE[mode]) {
-		const binding = primaryShortcuts.current(commandId);
+		const binding = store.current(commandId);
 		if (binding) return keyBindingToLabel(binding, os.isApple);
 	}
 	return '';
+}
+
+/**
+ * The single label that starts this recording mode on this platform, from the
+ * primary backend. Callers that only need to know whether *a* shortcut exists
+ * (the recording controllers) read this; the home hint reads both slots through
+ * {@link getRecordingShortcutLabels}.
+ */
+export function getRecordingShortcutLabel(mode: RecordingShortcutMode): string {
+	return shortcutLabelFor(primaryShortcuts, mode);
+}
+
+/**
+ * Both reach slots for this recording mode: the in-app (`focused`) key and the
+ * system-global (`global`) key. `focused` is `''` when unbound. `global` is `null`
+ * when this platform has no system backend (web), and `''` when it has one but the
+ * slot is unbound (desktop): one source of truth for "is there a from-anywhere tier
+ * at all" versus "there is, but it needs setting up". The home hint teaches both, so
+ * a desktop user learns the quick in-app tap *and* the from-anywhere gesture (and,
+ * for VAD, the in-app key the single-label hint never surfaced, since VAD ships no
+ * global default).
+ *
+ * This is the read-only badge philosophy of ADR-0052 applied to the home screen:
+ * the user still expresses reach only by choosing a key, and the hint reflects
+ * what each key's reach turned out to be. It is not a scope chooser.
+ */
+export function getRecordingShortcutLabels(mode: RecordingShortcutMode): {
+	focused: string;
+	global: string | null;
+} {
+	return {
+		focused: shortcutLabelFor(focusedShortcuts, mode),
+		global: systemShortcuts ? shortcutLabelFor(systemShortcuts, mode) : null,
+	};
 }

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -42,7 +42,10 @@
 	import { manualRecorder } from '$lib/state/manual-recorder.svelte';
 	import { recordings } from '$lib/state/recordings.svelte';
 	import { settings } from '$lib/state/settings.svelte';
-	import { getRecordingShortcutLabel } from '$lib/utils/recording-shortcut';
+	import {
+		getRecordingShortcutLabels,
+		type RecordingShortcutMode,
+	} from '$lib/utils/recording-shortcut';
 	import { viewTransition } from '$lib/utils/viewTransitions';
 	import studioMicrophone from '$lib/assets/studio-microphone.png';
 	import { tauri } from '#platform/tauri';
@@ -63,18 +66,97 @@
 			settings.get('transformation.selectedId') ?? null,
 		),
 	);
-	// The recording shortcut that actually fires on this platform, via the
-	// recording-shortcut label helper: desktop binds push-to-talk (Fn) globally
-	// and ships the toggle unbound, so prefer it; the browser shows the local
-	// toggle. `''` means nothing is bound (hide the hint, fall back to "click").
-	const manualShortcutLabel = $derived(getRecordingShortcutLabel('manual'));
-	const vadShortcutLabel = $derived(getRecordingShortcutLabel('vad'));
-	// On desktop the taught gesture is the global rdev tap, so it only fires when
-	// the capability is `active`. When it can't (macOS Accessibility ungranted or
-	// stale, or Linux Wayland), we still show the key so the user learns it, but dim
-	// it; the `DictationCapabilityNotice` above carries the fix. This reads the same
-	// capability fact the notice does, so the two always agree. Always false on the
-	// browser, where the in-app shortcut needs no grant.
+	// The verb fragments the hint drops around each key, per mode. `here` and
+	// `anywhere` annotate the in-app and global keys with their reach; `fresh` is the
+	// bare prompt shown when nothing is bound at all.
+	type RecordingHintWords = { here: string; anywhere: string; fresh: string };
+	const MANUAL_HINT_WORDS: RecordingHintWords = {
+		here: 'record here',
+		anywhere: 'record from anywhere',
+		fresh: 'start recording',
+	};
+	const VAD_HINT_WORDS: RecordingHintWords = {
+		here: 'listen here',
+		anywhere: 'listen from anywhere',
+		fresh: 'start a voice-activated session',
+	};
+	// A shortcut option in the hint: a bound key (a `Kbd` chip) or a call to set one
+	// up. Both link into /settings/shortcuts, so the hint doubles as the way to
+	// configure each key. `dimmable` is the global key, which dims when its backend
+	// is unavailable; the in-app key needs no grant and never dims.
+	type HintLink =
+		| { kind: 'key'; label: string; tooltip: string; dimmable: boolean }
+		| { kind: 'cta'; label: string; tooltip: string };
+	// One way to start a recording, as a "{lead}{link}{tail}" run. Spaces live inside
+	// `lead`/`tail` so the parts concatenate verbatim when the hint joins them; `link`
+	// is null for the mic, which names the on-screen button rather than a setting.
+	type RecordingWay = { lead: string; link: HintLink | null; tail: string };
+	// The ordered ways to start `mode`. The mic always works and leads; the in-app key
+	// reaches "here" and the global key "from anywhere" when bound. The mic states its
+	// own verb only when it is the only way.
+	function recordingWays(
+		mode: RecordingShortcutMode,
+		words: RecordingHintWords,
+	): RecordingWay[] {
+		const { focused, global } = getRecordingShortcutLabels(mode);
+		const ways: RecordingWay[] = [];
+		if (focused) {
+			ways.push({
+				lead: 'press ',
+				link: {
+					kind: 'key',
+					label: focused,
+					tooltip: 'Configure the in-app shortcut',
+					dimmable: false,
+				},
+				tail: ` to ${words.here}`,
+			});
+		}
+		// The from-anywhere tier exists only where there is a system backend, which
+		// `global` reports as non-null (`''` there means the slot is just unbound).
+		if (global !== null) {
+			ways.push(
+				global
+					? {
+							lead: 'press ',
+							link: {
+								kind: 'key',
+								label: global,
+								tooltip: 'Configure the global shortcut',
+								dimmable: true,
+							},
+							tail: ` to ${words.anywhere}`,
+						}
+					: {
+							lead: '',
+							link: {
+								kind: 'cta',
+								label: 'set a global shortcut',
+								tooltip: 'Set a global shortcut',
+							},
+							tail: ` to ${words.anywhere}`,
+						},
+			);
+		}
+		ways.unshift({
+			lead: 'Click the microphone',
+			link: null,
+			tail: ways.length ? '' : ` to ${words.fresh}`,
+		});
+		return ways;
+	}
+	// Join the ways as an or-list: "a", "a, or b", "a, b, or c".
+	const orPrefix = (index: number, count: number) =>
+		index === 0 ? '' : index === count - 1 ? ', or ' : ', ';
+	const manualWays = $derived(recordingWays('manual', MANUAL_HINT_WORDS));
+	const vadWays = $derived(recordingWays('vad', VAD_HINT_WORDS));
+	// On desktop the global rdev gesture only fires when the capability is `active`.
+	// When it can't (macOS Accessibility ungranted or stale, or Linux Wayland), we
+	// still show the key so the user learns it, but dim it; the
+	// `DictationCapabilityNotice` above carries the fix. This reads the same
+	// capability fact the notice does, so the two always agree. It dims only the
+	// global key: the in-app key runs on the webview keydown matcher, which needs no
+	// grant. Always false on the browser, where there is no global key at all.
 	const shortcutUnavailable = $derived(dictationCapability.isUnavailable);
 
 	const PageError = defineErrors({
@@ -345,45 +427,11 @@
 		<div class="flex flex-col items-center gap-3">
 			{#if captureSurface.current === 'manual'}
 				<p class="text-foreground/75 text-center text-sm">
-					{#if manualShortcutLabel}
-						Click the microphone to record{tauri ? ' here' : ''}, or press
-						<Link
-							tooltip="Configure the recording shortcut"
-							href="/settings/shortcuts"
-						>
-							<Kbd.Root class={shortcutUnavailable ? 'opacity-50' : undefined}
-								>{manualShortcutLabel}</Kbd.Root>
-						</Link>
-						{tauri ? 'to record from anywhere.' : 'to record.'}
-					{:else if tauri}
-						Click the microphone to record, or
-						<Link tooltip="Set a global shortcut" href="/settings/shortcuts"
-							>set a global shortcut</Link>
-						to record from anywhere.
-					{:else}
-						Click the microphone to start recording.
-					{/if}
+					{@render recordingHint(manualWays)}
 				</p>
 			{:else if captureSurface.current === 'vad'}
 				<p class="text-foreground/75 text-center text-sm">
-					{#if vadShortcutLabel}
-						Click the microphone to listen{tauri ? ' here' : ''}, or press
-						<Link
-							tooltip="Configure the voice activation shortcut"
-							href="/settings/shortcuts"
-						>
-							<Kbd.Root class={shortcutUnavailable ? 'opacity-50' : undefined}
-								>{vadShortcutLabel}</Kbd.Root>
-						</Link>
-						{tauri ? 'to listen from anywhere.' : 'to listen.'}
-					{:else if tauri}
-						Click the microphone to start a voice activated session, or
-						<Link tooltip="Set a global shortcut" href="/settings/shortcuts"
-							>set a global shortcut</Link>
-						to listen from anywhere.
-					{:else}
-						Click the microphone to start a voice activated session.
-					{/if}
+					{@render recordingHint(vadWays)}
 				</p>
 			{/if}
 			<p class="text-muted-foreground text-center text-sm font-light">
@@ -402,3 +450,25 @@
 		</div>
 	{/if}
 </div>
+
+<!-- A shortcut option as a link into settings: a key chip, or the "set one up" call
+to action. The global key dims when its backend is unavailable; nothing else does. -->
+{#snippet shortcutLink(link: HintLink)}
+	<Link tooltip={link.tooltip} href="/settings/shortcuts">
+		{#if link.kind === 'key'}
+			<Kbd.Root
+				class={link.dimmable && shortcutUnavailable ? 'opacity-50' : undefined}
+				>{link.label}</Kbd.Root>
+		{:else}{link.label}{/if}
+	</Link>
+{/snippet}
+
+<!-- One way rendered as its "{lead}{link}{tail}" run. Kept on one line so no template
+whitespace creeps between the parts; every needed space lives in the strings. -->
+{#snippet hintWay(way: RecordingWay)}{way.lead}{#if way.link}{@render shortcutLink(way.link)}{/if}{way.tail}{/snippet}
+
+<!-- The home recording hint: every way to start a recording, joined as an or-list.
+`recordingWays` decides which ways exist; this only joins and punctuates them. -->
+{#snippet recordingHint(ways: RecordingWay[])}
+	{#each ways as way, i}{orPrefix(i, ways.length)}{@render hintWay(way)}{/each}.
+{/snippet}


### PR DESCRIPTION
The home recording hint only read one shortcut tier. On desktop that meant the global shortcut store, so the in-app binding was never taught. For voice activation the copy was worse: VAD ships with an in-app `V` binding and no global default, but the hint told users to set a global shortcut.

The hint now reads both ADR-0052 reach slots. In-app keys are described as working here, global keys as working from anywhere, and an unbound global slot becomes the setup prompt. Every key chip and setup prompt links to shortcut settings.

```txt
Before:
Click the microphone to start a voice activated session, or set a global shortcut to listen from anywhere.

After:
Click the microphone, press V to listen here, or set a global shortcut to listen from anywhere.
```

`getRecordingShortcutLabels` reports `global: null` when the platform has no system backend and `global: ""` when it has one but the slot is unbound, so the hint builder consumes one signal instead of re-deriving platform reach.

## Changelog

- The Whispering recording hint now shows both in-app and global shortcuts for manual recording and voice activation.
