### PR TITLE
feat(whispering): give the recording card a live meter and its own cancel

### DIFF
--- a/apps/whispering/src/lib/components/LevelMeter.svelte
+++ b/apps/whispering/src/lib/components/LevelMeter.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { cn } from '@epicenter/ui/utils';
+
+	// The live mic meter: a fixed bank of bars whose heights ride the smoothed
+	// `level`. Shared by the floating recording pill and the in-window recording
+	// card so both speak one visual language by construction, rather than keeping
+	// two copies of the envelope and height math in sync by hand (ADR-0039). The
+	// caller styles the bars (width, color) and the container (height, gap); the
+	// defaults render the pill's 3px white bar.
+	let {
+		level,
+		minPx = 3,
+		maxPx = 18,
+		barClass,
+		class: className,
+	}: {
+		/** Smoothed mic loudness, 0 (silent) to 1 (loud). */
+		level: number;
+		/** Bar height floor (silent) and ceiling (loud), in px. */
+		minPx?: number;
+		maxPx?: number;
+		/** Per-bar classes: width and color. */
+		barClass?: string;
+		/** Container classes: height and gap. */
+		class?: string;
+	} = $props();
+
+	// Per-bar height envelope (taller in the middle) scaled by `level`. Reacting
+	// the same amplitude through a fixed shape reads as a meter, not a flat block.
+	const ENVELOPE = [
+		0.35, 0.5, 0.68, 0.84, 0.95, 1, 0.95, 0.84, 0.68, 0.5, 0.35,
+	];
+
+	function barHeight(envelope: number): number {
+		return minPx + envelope * level * (maxPx - minPx);
+	}
+</script>
+
+<div class={cn('flex items-center gap-[3px]', className)} aria-hidden="true">
+	{#each ENVELOPE as envelope, i (i)}
+		<!-- Height is set inline from the live mic level; the transition glides
+		     between samples (~20-30 Hz) so the meter looks continuous, and is
+		     dropped under reduced motion. -->
+		<span
+			class={cn(
+				'w-[3px] rounded-full bg-white/80 transition-[height] duration-[80ms] ease-linear motion-reduce:transition-none',
+				barClass,
+			)}
+			style="height: {barHeight(envelope)}px"
+		></span>
+	{/each}
+</div>

--- a/apps/whispering/src/lib/recording-overlay/RecordingPill.svelte
+++ b/apps/whispering/src/lib/recording-overlay/RecordingPill.svelte
@@ -7,6 +7,7 @@
 	import SquareIcon from '@lucide/svelte/icons/square';
 	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 	import XIcon from '@lucide/svelte/icons/x';
+	import LevelMeter from '$lib/components/LevelMeter.svelte';
 	import type { DeliveryReach } from '$lib/operations/delivery';
 	import {
 		FAILURE_LABEL,
@@ -100,18 +101,6 @@
 		}
 	});
 
-	// Per-bar height envelope (taller in the middle) scaled by `level`. Reacting
-	// the same amplitude through a fixed shape reads as a meter, not a flat block.
-	const BAR_ENVELOPE = [
-		0.35, 0.5, 0.68, 0.84, 0.95, 1, 0.95, 0.84, 0.68, 0.5, 0.35,
-	];
-	const MIN_BAR_PX = 3;
-	const MAX_BAR_PX = 18;
-
-	function barHeight(envelope: number): number {
-		return MIN_BAR_PX + envelope * level * (MAX_BAR_PX - MIN_BAR_PX);
-	}
-
 	// Resting state is a filled chip, not a bare icon, so the controls read as
 	// buttons at a glance in the small pill. Each control composes its own tone over
 	// this shared base, which carries the hover/press feedback: background and
@@ -176,22 +165,13 @@
 				{/if}
 			</div>
 
-			<div class="flex h-5 items-center gap-[3px]" aria-hidden="true">
-				{#each BAR_ENVELOPE as envelope, i (i)}
-					<!-- Height is set inline from the live mic level; the transition glides
-					     between samples (~20-30 Hz) so the meter looks continuous, and is
-					     dropped under reduced motion. Speech detected (VAD) tints the bar so
-					     the user sees it cross the threshold, on top of the height already
-					     reacting to loudness. -->
-					<span
-						class={cn(
-							'w-[3px] rounded-full bg-white/80 transition-[height] duration-[80ms] ease-linear motion-reduce:transition-none',
-							isSpeaking && 'bg-[#ffe5ee]',
-						)}
-						style="height: {barHeight(envelope)}px"
-					></span>
-				{/each}
-			</div>
+			<!-- Speech detected (VAD) tints the bars so the user sees capture cross the
+			     threshold, on top of the height already reacting to loudness. -->
+			<LevelMeter
+				{level}
+				class="h-5"
+				barClass={isSpeaking ? 'bg-[#ffe5ee]' : undefined}
+			/>
 
 			<!-- Trailing cluster: a contextual slot, then stop as the constant right
 			     anchor. Manual and VAD share this skeleton (slot then stop), so the

--- a/apps/whispering/src/lib/recording-overlay/RecordingPillHost.svelte
+++ b/apps/whispering/src/lib/recording-overlay/RecordingPillHost.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { page } from '$app/state';
 	import { tauri } from '#platform/tauri';
 	import { dispatchPillAction } from '$lib/recording-overlay/pill-actions';
 	import RecordingPill from '$lib/recording-overlay/RecordingPill.svelte';
@@ -13,9 +14,19 @@
 	// The pill body has no reveal action on web: the app window is already in
 	// front, and a failure is surfaced by the notification and the recordings row.
 	const status = $derived(projectLifecycleToStatus(dictationLifecycle.current));
+
+	// The home route's recording card carries its own live meter and stop/cancel,
+	// so the floating pill would only double it there. Yield the recording phase to
+	// the card on '/', but keep the pill for the outcome phases (transcribing,
+	// delivered, failed) the card never shows, and for every phase on the other app
+	// routes (recordings, settings, ...), which have no in-window capture card.
+	const isHomeRoute = $derived(page.url.pathname === '/');
+	const showPill = $derived(
+		!!status && !(isHomeRoute && status.phase === 'recording'),
+	);
 </script>
 
-{#if !tauri && status}
+{#if !tauri && showPill}
 	<!-- Bottom-center, matching the desktop overlay's resting position
 	     (OVERLAY_BOTTOM_MARGIN). Above page content, below modals and toasts. -->
 	<div class="fixed bottom-[72px] left-1/2 z-50 -translate-x-1/2">

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -1,17 +1,14 @@
 <script lang="ts">
-	import { Button } from '@epicenter/ui/button';
 	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { FileDropZone } from '@epicenter/ui/file-drop-zone';
 	import * as Kbd from '@epicenter/ui/kbd';
 	import { Link } from '@epicenter/ui/link';
 	import * as SectionHeader from '@epicenter/ui/section-header';
 	import * as ToggleGroup from '@epicenter/ui/toggle-group';
-	import XIcon from '@lucide/svelte/icons/x';
 	import type { UnlistenFn } from '@tauri-apps/api/event';
 	import { onDestroy, onMount } from 'svelte';
 	import { defineErrors, extractErrorMessage } from 'wellcrafted/error';
 	import { tryAsync } from 'wellcrafted/result';
-	import { commandRunners } from '$lib/commands';
 	import DictationCapabilityNotice from '$lib/components/DictationCapabilityNotice.svelte';
 	import {
 		TranscriptionRuntimeConfig,
@@ -39,7 +36,6 @@
 	import { getTranscriptionReadiness } from '$lib/settings/transcription-validation';
 	import { captureSurface } from '$lib/state/capture-surface.svelte';
 	import { dictationCapability } from '$lib/state/dictation-capability.svelte';
-	import { manualRecorder } from '$lib/state/manual-recorder.svelte';
 	import { recordings } from '$lib/state/recordings.svelte';
 	import { settings } from '$lib/state/settings.svelte';
 	import {
@@ -335,17 +331,6 @@
 						</CapturePipeline>
 					{/snippet}
 				</ManualRecordingAction>
-				{#if manualRecorder.state === 'RECORDING'}
-					<Button
-						tooltip="Cancel recording and discard audio"
-						onclick={() => commandRunners.cancelRecording()}
-						variant="ghost-destructive"
-						size="sm"
-					>
-						<XIcon class="size-4" />
-						Cancel
-					</Button>
-				{/if}
 			</div>
 		{:else if captureSurface.current === 'vad'}
 			<div class="flex w-full flex-col items-center gap-3">

--- a/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
+++ b/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
@@ -3,8 +3,12 @@
 	import * as Kbd from '@epicenter/ui/kbd';
 	import { Spinner } from '@epicenter/ui/spinner';
 	import { cn } from '@epicenter/ui/utils';
+	import XIcon from '@lucide/svelte/icons/x';
 	import type { Snippet } from 'svelte';
+	import LevelMeter from '$lib/components/LevelMeter.svelte';
+	import { webPillLevel } from '$lib/recording-overlay/web-pill.svelte';
 	import { dictationCapability } from '$lib/state/dictation-capability.svelte';
+	import { tauri } from '#platform/tauri';
 	import type { RecordingActionController } from './recording-action-controller';
 
 	// The controller owns the state machine and every derived label/icon. The card
@@ -32,6 +36,16 @@
 			? `${controller.label} (${controller.shortcutLabel})`
 			: controller.label,
 	);
+
+	// Exactly one live meter shows at a time, on the surface holding your
+	// attention. On desktop the always-on-top overlay is that meter: it floats over
+	// even the focused app for the whole recording, so the card defers to it with a
+	// static glyph and a second meter here would only double the overlay's. On web
+	// there is no floating overlay, so the in-window surface carries the meter: this
+	// card on the home route (where the in-page pill stands down), the pill on the
+	// other routes. The smoothed level is already in this window on web
+	// (`webPillLevel`); on desktop it is emitted straight to the overlay, not here.
+	const showsLiveMeter = !tauri;
 </script>
 
 <div
@@ -64,6 +78,16 @@
 		>
 			{#if controller.pending}
 				<Spinner class="size-7" />
+			{:else if controller.active && showsLiveMeter}
+				<!-- Live capture: the glyph slot becomes the meter, the same bars the
+				floating pill draws, scaled to fit the box. -->
+				<LevelMeter
+					level={webPillLevel.level}
+					class="gap-[2px]"
+					barClass="w-[2px] bg-destructive"
+					minPx={3}
+					maxPx={28}
+				/>
 			{:else}
 				{@const Icon = controller.icon}
 				<span
@@ -105,7 +129,28 @@
 		{/if}
 	</Button>
 
-	{#if footer && !controller.active}
+	<!-- The footer slot is the card's secondary zone: at rest it configures the
+	pipeline; while live it discards the take. Keeping the slot filled in both
+	states keeps the discard control tethered to the card (not orphaned below it)
+	and holds the card's height steady across start/stop. VAD has no discard, so
+	its live footer is empty and the slot collapses. -->
+	{#if controller.active}
+		{#if controller.cancel}
+			<div
+				class="flex justify-center border-t border-border/60 bg-background/20 px-3 py-2"
+			>
+				<Button
+					tooltip="Cancel recording and discard audio"
+					onclick={() => controller.cancel?.()}
+					variant="ghost-destructive"
+					size="sm"
+				>
+					<XIcon class="size-4" />
+					Cancel recording
+				</Button>
+			</div>
+		{/if}
+	{:else if footer}
 		<div class="border-t border-border/60 bg-background/20 px-3 py-2">
 			{@render footer()}
 		</div>

--- a/apps/whispering/src/routes/(app)/_components/manual-recording-controller.svelte.ts
+++ b/apps/whispering/src/routes/(app)/_components/manual-recording-controller.svelte.ts
@@ -1,6 +1,7 @@
 import { createMutation } from '@tanstack/svelte-query';
 import { MANUAL_RECORDING_BUTTON } from '$lib/constants/audio';
 import {
+	cancelRecording,
 	startManualRecording,
 	stopManualRecording,
 } from '$lib/operations/recording';
@@ -75,6 +76,10 @@ export function createManualRecordingController(): RecordingActionController {
 		toggle() {
 			if (isRecording) stopMutation.mutate();
 			else startMutation.mutate();
+		},
+		cancel() {
+			// Self-reports failures and plays the discard sound; fire-and-forget.
+			void cancelRecording();
 		},
 	};
 }

--- a/apps/whispering/src/routes/(app)/_components/recording-action-controller.ts
+++ b/apps/whispering/src/routes/(app)/_components/recording-action-controller.ts
@@ -22,4 +22,11 @@ export type RecordingActionController = {
 	readonly shortcutLabel: string;
 	/** Start when idle, stop when active. */
 	toggle(): void;
+	/**
+	 * Discard the in-progress capture without keeping its audio. Present only
+	 * when the recorder has a discard-vs-finalize split (manual). Absent for VAD,
+	 * where stopping the session is the only way to abort it, so a separate cancel
+	 * would just duplicate the toggle.
+	 */
+	cancel?(): void;
 };


### PR DESCRIPTION
The home recording card was not the owner of its live state. While recording, it showed a static glyph and left Cancel as an orphaned button below the card, while the live audio meter existed only in the floating pill.

The card now owns the live web recording surface: the status slot renders the shared `LevelMeter`, and the footer slot swaps from pipeline controls to Cancel while a cancellable manual recording is active. `RecordingActionController` exposes an optional `cancel()` for manual recording; VAD does not implement it because stopping is its abort path.

The single-meter rule is explicit: show one live meter on the surface holding the user's attention. On desktop, the native overlay already owns that surface and the card stays static. On web home, the card owns it and the floating pill yields the recording phase. On config routes, the pill stays visible because there is no in-window capture card.

## Changelog

- Add the live recording meter to the Whispering home card on web.
- Move the manual recording Cancel action into the recording card while recording.
