### PR TITLE
feat(local-books): agent write-back (recategorize) and live reports, gated by a read-only capability lattice

### DIFF
--- a/apps/local-books/AGENTS.md
+++ b/apps/local-books/AGENTS.md
@@ -40,7 +40,8 @@ Mode is chosen from stored state: `--full` / no cursor / cursor older than the C
 `books.ts` + `mount.ts` wrap the mirror as an Epicenter **data daemon**: it holds the SQLite and serves it as dispatched actions, but never runs inference. A client agent loop (`@epicenter/workspace/agent`) opens the same synced room and dispatches the tools; the financial data leaves the machine only as a tool result.
 
 - `src/agent/books-query.ts` — `books_sql_query`, a read-only SQL query (`query`, auto-approved). Enforced read-only by a `new Database(path, { readonly: true })` connection, not a string check; results are row-capped.
-- `src/agent/books-actions.ts` — `createBooksAgentActions({ dbPath })`, the served registry. The write tools (`mark_reviewed`, `add_note`) need an overlay table (parked in the spec) and land here next, gated by the synchronous approval pause.
+- `src/agent/recategorize.ts` — `recategorize_expense`, the one QuickBooks write-back (`mutation`, so the loop pauses for approval). Write-THROUGH, never write-to-mirror: it reads the `SyncToken` from the mirror, sparse-updates the expense line `AccountRef` on a Purchase/Bill via `qb.update(...)`, then folds QuickBooks' authoritative response back into the mirror; the next CDC sync reconfirms it. A stale `SyncToken` is a 409, never a clobber. The QB client never holds credentials in this layer; `src/agent/qb-access.ts` (`makeQbAccess`) lazily opens a write-capable client from the realm's keyring.
+- `src/agent/books-actions.ts` — `createBooksAgentActions({ dbPath, openQb? })`, the served registry. Omit `openQb` for a read-only daemon; `recategorize_expense` then returns a clear "unavailable" error and the query still works. Local annotation tools (`mark_reviewed`, `add_note`) over an overlay table remain parked in the spec.
 
 The CLI binary (`bin.ts` -> `cli.ts`) does not import this layer, so `bun build --compile` of the CLI stays lean.
 

--- a/apps/local-books/AGENTS.md
+++ b/apps/local-books/AGENTS.md
@@ -33,15 +33,17 @@ Mode is chosen from stored state: `--full` / no cursor / cursor older than the C
 - `LOCAL_BOOKS_QB_ENV` — `sandbox` (default) or `production`.
 - `LOCAL_BOOKS_DIR` / `--data-dir` — data directory override.
 - `LOCAL_BOOKS_KEYRING_FILE` — opt-in plaintext file token store (CI / headless boxes without a keyring daemon, and the test harness). Default is the OS keyring.
+- `LOCAL_BOOKS_READ_ONLY` — serve the agent a read-only surface (both reads, no `recategorize_expense` write tool). See the agent-surface capability lattice below.
 - Base-URL overrides (`LOCAL_BOOKS_QB_API_BASE`, `_TOKEN_URL`, `_AUTHORIZE_URL`) point the client at a mock server for tests.
 
-## Agent surface (ADR-0047)
+## Agent surface (ADR-0047, ADR-0061)
 
-`books.ts` + `mount.ts` wrap the mirror as an Epicenter **data daemon**: it holds the SQLite and serves it as dispatched actions, but never runs inference. A client agent loop (`@epicenter/workspace/agent`) opens the same synced room and dispatches the tools; the financial data leaves the machine only as a tool result.
+`books.ts` + `mount.ts` wrap the mirror as an Epicenter **data daemon**: it holds the SQLite and serves it as dispatched actions, but never runs inference. A client agent loop (`@epicenter/workspace/agent`) opens the same synced room and dispatches the tools; the financial data leaves the machine only as a tool result. Sourcing rule (ADR-0061): mirror the *facts* (rows), ask QuickBooks for the *opinions* it computes (reports); the mirror is never the write target.
 
-- `src/agent/books-query.ts` — `books_sql_query`, a read-only SQL query (`query`, auto-approved). Enforced read-only by a `new Database(path, { readonly: true })` connection, not a string check; results are row-capped.
-- `src/agent/recategorize.ts` — `recategorize_expense`, the one QuickBooks write-back (`mutation`, so the loop pauses for approval). Write-THROUGH, never write-to-mirror: it reads the `SyncToken` from the mirror, sparse-updates the expense line `AccountRef` on a Purchase/Bill via `qb.update(...)`, then folds QuickBooks' authoritative response back into the mirror; the next CDC sync reconfirms it. A stale `SyncToken` is a 409, never a clobber. The QB client never holds credentials in this layer; `src/agent/qb-access.ts` (`makeQbAccess`) lazily opens a write-capable client from the realm's keyring.
-- `src/agent/books-actions.ts` — `createBooksAgentActions({ dbPath, openQb? })`, the served registry. Omit `openQb` for a read-only daemon; `recategorize_expense` then returns a clear "unavailable" error and the query still works. Local annotation tools (`mark_reviewed`, `add_note`) over an overlay table remain parked in the spec.
+- `src/agent/books-query.ts` — `books_sql_query`, open read-only SQL over the **local mirror** (`query`, auto-approved). Enforced read-only by a `new Database(path, { readonly: true })` connection, not a string check; results are row-capped. The high-volume, offline, row-level surface.
+- `src/agent/report.ts` — `books_report`, a **live** QuickBooks Reports API read (`query`, auto-approved): P&L, balance sheet, cash flow, A/R + A/P aging, trial balance. Never mirrored, never cached (reports have no CDC, so a cache would be a stale snapshot); one cheap call for whole-ledger aggregates.
+- `src/agent/recategorize.ts` — `recategorize_expense`, the one QuickBooks write-back (`mutation`, so the loop pauses for approval). Write-THROUGH, never write-to-mirror: it reads the `SyncToken` from the mirror, sparse-updates the expense line `AccountRef` on a Purchase/Bill via `qb.update(...)`, then folds QuickBooks' authoritative response back into the mirror; the next CDC sync reconfirms it. A stale `SyncToken` is a 409, never a clobber. `src/agent/qb-access.ts` (`makeQbAccess`) lazily opens a QB client from the realm's keyring, so this layer holds no credentials directly.
+- `src/agent/books-actions.ts` — `createBooksAgentActions({ dbPath, openQb?, readOnly? })`, a **capability lattice** so the agent is only offered what the daemon can do: `books_sql_query` always; `books_report` when `openQb` is present; `recategorize_expense` when `openQb` is present and not `readOnly`. No `openQb` = fully-offline, mirror-only; `readOnly` (env `LOCAL_BOOKS_READ_ONLY`) = both reads, no write. Local annotation tools (`mark_reviewed`, `add_note`) remain parked in the spec.
 
 The CLI binary (`bin.ts` -> `cli.ts`) does not import this layer, so `bun build --compile` of the CLI stays lean.
 

--- a/apps/local-books/mount.ts
+++ b/apps/local-books/mount.ts
@@ -13,6 +13,9 @@
 import { nodeMountRuntime } from '@epicenter/workspace/node';
 import { localBooksWorkspace } from './books.ts';
 import { createBooksAgentActions } from './src/agent/books-actions.ts';
+import { makeQbAccess } from './src/agent/qb-access.ts';
+import { loadConfig } from './src/config.ts';
+import { createKeyring } from './src/keyring.ts';
 import { dbPath } from './src/paths.ts';
 
 export type LocalBooksMountOptions = {
@@ -29,11 +32,25 @@ export function localBooksMount({
 	dataDir,
 	realmId,
 }: LocalBooksMountOptions) {
+	// The write tool (`recategorize_expense`) needs a QuickBooks client; build the
+	// opener from the same config + keyring the CLI uses. The read tool needs only
+	// the mirror path. Token loading stays lazy (inside the opener), so `compose`
+	// itself does no async work.
+	const config = loadConfig({ dataDir });
+	const openQb = makeQbAccess({
+		config,
+		realmId,
+		keyring: createKeyring(config),
+		now: () => Date.now(),
+	});
 	return localBooksWorkspace.mount({
 		baseURL,
 		runtime: nodeMountRuntime(),
 		compose: () => ({
-			actions: createBooksAgentActions({ dbPath: dbPath(dataDir, realmId) }),
+			actions: createBooksAgentActions({
+				dbPath: dbPath(dataDir, realmId),
+				openQb,
+			}),
 		}),
 	});
 }

--- a/apps/local-books/mount.ts
+++ b/apps/local-books/mount.ts
@@ -50,6 +50,7 @@ export function localBooksMount({
 			actions: createBooksAgentActions({
 				dbPath: dbPath(dataDir, realmId),
 				openQb,
+				readOnly: config.readOnly,
 			}),
 		}),
 	});

--- a/apps/local-books/mount.ts
+++ b/apps/local-books/mount.ts
@@ -13,7 +13,7 @@
 import { nodeMountRuntime } from '@epicenter/workspace/node';
 import { localBooksWorkspace } from './books.ts';
 import { createBooksAgentActions } from './src/agent/books-actions.ts';
-import { makeQbAccess } from './src/agent/qb-access.ts';
+import { createQbAccess } from './src/agent/qb-access.ts';
 import { loadConfig } from './src/config.ts';
 import { createKeyring } from './src/keyring.ts';
 import { dbPath } from './src/paths.ts';
@@ -37,7 +37,7 @@ export function localBooksMount({
 	// the mirror path. Token loading stays lazy (inside the opener), so `compose`
 	// itself does no async work.
 	const config = loadConfig({ dataDir });
-	const openQb = makeQbAccess({
+	const openQb = createQbAccess({
 		config,
 		realmId,
 		keyring: createKeyring(config),

--- a/apps/local-books/src/agent/books-actions.test.ts
+++ b/apps/local-books/src/agent/books-actions.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The advertised tool surface is a capability lattice: the agent is only offered
+ * what the daemon can actually do. This pins which tools each mode exposes,
+ * resolved through the same dispatch catalog the client agent loop uses.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+	createDispatchToolCatalog,
+	type DispatchSurface,
+} from '@epicenter/workspace/agent';
+import { Ok } from 'wellcrafted/result';
+import type { QbClient } from '../qb-client.ts';
+import { createBooksAgentActions } from './books-actions.ts';
+import type { OpenQbClient } from './qb-access.ts';
+
+const LOCAL_ONLY: DispatchSurface = {
+	peers: { list: () => [] },
+	dispatch: () => Promise.resolve(Ok(null)),
+};
+
+/** A QuickBooks opener that is never invoked here; only the manifest is read. */
+const STUB_QB: OpenQbClient = () =>
+	Promise.resolve(Ok(undefined as unknown as QbClient));
+
+function advertised(opts: Parameters<typeof createBooksAgentActions>[0]) {
+	const catalog = createDispatchToolCatalog(LOCAL_ONLY, {
+		localActions: createBooksAgentActions(opts),
+	});
+	return catalog
+		.definitions()
+		.map((d) => d.name)
+		.sort();
+}
+
+describe('the advertised tool capability lattice', () => {
+	test('mirror-only daemon (no QuickBooks client) offers only the SQL read', () => {
+		expect(advertised({ dbPath: '/tmp/unused.db' })).toEqual([
+			'books_sql_query',
+		]);
+	});
+
+	test('read-only daemon offers both reads but withholds the write', () => {
+		expect(
+			advertised({ dbPath: '/tmp/unused.db', openQb: STUB_QB, readOnly: true }),
+		).toEqual(['books_report', 'books_sql_query']);
+	});
+
+	test('full daemon offers both reads and the write', () => {
+		expect(
+			advertised({
+				dbPath: '/tmp/unused.db',
+				openQb: STUB_QB,
+				readOnly: false,
+			}),
+		).toEqual(['books_report', 'books_sql_query', 'recategorize_expense']);
+	});
+
+	test('recategorize_expense is a mutation; the reads are queries', () => {
+		const catalog = createDispatchToolCatalog(LOCAL_ONLY, {
+			localActions: createBooksAgentActions({
+				dbPath: '/tmp/unused.db',
+				openQb: STUB_QB,
+			}),
+		});
+		const byName = new Map(
+			catalog.definitions().map((d) => [d.name, d.kind] as const),
+		);
+		expect(byName.get('books_sql_query')).toBe('query');
+		expect(byName.get('books_report')).toBe('query');
+		expect(byName.get('recategorize_expense')).toBe('mutation');
+	});
+});

--- a/apps/local-books/src/agent/books-actions.ts
+++ b/apps/local-books/src/agent/books-actions.ts
@@ -3,33 +3,50 @@
  * (ADR-0047). The daemon holds the QuickBooks mirror and runs these; the client
  * dispatches them as tools.
  *
- * Two tools today:
- * - `books_sql_query` (read): open read-only SQL over the mirror, auto-approved.
- * - `recategorize_expense` (write): the one QuickBooks write-back, gated by the
- *   loop's synchronous approval pause. Available only when the daemon was given
- *   a way to open a QuickBooks client (`openQb`); otherwise it returns a clear
- *   "unavailable" error and the read tool still works.
+ * The advertised tools are a capability lattice, so the agent is only offered
+ * what the daemon can actually do (it never sees a tool it cannot use):
+ *
+ * - `books_sql_query` (read, local mirror): always. Needs no QuickBooks client.
+ * - `books_report` (read, live QuickBooks): when a QuickBooks client is available
+ *   (`openQb`). Omitting `openQb` is a fully-offline, mirror-only daemon.
+ * - `recategorize_expense` (write, QuickBooks): when a client is available AND
+ *   the daemon is not read-only. `readOnly` withholds the write while keeping
+ *   both reads, the safety posture of "analyze my books, don't mutate them".
+ *
+ * Local annotation tools (`mark_reviewed`, `add_note`) over an overlay table
+ * remain parked in the spec.
  */
 
 import { defineActions } from '@epicenter/workspace';
 import { createBooksQueryAction } from './books-query.ts';
 import type { OpenQbClient } from './qb-access.ts';
 import { createRecategorizeAction } from './recategorize.ts';
+import { createReportAction } from './report.ts';
 
 /** Build the daemon's served actions over the mirror at `dbPath`. */
 export function createBooksAgentActions({
 	dbPath,
 	openQb,
+	readOnly = false,
 	now = () => Date.now(),
 }: {
 	dbPath: string;
-	/** Opens a write-capable QuickBooks client; omit for a read-only daemon. */
+	/** Opens a QuickBooks client; omit for a fully-offline, mirror-only daemon. */
 	openQb?: OpenQbClient;
+	/** Withhold the write tool while keeping both reads. */
+	readOnly?: boolean;
 	/** Clock for the mirror write-back timestamp; injectable for tests. */
 	now?: () => number;
 }) {
+	const books_sql_query = createBooksQueryAction({ dbPath });
+	if (!openQb) return defineActions({ books_sql_query });
+
+	const books_report = createReportAction({ openQb });
+	if (readOnly) return defineActions({ books_sql_query, books_report });
+
 	return defineActions({
-		books_sql_query: createBooksQueryAction({ dbPath }),
+		books_sql_query,
+		books_report,
 		recategorize_expense: createRecategorizeAction({ openQb, dbPath, now }),
 	});
 }

--- a/apps/local-books/src/agent/books-actions.ts
+++ b/apps/local-books/src/agent/books-actions.ts
@@ -3,17 +3,33 @@
  * (ADR-0047). The daemon holds the QuickBooks mirror and runs these; the client
  * dispatches them as tools.
  *
- * Today it is the read-only `books_sql_query`. The write tools the mirror needs
- * an overlay table for (`mark_reviewed`, `add_note`) are the next increment;
- * they land here beside the query, gated by the synchronous approval pause.
+ * Two tools today:
+ * - `books_sql_query` (read): open read-only SQL over the mirror, auto-approved.
+ * - `recategorize_expense` (write): the one QuickBooks write-back, gated by the
+ *   loop's synchronous approval pause. Available only when the daemon was given
+ *   a way to open a QuickBooks client (`openQb`); otherwise it returns a clear
+ *   "unavailable" error and the read tool still works.
  */
 
 import { defineActions } from '@epicenter/workspace';
 import { createBooksQueryAction } from './books-query.ts';
+import type { OpenQbClient } from './qb-access.ts';
+import { createRecategorizeAction } from './recategorize.ts';
 
 /** Build the daemon's served actions over the mirror at `dbPath`. */
-export function createBooksAgentActions({ dbPath }: { dbPath: string }) {
+export function createBooksAgentActions({
+	dbPath,
+	openQb,
+	now = () => Date.now(),
+}: {
+	dbPath: string;
+	/** Opens a write-capable QuickBooks client; omit for a read-only daemon. */
+	openQb?: OpenQbClient;
+	/** Clock for the mirror write-back timestamp; injectable for tests. */
+	now?: () => number;
+}) {
 	return defineActions({
 		books_sql_query: createBooksQueryAction({ dbPath }),
+		recategorize_expense: createRecategorizeAction({ openQb, dbPath, now }),
 	});
 }

--- a/apps/local-books/src/agent/qb-access.ts
+++ b/apps/local-books/src/agent/qb-access.ts
@@ -1,0 +1,39 @@
+/**
+ * Lazily open a write-capable QuickBooks client for the daemon's realm. The
+ * agent action layer never holds QB credentials directly; instead the mount
+ * hands the write tools this thunk. It reloads the token from the keyring on
+ * each call, so it always starts from the newest persisted (possibly rotated)
+ * credentials and stays out of the mount's synchronous `compose` path.
+ */
+
+import { Err, Ok, type Result } from 'wellcrafted/result';
+import type { AppConfig } from '../config.ts';
+import type { Keyring } from '../keyring.ts';
+import { createQbClient, type QbClient } from '../qb-client.ts';
+import { createTokenManager, loadToken } from '../token-manager.ts';
+
+/** Opens a QB client for the realm, or a user-facing reason it cannot. */
+export type OpenQbClient = () => Promise<Result<QbClient, string>>;
+
+export function makeQbAccess({
+	config,
+	realmId,
+	keyring,
+	now,
+}: {
+	config: AppConfig;
+	realmId: string;
+	keyring: Keyring;
+	now: () => number;
+}): OpenQbClient {
+	return async () => {
+		const token = await loadToken(keyring, realmId);
+		if (!token) {
+			return Err(
+				`No stored token for company ${realmId}. Run "local-books auth" on the host that runs this daemon.`,
+			);
+		}
+		const tokens = createTokenManager({ config, keyring, token, now });
+		return Ok(createQbClient({ config, realmId, tokens }));
+	};
+}

--- a/apps/local-books/src/agent/qb-access.ts
+++ b/apps/local-books/src/agent/qb-access.ts
@@ -15,7 +15,7 @@ import { createTokenManager, loadToken } from '../token-manager.ts';
 /** Opens a QB client for the realm, or a user-facing reason it cannot. */
 export type OpenQbClient = () => Promise<Result<QbClient, string>>;
 
-export function makeQbAccess({
+export function createQbAccess({
 	config,
 	realmId,
 	keyring,

--- a/apps/local-books/src/agent/recategorize.test.ts
+++ b/apps/local-books/src/agent/recategorize.test.ts
@@ -1,0 +1,194 @@
+/**
+ * `recategorize_expense` reached the way the client agent loop reaches it: as a
+ * dispatched action resolved through `createDispatchToolCatalog`, driven against
+ * a mock QuickBooks server and a seeded mirror. Proves the write-through path end
+ * to end: read the SyncToken from the mirror -> sparse-update QuickBooks -> fold
+ * the authoritative response back into the mirror. Also proves the safety
+ * primitive: a stale SyncToken is rejected, never clobbered.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+	createDispatchToolCatalog,
+	type DispatchSurface,
+} from '@epicenter/workspace/agent';
+import { Ok } from 'wellcrafted/result';
+import { makeConfig } from '../../test/helpers.ts';
+import { makePurchase, startMockQbServer } from '../../test/mock-qb-server.ts';
+import { openBooksDb } from '../db.ts';
+import { entityDef } from '../entities.ts';
+import { createFileKeyring } from '../keyring.ts';
+import type { TokenSet } from '../tokens.ts';
+import { createBooksAgentActions } from './books-actions.ts';
+import { makeQbAccess } from './qb-access.ts';
+
+/** No peers: a books action resolves in-process; dispatch is never reached. */
+const LOCAL_ONLY: DispatchSurface = {
+	peers: { list: () => [] },
+	dispatch: () => Promise.resolve(Ok(null)),
+};
+
+const NOW = Date.parse('2026-02-01T00:00:00.000Z');
+const now = () => NOW;
+
+/**
+ * Boot a mock company with one Purchase, seed its token + mirror, and return a
+ * catalog wired to the write tool. `mirrorSyncToken` lets a test seed the mirror
+ * with a stale token to exercise the 409 path.
+ */
+async function setup(
+	opts: { mockSyncToken?: string; mirrorSyncToken?: string } = {},
+) {
+	const dir = mkdtempSync(join(tmpdir(), 'local-books-'));
+	const mock = startMockQbServer({ now });
+	mock.put(
+		'Purchase',
+		makePurchase('p1', { SyncToken: opts.mockSyncToken ?? '0' }),
+	);
+
+	const keyringFile = join(dir, 'keyring.json');
+	const config = makeConfig({
+		dataDir: dir,
+		apiBase: mock.apiBase,
+		tokenUrl: mock.tokenUrl,
+		keyringFile,
+		entities: ['Purchase'],
+	});
+	const keyring = createFileKeyring(keyringFile);
+	const token: TokenSet = {
+		realmId: mock.realmId,
+		environment: 'sandbox',
+		accessToken: 'access-seed',
+		refreshToken: 'refresh-seed',
+		accessTokenExpiresAt: new Date(NOW + 86_400_000).toISOString(),
+		refreshTokenExpiresAt: new Date(NOW + 8_726_400_000).toISOString(),
+		obtainedAt: new Date(NOW).toISOString(),
+	};
+	await keyring.set(mock.realmId, JSON.stringify(token));
+
+	const path = join(dir, mock.realmId, 'books.db');
+	const db = openBooksDb(path);
+	db.upsertObjects(
+		entityDef('Purchase'),
+		[
+			{
+				id: 'p1',
+				raw: JSON.stringify(
+					makePurchase('p1', { SyncToken: opts.mirrorSyncToken ?? '0' }),
+				),
+				updatedAt: '2026-01-15T00:00:00.000Z',
+			},
+		],
+		'2026-01-20T00:00:00.000Z',
+	);
+	db.close();
+
+	const openQb = makeQbAccess({ config, realmId: mock.realmId, keyring, now });
+	const catalog = createDispatchToolCatalog(LOCAL_ONLY, {
+		localActions: createBooksAgentActions({ dbPath: path, openQb, now }),
+	});
+	return {
+		mock,
+		path,
+		catalog,
+		cleanup: () => {
+			mock.stop();
+			rmSync(dir, { recursive: true, force: true });
+		},
+	};
+}
+
+function recategorize(
+	catalog: ReturnType<typeof createDispatchToolCatalog>,
+	input: Record<string, string>,
+) {
+	return catalog.resolve(
+		{ toolCallId: 't1', toolName: 'recategorize_expense', input },
+		new AbortController().signal,
+	);
+}
+
+function lineAccount(obj: Record<string, unknown>): string | undefined {
+	const line = (obj.Line as Record<string, unknown>[] | undefined)?.[0];
+	const detail = line?.AccountBasedExpenseLineDetail as
+		| { AccountRef?: { value?: string } }
+		| undefined;
+	return detail?.AccountRef?.value;
+}
+
+describe('recategorize_expense as a dispatched action', () => {
+	test('the catalog advertises it as a mutation (needs approval)', async () => {
+		const { catalog, cleanup } = await setup();
+		const def = catalog
+			.definitions()
+			.find((d) => d.name === 'recategorize_expense');
+		expect(def?.kind).toBe('mutation');
+		cleanup();
+	});
+
+	test('moves the expense line in QuickBooks and folds it into the mirror', async () => {
+		const { mock, path, catalog, cleanup } = await setup();
+
+		const outcome = await recategorize(catalog, {
+			entity: 'Purchase',
+			id: 'p1',
+			account_id: '77',
+			account_name: 'Cloud Infrastructure',
+		});
+		expect(outcome.isError).toBe(false);
+		expect(mock.hits.update).toBe(1);
+
+		// QuickBooks (the source of truth) now has the new category + a bumped token.
+		const remote = mock.get('Purchase', 'p1');
+		expect(remote && lineAccount(remote)).toBe('77');
+		expect(remote?.SyncToken).toBe('1');
+
+		// The mirror reflects the authoritative response (token '1', not the old '0').
+		const db = openBooksDb(path);
+		const row = db.raw
+			.query<{ raw: string }, []>(`SELECT raw FROM purchases WHERE id = 'p1'`)
+			.get();
+		const mirrored = JSON.parse(row?.raw ?? '{}');
+		expect(lineAccount(mirrored)).toBe('77');
+		expect(mirrored.SyncToken).toBe('1');
+		db.close();
+
+		cleanup();
+	});
+
+	test('a stale SyncToken is rejected, leaving QuickBooks untouched', async () => {
+		// Mirror thinks the token is '0'; QuickBooks has moved on to '5'.
+		const { mock, catalog, cleanup } = await setup({
+			mockSyncToken: '5',
+			mirrorSyncToken: '0',
+		});
+
+		const outcome = await recategorize(catalog, {
+			entity: 'Purchase',
+			id: 'p1',
+			account_id: '77',
+		});
+		expect(outcome.isError).toBe(true);
+
+		// QuickBooks kept the original category: no clobber on a stale write.
+		const remote = mock.get('Purchase', 'p1');
+		expect(remote && lineAccount(remote)).toBe('60');
+		expect(remote?.SyncToken).toBe('5');
+		cleanup();
+	});
+
+	test('errors clearly when the transaction is not in the mirror', async () => {
+		const { catalog, cleanup } = await setup();
+		const outcome = await recategorize(catalog, {
+			entity: 'Purchase',
+			id: 'does-not-exist',
+			account_id: '77',
+		});
+		expect(outcome.isError).toBe(true);
+		expect(String(outcome.output)).toContain('mirror');
+		cleanup();
+	});
+});

--- a/apps/local-books/src/agent/recategorize.test.ts
+++ b/apps/local-books/src/agent/recategorize.test.ts
@@ -23,7 +23,7 @@ import { entityDef } from '../entities.ts';
 import { createFileKeyring } from '../keyring.ts';
 import type { TokenSet } from '../tokens.ts';
 import { createBooksAgentActions } from './books-actions.ts';
-import { makeQbAccess } from './qb-access.ts';
+import { createQbAccess } from './qb-access.ts';
 
 /** No peers: a books action resolves in-process; dispatch is never reached. */
 const LOCAL_ONLY: DispatchSurface = {
@@ -86,7 +86,7 @@ async function setup(
 	);
 	db.close();
 
-	const openQb = makeQbAccess({ config, realmId: mock.realmId, keyring, now });
+	const openQb = createQbAccess({ config, realmId: mock.realmId, keyring, now });
 	const catalog = createDispatchToolCatalog(LOCAL_ONLY, {
 		localActions: createBooksAgentActions({ dbPath: path, openQb, now }),
 	});

--- a/apps/local-books/src/agent/recategorize.test.ts
+++ b/apps/local-books/src/agent/recategorize.test.ts
@@ -86,7 +86,12 @@ async function setup(
 	);
 	db.close();
 
-	const openQb = createQbAccess({ config, realmId: mock.realmId, keyring, now });
+	const openQb = createQbAccess({
+		config,
+		realmId: mock.realmId,
+		keyring,
+		now,
+	});
 	const catalog = createDispatchToolCatalog(LOCAL_ONLY, {
 		localActions: createBooksAgentActions({ dbPath: path, openQb, now }),
 	});

--- a/apps/local-books/src/agent/recategorize.ts
+++ b/apps/local-books/src/agent/recategorize.ts
@@ -1,0 +1,212 @@
+/**
+ * `recategorize_expense`: the one QuickBooks write-back tool (ADR-0047). It
+ * moves an expense transaction's category by sparse-updating the `AccountRef` on
+ * its expense lines, then folds QuickBooks' response back into the local mirror.
+ *
+ * It is a `mutation`, so the client agent loop pauses for approval before
+ * dispatching it (unlike the auto-approved `books_sql_query`). The write is
+ * write-THROUGH: QuickBooks owns the change; the mirror is updated from the
+ * authoritative response (with the bumped `SyncToken`), and the next CDC sync
+ * reconfirms it. The mirror is never the write target.
+ *
+ * Concurrency: the current `SyncToken` is read from the mirror and sent with the
+ * update. If a bookkeeper changed the object in QuickBooks since the last sync,
+ * QuickBooks rejects the stale token (a 409 `Http` error) rather than clobbering
+ * their change; the caller should re-sync and retry.
+ */
+
+import { defineMutation } from '@epicenter/workspace';
+import { Type } from 'typebox';
+import { defineErrors, type InferErrors } from 'wellcrafted/error';
+import { Err, Ok } from 'wellcrafted/result';
+import { openBooksDb } from '../db.ts';
+import { entityDef, lastUpdatedTime } from '../entities.ts';
+import type { OpenQbClient } from './qb-access.ts';
+
+/** The line shape that carries an account-based expense category. */
+const LINE_DETAIL = 'AccountBasedExpenseLineDetail';
+
+export const RecategorizeError = defineErrors({
+	WriteBackUnavailable: ({ detail }: { detail: string }) => ({
+		message: `Recategorize is unavailable: ${detail}`,
+		detail,
+	}),
+	NotInMirror: ({ entity, id }: { entity: string; id: string }) => ({
+		message: `No ${entity} ${id} in the local mirror. Run \`local-books sync\` first.`,
+	}),
+	NoExpenseLine: ({
+		entity,
+		id,
+		lineId,
+	}: {
+		entity: string;
+		id: string;
+		lineId?: string;
+	}) => ({
+		message: lineId
+			? `${entity} ${id} has no expense line ${lineId} to recategorize.`
+			: `${entity} ${id} has no account-based expense line to recategorize.`,
+	}),
+});
+export type RecategorizeError = InferErrors<typeof RecategorizeError>;
+
+const RecategorizeInput = Type.Object({
+	entity: Type.Union([Type.Literal('Purchase'), Type.Literal('Bill')], {
+		description:
+			'Which expense transaction to recategorize: a Purchase (card/cash/check expense) or a Bill (vendor bill).',
+	}),
+	id: Type.String({
+		minLength: 1,
+		description: 'The QuickBooks Id of the transaction (the mirror row `id`).',
+	}),
+	account_id: Type.String({
+		minLength: 1,
+		description:
+			'The target expense account Id (an `accounts` row `id`), set as the line AccountRef.value.',
+	}),
+	account_name: Type.Optional(
+		Type.String({
+			description:
+				'The target account display name, set as AccountRef.name (for readable books).',
+		}),
+	),
+	line_id: Type.Optional(
+		Type.String({
+			description:
+				'Recategorize only this line (its `Id`). Omit to recategorize every expense line on the transaction.',
+		}),
+	),
+});
+
+type ExpenseLine = Record<string, unknown> & {
+	Id?: string | number;
+	[LINE_DETAIL]?: { AccountRef?: { value?: string; name?: string } };
+};
+
+/** Build the `recategorize_expense` mutation over the mirror at `dbPath`. */
+export function createRecategorizeAction({
+	openQb,
+	dbPath,
+	now,
+}: {
+	openQb: OpenQbClient | undefined;
+	dbPath: string;
+	now: () => number;
+}) {
+	return defineMutation({
+		title: 'Recategorize an expense',
+		description:
+			'Move an expense transaction to a different account (its category) in ' +
+			'QuickBooks, then update the local mirror. Targets the expense lines of a ' +
+			'Purchase or Bill. Find the transaction and the target account first with ' +
+			'`books_sql_query` (the current category lives in raw, e.g. ' +
+			"json_extract(raw, '$.Line')).",
+		input: RecategorizeInput,
+		handler: async (input) => {
+			if (!openQb) {
+				return RecategorizeError.WriteBackUnavailable({
+					detail: 'this daemon was started without a QuickBooks client',
+				});
+			}
+			const def = entityDef(input.entity);
+			const db = openBooksDb(dbPath);
+			try {
+				const tableExists = db.raw
+					.query(`SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?`)
+					.get(def.table);
+				if (!tableExists) {
+					return RecategorizeError.NotInMirror({
+						entity: input.entity,
+						id: input.id,
+					});
+				}
+				const row = db.raw
+					.query<{ raw: string }, [string]>(
+						`SELECT raw FROM ${def.table} WHERE id = ? AND deleted = 0`,
+					)
+					.get(input.id);
+				if (!row) {
+					return RecategorizeError.NotInMirror({
+						entity: input.entity,
+						id: input.id,
+					});
+				}
+
+				const obj = JSON.parse(row.raw) as Record<string, unknown>;
+				const lines: ExpenseLine[] = Array.isArray(obj.Line)
+					? (obj.Line as ExpenseLine[])
+					: [];
+				const targets = lines.filter(
+					(line) =>
+						line[LINE_DETAIL] != null &&
+						(input.line_id == null || String(line.Id) === input.line_id),
+				);
+				if (targets.length === 0) {
+					return RecategorizeError.NoExpenseLine({
+						entity: input.entity,
+						id: input.id,
+						lineId: input.line_id,
+					});
+				}
+
+				const toName = input.account_name ?? input.account_id;
+				const changed = targets.map((line) => {
+					const detail = line[LINE_DETAIL];
+					const fromRef = detail?.AccountRef;
+					const change = {
+						lineId: line.Id != null ? String(line.Id) : null,
+						fromAccount: fromRef?.name ?? fromRef?.value ?? null,
+						toAccount: toName,
+					};
+					line[LINE_DETAIL] = {
+						...detail,
+						AccountRef: {
+							value: input.account_id,
+							...(input.account_name ? { name: input.account_name } : {}),
+						},
+					};
+					return change;
+				});
+
+				const { data: qb, error: openError } = await openQb();
+				if (openError !== null) {
+					return RecategorizeError.WriteBackUnavailable({ detail: openError });
+				}
+
+				// Sparse update: send the full (modified) Line array with Id + the
+				// SyncToken read from the mirror; QuickBooks merges the named fields.
+				const { data: updated, error } = await qb.update(input.entity, {
+					Id: obj.Id,
+					SyncToken: obj.SyncToken,
+					sparse: true,
+					Line: lines,
+				});
+				// Re-wrap as a Result: a bare error variant would be Ok-wrapped by
+				// invokeAction and read as success. A stale SyncToken (409) lands here.
+				if (error) return Err(error);
+
+				db.upsertObjects(
+					def,
+					[
+						{
+							id: String(updated.Id),
+							raw: JSON.stringify(updated),
+							updatedAt: lastUpdatedTime(updated),
+						},
+					],
+					new Date(now()).toISOString(),
+				);
+
+				return Ok({
+					entity: input.entity,
+					id: String(updated.Id),
+					changed,
+					syncToken:
+						typeof updated.SyncToken === 'string' ? updated.SyncToken : null,
+				});
+			} finally {
+				db.close();
+			}
+		},
+	});
+}

--- a/apps/local-books/src/agent/recategorize.ts
+++ b/apps/local-books/src/agent/recategorize.ts
@@ -27,8 +27,8 @@ import type { OpenQbClient } from './qb-access.ts';
 const LINE_DETAIL = 'AccountBasedExpenseLineDetail';
 
 export const RecategorizeError = defineErrors({
-	WriteBackUnavailable: ({ detail }: { detail: string }) => ({
-		message: `Recategorize is unavailable: ${detail}`,
+	NotAuthenticated: ({ detail }: { detail: string }) => ({
+		message: `Recategorize could not reach QuickBooks: ${detail}`,
 		detail,
 	}),
 	NotInMirror: ({ entity, id }: { entity: string; id: string }) => ({
@@ -89,7 +89,7 @@ export function createRecategorizeAction({
 	dbPath,
 	now,
 }: {
-	openQb: OpenQbClient | undefined;
+	openQb: OpenQbClient;
 	dbPath: string;
 	now: () => number;
 }) {
@@ -103,11 +103,6 @@ export function createRecategorizeAction({
 			"json_extract(raw, '$.Line')).",
 		input: RecategorizeInput,
 		handler: async (input) => {
-			if (!openQb) {
-				return RecategorizeError.WriteBackUnavailable({
-					detail: 'this daemon was started without a QuickBooks client',
-				});
-			}
 			const def = entityDef(input.entity);
 			const db = openBooksDb(dbPath);
 			try {
@@ -170,7 +165,7 @@ export function createRecategorizeAction({
 
 				const { data: qb, error: openError } = await openQb();
 				if (openError !== null) {
-					return RecategorizeError.WriteBackUnavailable({ detail: openError });
+					return RecategorizeError.NotAuthenticated({ detail: openError });
 				}
 
 				// Sparse update: send the full (modified) Line array with Id + the

--- a/apps/local-books/src/agent/recategorize.ts
+++ b/apps/local-books/src/agent/recategorize.ts
@@ -106,28 +106,15 @@ export function createRecategorizeAction({
 			const def = entityDef(input.entity);
 			const db = openBooksDb(dbPath);
 			try {
-				const tableExists = db.raw
-					.query(`SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?`)
-					.get(def.table);
-				if (!tableExists) {
-					return RecategorizeError.NotInMirror({
-						entity: input.entity,
-						id: input.id,
-					});
-				}
-				const row = db.raw
-					.query<{ raw: string }, [string]>(
-						`SELECT raw FROM ${def.table} WHERE id = ? AND deleted = 0`,
-					)
-					.get(input.id);
-				if (!row) {
+				const raw = db.readLiveRaw(def, input.id);
+				if (raw === null) {
 					return RecategorizeError.NotInMirror({
 						entity: input.entity,
 						id: input.id,
 					});
 				}
 
-				const obj = JSON.parse(row.raw) as Record<string, unknown>;
+				const obj = JSON.parse(raw) as Record<string, unknown>;
 				const lines: ExpenseLine[] = Array.isArray(obj.Line)
 					? (obj.Line as ExpenseLine[])
 					: [];

--- a/apps/local-books/src/agent/report.test.ts
+++ b/apps/local-books/src/agent/report.test.ts
@@ -1,0 +1,100 @@
+/**
+ * `books_report` reached as a dispatched action, driven against the mock
+ * QuickBooks Reports endpoint. Proves the live passthrough: a tool call hits the
+ * QuickBooks Reports API (no mirror, no cache) and the report comes back with the
+ * period params passed through.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+	createDispatchToolCatalog,
+	type DispatchSurface,
+} from '@epicenter/workspace/agent';
+import { Ok } from 'wellcrafted/result';
+import { makeConfig } from '../../test/helpers.ts';
+import { startMockQbServer } from '../../test/mock-qb-server.ts';
+import { createFileKeyring } from '../keyring.ts';
+import type { TokenSet } from '../tokens.ts';
+import { createBooksAgentActions } from './books-actions.ts';
+import { makeQbAccess } from './qb-access.ts';
+
+const LOCAL_ONLY: DispatchSurface = {
+	peers: { list: () => [] },
+	dispatch: () => Promise.resolve(Ok(null)),
+};
+
+const NOW = Date.parse('2026-02-01T00:00:00.000Z');
+const now = () => NOW;
+
+async function setup() {
+	const dir = mkdtempSync(join(tmpdir(), 'local-books-'));
+	const mock = startMockQbServer({ now });
+	const keyringFile = join(dir, 'keyring.json');
+	const config = makeConfig({
+		dataDir: dir,
+		apiBase: mock.apiBase,
+		tokenUrl: mock.tokenUrl,
+		keyringFile,
+	});
+	const keyring = createFileKeyring(keyringFile);
+	const token: TokenSet = {
+		realmId: mock.realmId,
+		environment: 'sandbox',
+		accessToken: 'access-seed',
+		refreshToken: 'refresh-seed',
+		accessTokenExpiresAt: new Date(NOW + 86_400_000).toISOString(),
+		refreshTokenExpiresAt: new Date(NOW + 8_726_400_000).toISOString(),
+		obtainedAt: new Date(NOW).toISOString(),
+	};
+	await keyring.set(mock.realmId, JSON.stringify(token));
+
+	const openQb = makeQbAccess({ config, realmId: mock.realmId, keyring, now });
+	const catalog = createDispatchToolCatalog(LOCAL_ONLY, {
+		localActions: createBooksAgentActions({
+			dbPath: join(dir, mock.realmId, 'books.db'),
+			openQb,
+			now,
+		}),
+	});
+	return {
+		mock,
+		catalog,
+		cleanup: () => {
+			mock.stop();
+			rmSync(dir, { recursive: true, force: true });
+		},
+	};
+}
+
+describe('books_report as a dispatched action', () => {
+	test('runs a report live against QuickBooks and passes the period through', async () => {
+		const { mock, catalog, cleanup } = await setup();
+
+		const outcome = await catalog.resolve(
+			{
+				toolCallId: 't1',
+				toolName: 'books_report',
+				input: {
+					report: 'ProfitAndLoss',
+					start_date: '2026-01-01',
+					end_date: '2026-03-31',
+				},
+			},
+			new AbortController().signal,
+		);
+
+		expect(outcome.isError).toBe(false);
+		expect(mock.hits.report).toBe(1);
+		const output = outcome.output as {
+			report: string;
+			data: { Header: { ReportName: string; StartPeriod: string } };
+		};
+		expect(output.report).toBe('ProfitAndLoss');
+		expect(output.data.Header.ReportName).toBe('ProfitAndLoss');
+		expect(output.data.Header.StartPeriod).toBe('2026-01-01');
+		cleanup();
+	});
+});

--- a/apps/local-books/src/agent/report.test.ts
+++ b/apps/local-books/src/agent/report.test.ts
@@ -19,7 +19,7 @@ import { startMockQbServer } from '../../test/mock-qb-server.ts';
 import { createFileKeyring } from '../keyring.ts';
 import type { TokenSet } from '../tokens.ts';
 import { createBooksAgentActions } from './books-actions.ts';
-import { makeQbAccess } from './qb-access.ts';
+import { createQbAccess } from './qb-access.ts';
 
 const LOCAL_ONLY: DispatchSurface = {
 	peers: { list: () => [] },
@@ -51,7 +51,7 @@ async function setup() {
 	};
 	await keyring.set(mock.realmId, JSON.stringify(token));
 
-	const openQb = makeQbAccess({ config, realmId: mock.realmId, keyring, now });
+	const openQb = createQbAccess({ config, realmId: mock.realmId, keyring, now });
 	const catalog = createDispatchToolCatalog(LOCAL_ONLY, {
 		localActions: createBooksAgentActions({
 			dbPath: join(dir, mock.realmId, 'books.db'),

--- a/apps/local-books/src/agent/report.test.ts
+++ b/apps/local-books/src/agent/report.test.ts
@@ -51,7 +51,12 @@ async function setup() {
 	};
 	await keyring.set(mock.realmId, JSON.stringify(token));
 
-	const openQb = createQbAccess({ config, realmId: mock.realmId, keyring, now });
+	const openQb = createQbAccess({
+		config,
+		realmId: mock.realmId,
+		keyring,
+		now,
+	});
 	const catalog = createDispatchToolCatalog(LOCAL_ONLY, {
 		localActions: createBooksAgentActions({
 			dbPath: join(dir, mock.realmId, 'books.db'),

--- a/apps/local-books/src/agent/report.ts
+++ b/apps/local-books/src/agent/report.ts
@@ -1,0 +1,88 @@
+/**
+ * `books_report`: the live computed-report tool (ADR-0047). Where `books_sql_query`
+ * answers row-level questions off the local mirror, this answers whole-ledger
+ * questions QuickBooks owns the *computation* of (P&L, balance sheet, cash flow,
+ * aging, trial balance).
+ *
+ * These are read LIVE from the QuickBooks Reports API, never mirrored and never
+ * cached: there is no CDC for reports, so a cached copy would be a stale snapshot.
+ * The mirror holds the facts; QuickBooks computes the opinions. A report is one
+ * cheap call asked a few times a day, so live is both correct and affordable.
+ *
+ * It is a `query` (auto-approved): a read, even though it crosses to the API.
+ */
+
+import { defineQuery } from '@epicenter/workspace';
+import { Type } from 'typebox';
+import { defineErrors, type InferErrors } from 'wellcrafted/error';
+import { Err, Ok } from 'wellcrafted/result';
+import type { OpenQbClient } from './qb-access.ts';
+
+export const ReportError = defineErrors({
+	Unavailable: ({ detail }: { detail: string }) => ({
+		message: `Reports are unavailable: ${detail}`,
+		detail,
+	}),
+});
+export type ReportError = InferErrors<typeof ReportError>;
+
+const ReportInput = Type.Object({
+	report: Type.Union(
+		[
+			Type.Literal('ProfitAndLoss'),
+			Type.Literal('BalanceSheet'),
+			Type.Literal('CashFlow'),
+			Type.Literal('AgedReceivables'),
+			Type.Literal('AgedPayables'),
+			Type.Literal('TrialBalance'),
+		],
+		{
+			description:
+				'Which QuickBooks report to run live. Use ProfitAndLoss for burn/net income, BalanceSheet for position, CashFlow for cash, AgedReceivables/AgedPayables for who owes whom, TrialBalance for the raw account balances.',
+		},
+	),
+	start_date: Type.Optional(
+		Type.String({
+			description: 'Report period start, YYYY-MM-DD (QuickBooks `start_date`).',
+		}),
+	),
+	end_date: Type.Optional(
+		Type.String({
+			description: 'Report period end, YYYY-MM-DD (QuickBooks `end_date`).',
+		}),
+	),
+	accounting_method: Type.Optional(
+		Type.Union([Type.Literal('Cash'), Type.Literal('Accrual')], {
+			description:
+				'Cash or Accrual basis; QuickBooks defaults to the company setting.',
+		}),
+	),
+});
+
+/** Build the `books_report` action; `openQb` opens the live QuickBooks client. */
+export function createReportAction({ openQb }: { openQb: OpenQbClient }) {
+	return defineQuery({
+		title: 'Run a QuickBooks report',
+		description:
+			'Get an authoritative computed financial statement LIVE from QuickBooks ' +
+			'(profit & loss, balance sheet, cash flow, A/R & A/P aging, trial balance). ' +
+			'Use this for whole-ledger totals (burn, net income, runway, what is owed); ' +
+			'use `books_sql_query` for row-level detail off the local mirror.',
+		input: ReportInput,
+		handler: async (input) => {
+			const { data: qb, error: openError } = await openQb();
+			if (openError !== null) {
+				return ReportError.Unavailable({ detail: openError });
+			}
+			const params: Record<string, string> = {};
+			if (input.start_date) params.start_date = input.start_date;
+			if (input.end_date) params.end_date = input.end_date;
+			if (input.accounting_method)
+				params.accounting_method = input.accounting_method;
+
+			const { data, error } = await qb.report(input.report, params);
+			if (error) return Err(error);
+			return Ok({ report: input.report, data });
+		},
+	});
+}

--- a/apps/local-books/src/config.ts
+++ b/apps/local-books/src/config.ts
@@ -45,6 +45,13 @@ export type AppConfig = {
 	 * as Intuit production requires: the tunnel forwards to this local port.
 	 */
 	callbackPort: number | null;
+	/**
+	 * Serve the agent a read-only surface: the daemon advertises the read tools
+	 * (`books_sql_query`, `books_report`) but withholds the QuickBooks write tool
+	 * (`recategorize_expense`). A safety posture for letting an agent analyze the
+	 * books without granting it the power to mutate QuickBooks. `LOCAL_BOOKS_READ_ONLY`.
+	 */
+	readOnly: boolean;
 };
 
 export type CliConfigOverrides = {
@@ -77,6 +84,7 @@ const ConfigFileSchema = Type.Object({
 	fullBackstopDays: Type.Optional(Type.Number({ exclusiveMinimum: 0 })),
 	pageSize: Type.Optional(Type.Number({ exclusiveMinimum: 0 })),
 	callbackPort: Type.Optional(Type.Number({ exclusiveMinimum: 0 })),
+	readOnly: Type.Optional(Type.Boolean()),
 });
 type ConfigFile = Static<typeof ConfigFileSchema>;
 
@@ -96,6 +104,13 @@ function readConfigFile(dataDir: string): ConfigFile {
 function env(name: string): string | undefined {
 	const value = process.env[name];
 	return value && value.length > 0 ? value : undefined;
+}
+
+/** A boolean env flag: present and not `0`/`false` is true; absent is undefined. */
+function envFlag(name: string): boolean | undefined {
+	const value = env(name);
+	if (value === undefined) return undefined;
+	return value !== '0' && value.toLowerCase() !== 'false';
 }
 
 function resolveEntities(file: ConfigFile): string[] {
@@ -151,5 +166,6 @@ export function loadConfig(overrides: CliConfigOverrides = {}): AppConfig {
 		callbackPort: callbackPortEnv
 			? Number(callbackPortEnv)
 			: (file.callbackPort ?? null),
+		readOnly: envFlag('LOCAL_BOOKS_READ_ONLY') ?? file.readOnly ?? false,
 	};
 }

--- a/apps/local-books/src/db.ts
+++ b/apps/local-books/src/db.ts
@@ -227,6 +227,23 @@ export function openBooksDb(path: string) {
 			tx();
 		},
 
+		/**
+		 * Fold just-mutated objects back into the mirror without advancing the CDC
+		 * cursor. The write-back path (recategorize) uses this so a read sees the
+		 * new state immediately after a QuickBooks update; the next CDC sync
+		 * reconfirms it through the normal cursor-advancing path.
+		 */
+		upsertObjects(def: EntityDef, rows: MirrorRow[], syncedAt: string): void {
+			ensureEntityTable(def);
+			const upsert = upsertStmtFor(def);
+			const tx = db.transaction(() => {
+				for (const row of rows) {
+					upsert.run(row.id, row.raw, row.updatedAt, syncedAt);
+				}
+			});
+			tx();
+		},
+
 		readSyncState,
 
 		getMeta(key: string): string | null {

--- a/apps/local-books/src/db.ts
+++ b/apps/local-books/src/db.ts
@@ -246,6 +246,28 @@ export function openBooksDb(path: string) {
 
 		readSyncState,
 
+		/**
+		 * The raw QB JSON of one live (non-deleted) row, or null if the table does
+		 * not exist yet or the row is absent/deleted. The write-back path reads the
+		 * current blob (and its `SyncToken`) through this typed method rather than
+		 * reaching through the `raw` escape hatch.
+		 */
+		readLiveRaw(def: EntityDef, id: string): string | null {
+			const table = assertIdent(def.table);
+			const exists = db
+				.query<{ n: number }, [string]>(
+					`SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name = ?`,
+				)
+				.get(def.table);
+			if (!exists || exists.n === 0) return null;
+			const row = db
+				.query<{ raw: string }, [string]>(
+					`SELECT raw FROM ${table} WHERE id = ? AND deleted = 0`,
+				)
+				.get(id);
+			return row?.raw ?? null;
+		},
+
 		getMeta(key: string): string | null {
 			return getMetaStmt.get(key)?.value ?? null;
 		},

--- a/apps/local-books/src/keyring.ts
+++ b/apps/local-books/src/keyring.ts
@@ -14,7 +14,11 @@ import type { AppConfig } from './config.ts';
  * every caller.
  */
 /** Which token store is in use; surfaced to the user as a status label. */
-export type KeyringBackend = 'macos-keychain' | 'secret-tool' | 'file' | 'memory';
+export type KeyringBackend =
+	| 'macos-keychain'
+	| 'secret-tool'
+	| 'file'
+	| 'memory';
 
 export type Keyring = {
 	readonly backend: KeyringBackend;

--- a/apps/local-books/src/keyring.ts
+++ b/apps/local-books/src/keyring.ts
@@ -13,8 +13,11 @@ import type { AppConfig } from './config.ts';
  * bubbles to the top-level CLI handler rather than threading a Result through
  * every caller.
  */
+/** Which token store is in use; surfaced to the user as a status label. */
+export type KeyringBackend = 'macos-keychain' | 'secret-tool' | 'file' | 'memory';
+
 export type Keyring = {
-	readonly backend: string;
+	readonly backend: KeyringBackend;
 	get(account: string): Promise<string | null>;
 	set(account: string, secret: string): Promise<void>;
 	delete(account: string): Promise<void>;

--- a/apps/local-books/src/qb-client.ts
+++ b/apps/local-books/src/qb-client.ts
@@ -69,6 +69,17 @@ export type QbClient = {
 		entity: string,
 		body: Record<string, unknown>,
 	): Promise<Result<QbObject, QbClientError>>;
+	/**
+	 * Run a computed report live (the Reports API, `GET /reports/<name>`). These
+	 * are the GAAP-structured statements QuickBooks owns the computation of (P&L,
+	 * balance sheet, ...); there is no CDC for them, so they are read live rather
+	 * than mirrored. `params` are passed through as the query string (`start_date`,
+	 * `end_date`, `accounting_method`, ...). Returns the report JSON verbatim.
+	 */
+	report(
+		name: string,
+		params: Record<string, string>,
+	): Promise<Result<Record<string, unknown>, QbClientError>>;
 };
 
 export type QbClientDeps = {
@@ -257,6 +268,17 @@ export function createQbClient(deps: QbClientDeps): QbClient {
 				});
 			}
 			return Ok(updated as QbObject);
+		},
+
+		async report(name, params) {
+			const { data, error } = await request(`reports/${name}`, params);
+			if (error) return { data: null, error };
+			if (data === null || typeof data !== 'object') {
+				return QbApiError.InvalidResponse({
+					detail: `report ${name} response was not a JSON object`,
+				});
+			}
+			return Ok(data as Record<string, unknown>);
 		},
 	};
 

--- a/apps/local-books/src/qb-client.ts
+++ b/apps/local-books/src/qb-client.ts
@@ -59,6 +59,16 @@ export type QbClient = {
 		entities: string[],
 		changedSince: string,
 	): Promise<Result<CdcResult, QbClientError>>;
+	/**
+	 * Sparse-update one entity (the QuickBooks update POST). `body` carries the
+	 * `Id`, the current `SyncToken`, `sparse: true`, and the changed fields;
+	 * QuickBooks returns the updated object with a bumped `SyncToken`. A stale
+	 * `SyncToken` surfaces as an `Http` error (409), never a silent re-apply.
+	 */
+	update(
+		entity: string,
+		body: Record<string, unknown>,
+	): Promise<Result<QbObject, QbClientError>>;
 };
 
 export type QbClientDeps = {
@@ -93,6 +103,7 @@ export function createQbClient(deps: QbClientDeps): QbClient {
 	async function request(
 		path: string,
 		params: Record<string, string>,
+		write?: { method: 'POST'; body: unknown },
 	): Promise<Result<unknown, QbClientError>> {
 		const url = new URL(`${config.apiBase}/v3/company/${realmId}/${path}`);
 		for (const [key, value] of Object.entries(params))
@@ -109,10 +120,13 @@ export function createQbClient(deps: QbClientDeps): QbClient {
 			let response: Response;
 			try {
 				response = await fetch(url.toString(), {
+					method: write?.method ?? 'GET',
 					headers: {
 						Authorization: `Bearer ${token.data}`,
 						Accept: 'application/json',
+						...(write ? { 'Content-Type': 'application/json' } : {}),
 					},
+					body: write ? JSON.stringify(write.body) : undefined,
 				});
 			} catch (cause) {
 				if (attempt < MAX_RETRIES) {
@@ -225,6 +239,24 @@ export function createQbClient(deps: QbClientDeps): QbClient {
 				}
 			}
 			return Ok({ changes });
+		},
+
+		async update(entity, body) {
+			// The update endpoint is the entity name lowercased; the response wraps
+			// the saved object under its capitalized name (e.g. `{ Purchase: {...} }`).
+			const { data, error } = await request(
+				entity.toLowerCase(),
+				{},
+				{ method: 'POST', body },
+			);
+			if (error) return { data: null, error };
+			const updated = (data as Record<string, unknown>)[entity];
+			if (!updated || typeof updated !== 'object') {
+				return QbApiError.InvalidResponse({
+					detail: `update response missing the ${entity} object`,
+				});
+			}
+			return Ok(updated as QbObject);
 		},
 	};
 

--- a/apps/local-books/test/helpers.ts
+++ b/apps/local-books/test/helpers.ts
@@ -23,6 +23,7 @@ export function makeConfig(over: Partial<AppConfig> = {}): AppConfig {
 		keyringFile: null,
 		realmOverride: null,
 		callbackPort: null,
+		readOnly: false,
 		...over,
 	};
 }

--- a/apps/local-books/test/mock-qb-server.ts
+++ b/apps/local-books/test/mock-qb-server.ts
@@ -20,9 +20,11 @@ export type MockQbServer = {
 	apiBase: string;
 	tokenUrl: string;
 	realmId: string;
-	hits: { query: number; cdc: number; token: number };
+	hits: { query: number; cdc: number; token: number; update: number };
 	/** Insert or update a live object; stamps a fresh LastUpdatedTime. */
 	put(entity: string, obj: Record<string, unknown>): void;
+	/** Read a stored object back (post-write assertions). */
+	get(entity: string, id: string): Record<string, unknown> | null;
 	/** Soft-delete: future CDC calls report it with status "Deleted". */
 	remove(entity: string, id: string): void;
 	/** Count of live (non-deleted) objects, what a full pull would return. */
@@ -64,7 +66,7 @@ export function startMockQbServer(
 	const tick = () => now();
 
 	const entities = new Map<string, Map<string, StoredObject>>();
-	const hits = { query: 0, cdc: 0, token: 0 };
+	const hits = { query: 0, cdc: 0, token: 0, update: 0 };
 	const rejectedTokens = new Set<string>();
 	let pending429 = 0;
 
@@ -81,7 +83,9 @@ export function startMockQbServer(
 		const ms = tick();
 		const id = String(obj.Id);
 		store(entity).set(id, {
-			obj: metaUpdated({ ...obj, Id: id }, ms),
+			// Every QB object carries a SyncToken (optimistic-concurrency version);
+			// default it to "0" so fixtures need not spell it out.
+			obj: metaUpdated({ SyncToken: '0', ...obj, Id: id }, ms),
 			updatedAt: ms,
 			deleted: false,
 			deletedAt: 0,
@@ -231,6 +235,60 @@ export function startMockQbServer(
 				});
 			}
 
+			// Entity update (sparse-update POST), e.g. POST /v3/company/<realm>/purchase.
+			const writeMatch = new RegExp(`^/v3/company/${realmId}/([a-z]+)$`).exec(
+				url.pathname,
+			);
+			const entityLc = writeMatch?.[1];
+			if (
+				request.method === 'POST' &&
+				entityLc &&
+				entityLc !== 'query' &&
+				entityLc !== 'cdc'
+			) {
+				const throttled = throttleProblem();
+				if (throttled) return throttled;
+				const denied = authProblem(request);
+				if (denied) return denied;
+
+				hits.update += 1;
+				const entity = entityLc.charAt(0).toUpperCase() + entityLc.slice(1);
+				const body = (await request.json()) as Record<string, unknown>;
+				const id = String(body.Id);
+				const stored = store(entity).get(id);
+				if (!stored || stored.deleted) {
+					return Response.json(
+						{ Fault: { Error: [{ Message: 'Object Not Found' }] } },
+						{ status: 400 },
+					);
+				}
+				// Optimistic concurrency: a stale SyncToken is rejected, never applied.
+				const currentToken = String(stored.obj.SyncToken ?? '0');
+				if (body.SyncToken != null && String(body.SyncToken) !== currentToken) {
+					return Response.json(
+						{
+							Fault: {
+								type: 'ValidationFault',
+								Error: [{ Message: 'Stale Object Error', code: '5010' }],
+							},
+						},
+						{ status: 409 },
+					);
+				}
+				const ms = tick();
+				const fields = { ...body };
+				delete fields.sparse;
+				delete fields.SyncToken;
+				const nextToken = String(Number(currentToken) + 1);
+				const merged = metaUpdated(
+					{ ...stored.obj, ...fields, SyncToken: nextToken },
+					ms,
+				);
+				stored.obj = merged;
+				stored.updatedAt = ms;
+				return Response.json({ [entity]: merged, time: nowIso(ms) });
+			}
+
 			return new Response('Not found', { status: 404 });
 		},
 	});
@@ -242,6 +300,7 @@ export function startMockQbServer(
 		realmId,
 		hits,
 		put,
+		get: (entity, id) => store(entity).get(id)?.obj ?? null,
 		remove,
 		liveCount: (entity) =>
 			[...store(entity).values()].filter((s) => !s.deleted).length,
@@ -270,6 +329,35 @@ export function makeInvoice(
 				Amount: 100 + Number(id),
 				DetailType: 'SalesItemLineDetail',
 				SalesItemLineDetail: { ItemRef: { value: '1', name: 'Services' } },
+			},
+		],
+		...overrides,
+	};
+}
+
+/**
+ * Minimal but realistic QuickBooks Purchase (an expense): one account-based
+ * expense line whose `AccountRef` is the category recategorize_expense moves.
+ */
+export function makePurchase(
+	id: string,
+	overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+	return {
+		Id: id,
+		SyncToken: '0',
+		TxnDate: '2026-01-15',
+		TotalAmt: 340,
+		PaymentType: 'CreditCard',
+		AccountRef: { value: '35', name: 'Mercury Checking' },
+		Line: [
+			{
+				Id: '1',
+				Amount: 340,
+				DetailType: 'AccountBasedExpenseLineDetail',
+				AccountBasedExpenseLineDetail: {
+					AccountRef: { value: '60', name: 'Uncategorized Expense' },
+				},
 			},
 		],
 		...overrides,

--- a/apps/local-books/test/mock-qb-server.ts
+++ b/apps/local-books/test/mock-qb-server.ts
@@ -20,7 +20,13 @@ export type MockQbServer = {
 	apiBase: string;
 	tokenUrl: string;
 	realmId: string;
-	hits: { query: number; cdc: number; token: number; update: number };
+	hits: {
+		query: number;
+		cdc: number;
+		token: number;
+		update: number;
+		report: number;
+	};
 	/** Insert or update a live object; stamps a fresh LastUpdatedTime. */
 	put(entity: string, obj: Record<string, unknown>): void;
 	/** Read a stored object back (post-write assertions). */
@@ -66,7 +72,7 @@ export function startMockQbServer(
 	const tick = () => now();
 
 	const entities = new Map<string, Map<string, StoredObject>>();
-	const hits = { query: 0, cdc: 0, token: 0, update: 0 };
+	const hits = { query: 0, cdc: 0, token: 0, update: 0, report: 0 };
 	const rejectedTokens = new Set<string>();
 	let pending429 = 0;
 
@@ -232,6 +238,31 @@ export function startMockQbServer(
 				return Response.json({
 					CDCResponse: [{ QueryResponse: blocks }],
 					time: nowIso(now()),
+				});
+			}
+
+			// Reports API (live computed statement), e.g. GET /v3/company/<realm>/reports/ProfitAndLoss.
+			const reportMatch = new RegExp(
+				`^/v3/company/${realmId}/reports/([A-Za-z]+)$`,
+			).exec(url.pathname);
+			if (request.method === 'GET' && reportMatch) {
+				const throttled = throttleProblem();
+				if (throttled) return throttled;
+				const denied = authProblem(request);
+				if (denied) return denied;
+
+				hits.report += 1;
+				const name = reportMatch[1];
+				// A minimal but shaped report: echoes the period so a test can prove
+				// the params were passed through.
+				return Response.json({
+					Header: {
+						ReportName: name,
+						StartPeriod: url.searchParams.get('start_date'),
+						EndPeriod: url.searchParams.get('end_date'),
+						ReportBasis: url.searchParams.get('accounting_method') ?? 'Accrual',
+					},
+					Rows: { Row: [] },
 				});
 			}
 

--- a/docs/adr/0061-local-books-reads-facts-from-the-mirror-reports-live-and-writes-through-one-approved-verb.md
+++ b/docs/adr/0061-local-books-reads-facts-from-the-mirror-reports-live-and-writes-through-one-approved-verb.md
@@ -1,0 +1,45 @@
+# 0061. Local Books serves row-level facts from the mirror, computed reports live, and writes back through one approved verb
+
+- **Status:** Accepted
+- **Date:** 2026-06-24
+
+## Context
+
+Local Books mirrors a QuickBooks Online company into a local SQLite database, kept fresh by Change Data Capture (ADR-0047 makes that mirror an agent-facing data daemon). The mirror earns the word "mirror" because CDC keeps it a faithful, re-pullable projection of QuickBooks' entities. Once an agent could read it with SQL, two pressures arrived: founders want to *ask their books* whole-ledger questions ("what's my burn, my P&L"), and they want to *fix the common mistake* (miscategorized expenses) without leaving the local-first loop.
+
+Neither falls out of the entity mirror for free. A profit & loss is not an entity; it is a GAAP-structured computation QuickBooks owns, over posting types the mirror does not even hold in full (no `SalesReceipt`, `JournalEntry`, `CreditMemo`). And a write is the opposite of a query: it mutates the authoritative source, so it cannot be open-ended SQL.
+
+## Decision
+
+The Local Books agent surface is three tools, each sourced from where its data actually lives, and gated as a capability lattice so the agent is only offered what the daemon can do.
+
+1. **`books_sql_query` reads row-level facts from the local mirror.** Open-ended read-only SQL (a `new Database(path, { readonly: true })` connection is the enforcement). This is the high-volume surface, the only thing that can answer arbitrary filtered/grouped/joined questions over thousands of rows offline.
+
+2. **`books_report` reads computed reports live from QuickBooks** (`GET /reports/<name>`: P&L, balance sheet, cash flow, A/R and A/P aging, trial balance). These are **never mirrored and never cached.** Reports have no CDC, so a cached copy would be a stale snapshot; reconstructing them from mirror rows would silently disagree with QuickBooks. They are one cheap call asked a few times a day, so live is both correct and affordable. The dividing line: mirror the *facts*, ask QuickBooks for the *opinions* it computes.
+
+3. **`recategorize_expense` writes back through one approved verb.** It is a closed, named `defineMutation` (so the client agent loop pauses for approval), never open write-SQL. It is **write-through, not write-to-mirror**: it reads the current `SyncToken` from the mirror, sends a sparse update of the expense-line `AccountRef` on a `Purchase`/`Bill`, and folds QuickBooks' authoritative response back into the mirror. QuickBooks stays the source of truth; the mirror is only ever updated from QuickBooks' reply, and the next CDC sync reconfirms it.
+
+The advertised set is a capability lattice keyed on what the daemon holds: `books_sql_query` always (needs no QuickBooks client); `books_report` when a client is available (`openQb`); `recategorize_expense` when a client is available **and** the daemon is not `readOnly`. `LOCAL_BOOKS_READ_ONLY` withholds the write while keeping both reads, the posture of "let the agent analyze my books, not mutate them." A daemon with no client at all is fully offline, mirror-only.
+
+The QuickBooks client is hand-rolled on `oauth4webapi` plus `fetch`, not an npm QuickBooks SDK.
+
+## Consequences
+
+- "What's my P&L / burn / runway" returns QuickBooks' authoritative number, not a SQL reconstruction we would have to defend. Granular drill-down ("every AWS charge") stays instant and offline on the mirror. The two read tools have honestly different shapes because they serve honestly different needs.
+- No report cache exists to go stale or to reconcile. The cost is that report answers require connectivity; that is acceptable because the tool is online when asked.
+- The write surface is auditable: a finite verb catalog with typed inputs and an approval pause, rather than an open write channel. A stale `SyncToken` is a 409 that leaves QuickBooks untouched (no clobber of a bookkeeper's concurrent edit), not a silent overwrite.
+- The agent never sees a tool it cannot use: a read-only daemon does not advertise the write at all. This makes "read-only" a real capability, not a runtime refusal.
+- Hand-rolling keeps the runtime pure-TS and dependency-light so `bun build --compile` stays a single binary, and reuses the token lifecycle already shared with `@epicenter/auth`. The cost is owning a thin QuickBooks client (one `request()` with `query`/`cdc`/`report`/`update`), which is small because the hard parts (refresh, 429 backoff, Result errors) were already solved for the read path.
+- Local annotation tools (`mark_reviewed`, `add_note`) over an overlay table remain out of scope; they were judged low-value for this audience (invisible to QuickBooks and the accountant) and are not part of this surface.
+
+## Considered alternatives
+
+- **A report cache (mirror reports like entities).** Rejected: reports have no CDC, so it is a stale snapshot, the cop-out "cache" with none of the mirror's freshness guarantee.
+- **Reconstruct reports from the mirror in SQL.** Rejected: requires mirroring every posting type and reimplementing QuickBooks' report engine (accrual vs cash, account roll-ups, sign conventions); any divergence from QuickBooks' number destroys trust in a finance tool. Straightforward sums over fully-mirrored rows can still be answered by `books_sql_query`; only judgment-laden statements go live.
+- **A generic "write SQL to QuickBooks" tool.** Rejected: writes are dangerous and must be legible to an approval gate; a closed verb catalog is the safe shape. Reads can be open SQL precisely because they are safe.
+- **Mutate the mirror directly, sync up later.** Rejected: it forks the cache from QuickBooks and breaks the re-pullable-mirror invariant. Writes go through to Intuit and return via the same upsert path.
+- **An npm QuickBooks SDK (`node-quickbooks`, `intuit-oauth`).** Rejected: both bring their own OAuth/token layer (colliding with the shared `oauth4webapi` manager) and break the single-binary build; the write surface is one POST shape, so a dependency made it harder, not easier.
+
+## Reference
+
+- Implemented in `apps/local-books/src/qb-client.ts` (`update`, `report`), `src/agent/recategorize.ts`, `src/agent/report.ts`, `src/agent/qb-access.ts`, `src/agent/books-actions.ts` (the capability lattice), and `mount.ts`. Builds on ADR-0047 (the mirror as a data daemon). The sync-engine design lives in `specs/20260621T100000-local-books-cli-sync-engine.md`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -126,5 +126,6 @@ Each option and the one reason it lost. Terse. This is not the spec.
 | [0056](0056-local-inference-is-a-delegated-engine-behind-the-openai-compatible-seam.md) | Local inference is a delegated engine behind the OpenAI-compatible seam; the runtime is a swappable default | Accepted |
 | [0057](0057-assistant-markdown-renders-as-a-shared-component-tree-not-a-sanitized-html-string.md) | Assistant markdown renders as a shared component tree, not a sanitized HTML string | Accepted |
 | [0058](0058-push-to-talk-owns-the-recording-it-starts-keyed-by-its-id-not-a-lifecycle-layer.md) | Push-to-talk owns the recording it starts, keyed by the recording's id, not a general lifecycle layer | Accepted |
+| [0061](0061-local-books-reads-facts-from-the-mirror-reports-live-and-writes-through-one-approved-verb.md) | Local Books serves row-level facts from the mirror, computed reports live, and writes back through one approved verb | Accepted |
 
 When you add an ADR, add its row here.

--- a/specs/20260621T100000-local-books-cli-sync-engine.md
+++ b/specs/20260621T100000-local-books-cli-sync-engine.md
@@ -3,6 +3,7 @@
 - Status: Draft
 - Date: 2026-06-21
 - Supersedes the data-layer intent of `specs/20260620T180000-local-books-agent-over-sql.md` (the agent-over-SQL daemon, the conversation doc, and the tool-approval seam are dropped; see Context). That spec should be retired once this one is in progress.
+- The agent read/write surface over this mirror (the `books_sql_query`, `books_report`, and `recategorize_expense` tools, and the read-only capability lattice) is settled in [ADR-0061](../docs/adr/0061-local-books-reads-facts-from-the-mirror-reports-live-and-writes-through-one-approved-verb.md). This spec covers only the sync engine beneath it.
 
 ## Context
 


### PR DESCRIPTION
Local Books already mirrors a QuickBooks Online company into local SQLite and lets an agent query it with read-only SQL. That answers row-level questions ("every AWS charge this quarter") but not the two things founders actually want from their books: whole-ledger numbers ("what's my burn?") and a way to fix the most common bookkeeping mistake (miscategorized expenses). This adds both, each sourced from where its data actually lives, and gates the whole surface by capability.

## The agent surface is now three tools

- **`books_sql_query`** (unchanged): open read-only SQL over the local mirror. The high-volume, offline, row-level surface.
- **`books_report`** (new): computed statements (P&L, balance sheet, cash flow, A/R + A/P aging, trial balance), read **live** from the QuickBooks Reports API.
- **`recategorize_expense`** (new): move an expense transaction's category in QuickBooks. A closed, approved write verb.

## Reads: mirror the facts, ask QuickBooks for the opinions

Row detail comes from the mirror; computed statements come live from QuickBooks. A report cache was deliberately rejected: reports have no CDC, so a cached copy is a stale snapshot, and reconstructing a P&L from mirror rows would silently disagree with QuickBooks (missing posting types, GAAP roll-ups). A report is one cheap call asked a few times a day, so live is both correct and affordable.

```
"what's my Q1 burn?"  -> books_report { report: 'ProfitAndLoss', start_date, end_date }  -> live GET /reports/ProfitAndLoss
"every AWS charge"    -> books_sql_query                                                  -> local mirror
```

## Writes: one approved verb, write-through, never write-to-mirror

`recategorize_expense` sparse-updates the expense-line `AccountRef` on a Purchase or Bill. It is write-**through**: it reads the current `SyncToken` from the mirror, sends the update to QuickBooks, and folds QuickBooks' authoritative response back into the mirror; the next CDC sync reconfirms it. QuickBooks stays the source of truth, and a stale `SyncToken` is a 409 that leaves QuickBooks untouched (no clobber of a bookkeeper's concurrent edit), never a silent overwrite. It is a `mutation`, so the client agent loop pauses for approval; writes stay a closed named catalog, not open write-SQL.

## A read-only capability lattice

The advertised tools follow what the daemon can actually do, so the agent never sees a tool it cannot use:

| Mode | `books_sql_query` | `books_report` | `recategorize_expense` |
| --- | --- | --- | --- |
| Full | yes | yes | yes |
| Read-only (`LOCAL_BOOKS_READ_ONLY`) | yes | yes | — |
| Mirror-only (no QuickBooks client) | yes | — | — |

`LOCAL_BOOKS_READ_ONLY` withholds the write while keeping both reads: the posture of "let the agent analyze my books, not mutate them."

The decisions here are recorded in [ADR-0061](docs/adr/0061-local-books-reads-facts-from-the-mirror-reports-live-and-writes-through-one-approved-verb.md). The QuickBooks client stays hand-rolled on `oauth4webapi` + `fetch` (no npm SDK), so `bun build --compile` remains a single binary.

## Changelog

- Local Books agents can now run live QuickBooks reports (P&L, balance sheet, cash flow, A/R and A/P aging, trial balance) via `books_report`, and recategorize an expense's account via `recategorize_expense` (approved, written through to QuickBooks).
- New `LOCAL_BOOKS_READ_ONLY` serves a read-only agent surface (both reads, no write tool).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784923046&installation_id=128463665&pr_number=2186&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2186&signature=3203a2172a5f8ce199df9039ae9124964dc132eea0faeb030ff022f856bb865b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->