### PR TITLE
fix(ui): size Separator with real orientation utilities

### DIFF
--- a/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
@@ -45,7 +45,6 @@
 	<Field.Description>
 		Configure your general Whispering preferences.
 	</Field.Description>
-	<Field.Separator />
 	<Field.Group>
 		<Field.Set>
 			<Field.Legend variant="label">Transcription output</Field.Legend>
@@ -57,8 +56,6 @@
 			</Field.Group>
 		</Field.Set>
 
-		<Field.Separator />
-
 		<Field.Set>
 			<Field.Legend variant="label">Transformation output</Field.Legend>
 			<Field.Description>
@@ -68,8 +65,6 @@
 				<OutputDeliveryControls scope="transformation" />
 			</Field.Group>
 		</Field.Set>
-
-		<Field.Separator />
 
 		<SettingSelect
 			store={settings}

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -192,6 +192,7 @@ on a re-vendor:
 | `showOnHover` actions overlay | `item/item-actions.svelte` | structural (absolute overlay + gradient) | yes |
 | `tooltip` prop (wraps in `Tooltip`) | `button/button.svelte`, `link/link.svelte` | Epicenter feature; upstream Button and Link have none | yes |
 | Standard loading shell | `loading/loading.svelte` | Epicenter wrapper around `Empty.Root` + `Spinner` for generic pending panes | yes |
+| Orientation sizing `data-[orientation=horizontal]:h-px …` | `separator/separator.svelte` | byte-identical to upstream; the size is gated on a Tailwind variant, which only attaches to real utilities. Routing it through `cn-separator-horizontal` (a plain class, not an `@utility`) makes the variant emit nothing, so the divider collapses (a fat bar inside `field-separator`, 0px standalone). Do **not** cn-ify it. | yes |
 
 Correctness wiring (making Vega work, not Epicenter style): `switch` and
 `alert-dialog` carry a `size` prop that emits `data-size`; sidebar menu and

--- a/packages/ui/src/separator/separator.svelte
+++ b/packages/ui/src/separator/separator.svelte
@@ -14,7 +14,9 @@
 	bind:ref
 	data-slot={dataSlot}
 	class={cn(
-		'cn-separator data-[orientation=horizontal]:cn-separator-horizontal data-[orientation=vertical]:cn-separator-vertical',
+		'bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px',
+		// this is different in shadcn/ui but self-stretch breaks things for us
+		'data-[orientation=vertical]:h-full',
 		className,
 	)}
 	{...restProps}


### PR DESCRIPTION
Every `Separator` was sized through Tailwind variants attached to plain `cn-separator-*` classes. Those classes are not real utilities, so Tailwind emitted no sizing CSS: standalone separators collapsed to 0px, and field separators could stretch into a thick bar.

The component goes back to upstream shadcn-svelte sizing, where the orientation variants attach to real utilities:

```svelte
<!-- Before: variant on plain classes, no emitted size -->
cn(
	'cn-separator',
	'data-[orientation=horizontal]:cn-separator-horizontal',
	'data-[orientation=vertical]:cn-separator-vertical',
)

<!-- After: variant on real utilities -->
cn(
	'bg-border shrink-0',
	'data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full',
	'data-[orientation=vertical]:w-px data-[orientation=vertical]:h-full',
)
```

The UI package README now records why this component keeps inline utilities, and the General settings page drops the extra field separators that were only over-segmenting the page.

## Changelog

- Fix separators rendering as a thick bar or disappearing instead of drawing a 1px line.
