### PR TITLE
refactor(whispering): lean the recordings surface (slim row + drop dead paths)

### DIFF
--- a/apps/whispering/src/lib/components/copyable/TextPreviewDialog.svelte
+++ b/apps/whispering/src/lib/components/copyable/TextPreviewDialog.svelte
@@ -3,7 +3,6 @@
 	import { CopyButton } from '@epicenter/ui/copy-button';
 	import * as InputGroup from '@epicenter/ui/input-group';
 	import * as Modal from '@epicenter/ui/modal';
-	import { Spinner } from '@epicenter/ui/spinner';
 	import { Textarea } from '@epicenter/ui/textarea';
 	import { createCopyFn } from '$lib/utils/createCopyFn';
 
@@ -24,17 +23,6 @@
 	 *   rows={1}
 	 * />
 	 * ```
-	 *
-	 * @example
-	 * ```svelte
-	 * <TextPreviewDialog
-	 *   id="loading-1"
-	 *   title="Transcript"
-	 *   text="..."
-	 *   label="transcript"
-	 *   loading={true}
-	 * />
-	 * ```
 	 */
 	let {
 		/** Unique identifier for view transitions */
@@ -49,8 +37,6 @@
 		rows = 2,
 		/** Whether the component is disabled */
 		disabled = false,
-		/** Whether to show a loading spinner instead of copy button */
-		loading = false,
 	}: {
 		id: string;
 		title: string;
@@ -58,15 +44,14 @@
 		label: string;
 		rows?: number;
 		disabled?: boolean;
-		loading?: boolean;
 	} = $props();
 
 	let isDialogOpen = $state(false);
 </script>
 
 <Modal.Root bind:open={isDialogOpen}>
-	<InputGroup.Root data-disabled={disabled || loading}>
-		<Modal.Trigger {id} disabled={disabled || loading} class="flex-1 min-w-0">
+	<InputGroup.Root data-disabled={disabled}>
+		<Modal.Trigger {id} {disabled} class="flex-1 min-w-0">
 			{#snippet child({ props })}
 				<textarea
 					{...props}
@@ -82,16 +67,12 @@
 			{/snippet}
 		</Modal.Trigger>
 		<InputGroup.Addon align="inline-end">
-			{#if loading}
-				<Spinner />
-			{:else}
-				<CopyButton
-					{text}
-					copyFn={createCopyFn(label)}
-					disabled={disabled || !text.trim()}
-					onclick={(e) => e.stopPropagation()}
-				></CopyButton>
-			{/if}
+			<CopyButton
+				{text}
+				copyFn={createCopyFn(label)}
+				disabled={disabled || !text.trim()}
+				onclick={(e) => e.stopPropagation()}
+			></CopyButton>
 		</InputGroup.Addon>
 	</InputGroup.Root>
 	<Modal.Content class="max-w-4xl">

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -55,7 +55,7 @@
 	import RecordingTranscriptCell from './RecordingTranscriptCell.svelte';
 	import RenderAudioUrl from './RenderAudioUrl.svelte';
 	import TranscriptionStatusBadge from './TranscriptionStatusBadge.svelte';
-	import { RecordingRowActions } from './actions';
+	import RecordingRowActions from './actions/RecordingRowActions.svelte';
 
 	/**
 	 * Returns a cell renderer for an instant, optionally using a row-owned

--- a/apps/whispering/src/routes/(app)/(config)/recordings/RecordingDetailModal.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/RecordingDetailModal.svelte
@@ -22,6 +22,7 @@
 	import DownloadRecordingButton from './actions/DownloadRecordingButton.svelte';
 	import TranscribeRecordingButton from './actions/TranscribeRecordingButton.svelte';
 	import TransformationPicker from './actions/TransformationPicker.svelte';
+	import ViewTransformationRunsDialog from './actions/ViewTransformationRunsDialog.svelte';
 
 	/**
 	 * The single detail surface for one recording: play it back, read and edit
@@ -201,6 +202,12 @@
 					showLabel
 				/>
 				<TransformationPicker
+					recordingId={recording.id}
+					variant="outline"
+					size="sm"
+					showLabel
+				/>
+				<ViewTransformationRunsDialog
 					recordingId={recording.id}
 					variant="outline"
 					size="sm"

--- a/apps/whispering/src/routes/(app)/(config)/recordings/actions/RecordingRowActions.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/actions/RecordingRowActions.svelte
@@ -1,23 +1,20 @@
 <script lang="ts">
-	import { Button } from '@epicenter/ui/button';
-	import { CopyButton } from '@epicenter/ui/copy-button';
 	import { Skeleton } from '@epicenter/ui/skeleton';
-	import FileStackIcon from '@lucide/svelte/icons/file-stack';
-	import TrashIcon from '@lucide/svelte/icons/trash-2';
-	import { deleteRecordingsWithConfirmation } from '$lib/operations/recordings';
 	import { recordings } from '$lib/state/recordings.svelte';
-	import { transformationRuns } from '$lib/state/transformation-runs.svelte';
-	import { createCopyFn } from '$lib/utils/createCopyFn';
-	import DownloadRecordingButton from './DownloadRecordingButton.svelte';
 	import TranscribeRecordingButton from './TranscribeRecordingButton.svelte';
 	import TransformationPicker from './TransformationPicker.svelte';
-	import ViewTransformationRunsDialog from './ViewTransformationRunsDialog.svelte';
 
+	/**
+	 * The compact per-row actions: only the things worth firing without opening
+	 * anything. Transcribe and transform are the hot path.
+	 *
+	 * Everything else has a better home and was duplicating it here: copy lives
+	 * in the transcript and transformation-output cells already, and download,
+	 * run history, and delete live in the recording detail modal (open it by
+	 * clicking the transcript). Keeping the row lean stops it from re-offering
+	 * what its neighboring columns and the modal already do.
+	 */
 	let { recordingId }: { recordingId: string } = $props();
-
-	const latestRun = $derived(
-		transformationRuns.getLatestByRecordingId(recordingId),
-	);
 
 	const recording = $derived(recordings.get(recordingId));
 </script>
@@ -26,41 +23,8 @@
 	{#if !recording}
 		<Skeleton class="size-8" />
 		<Skeleton class="size-8" />
-		<Skeleton class="size-8" />
-		<Skeleton class="size-8" />
-		<Skeleton class="size-8" />
 	{:else}
 		<TranscribeRecordingButton {recording} />
-
 		<TransformationPicker recordingId={recording.id} />
-
-		<CopyButton
-			text={recording.transcript}
-			copyFn={createCopyFn('transcript')}
-		/>
-
-		{#if latestRun?.result?.status === 'completed'}
-			<CopyButton
-				text={latestRun.result.output}
-				copyFn={createCopyFn('latest transformation run output')}
-			>
-				{#snippet icon()}
-					<FileStackIcon class="size-4" />
-				{/snippet}
-			</CopyButton>
-		{/if}
-
-		<ViewTransformationRunsDialog {recordingId} />
-
-		<DownloadRecordingButton {recording} />
-
-		<Button
-			tooltip="Delete recording"
-			onclick={() => deleteRecordingsWithConfirmation(recording)}
-			variant="ghost"
-			size="icon"
-		>
-			<TrashIcon class="size-4" />
-		</Button>
 	{/if}
 </div>

--- a/apps/whispering/src/routes/(app)/(config)/recordings/actions/ViewTransformationRunsDialog.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/actions/ViewTransformationRunsDialog.svelte
@@ -2,10 +2,26 @@
 	import { Button } from '@epicenter/ui/button';
 	import * as Modal from '@epicenter/ui/modal';
 	import HistoryIcon from '@lucide/svelte/icons/history';
+	import type { ComponentProps } from 'svelte';
 	import { Runs } from '$lib/components/transformations-editor';
 	import { transformationRuns } from '$lib/state/transformation-runs.svelte';
 
-	let { recordingId }: { recordingId: string } = $props();
+	/**
+	 * Opens the full transformation-run history for a recording. Lives in the
+	 * recording detail modal toolbar; the compact row no longer carries it.
+	 */
+	let {
+		recordingId,
+		variant = 'ghost',
+		size = 'icon',
+		showLabel = false,
+	}: {
+		recordingId: string;
+		variant?: ComponentProps<typeof Button>['variant'];
+		size?: ComponentProps<typeof Button>['size'];
+		/** Render the action's text beside the icon (detail modal toolbar). */
+		showLabel?: boolean;
+	} = $props();
 
 	const runs = $derived(transformationRuns.getByRecordingId(recordingId));
 
@@ -15,13 +31,9 @@
 <Modal.Root bind:open={isOpen}>
 	<Modal.Trigger>
 		{#snippet child({ props })}
-			<Button
-				{...props}
-				variant="ghost"
-				size="icon"
-				tooltip="View Transformation Runs"
-			>
+			<Button {...props} {variant} {size} tooltip="View transformation runs">
 				<HistoryIcon class="size-4" />
+				{#if showLabel}Runs{/if}
 			</Button>
 		{/snippet}
 	</Modal.Trigger>

--- a/apps/whispering/src/routes/(app)/(config)/recordings/actions/index.ts
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/actions/index.ts
@@ -1,1 +1,0 @@
-export { default as RecordingRowActions } from './RecordingRowActions.svelte';


### PR DESCRIPTION
The recordings table had become a second detail surface after #2188 introduced the modal. Each row already showed transcript, transformation output, audio, and status in dedicated columns, but the actions column repeated copy, download, run history, and delete anyway.

The row now keeps only the hot-path actions: transcribe or retry, and run a transformation. Copy stays with the transcript and output cells. Download, transformation-run history, and delete move to the detail modal, which is one click away from the transcript cell.

`TextPreviewDialog.loading` also dies. No caller ever set it, so the spinner branch and its `disabled || loading` gates were unreachable. The dialog returns to a plain preview trigger with a copy affordance, and the page imports `RecordingRowActions.svelte` directly instead of routing one component through a single-export barrel.
