### PR TITLE
feat(chat): give opensidian a chat list and bundle the chat setup

### DIFF
--- a/apps/opensidian/src/lib/components/chat/AiChat.svelte
+++ b/apps/opensidian/src/lib/components/chat/AiChat.svelte
@@ -1,27 +1,23 @@
 <script lang="ts">
-	import { AgentChatThread } from '@epicenter/app-shell/agent-chat';
-	import { Button } from '@epicenter/ui/button';
-	import SquarePenIcon from '@lucide/svelte/icons/square-pen';
+	import {
+		AgentChatThread,
+		ConversationSwitcher,
+	} from '@epicenter/app-shell/agent-chat';
 	import { requireOpensidian } from '$lib/session';
 	import { inferenceConnections } from '$lib/state/inference-connections.svelte';
 
 	const opensidian = requireOpensidian();
-	const active = $derived(opensidian.state.chat.active);
+	const chat = opensidian.state.chat;
+	const active = $derived(chat.active);
 </script>
 
 <div class="flex h-full flex-col">
-	<!-- Header -->
-	<div class="flex items-center justify-between border-b px-3 py-2">
-		<h2 class="text-sm font-medium">AI Chat</h2>
-		<Button
-			variant="ghost"
-			size="sm"
-			onclick={() => opensidian.state.chat.createConversation()}
-		>
-			<SquarePenIcon class="size-3.5" />
-			New Chat
-		</Button>
-	</div>
+	<ConversationSwitcher
+		conversations={chat.conversations}
+		activeConversationId={chat.activeConversationId}
+		onSwitch={(id) => chat.switchTo(id)}
+		onCreate={() => chat.createConversation()}
+	/>
 
 	{#if active}
 		<AgentChatThread

--- a/apps/opensidian/src/lib/session.ts
+++ b/apps/opensidian/src/lib/session.ts
@@ -45,27 +45,7 @@ export const session = createSession({
 			table: opensidian.tables.conversations,
 			whenLoaded: opensidian.idb.whenLoaded,
 			connections: inferenceConnections,
-			buildSystemPrompts: () =>
-				[
-					OPENSIDIAN_SYSTEM_PROMPT,
-					buildGlobalSkillsPrompt(
-						skills.globalSkills.map((skill) => ({
-							name: skill.name,
-							instructions: skill.instructions,
-						})),
-					),
-					buildVaultSkillsPrompt(
-						skills.vaultSkills.map((skill) => ({
-							name: skill.name,
-							content: skill.content,
-						})),
-					),
-				].filter(Boolean),
 			generateId: generateChatMessageId,
-			defaultModel: DEFAULT_MODEL,
-			toolCatalog: createDispatchToolCatalog(opensidian.collaboration, {
-				localActions: opensidian.actions,
-			}),
 			activeConversation: {
 				get current() {
 					return searchParams.chat;
@@ -73,6 +53,28 @@ export const session = createSession({
 				select(id) {
 					searchParams.update({ chat: id });
 				},
+			},
+			agent: {
+				buildSystemPrompts: () =>
+					[
+						OPENSIDIAN_SYSTEM_PROMPT,
+						buildGlobalSkillsPrompt(
+							skills.globalSkills.map((skill) => ({
+								name: skill.name,
+								instructions: skill.instructions,
+							})),
+						),
+						buildVaultSkillsPrompt(
+							skills.vaultSkills.map((skill) => ({
+								name: skill.name,
+								content: skill.content,
+							})),
+						),
+					].filter(Boolean),
+				defaultModel: DEFAULT_MODEL,
+				toolCatalog: createDispatchToolCatalog(opensidian.collaboration, {
+					localActions: opensidian.actions,
+				}),
 			},
 		});
 		const sampleData = createSampleDataLoader(opensidian);

--- a/apps/tab-manager/src/lib/components/chat/AiChat.svelte
+++ b/apps/tab-manager/src/lib/components/chat/AiChat.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
-	import { AgentChatThread } from '@epicenter/app-shell/agent-chat';
+	import {
+		AgentChatThread,
+		ConversationSwitcher,
+	} from '@epicenter/app-shell/agent-chat';
 	import { requireTabManager } from '$lib/session.svelte';
 	import { inferenceConnections } from '$lib/state/inference-connections.svelte';
-	import ConversationPicker from './ConversationPicker.svelte';
 
 	const tabManager = requireTabManager();
 	const aiChat = $derived(tabManager.state.aiChat);
@@ -25,9 +27,9 @@
 </script>
 
 <div class="flex h-full flex-col">
-	<ConversationPicker
+	<ConversationSwitcher
 		conversations={aiChat.conversations}
-		activeId={aiChat.activeConversationId}
+		activeConversationId={aiChat.activeConversationId}
 		onSwitch={(id) => aiChat.switchTo(id)}
 		onCreate={() => aiChat.createConversation()}
 	/>

--- a/apps/tab-manager/src/lib/session.svelte.ts
+++ b/apps/tab-manager/src/lib/session.svelte.ts
@@ -77,22 +77,24 @@ function buildSession(
 				table: tabManager.tables.conversations,
 				whenLoaded: tabManager.idb.whenLoaded,
 				connections: inferenceConnections,
-				buildSystemPrompts: () => [
-					buildDeviceConstraints(tabManager.nodeId),
-					TAB_MANAGER_SYSTEM_PROMPT,
-				],
 				generateId,
-				defaultModel: DEFAULT_MODEL,
-				toolCatalog: createDispatchToolCatalog(tabManager.collaboration, {
-					localActions: tabManager.actions,
-					selfNodeId: tabManager.nodeId,
-				}),
-				// A tool the user chose to "Always Allow" auto-approves; otherwise a
-				// query runs unattended and a mutation asks (ADR-0044).
-				decideApproval: (call, definition) =>
-					toolTrust.shouldAutoApprove(call.toolName)
-						? 'auto'
-						: defaultApprovalDecision(call, definition),
+				agent: {
+					buildSystemPrompts: () => [
+						buildDeviceConstraints(tabManager.nodeId),
+						TAB_MANAGER_SYSTEM_PROMPT,
+					],
+					defaultModel: DEFAULT_MODEL,
+					toolCatalog: createDispatchToolCatalog(tabManager.collaboration, {
+						localActions: tabManager.actions,
+						selfNodeId: tabManager.nodeId,
+					}),
+					// A tool the user chose to "Always Allow" auto-approves; otherwise a
+					// query runs unattended and a mutation asks (ADR-0044).
+					decideApproval: (call, definition) =>
+						toolTrust.shouldAutoApprove(call.toolName)
+							? 'auto'
+							: defaultApprovalDecision(call, definition),
+				},
 			});
 			const state = { savedTabs, bookmarks, toolTrust, unifiedView, aiChat };
 

--- a/apps/vocab/src/routes/(signed-in)/+page.svelte
+++ b/apps/vocab/src/routes/(signed-in)/+page.svelte
@@ -29,9 +29,11 @@
 		table: vocab.tables.conversations,
 		whenLoaded: vocab.idb.whenLoaded,
 		connections: inferenceConnections,
-		buildSystemPrompts: () => [VOCAB_SYSTEM_PROMPT],
 		generateId: generateMessageId,
-		defaultModel: VOCAB_MODEL,
+		agent: {
+			buildSystemPrompts: () => [VOCAB_SYSTEM_PROMPT],
+			defaultModel: VOCAB_MODEL,
+		},
 	});
 
 	onDestroy(() => chat[Symbol.dispose]());

--- a/packages/app-shell/src/agent-chat/agent-chat.svelte.ts
+++ b/packages/app-shell/src/agent-chat/agent-chat.svelte.ts
@@ -15,16 +15,18 @@
  * Inference rides the OpenAI-compatible gateway (ADR-0049/0050). The engine is
  * built here, once: per turn it resolves the conversation's model (ADR-0055)
  * against this device's connection registry (ADR-0059, `resolveOrHosted`) and
- * reads the app's system prompts. Everything an app varies is injected:
+ * reads the app's system prompts. What the agent can do is grouped into one
+ * `agent` bundle ({@link AgentKit}), since every field of it varies with the
+ * app's persona; the loop's other collaborators are passed alongside:
  *
- * - `buildSystemPrompts`  the layered prompts an answer is generated under.
- * - `toolCatalog`         the live tool surface; omit for a capability-free app.
- * - `decideApproval`      the per-call approval policy; defaults to query-runs,
- *                         mutation-asks. The synchronous pause is owned here.
- * - `activeConversation`  the active-conversation source; defaults to internal
- *                         state. An app that keeps it in the URL injects its own.
- * - `generateId` / `defaultModel`  the message-id minter and the model a brand
- *                         new conversation starts on.
+ * - `agent.buildSystemPrompts`  the layered prompts an answer is generated under.
+ * - `agent.toolCatalog`         the live tool surface; omit for a capability-free app.
+ * - `agent.decideApproval`      the per-call approval policy; defaults to query-runs,
+ *                               mutation-asks. The synchronous pause is owned here.
+ * - `agent.defaultModel`        the model a brand new conversation starts on.
+ * - `activeConversation`        the active-conversation source; defaults to internal
+ *                               state. An app that keeps it in the URL injects its own.
+ * - `generateId`                the message-id minter.
  *
  * A mutation is approval-gated by a synchronous pause: the loop waits on an
  * in-client decision, recorded per handle in `pendingApproval`. The "Always
@@ -76,16 +78,35 @@ export type AgentChatState = ReturnType<typeof createAgentChatState>;
 /** A reactive handle for a single conversation backed by the client loop. */
 export type ConversationHandle = NonNullable<AgentChatState['active']>;
 
+/**
+ * What the agent can do: the persona and capabilities an app gives its chat
+ * loop. Grouped because every field varies with the app, not the device or the
+ * route. The workspace handles, connections, id minter, and active-conversation
+ * source the loop also needs are passed separately; they have different owners.
+ */
+export type AgentKit = {
+	/** The layered system prompts an answer is generated under, read per turn. */
+	buildSystemPrompts: () => string[];
+	/** The live tool surface; omit for a capability-free app (Vocab). */
+	toolCatalog?: ToolCatalog;
+	/** The model a brand new conversation starts on when none is carried forward. */
+	defaultModel: string;
+	/** The per-call approval policy; defaults to query-runs, mutation-asks. */
+	decideApproval?: Approval['decide'];
+};
+
 export function createAgentChatState({
 	table,
 	whenLoaded,
 	connections,
-	buildSystemPrompts,
 	generateId,
-	defaultModel,
-	toolCatalog,
-	decideApproval = defaultApprovalDecision,
 	activeConversation,
+	agent: {
+		buildSystemPrompts,
+		toolCatalog,
+		defaultModel,
+		decideApproval = defaultApprovalDecision,
+	},
 }: {
 	/** The conversations table handle (`workspace.tables.conversations`). */
 	table: ConversationsTable;
@@ -93,18 +114,12 @@ export function createAgentChatState({
 	whenLoaded: Promise<unknown>;
 	/** The device connection registry (ADR-0059); resolves a model to a transport. */
 	connections: InferenceConnections;
-	/** The layered system prompts an answer is generated under, read per turn. */
-	buildSystemPrompts: () => string[];
 	/** Mint a message id. */
 	generateId: () => string;
-	/** The model a brand new conversation starts on when none is carried forward. */
-	defaultModel: string;
-	/** The live tool surface; omit for a capability-free app (Vocab). */
-	toolCatalog?: ToolCatalog;
-	/** The per-call approval policy; defaults to query-runs, mutation-asks. */
-	decideApproval?: Approval['decide'];
 	/** The active-conversation source; defaults to internal `$state`. */
 	activeConversation?: ActiveConversation;
+	/** What the agent can do: the app's persona and capabilities. */
+	agent: AgentKit;
 }) {
 	const conversationsMap = fromTable(table);
 

--- a/packages/app-shell/src/agent-chat/conversation-switcher.svelte
+++ b/packages/app-shell/src/agent-chat/conversation-switcher.svelte
@@ -10,17 +10,17 @@
 	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
 	import MessageSquarePlusIcon from '@lucide/svelte/icons/message-square-plus';
 	import TrashIcon from '@lucide/svelte/icons/trash-2';
-	import type { ConversationHandle } from '@epicenter/app-shell/agent-chat';
 	import type { ConversationId } from '@epicenter/chat';
+	import type { ConversationHandle } from './agent-chat.svelte.js';
 
 	let {
 		conversations,
-		activeId,
+		activeConversationId,
 		onSwitch,
 		onCreate,
 	}: {
 		conversations: ConversationHandle[];
-		activeId: ConversationId | null;
+		activeConversationId: ConversationId | null;
 		onSwitch: (id: ConversationId) => void;
 		onCreate: () => void;
 	} = $props();
@@ -41,7 +41,8 @@
 
 	/** Active conversation title for the header bar. */
 	const activeTitle = $derived(
-		conversations.find((c) => c.id === activeId)?.title ?? 'New Chat',
+		conversations.find((c) => c.id === activeConversationId)?.title ??
+			'New Chat',
 	);
 
 	/** Format an ISO instant (the row's `updatedAt`) as a short relative time. */
@@ -106,7 +107,8 @@
 									<span class="flex min-w-0 items-center gap-1.5">
 										<CheckIcon
 											class={cn('mr-0.5 size-3 shrink-0', {
-												'text-transparent': conv.id !== activeId,
+												'text-transparent':
+													conv.id !== activeConversationId,
 											})}
 										/>
 										<span class="min-w-0 truncate font-medium"

--- a/packages/app-shell/src/agent-chat/index.ts
+++ b/packages/app-shell/src/agent-chat/index.ts
@@ -5,3 +5,4 @@ export {
 	createAgentChatState,
 } from './agent-chat.svelte.js';
 export { default as AgentChatThread } from './agent-chat-thread.svelte';
+export { default as ConversationSwitcher } from './conversation-switcher.svelte';

--- a/packages/app-shell/src/agent-chat/index.ts
+++ b/packages/app-shell/src/agent-chat/index.ts
@@ -1,6 +1,7 @@
 export {
 	type ActiveConversation,
 	type AgentChatState,
+	type AgentKit,
 	type ConversationHandle,
 	createAgentChatState,
 } from './agent-chat.svelte.js';


### PR DESCRIPTION
opensidian had the shared active chat thread from #2195, but not the shared conversation-list surface. Past conversations were reachable only through `?chat=`, while tab-manager already had the switcher shape the shared thread needed.

`ConversationSwitcher` now lives in `@epicenter/app-shell/agent-chat`, with the active id prop named after the engine getter it consumes:

```svelte
<ConversationSwitcher
	conversations={chat.conversations}
	activeConversationId={chat.activeConversationId}
	onSwitch={(id) => chat.switchTo(id)}
	onCreate={chat.createConversation}
/>
```

opensidian uses that switcher in the chat pane, so the active title opens the recency list with search, preview, and delete. tab-manager drops its local copy and consumes the same component.

The chat factory also gets a narrower setup boundary. The four fields that describe what the agent can do now travel as one `AgentKit`, while persistence, loading, connection resolution, generated ids, and active-conversation storage stay separate because they have different owners.

```ts
createAgentChatState({
	agent: { buildSystemPrompts, toolCatalog, defaultModel, decideApproval },
	table,
	whenLoaded,
	connections,
});
```

## Changelog

- opensidian chat now has a conversation switcher, so older conversations are reachable from the UI instead of only through `?chat=`.
