### PR TITLE
feat(opensidian): add self-hosted instance setting

### DIFF
--- a/apps/opensidian/src/lib/components/InstanceSettingsModal.svelte
+++ b/apps/opensidian/src/lib/components/InstanceSettingsModal.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+	import { normalizeInstanceUrl } from '@epicenter/auth';
+	import { Button } from '@epicenter/ui/button';
+	import { Input } from '@epicenter/ui/input';
+	import { Label } from '@epicenter/ui/label';
+	import * as Modal from '@epicenter/ui/modal';
+	import {
+		clearInstance,
+		isDefaultInstance,
+		readInstance,
+		writeInstance,
+	} from '$lib/instance';
+
+	let { open = $bindable(false) }: { open?: boolean } = $props();
+
+	// Read once when the component mounts; saving reloads the app, so there is no
+	// live value to track.
+	const instance = readInstance();
+	const hasOverride = !isDefaultInstance(instance);
+
+	let urlInput = $state(hasOverride ? instance.baseURL : '');
+	let tokenInput = $state(instance.token ?? '');
+	let urlError = $state<string | null>(null);
+
+	// No pre-save connection test: saving reloads, and the signed-out gate then
+	// reports connected-or-failed (with a "Retry connection") from the auth
+	// client's own boot check. One surface verifies the credential, not two.
+	function save() {
+		const { data: baseURL, error } = normalizeInstanceUrl(urlInput);
+		if (error) {
+			urlError = error.message;
+			return;
+		}
+		writeInstance({ baseURL, token: tokenInput.trim() || undefined });
+		location.reload();
+	}
+
+	function useHosted() {
+		clearInstance();
+		location.reload();
+	}
+</script>
+
+<Modal.Root bind:open>
+	<Modal.Content class="sm:max-w-md">
+		<Modal.Header>
+			<Modal.Title>Connect to a self-hosted instance</Modal.Title>
+			<Modal.Description>
+				Point Opensidian at your own Epicenter star. Your data and token go only
+				to this origin; the hosted cloud is never an endpoint.
+			</Modal.Description>
+		</Modal.Header>
+		<div class="flex flex-col gap-4">
+			<div class="space-y-1.5">
+				<Label for="instance-url">Instance URL</Label>
+				<Input
+					id="instance-url"
+					bind:value={urlInput}
+					placeholder="http://localhost:8788"
+					autocomplete="off"
+					autocapitalize="off"
+					spellcheck={false}
+				/>
+			</div>
+			<div class="space-y-1.5">
+				<Label for="instance-token">Instance token</Label>
+				<Input
+					id="instance-token"
+					type="password"
+					bind:value={tokenInput}
+					placeholder="Paste the token your instance printed"
+					autocomplete="off"
+				/>
+				<p class="text-xs text-muted-foreground">
+					Leave blank to sign in with Epicenter OAuth against this origin
+					instead.
+				</p>
+			</div>
+			{#if urlError}
+				<p class="text-xs text-destructive">{urlError}</p>
+			{/if}
+		</div>
+		<Modal.Footer class="flex-col gap-2 sm:flex-row sm:justify-between">
+			{#if hasOverride}
+				<Button variant="ghost" type="button" onclick={useHosted}>
+					Use hosted Epicenter
+				</Button>
+			{/if}
+			<Button class="sm:ml-auto" type="button" onclick={save}>
+				Save and reload
+			</Button>
+		</Modal.Footer>
+	</Modal.Content>
+</Modal.Root>

--- a/apps/opensidian/src/lib/instance.ts
+++ b/apps/opensidian/src/lib/instance.ts
@@ -1,0 +1,63 @@
+/**
+ * The persisted choice of which Epicenter star this Opensidian install talks to
+ * (ADR-0069: privacy is which deployment runs the program). Default is the
+ * hosted cloud with no token (normal OAuth); a self-hoster overrides the base
+ * URL and pastes a token their box minted.
+ *
+ * Plain localStorage, not a reactive store: `$platform/auth` reads it once,
+ * synchronously, while constructing the auth client at module load. Changing the
+ * instance writes here and reloads, so construction re-reads the new value. The
+ * settings UI keeps its own form `$state` and never needs this to be reactive.
+ */
+
+import { type Instance, normalizeInstanceUrl } from '@epicenter/auth';
+import { APP_URLS } from '@epicenter/constants/vite';
+
+const STORAGE_KEY = 'opensidian.instance';
+
+/**
+ * The hosted default: the build-time API origin with no token, so the app uses
+ * the normal OAuth flow. Reverting to this is "use hosted Epicenter".
+ */
+export const defaultInstance: Instance = { baseURL: APP_URLS.API };
+
+/** True when the instance is the hosted default (no override is in effect). */
+export function isDefaultInstance(instance: Instance): boolean {
+	return instance.baseURL === defaultInstance.baseURL && !instance.token;
+}
+
+/**
+ * Read the persisted instance, falling back to the hosted default. A missing,
+ * non-JSON, or unparseable record reads as the default rather than throwing, so
+ * a bad write can never wedge the app at boot. The base URL is re-normalized on
+ * read so a hand-edited record cannot smuggle in a malformed origin.
+ */
+export function readInstance(): Instance {
+	if (typeof localStorage === 'undefined') return defaultInstance;
+	const raw = localStorage.getItem(STORAGE_KEY);
+	if (raw === null) return defaultInstance;
+	try {
+		const parsed = JSON.parse(raw) as Partial<Instance>;
+		const { data: baseURL } = normalizeInstanceUrl(
+			String(parsed.baseURL ?? ''),
+		);
+		if (!baseURL) return defaultInstance;
+		const token =
+			typeof parsed.token === 'string' && parsed.token.trim() !== ''
+				? parsed.token
+				: undefined;
+		return { baseURL, token };
+	} catch {
+		return defaultInstance;
+	}
+}
+
+/** Persist an instance. The caller reloads so auth construction re-reads it. */
+export function writeInstance(instance: Instance): void {
+	localStorage.setItem(STORAGE_KEY, JSON.stringify(instance));
+}
+
+/** Forget the override and revert to the hosted default. */
+export function clearInstance(): void {
+	localStorage.removeItem(STORAGE_KEY);
+}

--- a/apps/opensidian/src/lib/platform/auth/auth.ts
+++ b/apps/opensidian/src/lib/platform/auth/auth.ts
@@ -1,25 +1,38 @@
 import { createWebStoragePersistedAuthStorage } from '@epicenter/auth';
 import { createBrowserOAuthLauncher } from '@epicenter/auth/oauth-launchers';
 import { EPICENTER_OPENSIDIAN_OAUTH_CLIENT_ID } from '@epicenter/constants/oauth-clients';
-import { APP_URLS } from '@epicenter/constants/vite';
-import { createOAuthAppAuth } from '@epicenter/svelte/auth';
+import {
+	createInstanceTokenAuth,
+	createOAuthAppAuth,
+} from '@epicenter/svelte/auth';
 import { base } from '$app/paths';
+import { readInstance } from '$lib/instance';
 
-export const auth = createOAuthAppAuth({
-	baseURL: APP_URLS.API,
-	clientId: EPICENTER_OPENSIDIAN_OAUTH_CLIENT_ID,
-	persistedAuthStorage: createWebStoragePersistedAuthStorage({
-		key: 'opensidian.auth.persisted',
-		storage: window.localStorage,
-	}),
-	launcher: createBrowserOAuthLauncher({
-		issuer: `${APP_URLS.API}/auth`,
-		clientId: EPICENTER_OPENSIDIAN_OAUTH_CLIENT_ID,
-		redirectUri: `${window.location.origin}${base}/auth/callback`,
-		resource: APP_URLS.API,
-		storage: window.sessionStorage,
-	}),
-});
+const instance = readInstance();
+
+// A configured instance token means a self-hosted star: authenticate with the
+// static bearer (ADR-0070) instead of OAuth. Otherwise the OAuth flow runs
+// against the instance origin, which is the hosted cloud by default.
+export const auth = instance.token
+	? createInstanceTokenAuth({
+			baseURL: instance.baseURL,
+			token: instance.token,
+		})
+	: createOAuthAppAuth({
+			baseURL: instance.baseURL,
+			clientId: EPICENTER_OPENSIDIAN_OAUTH_CLIENT_ID,
+			persistedAuthStorage: createWebStoragePersistedAuthStorage({
+				key: 'opensidian.auth.persisted',
+				storage: window.localStorage,
+			}),
+			launcher: createBrowserOAuthLauncher({
+				issuer: `${instance.baseURL}/auth`,
+				clientId: EPICENTER_OPENSIDIAN_OAUTH_CLIENT_ID,
+				redirectUri: `${window.location.origin}${base}/auth/callback`,
+				resource: instance.baseURL,
+				storage: window.sessionStorage,
+			}),
+		});
 
 if (import.meta.hot) {
 	import.meta.hot.dispose(() => {

--- a/apps/opensidian/src/routes/(signed-in)/+layout.svelte
+++ b/apps/opensidian/src/routes/(signed-in)/+layout.svelte
@@ -2,6 +2,8 @@
 	import { WorkspaceGate } from '@epicenter/app-shell/workspace-gate';
 	import { Button } from '@epicenter/ui/button';
 	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
+	import InstanceSettingsModal from '$lib/components/InstanceSettingsModal.svelte';
+	import { isDefaultInstance, readInstance } from '$lib/instance';
 	import { requireOpensidian, session } from '$lib/session';
 	import { auth } from '$platform/auth';
 
@@ -9,6 +11,11 @@
 
 	let signingIn = $state(false);
 	let signInError = $state<string | null>(null);
+	let instanceModalOpen = $state(false);
+
+	const instance = readInstance();
+	const usingToken = instance.token !== undefined;
+	const instanceHost = new URL(instance.baseURL).host;
 
 	async function startSignIn() {
 		signInError = null;
@@ -35,9 +42,13 @@
 		class="flex h-dvh flex-col items-center justify-center gap-3 px-6 text-center"
 	>
 		<div class="space-y-1">
-			<p class="text-sm font-medium">Sign in to Opensidian</p>
+			<p class="text-sm font-medium">
+				{usingToken ? `Connect to ${instanceHost}` : 'Sign in to Opensidian'}
+			</p>
 			<p class="text-xs text-muted-foreground">
-				Sync your notes across devices.
+				{usingToken
+					? 'Sign in to your self-hosted instance.'
+					: 'Sync your notes across devices.'}
 			</p>
 		</div>
 		{#if signInError}
@@ -46,10 +57,22 @@
 		<Button class="w-full max-w-xs" onclick={startSignIn} disabled={signingIn}>
 			{#if signingIn}
 				<LoaderCircle class="size-4 animate-spin" />
-				Signing in…
+				{usingToken ? 'Connecting…' : 'Signing in…'}
 			{:else}
-				Sign in with Epicenter
+				{usingToken ? 'Retry connection' : 'Sign in with Epicenter'}
 			{/if}
+		</Button>
+		<Button
+			variant="link"
+			size="sm"
+			class="text-muted-foreground"
+			onclick={() => (instanceModalOpen = true)}
+		>
+			{isDefaultInstance(instance)
+				? 'Connect to a self-hosted instance'
+				: 'Change instance'}
 		</Button>
 	</div>
 {/if}
+
+<InstanceSettingsModal bind:open={instanceModalOpen} />


### PR DESCRIPTION
Opensidian hardcoded production OAuth, so it could only ever talk to the hosted Epicenter cloud. PR #2192 gave fuji a client-side "which Epicenter instance" setting (ADR-0069/0070: privacy is which deployment runs the program), but opensidian, tab-manager, and vocab were left on the hardcoded path. This brings opensidian to parity with fuji.

Opensidian now persists a per-app `Instance` (`{ baseURL, token? }`, localStorage key `opensidian.instance`). The auth seam reads it once at construction and branches on the token:

```ts
const instance = readInstance();

export const auth = instance.token
	? createInstanceTokenAuth({ baseURL: instance.baseURL, token: instance.token })
	: createOAuthAppAuth({ baseURL: instance.baseURL, clientId: /* ... */ });
```

A configured token means a self-hosted star: authenticate with the static bearer (ADR-0070). No token means the normal OAuth flow against the instance origin, which defaults to the hosted cloud, so existing installs are unchanged.

The signed-out gate gains a "Connect to a self-hosted instance" / "Change instance" link that opens `InstanceSettingsModal`, so the instance is chosen before sign-in. This mirrors fuji, where the setting is also reachable only while signed out.

This is a direct port of fuji's reference (`apps/fuji/src/lib/instance.ts`, `platform/auth.browser.ts`, `components/InstanceSettingsModal.svelte`). `instance.ts` and the modal are kept per-app for now (only the storage key and the app name in copy differ), matching the per-app shape #2192 established; extracting a shared helper becomes worthwhile once tab-manager and vocab are also ported.

## Changelog

- Opensidian can now connect to a self-hosted Epicenter instance. On the sign-in screen, choose "Connect to a self-hosted instance", enter your instance URL and token, and Opensidian talks to your own server instead of the hosted cloud.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785012442&installation_id=128463665&pr_number=2197&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2197&signature=7798bbafbd1c83a50446e5226b5bfd82aba976ddeff8c349b083fc0216ec4939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->