### PR TITLE
fix(opensidian): add the root Tooltip.Provider its chrome requires

### DIFF
--- a/apps/opensidian/src/routes/+layout.svelte
+++ b/apps/opensidian/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { ConfirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { Toaster } from '@epicenter/ui/sonner';
+	import * as Tooltip from '@epicenter/ui/tooltip';
 	import { ModeWatcher } from 'mode-watcher';
 	import '../app.css';
 
@@ -11,4 +12,6 @@
 <Toaster />
 <ModeWatcher />
 
-{@render children()}
+<Tooltip.Provider>
+	{@render children()}
+</Tooltip.Provider>

--- a/packages/app-shell/src/account-popover/account-popover.svelte
+++ b/packages/app-shell/src/account-popover/account-popover.svelte
@@ -37,7 +37,9 @@
 	 * `Collaboration` value, so RPC, peers, and presence do not leak into the
 	 * account UI surface.
 	 *
-	 * Mount once in each app's root layout alongside `<ConfirmationDialog />`.
+	 * Mount once in each app's root layout, alongside `<ConfirmationDialog />`
+	 * and inside a `<Tooltip.Provider>`: the trigger pill renders a tooltip,
+	 * which a `Tooltip.Root` needs as an ancestor.
 	 */
 	type AccountPopoverProps = {
 		/** The auth client from `createOAuthAppAuth()`. */


### PR DESCRIPTION
opensidian's signed-in shell crashed on mount with `Context "Tooltip.Provider" not found`, stranding the app on the workspace loader. The account/sync pill in the tab bar (`AccountPopover`, shared chrome from `@epicenter/app-shell`) renders a `<Button tooltip>`, which mounts a bits-ui `Tooltip.Root`; that throws without a `Tooltip.Provider` ancestor. opensidian never wrapped its app in a root provider, so the pill took the whole shell down the moment it rendered. The crash predates the conversation-switcher work and is present on `main` on its own.

In bits-ui a tooltip provider is an app-root singleton: one provider coordinates open and skip delay across every tooltip beneath it. whispering already wraps its root layout and tab-manager wraps its signed-in shell, so opensidian was the only consumer missing one. This adds it to opensidian's root `+layout.svelte` beside the other root singletons (`ConfirmationDialog`, `Toaster`), which also covers opensidian's own tooltips in the command palette and search panel. `AccountPopover`'s doc comment now names the requirement next to the `<ConfirmationDialog />` one it already documented.

## Changelog
- Fixed opensidian failing to load the workspace after signing in.