### PR TITLE
feat(opensidian): default to dark with a pre-paint theme script

### DIFF
--- a/apps/opensidian/src/app.html
+++ b/apps/opensidian/src/app.html
@@ -4,6 +4,16 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>Opensidian</title>
+		<script>
+			const mode = localStorage.getItem('mode-watcher-mode') ?? 'dark';
+			const isLight =
+				mode === 'light' ||
+				(mode === 'system' &&
+					matchMedia('(prefers-color-scheme: light)').matches);
+			document.documentElement.classList.toggle('dark', !isLight);
+			document.documentElement.style.colorScheme = isLight ? 'light' : 'dark';
+			localStorage.setItem('mode-watcher-mode', mode);
+		</script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/apps/opensidian/src/routes/+layout.svelte
+++ b/apps/opensidian/src/routes/+layout.svelte
@@ -10,7 +10,7 @@
 
 <ConfirmationDialog />
 <Toaster />
-<ModeWatcher />
+<ModeWatcher defaultMode="dark" track={false} />
 
 <Tooltip.Provider>
 	{@render children()}


### PR DESCRIPTION
Opensidian renders as a pure SPA (`ssr = false` with an `adapter-static` fallback), so `<ModeWatcher>`'s own anti-flash head script only runs once the bundle hydrates. Until then the page paints in the browser default theme: a visible flash of light on every load, and no dark default at all.

This adds the same inline `app.html` script Whispering already uses. It runs before first paint, reads mode-watcher's `mode-watcher-mode` localStorage key, and toggles the `dark` class on `<html>` so the right theme is in place immediately. Pairing it with `<ModeWatcher defaultMode="dark" track={false} />` keeps the pre-paint default and the runtime watcher in agreement, and converges Opensidian onto the dark-default convention already shared by Whispering, Fuji, Honeycrisp, Matter, and the API dashboard.

## Changelog

- Opensidian now defaults to dark mode and no longer flashes a light theme before the app loads.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785047938&installation_id=128463665&pr_number=2203&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2203&signature=7ad443f7ff1a9f1456ec5ad809a9cd29177c28e4cf66612f915607cd43683128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->