### PR TITLE
ci: deploy PR previews with the repo's own wrangler

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -164,7 +164,8 @@ keep `changeset version` (it owns version math and changelogs) but replaced
 
 | Secret | Used by | Description |
 |---|---|---|
-| `CLOUDFLARE_API_TOKEN` | `deploy.cloudflare`, `deploy.cloudflare-preview` | Cloudflare API token. Named `github-actions-cloudflare-deploy` in the CF dashboard (Account API Tokens). Use the "Edit Cloudflare Workers" template. |
+| `CLOUDFLARE_API_TOKEN` | `deploy.cloudflare` | Production Cloudflare API token. Named `github-actions-cloudflare-deploy` in the CF dashboard (Account API Tokens). Uses the "Edit Cloudflare Workers" template (`deploy` needs zone Workers Routes for custom domains, which previews do not). |
+| `CLOUDFLARE_PREVIEW_API_TOKEN` | `deploy.cloudflare-preview` | Least-privilege Cloudflare API token for PR previews. Custom token, **Account › Workers Scripts › Edit** only (covers Static Assets; no zone/routes/KV/R2/D1), scoped to the one account. Separate from the prod token so a leak from the PR-triggered preview path cannot reach production. |
 | `CLOUDFLARE_ACCOUNT_ID` | `deploy.cloudflare`, `deploy.cloudflare-preview` | Cloudflare account ID |
 | `DISCORD_WEBHOOK_URL` | `deploy.cloudflare` | Discord webhook for deployment notifications (optional) |
 | `TAURI_SIGNING_PRIVATE_KEY` | `release.whispering`, `pr-preview.whispering` | Tauri update signing key |

--- a/.github/workflows/deploy.cloudflare-preview.yml
+++ b/.github/workflows/deploy.cloudflare-preview.yml
@@ -63,7 +63,11 @@ jobs:
       # upload failure is reported in the PR comment without sinking the others.
       - name: Upload previews
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # wrangler reads the env var named CLOUDFLARE_API_TOKEN; we source it
+          # from a dedicated least-privilege preview token (Workers Scripts:Edit
+          # only, no zone/routes) rather than the full-scope production deploy
+          # token, so a leak from this PR-triggered path can't touch prod.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PREVIEW_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           # Passed via env (not inlined into the script) so a crafted PR title

--- a/.github/workflows/deploy.cloudflare-preview.yml
+++ b/.github/workflows/deploy.cloudflare-preview.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'apps/whispering/**'
       - 'apps/landing/**'
+      - 'apps/opensidian/**'
+      - 'apps/fuji/**'
+      - 'apps/honeycrisp/**'
+      - 'apps/vocab/**'
       - 'packages/**'
       - '.github/workflows/deploy.cloudflare-preview.yml'
 
@@ -17,6 +21,11 @@ jobs:
   preview:
     name: Deploy Previews
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Previews need the Cloudflare secret to upload and a write token to comment,
+    # neither of which GitHub grants to pull requests from forks, so a fork run
+    # could only fail. Gate to same-repo branches; this also avoids executing
+    # fork-authored build.command code on the runner.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       pull-requests: write
@@ -37,47 +46,85 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # `versions upload` runs each worker's `wrangler.jsonc` build.command, so
-      # previews build through the same definition as production deploys. No
-      # separate build step needed.
-      - name: Upload Whispering preview
-        id: whispering
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: apps/whispering
-          packageManager: bun
-          command: versions upload --preview-alias "pr-${{ github.event.pull_request.number }}" --tag "pr-${{ github.event.pull_request.number }}" --message "PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}"
+      # Drive the repo's own catalog-pinned wrangler directly instead of
+      # cloudflare/wrangler-action, which can't detect a bun-installed binary
+      # (`bun run wrangler` is a script lookup) and silently installs its own
+      # default wrangler@3.90.0, which predates `--preview-alias`. `bunx
+      # --no-install` runs the exact wrangler that `bun install` hoisted, so the
+      # catalog stays the single source of truth for the version.
+      #
+      # `versions upload` runs each app's wrangler.jsonc build.command, so a
+      # preview builds through that app's normal build. (The production deploy in
+      # deploy.cloudflare.yml still uses wrangler-action; converging it onto this
+      # same invocation is a follow-up.)
+      #
+      # To preview another app, add it to `apps` below; it needs `preview_urls:
+      # true` in its wrangler.jsonc. Each app uploads independently: a build or
+      # upload failure is reported in the PR comment without sinking the others.
+      - name: Upload previews
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Passed via env (not inlined into the script) so a crafted PR title
+          # cannot inject shell commands.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Per-app failures are reported in the comment (:x:) without failing
+          # the job: previews are informational and main is unprotected. That is
+          # why we use `-uo pipefail` but deliberately NOT `set -e`, which would
+          # abort the loop on the first app that fails to build or upload.
+          set -uo pipefail
 
-      - name: Upload Landing preview
-        id: landing
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: apps/landing
-          packageManager: bun
-          command: versions upload --preview-alias "pr-${{ github.event.pull_request.number }}" --tag "pr-${{ github.event.pull_request.number }}" --message "PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}"
+          apps=(whispering landing opensidian fuji honeycrisp vocab)
+          preview_alias="pr-${PR_NUMBER}"
+          rows=""
+          for app in "${apps[@]}"; do
+            echo "::group::Upload preview: ${app}"
+            outdir="$(mktemp -d)"
+            # --cwd loads apps/<app>/wrangler.jsonc and runs its build.command
+            #   there, so the shell stays in the repo root where wrangler is
+            #   hoisted. --no-install pins us to that hoisted binary: if it is
+            #   ever missing, fail loudly rather than download the latest.
+            if WRANGLER_OUTPUT_FILE_DIRECTORY="${outdir}" \
+                 bunx --no-install wrangler --cwd "apps/${app}" versions upload \
+                   --preview-alias "${preview_alias}" \
+                   --tag "${preview_alias}" \
+                   --message "PR #${PR_NUMBER}: ${PR_TITLE}"; then
+              # wrangler writes one NDJSON file; its {"type":"version-upload"}
+              # line carries the stable pr-N alias URL in .preview_alias_url.
+              url="$(jq -rs 'map(select(.type=="version-upload")) | last | .preview_alias_url // empty' "${outdir}"/*.json)"
+              if [ -n "${url}" ]; then
+                rows+="| ${app} | ${url} |"$'\n'
+              else
+                rows+="| ${app} | uploaded (no preview URL returned) |"$'\n'
+              fi
+            else
+              rows+="| ${app} | :x: build or upload failed (see logs) |"$'\n'
+            fi
+            echo "::endgroup::"
+          done
+
+          {
+            echo "## Preview Deployment"
+            echo ""
+            echo "| App | Preview URL |"
+            echo "|-----|-------------|"
+            printf '%s' "${rows}"
+            echo ""
+            echo "Previews update automatically with new commits to this PR. No cleanup needed: previews are version aliases on the existing workers."
+            echo ""
+            echo "<sub>Commit ${HEAD_SHA}</sub>"
+          } > "${RUNNER_TEMP}/preview-comment.md"
 
       - name: Comment on PR
+        if: always()
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          BODY=$(cat <<'EOF'
-          ## Preview Deployment
-
-          | App | Preview URL |
-          |-----|-------------|
-          | Whispering | ${{ steps.whispering.outputs.deployment-url }} |
-          | Landing | ${{ steps.landing.outputs.deployment-url }} |
-
-          These previews update automatically with new commits to this PR.
-          No cleanup needed — previews are version aliases on the existing workers.
-
-          ---
-          <sub>Commit ${{ github.event.pull_request.head.sha }}</sub>
-          EOF
-          )
-          gh pr comment ${{ github.event.pull_request.number }} --body "$BODY" --edit-last || \
-          gh pr comment ${{ github.event.pull_request.number }} --body "$BODY"
+          body="${RUNNER_TEMP}/preview-comment.md"
+          [ -f "${body}" ] || { echo "No comment body was produced; skipping."; exit 0; }
+          gh pr comment "${PR_NUMBER}" --body-file "${body}" --edit-last \
+            || gh pr comment "${PR_NUMBER}" --body-file "${body}"

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",
@@ -13,6 +12,7 @@
         "@changesets/cli": "^2.31.0",
         "@types/bun": "catalog:",
         "jsrepo": "^3.6.2",
+        "wrangler": "catalog:",
       },
     },
     "apps/api": {

--- a/package.json
+++ b/package.json
@@ -155,7 +155,8 @@
 		"@biomejs/biome": "catalog:",
 		"@changesets/cli": "^2.31.0",
 		"@types/bun": "catalog:",
-		"jsrepo": "^3.6.2"
+		"jsrepo": "^3.6.2",
+		"wrangler": "catalog:"
 	},
 	"dependencies": {
 		"@epicenter/constants": "workspace:*",


### PR DESCRIPTION
Every PR's "Deploy Previews" job failed on `Unknown arguments: preview-alias`. The cause was infra, not app code: the step used `cloudflare/wrangler-action`, which can't detect a bun-installed binary (its probe is a `bun run wrangler` script lookup), so it silently installed its own default `wrangler@3.90.0`. That version predates `--preview-alias`, so the upload was rejected before any build ran. `main` is unprotected, so it never blocked.

Rather than pin the action's `wranglerVersion` (a band-aid that adds a second wrangler-version owner beside the catalog and keeps a redundant install), this drops the action and drives the repo's own catalog-pinned wrangler directly:

```bash
bunx --no-install wrangler --cwd "apps/${app}" versions upload --preview-alias "pr-${PR_NUMBER}" ...
```

`bunx --no-install` runs the exact wrangler that `bun install` hoisted, so the catalog is the single source of truth for the version; if that binary is ever missing it fails loudly instead of silently downloading the latest. The stable preview URL is read from wrangler's own `WRANGLER_OUTPUT_FILE_DIRECTORY` output (`preview_alias_url`), which is the only thing the action did for us here anyway.

A few things improve as a result:

- **Every `preview_urls: true` app is driven from one list**, so adding an app is a one-line edit. Each app uploads independently, so a build or upload failure is reported in the PR comment without sinking the others. The old two sequential steps had the opposite behavior: a Whispering failure skipped the Landing step entirely.
- **The job is gated to same-repo branches** (`head.repo.full_name == github.repository`). Fork PRs receive no Cloudflare secret and only a read-only token, so a fork run could only fail; gating also avoids executing fork-authored `build.command` code on the runner.
- The PR title reaches the script through an `env:` var, not `${{ }}` interpolation, so a crafted title can't inject shell commands.

Note that apps not yet building green in CI will show `:x:` in the preview comment until their separate build issues are fixed; that is reported per app and does not fail the job.

Deliberately left as follow-ups: minting a dedicated least-privilege preview token instead of sharing the production deploy token, and converging `deploy.cloudflare.yml` onto this same direct-wrangler invocation so local, preview, and production share one build path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785048984&installation_id=128463665&pr_number=2204&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2204&signature=77f6cb5953aeed378cbccf6b38fcac5c94b381a3a8c2b304a2f857bec5030731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->