### PR TITLE
ci: converge production deploy onto direct wrangler invocation

### DIFF
--- a/.github/workflows/deploy.cloudflare.yml
+++ b/.github/workflows/deploy.cloudflare.yml
@@ -32,39 +32,74 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # Each `deploy` runs the worker's own `wrangler.jsonc` build.command first,
-      # so build stays coupled to deploy (no stale assets) without a separate
-      # build step here. The same build runs on local `wrangler deploy` and in
-      # the preview workflow's `versions upload`, so there is one build path.
+      # Drive the repo's own catalog-pinned wrangler directly, the same call path
+      # as local `wrangler deploy` and the PR-preview workflow's `versions upload`.
+      # `bunx --no-install` runs the exact wrangler that `bun install` hoisted to the
+      # repo root (pinned by the root `wrangler: "catalog:"` devDep): if it is ever
+      # missing, fail loudly rather than silently download the latest. That is why we
+      # do NOT use cloudflare/wrangler-action, which can't detect a bun-installed
+      # binary and installs its own default wrangler instead.
+      #
+      # Each `deploy` runs the worker's own `wrangler.jsonc` build.command first, so
+      # build stays coupled to deploy (no stale assets) without a separate build step
+      # here; local, CI prod, and CI preview all build through that one definition.
+      #
+      # wrangler-action exposed `outputs.deployment-url`. Moving off it, we re-derive
+      # that URL from wrangler's NDJSON output (WRANGLER_OUTPUT_FILE_DIRECTORY + jq)
+      # and republish it as each step's `deployment-url` output, so the summary and
+      # Discord steps below keep reading `steps.<id>.outputs.deployment-url` unchanged.
+      # For a `deploy` the URL is the {"type":"deploy"} entry's first target
+      # (`.targets[0]`), which is exactly what wrangler-action set deployment-url to.
+      #
+      # Unlike the preview workflow's fault-tolerant loop, these are three separate
+      # fail-fast steps (`set -euo pipefail`, no `if: always()`): a failed production
+      # deploy MUST fail the job so the Discord alert fires, and keeping the steps
+      # separate shows which app failed. URL extraction is best-effort (`|| true`), so
+      # a parsing hiccup can never turn an already-successful deploy red.
+      #
+      # Token asymmetry is deliberate: production uses the full-scope
+      # CLOUDFLARE_API_TOKEN (it needs Zone > Workers Routes > Edit for the custom
+      # domains), NOT the least-privilege preview token.
       - name: Deploy Whispering
         id: whispering
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: apps/whispering
-          packageManager: bun
-          command: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          outdir="$(mktemp -d)"
+          WRANGLER_OUTPUT_FILE_DIRECTORY="${outdir}" \
+            bunx --no-install wrangler --cwd apps/whispering deploy
+          # wrangler writes one NDJSON file; its {"type":"deploy"} line carries the
+          # deployment URLs in .targets. wrangler-action published .targets[0]; match it.
+          url="$(jq -rs 'map(select(.type=="deploy")) | last | .targets[0] // empty' "${outdir}"/*.json || true)"
+          echo "deployment-url=${url}" >> "${GITHUB_OUTPUT}"
 
       - name: Deploy Landing
         id: landing
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: apps/landing
-          packageManager: bun
-          command: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          outdir="$(mktemp -d)"
+          WRANGLER_OUTPUT_FILE_DIRECTORY="${outdir}" \
+            bunx --no-install wrangler --cwd apps/landing deploy
+          url="$(jq -rs 'map(select(.type=="deploy")) | last | .targets[0] // empty' "${outdir}"/*.json || true)"
+          echo "deployment-url=${url}" >> "${GITHUB_OUTPUT}"
 
       - name: Deploy API
         id: api
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: apps/api
-          packageManager: bun
-          command: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          outdir="$(mktemp -d)"
+          WRANGLER_OUTPUT_FILE_DIRECTORY="${outdir}" \
+            bunx --no-install wrangler --cwd apps/api deploy
+          url="$(jq -rs 'map(select(.type=="deploy")) | last | .targets[0] // empty' "${outdir}"/*.json || true)"
+          echo "deployment-url=${url}" >> "${GITHUB_OUTPUT}"
 
       - name: Deployment summary
         if: always()


### PR DESCRIPTION
Production deploys (push to main) still ran through `cloudflare/wrangler-action@v3`, while local `wrangler deploy` and the PR previews from #2204 drive the repo's own catalog-pinned wrangler directly. Production was the last place that didn't run the same command as everywhere else. This converges it, so local, previews, and production all build through one call path: `bunx --no-install wrangler --cwd apps/<app> ...`.

Per app (Whispering / Landing / API):

```yaml
# before
- uses: cloudflare/wrangler-action@v3
  with:
    apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
    accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
    workingDirectory: apps/whispering
    command: deploy

# after
- env:
    CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
    CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
  run: |
    set -euo pipefail
    outdir="$(mktemp -d)"
    WRANGLER_OUTPUT_FILE_DIRECTORY="${outdir}" \
      bunx --no-install wrangler --cwd apps/whispering deploy
    url="$(jq -rs 'map(select(.type=="deploy")) | last | .targets[0] // empty' "${outdir}"/*.json || true)"
    echo "deployment-url=${url}" >> "${GITHUB_OUTPUT}"
```

The reason for this shape is:

Cloudflare recommends `wrangler-action`, but that recommendation assumes npm. Under bun it is quietly broken: the action looks for an already-installed wrangler by running `bun run wrangler --version`, which is a `package.json` script lookup, not the wrangler binary. Detection fails, so the action silently installs its own default wrangler instead (the 3.90.0 that predated `--preview-alias` and broke previews in #2204). To use the action correctly under bun you would pin a second copy of the version by hand (which drifts from the catalog) and pay a redundant reinstall on every deploy. `bunx --no-install wrangler` runs the exact version the catalog already pins, and fails loudly if it is ever missing rather than reaching for latest. So this is not just consistency for its own sake: the direct call is the more predictable one.

What we take on, and why it is safe:

The action's one real freebie was `outputs.deployment-url`. We re-derive it from wrangler's output file (`WRANGLER_OUTPUT_FILE_DIRECTORY`), reading the first target of the `{"type":"deploy"}` record (`targets[0]`), which is the same field the action reads. That file is a documented, supported interface (Cloudflare's docs call it "useful for CI/CD pipelines and automation tools that need to programmatically access deployment information"), not an internal detail, so the trade is one line of jq against a stable contract. The output keeps the name `deployment-url`, so the deployment summary and the Discord embed are untouched.

What deliberately stays different from the preview workflow:

This is not a copy of the preview loop. Production keeps the full-scope `CLOUDFLARE_API_TOKEN` (it needs Zone › Workers Routes › Edit for the custom domains; the preview token is Workers Scripts only). It stays fail-fast (`set -euo pipefail`, three separate steps, no fault-tolerant loop): a failed production deploy must fail the job so the Discord alert fires, where previews intentionally keep going so one app cannot sink the others. And it deploys exactly whispering / landing / api; the four preview-only apps (opensidian, fuji, honeycrisp, vocab) have never shipped to production and are not added here.

This workflow runs only on push to main, so the production deploy itself is the final proof, at merge.