### PR TITLE
fix(workspace): heal corrupt IndexedDB loads via a y-indexeddb patch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",
@@ -1015,6 +1014,9 @@
         "yjs": "catalog:",
       },
     },
+  },
+  "patchedDependencies": {
+    "y-indexeddb@9.0.12": "patches/y-indexeddb@9.0.12.patch",
   },
   "overrides": {
     "@protobufjs/utf8": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -161,5 +161,8 @@
 	"dependencies": {
 		"@epicenter/constants": "workspace:*",
 		"tinyexec": "^1.0.4"
+	},
+	"patchedDependencies": {
+		"y-indexeddb@9.0.12": "patches/y-indexeddb@9.0.12.patch"
 	}
 }

--- a/packages/workspace/src/document/attach-indexed-db.ts
+++ b/packages/workspace/src/document/attach-indexed-db.ts
@@ -8,6 +8,13 @@ export function attachIndexedDb(
 	options: { databaseName?: string } = {},
 ) {
 	const databaseName = options.databaseName ?? ydoc.guid;
+	// Corrupt-store healing lives in `patches/y-indexeddb@9.0.12.patch`, not here.
+	// The upstream loader applies persisted updates with no `.catch`, so a single
+	// undecodable update both wedges `whenSynced` forever and floats an uncatchable
+	// decode error. The patch wraps the per-update apply in a `try/catch` that skips
+	// the bad bytes (server resync supplies them) and still emits `'synced'`.
+	// `attach-local-storage-corrupt-load.test.ts` is the regression gate: it goes
+	// red the day the patch stops applying.
 	const idb = new IndexeddbPersistence(databaseName, ydoc);
 	// `IndexeddbPersistence`'s constructor binds `doc.on('destroy', this.destroy)`
 	// eagerly, and its `destroy()` has no top-level idempotency guard: two calls
@@ -32,7 +39,8 @@ export function attachIndexedDb(
 		 * Resolves when local IndexedDB state has loaded into the Y.Doc: "your
 		 * draft is in memory, edits are safe." Not CRDT convergence despite
 		 * `y-indexeddb`'s upstream `whenSynced` name. Pair with `sync.whenConnected`
-		 * when you also need remote state.
+		 * when you also need remote state. The patched loader skips undecodable
+		 * updates rather than hanging, so this never wedges on a corrupt store.
 		 */
 		whenLoaded,
 		/** Delete the local IndexedDB document without destroying the Y.Doc. */

--- a/packages/workspace/src/document/attach-local-storage-corrupt-load.test.ts
+++ b/packages/workspace/src/document/attach-local-storage-corrupt-load.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Regression gate for `patches/y-indexeddb@9.0.12.patch`.
+ *
+ * Before the patch, a single corrupt update persisted in IndexedDB broke the
+ * y-indexeddb load path in two user-visible ways at once:
+ *
+ *   1. `whenLoaded` NEVER resolved. y-indexeddb applies stored updates inside
+ *      the `getAll().then(...)` callback and only emits `'synced'` AFTER the
+ *      apply loop. A throw in the loop skipped the emit, so `whenSynced` (which
+ *      `attachIndexedDb` exposes as `whenLoaded`) was wedged forever and the app
+ *      hung on boot waiting for its draft to load.
+ *
+ *   2. The decode error floated as an UNHANDLED rejection. `fetchUpdates`'
+ *      promise is discarded in the IndexeddbPersistence constructor and the
+ *      `_db.then(...)` has no `.catch`, so the throw surfaced as
+ *      `Uncaught (in promise) Error: Unexpected end of array` with lib0's
+ *      useless singleton stack.
+ *
+ * The patch wraps the per-update `Y.applyUpdate` in a `try/catch` that skips the
+ * bad bytes (server resync supplies them) and lets `'synced'` still fire. This
+ * test asserts that healed behavior: `whenLoaded` resolves and no rejection
+ * floats. It goes RED the day the patch stops applying (an unverified
+ * y-indexeddb bump), which is the whole reason to keep it.
+ */
+
+import { expect, test } from 'bun:test';
+import { asOwnerId } from '@epicenter/identity';
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb';
+import * as Y from 'yjs';
+import { attachLocalStorage } from './attach-local-storage.js';
+import { wipeLocalStorage } from './wipe-local-storage.js';
+
+Object.assign(globalThis, { indexedDB, IDBKeyRange });
+
+const SERVER = 'api.epicenter.so';
+
+function tick(ms = 0): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Overwrite every stored update with an unterminated varuint (`0x80`). The
+ * high bit signals "another byte follows," but the buffer ends, so the first
+ * `readVarUint` in `Y.applyUpdate` overruns: the exact `Unexpected end of
+ * array` a half-written update produces.
+ */
+async function corruptStoredUpdates(databaseName: string): Promise<void> {
+	const db = await new Promise<IDBDatabase>((resolve, reject) => {
+		const request = indexedDB.open(databaseName);
+		request.onerror = () => reject(request.error);
+		request.onsuccess = () => resolve(request.result);
+	});
+	try {
+		const transaction = db.transaction(['updates'], 'readwrite');
+		const store = transaction.objectStore('updates');
+		await new Promise<void>((resolve, reject) => {
+			const request = store.openCursor();
+			request.onerror = () => reject(request.error);
+			request.onsuccess = () => {
+				const cursor = request.result;
+				if (!cursor) {
+					resolve();
+					return;
+				}
+				cursor.update(new Uint8Array([0x80]));
+				cursor.continue();
+			};
+		});
+	} finally {
+		db.close();
+	}
+}
+
+// Capture any decode rejection that escapes to the process boundary. Pre-patch
+// the load floated an uncatchable one here (the only place it could be seen);
+// post-patch this array must stay empty, which is assertion 4b below.
+const rejections: unknown[] = [];
+process.on('unhandledRejection', (reason) => {
+	rejections.push(reason);
+});
+
+test('a corrupt persisted update is skipped: whenLoaded resolves and no decode error floats', async () => {
+	const userId = `user-${crypto.randomUUID()}`;
+	const guid = 'plaintext-idb-corrupt-load';
+	const databaseName = `epicenter/${SERVER}/owners/${userId}/${guid}`;
+
+	// 1. Persist a real doc so the store exists with genuine update bytes.
+	const firstDoc = new Y.Doc({ guid, gc: true });
+	const firstIdb = attachLocalStorage(firstDoc, {
+		server: SERVER,
+		ownerId: asOwnerId(userId),
+	});
+	await firstIdb.whenLoaded;
+	firstDoc.getText('body').insert(0, 'real content');
+	await tick();
+	firstDoc.destroy();
+	await firstIdb.whenDisposed;
+
+	// 2. Corrupt what is on disk (simulates a half-written / old-format update).
+	await corruptStoredUpdates(databaseName);
+
+	// 3. Re-attach a fresh doc, as a cold boot would.
+	const secondDoc = new Y.Doc({ guid, gc: true });
+	const secondIdb = attachLocalStorage(secondDoc, {
+		server: SERVER,
+		ownerId: asOwnerId(userId),
+	});
+
+	// Healed behavior (the patch skips the bad update and still emits 'synced'):
+
+	// 4a. whenLoaded must RESOLVE, not hang. Pre-patch it lost this race to the
+	//     timeout because 'synced' never fired after the apply threw.
+	const outcome = await Promise.race([
+		secondIdb.whenLoaded.then(() => 'loaded' as const),
+		tick(250).then(() => 'hung' as const),
+	]);
+	expect(outcome).toBe('loaded');
+
+	// 4b. No decode error must float. Pre-patch one did (the uncatchable rejection).
+	await tick();
+	const floatedDecodeError = rejections.some(
+		(reason) =>
+			reason instanceof Error &&
+			reason.message.includes('Unexpected end of array'),
+	);
+	expect(floatedDecodeError).toBe(false);
+
+	// Best-effort cleanup; the assertions above are what matter.
+	secondDoc.destroy();
+	await wipeLocalStorage({ server: SERVER, ownerId: asOwnerId(userId) });
+});

--- a/packages/workspace/src/document/attach-local-storage-corrupt-load.test.ts
+++ b/packages/workspace/src/document/attach-local-storage-corrupt-load.test.ts
@@ -23,7 +23,7 @@
  * y-indexeddb bump), which is the whole reason to keep it.
  */
 
-import { expect, test } from 'bun:test';
+import { afterAll, beforeAll, expect, test } from 'bun:test';
 import { asOwnerId } from '@epicenter/identity';
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb';
 import * as Y from 'yjs';
@@ -73,11 +73,15 @@ async function corruptStoredUpdates(databaseName: string): Promise<void> {
 
 // Capture any decode rejection that escapes to the process boundary. Pre-patch
 // the load floated an uncatchable one here (the only place it could be seen);
-// post-patch this array must stay empty, which is assertion 4b below.
+// post-patch this array must stay empty, which is assertion 4b below. Scope the
+// listener to this test so it can't swallow another test file's genuine
+// unhandled rejection in the shared bun process.
 const rejections: unknown[] = [];
-process.on('unhandledRejection', (reason) => {
+const collectRejection = (reason: unknown): void => {
 	rejections.push(reason);
-});
+};
+beforeAll(() => process.on('unhandledRejection', collectRejection));
+afterAll(() => process.off('unhandledRejection', collectRejection));
 
 test('a corrupt persisted update is skipped: whenLoaded resolves and no decode error floats', async () => {
 	const userId = `user-${crypto.randomUUID()}`;

--- a/packages/workspace/src/document/attach-local-storage-corrupt-load.test.ts
+++ b/packages/workspace/src/document/attach-local-storage-corrupt-load.test.ts
@@ -71,6 +71,31 @@ async function corruptStoredUpdates(databaseName: string): Promise<void> {
 	}
 }
 
+/** Read every value currently in the `updates` object store. */
+async function readStoredUpdates(databaseName: string): Promise<Uint8Array[]> {
+	const db = await new Promise<IDBDatabase>((resolve, reject) => {
+		const request = indexedDB.open(databaseName);
+		request.onerror = () => reject(request.error);
+		request.onsuccess = () => resolve(request.result);
+	});
+	try {
+		const transaction = db.transaction(['updates'], 'readonly');
+		const store = transaction.objectStore('updates');
+		return await new Promise<Uint8Array[]>((resolve, reject) => {
+			const request = store.getAll();
+			request.onerror = () => reject(request.error);
+			request.onsuccess = () => resolve(request.result as Uint8Array[]);
+		});
+	} finally {
+		db.close();
+	}
+}
+
+/** The corruption marker `corruptStoredUpdates` writes: a lone `0x80` byte. */
+function hasCorruptUpdate(updates: Uint8Array[]): boolean {
+	return updates.some((update) => update.length === 1 && update[0] === 0x80);
+}
+
 // Capture any decode rejection that escapes to the process boundary. Pre-patch
 // the load floated an uncatchable one here (the only place it could be seen);
 // post-patch this array must stay empty, which is assertion 4b below. Scope the
@@ -128,6 +153,20 @@ test('a corrupt persisted update is skipped: whenLoaded resolves and no decode e
 			reason.message.includes('Unexpected end of array'),
 	);
 	expect(floatedDecodeError).toBe(false);
+
+	// 4c. The self-heal compacts the store ONCE after a skip. `storeState(this,
+	//     true)` (triggered after 'synced') snapshots the healed doc and trims the
+	//     old updates, so the undecodable bytes leave disk instead of re-decoding
+	//     and re-logging on every future boot. The compaction is async, so poll
+	//     until it lands; if it never does, this fails instead of hanging.
+	const corruptBytesTrimmed = await (async () => {
+		for (let waited = 0; waited <= 1000; waited += 20) {
+			if (!hasCorruptUpdate(await readStoredUpdates(databaseName))) return true;
+			await tick(20);
+		}
+		return false;
+	})();
+	expect(corruptBytesTrimmed).toBe(true);
 
 	// Best-effort cleanup; the assertions above are what matter.
 	secondDoc.destroy();

--- a/patches/y-indexeddb@9.0.12.patch
+++ b/patches/y-indexeddb@9.0.12.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/y-indexeddb.cjs b/dist/y-indexeddb.cjs
-index f613233258d7be3d3d8fb08506aa7ca09e50a457..03d61a073caff8b321b6021fc22430ddb7936706 100644
+index f613233258d7be3d3d8fb08506aa7ca09e50a457..f86f6d28add33693c9e48b2e7dc3a770238dbc48 100644
 --- a/dist/y-indexeddb.cjs
 +++ b/dist/y-indexeddb.cjs
-@@ -23,7 +23,18 @@ const fetchUpdates = (idbPersistence, beforeApplyUpdatesCallback = () => {}, aft
+@@ -23,7 +23,22 @@ const fetchUpdates = (idbPersistence, beforeApplyUpdatesCallback = () => {}, aft
      if (!idbPersistence._destroyed) {
        beforeApplyUpdatesCallback(updatesStore);
        Y.transact(idbPersistence.doc, () => {
@@ -16,17 +16,51 @@ index f613233258d7be3d3d8fb08506aa7ca09e50a457..03d61a073caff8b321b6021fc22430dd
 +          try {
 +            Y.applyUpdate(idbPersistence.doc, val);
 +          } catch (err) {
++            // Flag the skip so the load path can compact the store once and drop
++            // these undecodable bytes, instead of re-reading and re-logging them
++            // on every future boot.
++            idbPersistence._corruptUpdateSkipped = true;
 +            console.error('y-indexeddb: skipped a corrupt persisted update', err);
 +          }
 +        });
        }, idbPersistence, false);
        afterApplyUpdatesCallback(updatesStore);
      }
+@@ -41,7 +56,10 @@ const storeState = (idbPersistence, forceStore = true) =>
+   fetchUpdates(idbPersistence)
+     .then(updatesStore => {
+       if (forceStore || idbPersistence._dbsize >= PREFERRED_TRIM_SIZE) {
+-        idb.addAutoKey(updatesStore, Y.encodeStateAsUpdate(idbPersistence.doc))
++        // PATCHED (epicenter): return the compaction chain so callers can await
++        // and catch it (the corrupt-skip self-heal below relies on this). The
++        // only other caller ignores the return, so this stays compatible.
++        return idb.addAutoKey(updatesStore, Y.encodeStateAsUpdate(idbPersistence.doc))
+           .then(() => idb.del(updatesStore, idb.createIDBKeyRangeUpperBound(idbPersistence._dbref, true)))
+           .then(() => idb.count(updatesStore).then(cnt => { idbPersistence._dbsize = cnt; }));
+       }
+@@ -93,6 +111,17 @@ class IndexeddbPersistence extends observable.Observable {
+         if (this._destroyed) return this
+         this.synced = true;
+         this.emit('synced', [this]);
++        // PATCHED (epicenter): if this load skipped a corrupt update, compact the
++        // store once so the undecodable bytes are dropped and stop re-logging on
++        // every boot. storeState() re-snapshots the healed doc and trims the old
++        // (corrupt) updates. It runs AFTER 'synced' so it can never wedge the
++        // load, and is fully guarded so a write failure just defers the heal to
++        // the next boot instead of floating a rejection.
++        if (this._corruptUpdateSkipped && !this._destroyed) {
++          Promise.resolve()
++            .then(() => storeState(this, true))
++            .catch(err => console.error('y-indexeddb: corrupt-skip compaction failed', err));
++        }
+       };
+       fetchUpdates(this, beforeApplyUpdatesCallback, afterApplyUpdatesCallback);
+     });
 diff --git a/src/y-indexeddb.js b/src/y-indexeddb.js
-index 07f4fbb6da0b0b0621b5696370aabf230f7293a8..772b67cb0ef6fa49038dba6a0c351c42e0ccafc9 100644
+index 07f4fbb6da0b0b0621b5696370aabf230f7293a8..a833208acd4031483e5a6cca6cf2bf9d79a754cc 100644
 --- a/src/y-indexeddb.js
 +++ b/src/y-indexeddb.js
-@@ -19,7 +19,18 @@ export const fetchUpdates = (idbPersistence, beforeApplyUpdatesCallback = () =>
+@@ -19,7 +19,22 @@ export const fetchUpdates = (idbPersistence, beforeApplyUpdatesCallback = () =>
      if (!idbPersistence._destroyed) {
        beforeApplyUpdatesCallback(updatesStore)
        Y.transact(idbPersistence.doc, () => {
@@ -40,9 +74,43 @@ index 07f4fbb6da0b0b0621b5696370aabf230f7293a8..772b67cb0ef6fa49038dba6a0c351c42
 +          try {
 +            Y.applyUpdate(idbPersistence.doc, val)
 +          } catch (err) {
++            // Flag the skip so the load path can compact the store once and drop
++            // these undecodable bytes, instead of re-reading and re-logging them
++            // on every future boot.
++            idbPersistence._corruptUpdateSkipped = true
 +            console.error('y-indexeddb: skipped a corrupt persisted update', err)
 +          }
 +        })
        }, idbPersistence, false)
        afterApplyUpdatesCallback(updatesStore)
      }
+@@ -37,7 +52,10 @@ export const storeState = (idbPersistence, forceStore = true) =>
+   fetchUpdates(idbPersistence)
+     .then(updatesStore => {
+       if (forceStore || idbPersistence._dbsize >= PREFERRED_TRIM_SIZE) {
+-        idb.addAutoKey(updatesStore, Y.encodeStateAsUpdate(idbPersistence.doc))
++        // PATCHED (epicenter): return the compaction chain so callers can await
++        // and catch it (the corrupt-skip self-heal below relies on this). The
++        // only other caller ignores the return, so this stays compatible.
++        return idb.addAutoKey(updatesStore, Y.encodeStateAsUpdate(idbPersistence.doc))
+           .then(() => idb.del(updatesStore, idb.createIDBKeyRangeUpperBound(idbPersistence._dbref, true)))
+           .then(() => idb.count(updatesStore).then(cnt => { idbPersistence._dbsize = cnt }))
+       }
+@@ -89,6 +107,17 @@ export class IndexeddbPersistence extends Observable {
+         if (this._destroyed) return this
+         this.synced = true
+         this.emit('synced', [this])
++        // PATCHED (epicenter): if this load skipped a corrupt update, compact the
++        // store once so the undecodable bytes are dropped and stop re-logging on
++        // every boot. storeState() re-snapshots the healed doc and trims the old
++        // (corrupt) updates. It runs AFTER 'synced' so it can never wedge the
++        // load, and is fully guarded so a write failure just defers the heal to
++        // the next boot instead of floating a rejection.
++        if (this._corruptUpdateSkipped && !this._destroyed) {
++          Promise.resolve()
++            .then(() => storeState(this, true))
++            .catch(err => console.error('y-indexeddb: corrupt-skip compaction failed', err))
++        }
+       }
+       fetchUpdates(this, beforeApplyUpdatesCallback, afterApplyUpdatesCallback)
+     })

--- a/patches/y-indexeddb@9.0.12.patch
+++ b/patches/y-indexeddb@9.0.12.patch
@@ -1,0 +1,48 @@
+diff --git a/dist/y-indexeddb.cjs b/dist/y-indexeddb.cjs
+index f613233258d7be3d3d8fb08506aa7ca09e50a457..03d61a073caff8b321b6021fc22430ddb7936706 100644
+--- a/dist/y-indexeddb.cjs
++++ b/dist/y-indexeddb.cjs
+@@ -23,7 +23,18 @@ const fetchUpdates = (idbPersistence, beforeApplyUpdatesCallback = () => {}, aft
+     if (!idbPersistence._destroyed) {
+       beforeApplyUpdatesCallback(updatesStore);
+       Y.transact(idbPersistence.doc, () => {
+-        updates.forEach(val => Y.applyUpdate(idbPersistence.doc, val));
++        updates.forEach(val => {
++          // PATCHED (epicenter, patches/y-indexeddb@9.0.12.patch): skip an
++          // undecodable persisted update instead of letting it abort the load.
++          // An uncaught throw here skips the 'synced' emit below, wedging
++          // whenSynced forever, and floats an uncatchable rejection. Peer/server
++          // resync supplies anything the skipped update carried.
++          try {
++            Y.applyUpdate(idbPersistence.doc, val);
++          } catch (err) {
++            console.error('y-indexeddb: skipped a corrupt persisted update', err);
++          }
++        });
+       }, idbPersistence, false);
+       afterApplyUpdatesCallback(updatesStore);
+     }
+diff --git a/src/y-indexeddb.js b/src/y-indexeddb.js
+index 07f4fbb6da0b0b0621b5696370aabf230f7293a8..772b67cb0ef6fa49038dba6a0c351c42e0ccafc9 100644
+--- a/src/y-indexeddb.js
++++ b/src/y-indexeddb.js
+@@ -19,7 +19,18 @@ export const fetchUpdates = (idbPersistence, beforeApplyUpdatesCallback = () =>
+     if (!idbPersistence._destroyed) {
+       beforeApplyUpdatesCallback(updatesStore)
+       Y.transact(idbPersistence.doc, () => {
+-        updates.forEach(val => Y.applyUpdate(idbPersistence.doc, val))
++        updates.forEach(val => {
++          // PATCHED (epicenter, patches/y-indexeddb@9.0.12.patch): skip an
++          // undecodable persisted update instead of letting it abort the load.
++          // An uncaught throw here skips the 'synced' emit below, wedging
++          // whenSynced forever, and floats an uncatchable rejection. Peer/server
++          // resync supplies anything the skipped update carried.
++          try {
++            Y.applyUpdate(idbPersistence.doc, val)
++          } catch (err) {
++            console.error('y-indexeddb: skipped a corrupt persisted update', err)
++          }
++        })
+       }, idbPersistence, false)
+       afterApplyUpdatesCallback(updatesStore)
+     }


### PR DESCRIPTION
## The bug

A single corrupt update in a doc's IndexedDB store hangs the app on boot and throws an uncatchable error. `y-indexeddb` loads persisted state by applying each stored update inside a `getAll().then(...)` callback whose promise is discarded (no `.catch`), and it emits `'synced'` only *after* that apply loop. So one update that fails to decode:

- wedges `whenSynced` / our `whenLoaded` forever (the boot gate never resolves), and
- floats an unhandled `Uncaught (in promise) Error: Unexpected end of array`, whose lib0 singleton stack names only the codec, not the site.

The defect is internal to `y-indexeddb`: a missing `try/catch` around one `Y.applyUpdate`. Its `whenSynced` never rejects, so the failure cannot be observed, let alone caught, from outside.

## The fix

Fix it where the defect lives. `patches/y-indexeddb@9.0.12.patch` wraps the per-update apply in a `try/catch` that skips an undecodable update and lets `'synced'` still fire:

```js
updates.forEach((val) => {
  try {
    Y.applyUpdate(idbPersistence.doc, val);
  } catch (err) {
    console.error('y-indexeddb: skipped a corrupt persisted update', err);
  }
});
```

A skipped update is supplied again by the next server/peer sync, so the doc converges. `attachIndexedDb` goes back to a plain synchronous construct with a breadcrumb comment pointing at the patch. The patch covers both the ESM (`src`) and CJS (`dist`) entry points.

The reason for this shape is:

The bug is a one-line library defect, so the smallest correct fix is a one-line library patch. The app-side alternative would have to re-open IndexedDB, re-read y-indexeddb's private `updates` store, and replay every update into a probe doc on every boot just to detect a failure the library hides: a shadow reimplementation of the loader, coupled to its internal store layout. The patch avoids all of it and keeps `attachIndexedDb` honest.

It also behaves better than clearing the store on corruption: it drops only the single bad update and keeps the rest of the local data, instead of wiping everything and re-syncing from scratch.

## Tradeoffs

- **Forever-fork.** y-indexeddb is effectively frozen upstream, so this patch is owned indefinitely. It is pinned to `9.0.12`; a future bump fails loudly (the patch stops applying) rather than silently reverting.
- **Discoverability.** The heal lives in `patches/`, not in reviewed TypeScript. Mitigated by the breadcrumb comment at the construction site and `attach-local-storage-corrupt-load.test.ts`, kept as the regression gate that goes red the day the patch stops applying.
- **Corrupt bytes linger.** The patch skips the bad update but does not delete it, so it is re-skipped (and re-logged) until y-indexeddb's normal log compaction trims it. Harmless, and it keeps the change minimal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785091751&installation_id=128463665&pr_number=2209&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2209&signature=0110afdc3f39d2ae0e15d77fd4af9b6441722a1aeaf5c2a6ff3374f3d6e0873b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
