### PR TITLE
fix: gate first paint on IndexedDB hydration across local-first apps

### DIFF
--- a/.agents/skills/workspace-app-composition/SKILL.md
+++ b/.agents/skills/workspace-app-composition/SKILL.md
@@ -182,13 +182,15 @@ surface is genuinely empty, so the gate shows nothing half-ready, it just delays
 the paint until the truth is in memory.
 
 One rule decides WHERE the gate goes: **gate at the outermost boundary that can
-reach the readiness promise.** The promise is always `idb.whenLoaded`; the only
-question is when it first exists, which is decided by where the workspace is
-built (NOT by the Shape A/B label, which describes the module-level handle):
+reach the readiness promise.** The promise is the workspace's readiness gate
+(`idb.whenLoaded`, exposed as `whenReady`; matter's is a `once()`-memoized store
+read, `ensureHydrated()`); the only question is when it first exists, which is
+decided by where the workspace is built (NOT by the Shape A/B label, which
+describes the module-level handle):
 
 | Where the workspace is built | Promise first reachable in | Gate with |
 | --- | --- | --- |
-| Eager module singleton (`export const x = open<App>Browser()`, no auth gate): todos, whispering, skills, matter | a route `load` (runs before paint) | `load`: `await x.whenReady` (blank shell, no skeleton) |
+| Eager module singleton (`export const x = open<App>Browser()`, no auth gate): todos, whispering, skills, matter | a route `load` (runs before paint) | `load`: `await x.whenReady` (matter: `ensureHydrated()`); blank shell, no skeleton |
 | Inside the `session`, post-auth (reachable only as `session.current`): fuji, honeycrisp, vocab, opensidian | the signed-in component | `<WorkspaceGate pending={session.current.idb.whenLoaded}>` (visible `<Loading>`) |
 | A Chrome extension entrypoint (no `load` boundary): tab-manager | the component | a nested `{#await idb.whenLoaded}` |
 

--- a/.agents/skills/workspace-app-composition/SKILL.md
+++ b/.agents/skills/workspace-app-composition/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workspace-app-composition
-description: 'How a workspace-backed app under `apps/*` is composed: the isomorphic doc factory (`create<App>`), the environment factories (`open<App>Browser` / `open<App>Extension` / tauri), the `#platform/*` build-time platform DI for multi-platform (Tauri) apps, the `session` singleton, daemon/script placement under per-project `workspaces/<app>/`, and the file layout itself. Use when creating a new app, naming or placing the iso/browser/extension factory, wiring `#platform/*` subpath imports for a Tauri seam, choosing between auth-gated (Shape A) vs module-singleton (Shape B), placing the session singleton, or registering daemon/script bindings.'
+description: 'How a workspace-backed app under `apps/*` is composed: the isomorphic doc factory (`create<App>`), the environment factories (`open<App>Browser` / `open<App>Extension` / tauri), the `#platform/*` build-time platform DI for multi-platform (Tauri) apps, the `session` singleton, daemon/script placement under per-project `workspaces/<app>/`, and the file layout itself. Use when creating a new app, naming or placing the iso/browser/extension factory, wiring `#platform/*` subpath imports for a Tauri seam, choosing between auth-gated (Shape A) vs module-singleton (Shape B), placing the session singleton, registering daemon/script bindings, or gating first paint on IndexedDB hydration (load gate vs WorkspaceGate).'
 metadata:
   author: epicenter
   version: '5.0'
@@ -172,6 +172,60 @@ export const requireHoneycrisp = session.require;
 This is the only home for the singleton. Do not add a `client.ts` or a second
 singleton site.
 
+## Gating Readiness on Hydration
+
+A workspace-backed surface reads empty tables until IndexedDB hydrates from disk,
+so it flashes an empty state ("No recordings yet", "All clear") for a frame
+before the real rows appear. Gate the first paint on `idb.whenLoaded` (exposed as
+`whenReady`). There is no useful partial UI here: the data is either loaded or the
+surface is genuinely empty, so the gate shows nothing half-ready, it just delays
+the paint until the truth is in memory.
+
+One rule decides WHERE the gate goes: **gate at the outermost boundary that can
+reach the readiness promise.** The promise is always `idb.whenLoaded`; the only
+question is when it first exists, which is decided by where the workspace is
+built (NOT by the Shape A/B label, which describes the module-level handle):
+
+| Where the workspace is built | Promise first reachable in | Gate with |
+| --- | --- | --- |
+| Eager module singleton (`export const x = open<App>Browser()`, no auth gate): todos, whispering, skills, matter | a route `load` (runs before paint) | `load`: `await x.whenReady` (blank shell, no skeleton) |
+| Inside the `session`, post-auth (reachable only as `session.current`): fuji, honeycrisp, vocab, opensidian | the signed-in component | `<WorkspaceGate pending={session.current.idb.whenLoaded}>` (visible `<Loading>`) |
+| A Chrome extension entrypoint (no `load` boundary): tab-manager | the component | a nested `{#await idb.whenLoaded}` |
+
+Opensidian and tab-manager export a module-level handle (Shape B) but build the
+workspace inside a `session`, so they component-gate like Shape A. The handle's
+shape does not decide the gate; the workspace's construction site does.
+
+Two riders:
+
+- **Correctness gates always go in `load`.** If resolving the route needs the
+  data (a 404, a redirect, a param lookup), it MUST be a `load`, because only
+  `load` can call `error()` / `redirect()`. Matter's `vault/[id]/+page.ts`
+  resolves an id against the open-vault list, so it gates in `load` even though
+  it also gates the paint.
+- **Blank-vs-Loading is a consequence, not a choice.** A `load` gate holds the
+  blank `app.html` shell until ready (right for fast local IDB, where a spinner
+  would just flash); `WorkspaceGate` shows a `<Loading>` (right when the
+  workspace rides in behind sign-in and the wait is longer). You pick the
+  boundary; the boundary picks the fallback UI.
+
+The load gate is two lines:
+
+```ts
+// apps/whispering/src/routes/(app)/(config)/recordings/+page.ts
+import { whispering } from '#platform/whispering';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async () => {
+	await whispering.whenReady;
+};
+```
+
+`whenReady` must be resolve-only, and it is: `whenLoaded = idb.whenSynced`, and
+the `y-indexeddb` corrupt-load patch makes the loader skip undecodable updates
+and still emit `synced` rather than wedge. A readiness promise that could reject
+or hang would block the paint forever. Do NOT add a timeout; fix the promise.
+
 ## Platform DI: the `#platform/*` seam
 
 Multi-platform apps (the two with `src-tauri/`: fuji, whispering) select
@@ -295,3 +349,7 @@ lifecycle command is `epicenter daemon up`, not `epicenter serve`.
 - Placing `daemon.ts` or `script.ts` inside the app package. They live under a
   project's `workspaces/<app>/` and are registered via `epicenter.config.ts`.
 - Restoring `serve` as the public lifecycle command (it is `epicenter daemon up`).
+- Load-gating a post-auth workspace (its `idb.whenLoaded` does not exist at
+  `load` time), or showing a `<Loading>` skeleton for a fast eager-workspace gate
+  (the spinner just flashes). Gate where the readiness promise is first
+  reachable; see Gating Readiness on Hydration.

--- a/.agents/skills/workspace-app-composition/SKILL.md
+++ b/.agents/skills/workspace-app-composition/SKILL.md
@@ -174,59 +174,30 @@ singleton site.
 
 ## Gating Readiness on Hydration
 
-A workspace-backed surface reads empty tables until IndexedDB hydrates from disk,
-so it flashes an empty state ("No recordings yet", "All clear") for a frame
-before the real rows appear. Gate the first paint on `idb.whenLoaded` (exposed as
-`whenReady`). There is no useful partial UI here: the data is either loaded or the
-surface is genuinely empty, so the gate shows nothing half-ready, it just delays
-the paint until the truth is in memory.
+A workspace-backed route reads empty tables until the workspace's readiness
+promise resolves (`idb.whenLoaded`, exposed as `whenReady`; matter's is the
+`once()`-memoized store read `ensureHydrated()`), so it flashes an empty state
+("No recordings yet", "All clear"). No useful partial UI exists here, so gate
+the first paint rather than skeleton it.
 
-One rule decides WHERE the gate goes: **gate at the outermost boundary that can
-reach the readiness promise.** The promise is the workspace's readiness gate
-(`idb.whenLoaded`, exposed as `whenReady`; matter's is a `once()`-memoized store
-read, `ensureHydrated()`); the only question is when it first exists, which is
-decided by where the workspace is built (NOT by the Shape A/B label, which
-describes the module-level handle):
+One rule: **gate where the readiness promise is first reachable**, decided by
+where the workspace is built (NOT the Shape A/B handle label).
 
-| Where the workspace is built | Promise first reachable in | Gate with |
+| Workspace built | Reachable in | Gate |
 | --- | --- | --- |
-| Eager module singleton (`export const x = open<App>Browser()`, no auth gate): todos, whispering, skills, matter | a route `load` (runs before paint) | `load`: `await x.whenReady` (matter: `ensureHydrated()`); blank shell, no skeleton |
-| Inside the `session`, post-auth (reachable only as `session.current`): fuji, honeycrisp, vocab, opensidian | the signed-in component | `<WorkspaceGate pending={session.current.idb.whenLoaded}>` (visible `<Loading>`) |
-| A Chrome extension entrypoint (no `load` boundary): tab-manager | the component | a nested `{#await idb.whenLoaded}` |
+| Eager module singleton, no auth gate: todos, whispering, skills, matter | a route `load` | `load`: `await x.whenReady` (matter: `ensureHydrated()`) |
+| Post-auth inside a `session` (only `session.current`): fuji, honeycrisp, vocab, opensidian | the signed-in component | `<WorkspaceGate pending={session.current.idb.whenLoaded}>` |
+| Extension entrypoint, no `load`: tab-manager | the component | `{#await idb.whenLoaded}` |
 
-Opensidian and tab-manager export a module-level handle (Shape B) but build the
-workspace inside a `session`, so they component-gate like Shape A. The handle's
-shape does not decide the gate; the workspace's construction site does.
+- Correctness gates (404 / redirect / param) always go in `load`; only `load`
+  can `error()` / `redirect()` (matter `vault/[id]`).
+- The promise must be resolve-only or the gate blocks paint forever
+  (`whenLoaded = idb.whenSynced`, kept resolve-only by the y-indexeddb
+  corrupt-load patch). Fix the promise, never add a timeout.
 
-Two riders:
-
-- **Correctness gates always go in `load`.** If resolving the route needs the
-  data (a 404, a redirect, a param lookup), it MUST be a `load`, because only
-  `load` can call `error()` / `redirect()`. Matter's `vault/[id]/+page.ts`
-  resolves an id against the open-vault list, so it gates in `load` even though
-  it also gates the paint.
-- **Blank-vs-Loading is a consequence, not a choice.** A `load` gate holds the
-  blank `app.html` shell until ready (right for fast local IDB, where a spinner
-  would just flash); `WorkspaceGate` shows a `<Loading>` (right when the
-  workspace rides in behind sign-in and the wait is longer). You pick the
-  boundary; the boundary picks the fallback UI.
-
-The load gate is two lines:
-
-```ts
-// apps/whispering/src/routes/(app)/(config)/recordings/+page.ts
-import { whispering } from '#platform/whispering';
-import type { PageLoad } from './$types';
-
-export const load: PageLoad = async () => {
-	await whispering.whenReady;
-};
-```
-
-`whenReady` must be resolve-only, and it is: `whenLoaded = idb.whenSynced`, and
-the `y-indexeddb` corrupt-load patch makes the loader skip undecodable updates
-and still emit `synced` rather than wedge. A readiness promise that could reject
-or hang would block the paint forever. Do NOT add a timeout; fix the promise.
+The blank-shell (load) vs `<Loading>` (`WorkspaceGate`) difference follows from
+the boundary, not a separate choice. For the `load`-blocks-render rule ground
+against `sveltejs/kit`; for the `{#await}` form see the `svelte` skill.
 
 ## Platform DI: the `#platform/*` seam
 

--- a/apps/skills/src/routes/+layout.ts
+++ b/apps/skills/src/routes/+layout.ts
@@ -1,1 +1,15 @@
+import { skills } from '$lib/skills/client';
+import type { LayoutLoad } from './$types';
+
 export const ssr = false;
+
+/**
+ * Gate the first paint on IndexedDB hydration. `SkillsList` reads an empty table
+ * until `idb.whenLoaded` resolves, so without this the "No skills yet" empty
+ * state flashes before the skills load from disk. SvelteKit blocks the route's
+ * render until this load resolves; `whenReady` is a single promise
+ * (`idb.whenLoaded`), so it resolves once and a reload never re-blocks.
+ */
+export const load: LayoutLoad = async () => {
+	await skills.whenReady;
+};

--- a/apps/todos/src/routes/+layout.ts
+++ b/apps/todos/src/routes/+layout.ts
@@ -1,1 +1,15 @@
+import { todos } from '$lib/todos/client';
+import type { LayoutLoad } from './$types';
+
 export const ssr = false;
+
+/**
+ * Gate the first paint on IndexedDB hydration. `todosState` reads an empty table
+ * until `idb.whenLoaded` resolves, so without this the "All clear" empty state
+ * flashes before the todos load from disk. SvelteKit blocks the route's render
+ * until this load resolves; `whenReady` is a single promise (`idb.whenLoaded`),
+ * so it resolves once and a reload never re-blocks.
+ */
+export const load: LayoutLoad = async () => {
+	await todos.whenReady;
+};

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.ts
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.ts
@@ -1,0 +1,14 @@
+import { whispering } from '#platform/whispering';
+import type { PageLoad } from './$types';
+
+/**
+ * Gate the recordings paint on IndexedDB hydration. The table reads
+ * `fromTable(whispering.tables.recordings)`, which is empty until
+ * `idb.whenLoaded` resolves, so without this gate the "No recordings yet" empty
+ * state flashes before recordings load from disk. SvelteKit blocks the route's
+ * render until this load resolves; `whenReady` is a single promise
+ * (`idb.whenLoaded`), so it resolves once and a later navigation never re-blocks.
+ */
+export const load: PageLoad = async () => {
+	await whispering.whenReady;
+};

--- a/apps/whispering/src/routes/(app)/(config)/transformations/+page.ts
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/+page.ts
@@ -1,0 +1,15 @@
+import { whispering } from '#platform/whispering';
+import type { PageLoad } from './$types';
+
+/**
+ * Gate the transformations paint on IndexedDB hydration. The table reads
+ * `fromTable(whispering.tables.transformations)`, which is empty until
+ * `idb.whenLoaded` resolves, so without this gate the "No transformations yet"
+ * empty state flashes before transformations load from disk. SvelteKit blocks
+ * the route's render until this load resolves; `whenReady` is a single promise
+ * (`idb.whenLoaded`), so it resolves once and a later navigation never re-blocks.
+ * Same gate as the sibling `recordings/+page.ts`.
+ */
+export const load: PageLoad = async () => {
+	await whispering.whenReady;
+};

--- a/packages/skills/src/browser.ts
+++ b/packages/skills/src/browser.ts
@@ -116,6 +116,7 @@ export function openSkillsBrowser() {
 	return {
 		...doc,
 		idb,
+		whenReady: idb.whenLoaded,
 		instructionsDocs,
 		referenceDocs,
 		actions,


### PR DESCRIPTION
Several local-first apps read their workspace tables before IndexedDB has hydrated from disk, so they flash an empty state on every load: todos shows "All clear", recordings shows "No recordings yet", transformations shows "No transformations yet", and skills shows "No skills yet", each for a frame before the real rows appear. There is no useful partial UI here; the data is either loaded or the app is genuinely empty.

Each app exposes `whenReady` (the workspace's `idb.whenLoaded` promise). This adds a single `load` that awaits it per surface, so SvelteKit blocks the route's first paint until disk has loaded, with no skeleton and no `whenReady` flag in the UI. The gate lives at whichever surface owns the data: a layout `load` for todos and skills (the list renders at the root), and a `+page.ts` `load` for the whispering recordings and transformations pages (only those pages render their tables). Skills had the seam but no consumer, so `openSkillsBrowser` now exposes `whenReady: idb.whenLoaded` to match todos and whispering.

These were held back until the y-indexeddb corrupt-load heal (#2209, now merged): before it, a corrupt store could wedge `whenSynced` forever and the gate would block the paint indefinitely. With the patched loader skipping undecodable updates, `whenLoaded` always resolves, so the gate is safe with no timeout.

The repo also had a second, competing idiom for the same problem: the `WorkspaceGate` component (fuji, honeycrisp, vocab, opensidian), which shows a `<Loading>` instead of blocking the paint. That split is not drift; it is forced by where the workspace is built. An eager module-singleton workspace exposes its readiness promise before `load` runs, so it can gate in `load` (blank shell). A workspace built post-auth inside a `session` is reachable only once the signed-in component mounts, so it must gate in the component (`WorkspaceGate`). The `workspace-app-composition` skill now documents the one rule: gate where `idb.whenLoaded` is first reachable, and always gate correctness (404/redirect) in `load`.

## Changelog
- Fixed a brief empty-state flash ("All clear" in todos, "No recordings yet" / "No transformations yet" in whispering, "No skills yet" in skills) that appeared on load before data hydrated from disk.
