### PR TITLE
fix(workspace): skip and heal corrupt SQLite Yjs log rows

### DIFF
--- a/apps/api/scripts/cli-auth-smoke.ts
+++ b/apps/api/scripts/cli-auth-smoke.ts
@@ -26,11 +26,12 @@
 
 import { resolveMachineAuthClient } from '@epicenter/auth/node';
 import { API_ROUTES } from '@epicenter/constants/api-routes';
+import { API_BUN_DEV_PORT } from '@epicenter/constants/apps';
 
 const baseURL = (
 	process.argv[2] ??
 	process.env.BASE_URL ??
-	'http://localhost:8788'
+	`http://localhost:${API_BUN_DEV_PORT}`
 ).replace(/\/+$/, '');
 
 let pass = 0;

--- a/apps/api/scripts/smoke.ts
+++ b/apps/api/scripts/smoke.ts
@@ -29,11 +29,12 @@
  */
 
 import { API_ROUTES } from '@epicenter/constants/api-routes';
+import { API_BUN_DEV_PORT } from '@epicenter/constants/apps';
 
 const BASE_URL = (
 	process.argv[2] ??
 	process.env.BASE_URL ??
-	'http://localhost:8788'
+	`http://localhost:${API_BUN_DEV_PORT}`
 ).replace(/\/+$/, '');
 
 // The dev resolver synthesizes the user from this id; personal-mode ownership

--- a/apps/api/server.ts
+++ b/apps/api/server.ts
@@ -31,6 +31,7 @@
  * serves the dashboard in dev, and billing is the hosted Worker's concern.
  */
 
+import { API_BUN_DEV_PORT } from '@epicenter/constants/apps';
 import {
 	BunHostBindings,
 	mountBlobsApp,
@@ -71,7 +72,7 @@ export function startBunApiServer(
 	// blob store; everything else is the shared Bun bootstrap.
 	const { origin, dataDir } = startBunServer({
 		env,
-		defaultPort: 8788,
+		defaultPort: API_BUN_DEV_PORT,
 		mode: 'hub',
 		ownership: personal(),
 		resolveTrustedOrigins: buildEpicenterTrustedOrigins,

--- a/packages/constants/src/apps.ts
+++ b/packages/constants/src/apps.ts
@@ -42,6 +42,17 @@ export const APPS = {
 export type AppId = keyof typeof APPS;
 
 /**
+ * Dev listen port for the apps/api Bun runtime (`apps/api/server.ts`,
+ * ADR-0066): the off-Cloudflare twin of the wrangler dev server on
+ * {@link APPS.API.port} (8787). The two are deliberately one apart so the
+ * runtime-parity smoke can run both backends at once (`apps/api/scripts/smoke.ts`
+ * targets :8788 and :8787). An operator overrides it with `PORT`; this is only
+ * the unset-`PORT` default. It is not an app origin (never a CORS or OAuth
+ * target), so it lives beside {@link APPS} rather than as a field inside it.
+ */
+export const API_BUN_DEV_PORT = 8788;
+
+/**
  * Local dev URL for an app, derived from its `port`. Single owner for the
  * `http://localhost:<port>` shape: the dev-server origin override, the OAuth
  * seed's local target, the Vite dev build, and the CSRF test all read this.

--- a/packages/workspace/src/document/attach-yjs-log-reader.test.ts
+++ b/packages/workspace/src/document/attach-yjs-log-reader.test.ts
@@ -129,4 +129,34 @@ describe('attachYjsLogReader', () => {
 
 		readerDoc.destroy();
 	});
+
+	test('a corrupt row is skipped instead of throwing the reader hydrate', async () => {
+		const filePath = join(workdir, 'corrupt-reader.sqlite');
+
+		const writerDoc = new Y.Doc();
+		const writer = attachYjsLog(writerDoc, { filePath });
+		writerDoc.getMap<number>('m').set('k', 7);
+		writerDoc.destroy();
+		await writer.whenDisposed;
+
+		// Append a corrupt row (lone 0x80 = unterminated varint) the read-only
+		// reader must tolerate. Pre-fix, replaying it threw and aborted the
+		// synchronous hydrate.
+		const rw = new Database(filePath);
+		rw.query('INSERT INTO updates (data) VALUES (?)').run(
+			new Uint8Array([0x80]),
+		);
+		rw.close();
+
+		const readerDoc = new Y.Doc();
+		const reader = attachYjsLogReader(readerDoc, { filePath });
+		expect(reader.fileExisted).toBe(true);
+		expect(readerDoc.getMap<number>('m').get('k')).toBe(7);
+
+		// Read-only: the reader skips but must NOT compact the bad row away;
+		// the writer owns healing the file on its next open.
+		expect(countRows(filePath)).toBe(2);
+
+		readerDoc.destroy();
+	});
 });

--- a/packages/workspace/src/document/attach-yjs-log-reader.ts
+++ b/packages/workspace/src/document/attach-yjs-log-reader.ts
@@ -22,6 +22,7 @@
 
 import { Database } from 'bun:sqlite';
 import { existsSync } from 'node:fs';
+import { createLogger, type Logger } from 'wellcrafted/logger';
 import * as Y from 'yjs';
 
 /**
@@ -29,7 +30,7 @@ import * as Y from 'yjs';
  * the Y.Doc. Returns the open db handle so the caller can close it on
  * destroy. File-doesn't-exist is the cold path: caller short-circuits.
  */
-function openAndReplay(filePath: string, ydoc: Y.Doc): Database {
+function openAndReplay(filePath: string, ydoc: Y.Doc, log: Logger): Database {
 	const db = new Database(filePath, { readonly: true });
 	// File is owned by the writer. No CREATE TABLE, no journal_mode pragma
 	// (the writer set WAL), no updateV2 listener, no compaction: pure
@@ -42,17 +43,34 @@ function openAndReplay(filePath: string, ydoc: Y.Doc): Database {
 		data: Uint8Array;
 	}[];
 	for (const row of rows) {
-		Y.applyUpdateV2(ydoc, row.data);
+		// Match the writer's replay guard: a corrupt BLOB makes applyUpdateV2
+		// throw, which would otherwise abort this synchronous hydrate. Skip it
+		// and log; the reader is read-only, so it cannot compact the bad row
+		// away, but the writer heals the file on its next open and resync fills
+		// the gap.
+		try {
+			Y.applyUpdateV2(ydoc, row.data);
+		} catch (cause) {
+			log.error(
+				new Error(
+					'Skipped a corrupt update row during replay; resync supplies it',
+					{ cause },
+				),
+			);
+		}
 	}
 	return db;
 }
 
 export function attachYjsLogReader(
 	ydoc: Y.Doc,
-	{ filePath }: { filePath: string },
+	{
+		filePath,
+		log = createLogger('workspace/attach-yjs-log-reader'),
+	}: { filePath: string; log?: Logger },
 ) {
 	const fileExisted = existsSync(filePath);
-	const db = fileExisted ? openAndReplay(filePath, ydoc) : undefined;
+	const db = fileExisted ? openAndReplay(filePath, ydoc, log) : undefined;
 
 	ydoc.once('destroy', () => {
 		db?.close();

--- a/packages/workspace/src/document/attach-yjs-log.test.ts
+++ b/packages/workspace/src/document/attach-yjs-log.test.ts
@@ -50,6 +50,41 @@ function countRows(filePath: string): number {
 	}
 }
 
+// A lone 0x80 byte is an unterminated varint: the first readVarUint in
+// applyUpdateV2 overruns the buffer, the same decode failure a half-written
+// row produces.
+const CORRUPT_BYTES = new Uint8Array([0x80]);
+
+function appendCorruptRow(filePath: string): void {
+	const db = new Database(filePath);
+	try {
+		db.query('INSERT INTO updates (data) VALUES (?)').run(CORRUPT_BYTES);
+	} finally {
+		db.close();
+	}
+}
+
+function corruptEveryRow(filePath: string): void {
+	const db = new Database(filePath);
+	try {
+		db.query('UPDATE updates SET data = ?').run(CORRUPT_BYTES);
+	} finally {
+		db.close();
+	}
+}
+
+function firstRowData(filePath: string): Uint8Array {
+	const db = new Database(filePath, { readonly: true });
+	try {
+		const row = db
+			.query('SELECT data FROM updates ORDER BY id LIMIT 1')
+			.get() as { data: Uint8Array };
+		return row.data;
+	} finally {
+		db.close();
+	}
+}
+
 describe('attachYjsLog', () => {
 	test('writer enables WAL journal mode on the file', async () => {
 		const filePath = join(workdir, 'wal.sqlite');
@@ -104,6 +139,67 @@ describe('attachYjsLog', () => {
 		expect(reopenDoc.getMap<number>('m').get('k4')).toBe(4);
 		reopenDoc.destroy();
 		await reopen.whenDisposed;
+	});
+
+	test('a corrupt row among good rows is skipped, data survives, and the log heals', async () => {
+		const filePath = join(workdir, 'corrupt-among-good.sqlite');
+
+		// Seed one clean compacted row with real content.
+		const writerDoc = new Y.Doc();
+		const writer = attachYjsLog(writerDoc, { filePath });
+		writerDoc.getMap<number>('m').set('k', 42);
+		writerDoc.destroy();
+		await writer.whenDisposed;
+
+		// Append a corrupt row after it. Pre-fix, replaying this row threw and
+		// aborted construction (the daemon could not open the mount at all).
+		appendCorruptRow(filePath);
+		expect(countRows(filePath)).toBe(2);
+
+		// Cold reopen must NOT throw, and the good row's data must survive.
+		const reopenDoc = new Y.Doc();
+		const reopen = attachYjsLog(reopenDoc, { filePath });
+		expect(reopenDoc.getMap<number>('m').get('k')).toBe(42);
+		reopenDoc.destroy();
+		await reopen.whenDisposed;
+
+		// The skip triggered a compaction that dropped the corrupt row, so the
+		// log is one clean snapshot and a third open is silent and correct.
+		expect(countRows(filePath)).toBe(1);
+		const thirdDoc = new Y.Doc();
+		const third = attachYjsLog(thirdDoc, { filePath });
+		expect(thirdDoc.getMap<number>('m').get('k')).toBe(42);
+		thirdDoc.destroy();
+		await third.whenDisposed;
+	});
+
+	test('a lone corrupt row is skipped and force-compacted into a clean snapshot', async () => {
+		const filePath = join(workdir, 'lone-corrupt.sqlite');
+
+		// Seed one clean row, then corrupt it so the whole log is undecodable.
+		const writerDoc = new Y.Doc();
+		const writer = attachYjsLog(writerDoc, { filePath });
+		writerDoc.getMap<number>('m').set('k', 1);
+		writerDoc.destroy();
+		await writer.whenDisposed;
+		corruptEveryRow(filePath);
+		expect(countRows(filePath)).toBe(1);
+
+		// Reopen: the single row is corrupt, so the doc hydrates empty. Without
+		// the force flag the destroy-time compaction would no-op at <= 1 row and
+		// leave the bad bytes; the skip-triggered force compaction must replace
+		// them with a decodable empty-doc snapshot.
+		const reopenDoc = new Y.Doc();
+		const reopen = attachYjsLog(reopenDoc, { filePath });
+		expect(reopenDoc.getMap<number>('m').size).toBe(0);
+		reopenDoc.destroy();
+		await reopen.whenDisposed;
+
+		// The lone row is now a decodable snapshot, not the corrupt bytes.
+		expect(countRows(filePath)).toBe(1);
+		expect(() =>
+			Y.applyUpdateV2(new Y.Doc(), firstRowData(filePath)),
+		).not.toThrow();
 	});
 
 	test('clearLocal drops all updates from the file', async () => {

--- a/packages/workspace/src/document/attach-yjs-log.ts
+++ b/packages/workspace/src/document/attach-yjs-log.ts
@@ -82,14 +82,22 @@ export function attachYjsLog(
 	 * Compact the SQLite update log into a single row.
 	 *
 	 * Encodes the current doc state via `Y.encodeStateAsUpdateV2`, which
-	 * produces smaller output than merging individual updates. No-ops if
-	 * the log already has <= 1 row or the compacted blob exceeds 2 MB.
+	 * produces smaller output than merging individual updates. No-ops if the
+	 * compacted blob exceeds 2 MB, or if the log already has <= 1 row (unless
+	 * `force` is set).
 	 *
+	 * @param force - Compact even at <= 1 row. The corrupt-row heal sets this
+	 *   so a lone undecodable row is replaced, not left to re-throw on every
+	 *   future open.
 	 * @returns `true` if compaction ran, `false` if it no-oped.
 	 */
-	function compactUpdateLog(): boolean {
+	function compactUpdateLog({
+		force = false,
+	}: {
+		force?: boolean;
+	} = {}): boolean {
 		const row = countUpdates.get() as { count: number };
-		if (row.count <= 1) return false;
+		if (!force && row.count <= 1) return false;
 
 		const compacted = Y.encodeStateAsUpdateV2(ydoc);
 		if (compacted.byteLength > MAX_COMPACTED_BYTES) return false;
@@ -103,11 +111,32 @@ export function attachYjsLog(
 	const rows = selectUpdates.all() as {
 		data: Uint8Array;
 	}[];
+	let corruptRowsSkipped = 0;
 	for (const row of rows) {
-		Y.applyUpdateV2(ydoc, row.data);
+		// A corrupt BLOB (a half-written or truncated row) makes
+		// Y.applyUpdateV2 throw mid-replay. Unguarded, that aborts construction
+		// and the daemon cannot open the mount at all. Skip the bad row: the
+		// doc still hydrates from the good rows, and cloud resync supplies
+		// whatever the skipped row carried (same contract as the y-indexeddb
+		// load patch on the browser side).
+		try {
+			Y.applyUpdateV2(ydoc, row.data);
+		} catch (cause) {
+			corruptRowsSkipped++;
+			log.error(
+				new Error(
+					'Skipped a corrupt update row during replay; resync supplies it',
+					{ cause },
+				),
+			);
+		}
 	}
 
-	compactUpdateLog();
+	// A skipped row stays on disk and would re-throw on every future open.
+	// Compaction rewrites the whole log as one clean snapshot of the hydrated
+	// doc, dropping the bad rows; force it past the usual <= 1-row no-op so a
+	// lone corrupt row cannot linger.
+	compactUpdateLog({ force: corruptRowsSkipped > 0 });
 
 	let bytesSinceCompaction = 0;
 


### PR DESCRIPTION
Closes the SQLite twin of the y-indexeddb corrupt-load bug (#2209), plus a small constants tidy bundled as a second commit.

## 1. Skip corrupt rows when replaying the SQLite Yjs log

`attachYjsLog` replays every persisted `updateV2` row into the `Y.Doc` on construction via a bare synchronous loop. A single corrupt BLOB (a half-written or truncated row) makes `Y.applyUpdateV2` throw mid-replay, which aborts construction. For a mount's root doc that surfaces as `WorkspaceAppError.MountOpenFailed` and the daemon cannot start at all, so every app mount goes dark on one bad row. This is the daemon-side analog of the browser `whenLoaded` hang the y-indexeddb patch fixed, with a worse failure mode.

The fix mirrors that contract:
- Guard the per-row apply: skip the bad row and log it (`log.error`), so the doc still hydrates from the good rows and cloud resync supplies whatever the skipped row carried.
- A skipped row would otherwise re-throw on every future open, so force a compaction afterward (past the usual `<=1`-row no-op) to rewrite the log as one clean snapshot and drop the corrupt bytes.
- Apply the same skip guard to the read-only twin `attachYjsLogReader`. It cannot compact (read-only), so it skips and logs only; the writer heals the file on its next open. A logger is injected to match the writer.

Regression tests cover: a corrupt row among good rows (data survives, log heals), a lone corrupt row (force-compacted into a decodable snapshot), and the reader skipping without throwing while leaving the file untouched.

## 2. Centralize the apps/api Bun dev port in the constants SSOT

The Bun runtime's default listen port (`8788`) was hardcoded in `apps/api/server.ts` and duplicated in two smoke scripts, while its wrangler-dev sibling (`8787`) already lives in the constants SSOT as `APPS.API.port`. Give `8788` the same home: a named `API_BUN_DEV_PORT` constant beside `APPS`, documenting that the two ports are deliberately one apart so the runtime-parity smoke can run both backends at once. It is a listen port, not an app origin, so it stays a sibling constant rather than a field on `APPS`.

Follow-up not included: `apps/self-host/server.ts` has the same hardcoded-port shape (`8787`), but it is a separate deployable whose port numerically collides with the wrangler port and deserves its own consideration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785134693&installation_id=128463665&pr_number=2216&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2216&signature=6751dd8de79e027927036491bd5cde8e6da4cb86ab6904bb6c188f57d60259ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->