### PR TITLE
refactor: tidy three loose threads from the recent merge train

### DIFF
--- a/apps/api/worker/index.ts
+++ b/apps/api/worker/index.ts
@@ -19,6 +19,7 @@ import {
 	cloudflare,
 	createServerApp,
 	mountBlobsApp,
+	mountHealth,
 	mountInferenceApp,
 	mountRoomsApp,
 	mountSessionApp,
@@ -76,9 +77,7 @@ const app = createServerApp({
 });
 
 // Public health endpoint at root.
-app.get('/', (c) =>
-	c.json({ mode: 'hub', version: '0.1.0', runtime: 'cloudflare' }),
-);
+mountHealth(app, { mode: 'hub', runtime: 'cloudflare' });
 
 // Auth surface (HTML pages + OAuth metadata; no /api prefix by design,
 // no deployment knobs).

--- a/apps/self-host/server.ts
+++ b/apps/self-host/server.ts
@@ -43,6 +43,7 @@ import {
 	startBunServer,
 } from '@epicenter/server/bun';
 import { type } from 'arktype';
+import { resolveSelfHostTrustedOrigins } from './trusted-origins.js';
 
 /**
  * Boot the apps/self-host Bun server, optionally with an injected user resolver.
@@ -99,10 +100,7 @@ export function startSelfHostServer(
 		ownership: shared({
 			admit: (c) => allowedMembers.has(c.var.user.email),
 		}),
-		resolveTrustedOrigins: (baseURL) => [
-			new URL(baseURL).origin,
-			'tauri://localhost',
-		],
+		resolveTrustedOrigins: resolveSelfHostTrustedOrigins,
 		// Undefined in production; `server.dev.ts` passes a dev bearer resolver.
 		resolveUser: opts.resolveUser,
 	});

--- a/apps/self-host/trusted-origins.ts
+++ b/apps/self-host/trusted-origins.ts
@@ -1,0 +1,16 @@
+/**
+ * The self-host shared-wiki trust policy, shared by both runtime entries
+ * (`server.ts` on Bun, `worker/index.ts` on Cloudflare) so the two cannot drift.
+ *
+ * `@epicenter/server` deliberately requires each deployable to declare its own
+ * `resolveTrustedOrigins` rather than defaulting one: the set gates CORS, Better
+ * Auth CSRF, and its `callbackURL` / `redirectTo` open-redirect allowlist, so
+ * implicit trust is a security hole. A self-host trusts its OWN origin and the
+ * Tauri desktop client, never Epicenter cloud's domains.
+ *
+ * Add any browser app origins you serve here (and the Epicenter browser-extension
+ * origin, if your users point it at this deployment).
+ */
+export function resolveSelfHostTrustedOrigins(baseURL: string): string[] {
+	return [new URL(baseURL).origin, 'tauri://localhost'];
+}

--- a/apps/self-host/worker/index.ts
+++ b/apps/self-host/worker/index.ts
@@ -20,6 +20,7 @@ import {
 	authApp,
 	cloudflare,
 	createServerApp,
+	mountHealth,
 	mountInferenceApp,
 	mountRoomsApp,
 	mountSessionApp,
@@ -70,9 +71,7 @@ const app = createServerApp({
 	},
 });
 
-app.get('/', (c) =>
-	c.json({ mode: 'shared', version: '0.1.0', runtime: 'cloudflare' }),
-);
+mountHealth(app, { mode: 'shared', runtime: 'cloudflare' });
 
 app.route('/', authApp);
 

--- a/apps/self-host/worker/index.ts
+++ b/apps/self-host/worker/index.ts
@@ -27,6 +27,7 @@ import {
 	requireBearerUser,
 	shared,
 } from '@epicenter/server';
+import { resolveSelfHostTrustedOrigins } from '../trusted-origins.js';
 
 const ownership = shared({
 	admit: (c) => {
@@ -63,14 +64,7 @@ const app = createServerApp({
 		// operator config, not a binding `ServerBindings` names, so it is read off
 		// this deployment's own `Cloudflare.Env` at the honest edge (ADR-0066).
 		resolveOrigin: (env) => (env as Cloudflare.Env).API_PUBLIC_ORIGIN,
-		// A self-host trusts its OWN origin and the Tauri desktop client, never
-		// Epicenter cloud's. Add any browser app origins you serve (and the
-		// Epicenter browser-extension origin, if your users point it at this
-		// deployment) here.
-		resolveTrustedOrigins: (baseURL) => [
-			new URL(baseURL).origin,
-			'tauri://localhost',
-		],
+		resolveTrustedOrigins: resolveSelfHostTrustedOrigins,
 		// No cookieDomain: a single-origin deployment uses host-only cookies
 		// scoped to its own host.
 	},

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -58,6 +58,7 @@ export { Room } from './room/backends/cloudflare/durable-object.js';
 // has no deployment knobs.
 export { authApp } from './routes/auth.js';
 export { mountBlobsApp } from './routes/blobs.js';
+export { mountHealth } from './routes/health.js';
 export { mountInferenceApp } from './routes/inference.js';
 export { mountRoomsApp } from './routes/rooms.js';
 export { mountSessionApp } from './routes/session.js';

--- a/packages/server/src/routes/health.ts
+++ b/packages/server/src/routes/health.ts
@@ -1,0 +1,25 @@
+import { Hono } from 'hono';
+import packageJson from '../../package.json' with { type: 'json' };
+import type { Env } from '../types.js';
+
+/**
+ * The version every deployable's health probe reports: the `@epicenter/server`
+ * runtime version they all embed, read from this package's own `package.json`
+ * so the three entries cannot drift from it or from the real published version.
+ * Hardcoding it in each entry let it rot (every copy read `0.1.0` while no
+ * package was at `0.1.0`); deriving it keeps the probe honest for free.
+ */
+const SERVER_VERSION = packageJson.version;
+
+/**
+ * Mount the public health probe at `GET /`, returning the deployable's identity:
+ * its ownership `mode` (`hub` | `shared`), the shared runtime `version`, and the
+ * `runtime` that serves it. One home for the probe's shape, shared by the Bun
+ * and Cloudflare entries so they cannot disagree.
+ */
+export function mountHealth(
+	app: Hono<Env>,
+	{ mode, runtime }: { mode: string; runtime: 'bun' | 'cloudflare' },
+): void {
+	app.get('/', (c) => c.json({ mode, version: SERVER_VERSION, runtime }));
+}

--- a/packages/server/src/start-bun-server.ts
+++ b/packages/server/src/start-bun-server.ts
@@ -30,6 +30,7 @@ import { requireBearerUser } from './middleware/require-auth.js';
 import type { OwnershipRule } from './ownership.js';
 import { createBunRooms } from './room/backends/bun/registry.js';
 import { authApp } from './routes/auth.js';
+import { mountHealth } from './routes/health.js';
 import { mountInferenceApp } from './routes/inference.js';
 import { mountRoomsApp } from './routes/rooms.js';
 import { mountSessionApp } from './routes/session.js';
@@ -131,7 +132,7 @@ export function startBunServer({
 		resolveUser,
 	});
 
-	app.get('/', (c) => c.json({ mode, version: '0.1.0', runtime: 'bun' }));
+	mountHealth(app, { mode, runtime: 'bun' });
 	app.route('/', authApp);
 	mountSessionApp(app, { ownership });
 	mountRoomsApp(app, { ownership });

--- a/packages/workspace/src/document/attach-yjs-log.test.ts
+++ b/packages/workspace/src/document/attach-yjs-log.test.ts
@@ -201,21 +201,4 @@ describe('attachYjsLog', () => {
 			Y.applyUpdateV2(new Y.Doc(), firstRowData(filePath)),
 		).not.toThrow();
 	});
-
-	test('clearLocal drops all updates from the file', async () => {
-		const filePath = join(workdir, 'clear.sqlite');
-		const writerDoc = new Y.Doc();
-		const writer = attachYjsLog(writerDoc, { filePath });
-		writerDoc.getMap<number>('m').set('k', 1);
-		writer.clearLocal();
-		writerDoc.destroy();
-		await writer.whenDisposed;
-
-		// Reopening should see no rehydrated state.
-		const reopenDoc = new Y.Doc();
-		const reopen = attachYjsLog(reopenDoc, { filePath });
-		expect(reopenDoc.getMap<number>('m').size).toBe(0);
-		reopenDoc.destroy();
-		await reopen.whenDisposed;
-	});
 });

--- a/packages/workspace/src/document/attach-yjs-log.ts
+++ b/packages/workspace/src/document/attach-yjs-log.ts
@@ -190,10 +190,6 @@ export function attachYjsLog(
 	});
 
 	return {
-		/** `DELETE FROM updates`. Drops the durable log without destroying the Y.Doc. */
-		clearLocal: () => {
-			deleteUpdates.run();
-		},
 		/** Resolves after final compaction runs and the SQLite handle closes. */
 		whenDisposed,
 	};


### PR DESCRIPTION
A small follow-up sweep over the code that landed in the last few days (#2192-#2216). A relentless collapse pass over those merges mostly confirmed they were clean: the big targets were already collapsed (#2208 folded the whispering providers onto one wire, #2195 unified chat, #2201 unified instance auth), and the apparent duplication that remained was either honest divergence or stale scope. Three real threads survived. None is a band-aid; each gives something one home it lacked.

## Drop a dead method

`attachYjsLog` exposed a `clearLocal()` that ran `DELETE FROM updates`, but no production code called it: its only caller was its own test. The compaction path keeps the `deleteUpdates` statement alive, so the method goes with no behavior lost. The IndexedDB attachment keeps its own (live) `clearLocal`; only the SQLite-log writer's unused twin is removed.

## Give the self-host trust policy one home

The self-host trusted-origin policy (`own origin + tauri://localhost`) was inlined identically in both runtime entries, `server.ts` (Bun) and `worker/index.ts` (Cloudflare). The copies had already drifted: only the Worker copy carried the comment explaining the policy and inviting operators to add origins. This is a security-relevant, operator-facing knob (it gates CSRF and Better Auth's open-redirect allowlist), so it earns a single documented home. `@epicenter/server` deliberately refuses to default `resolveTrustedOrigins`, so the shared piece stays inside the deployable, mirroring how `apps/api` already keeps its own trusted-origins module. The Worker entry stays the lean reference its `AGENTS.md` asks for.

## Make the health probe stop lying about its version

The public health probe (`GET /`) returned `{ mode, version, runtime }` from three hand-copied call sites, each hardcoding `version: '0.1.0'`. No package was ever at `0.1.0` (the server is `0.1.1`, the apps `0.0.2`), so every probe reported a version matching nothing, and the shape was duplicated three ways.

One `mountHealth` in `@epicenter/server` now owns the response shape and reads the version from the package's own `package.json` (the shared runtime all three embed), matching the import-attribute pattern already used in `packages/cli`:

```ts
// apps/api/worker/index.ts
mountHealth(app, { mode: 'hub', runtime: 'cloudflare' });
// -> { mode: 'hub', version: '0.1.1', runtime: 'cloudflare' }
```

The probe is honest for free and cannot drift again.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785139435&installation_id=128463665&pr_number=2217&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2217&signature=251415545644460112a8279a75b58b5edbe3d5c32437cb23f99cca96ac13c1bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->