### PR TITLE
fix(whispering): auto-provision a stable dev codesigning identity

### DIFF
--- a/apps/whispering/scripts/dev-doctor.ts
+++ b/apps/whispering/scripts/dev-doctor.ts
@@ -67,10 +67,13 @@ const identifierMatches = identifierLine === expectedIdentifier;
 console.log('\nverdict:');
 if (isAdhoc) {
 	console.log(
-		'  ✗ ad-hoc signature — the grant will NOT survive rebuilds. Install a',
+		'  ✗ ad-hoc signature — the grant will NOT survive rebuilds. The runner',
 	);
 	console.log(
-		'    codesigning cert or set WHISPERING_DEV_SIGNING_IDENTITY, then rebuild.',
+		'    normally mints a self-signed cert instead; re-run `bun run dev:local`',
+	);
+	console.log(
+		'    (or set WHISPERING_DEV_SIGNING_IDENTITY) and rebuild.',
 	);
 } else if (!identifierMatches) {
 	console.log(
@@ -91,10 +94,11 @@ console.log(
 );
 
 console.log(
-	'\nreset the dev grant (after the app has launched at least once):',
+	'\nreset the dev grants (after the app has launched at least once):',
 );
+console.log(`  tccutil reset Microphone ${expectedIdentifier}`);
 console.log(`  tccutil reset Accessibility ${expectedIdentifier}`);
-console.log('  then relaunch dev and grant the new Accessibility entry.');
+console.log('  then relaunch dev and grant the new Microphone/Accessibility entries.');
 
 console.log('\nlive trust / capability / listener health:');
 console.log(

--- a/apps/whispering/scripts/dev-doctor.ts
+++ b/apps/whispering/scripts/dev-doctor.ts
@@ -72,9 +72,7 @@ if (isAdhoc) {
 	console.log(
 		'    normally mints a self-signed cert instead; re-run `bun run dev:local`',
 	);
-	console.log(
-		'    (or set WHISPERING_DEV_SIGNING_IDENTITY) and rebuild.',
-	);
+	console.log('    (or set WHISPERING_DEV_SIGNING_IDENTITY) and rebuild.');
 } else if (!identifierMatches) {
 	console.log(
 		`  ✗ signed identifier is "${identifierLine}", expected "${expectedIdentifier}".`,
@@ -98,7 +96,9 @@ console.log(
 );
 console.log(`  tccutil reset Microphone ${expectedIdentifier}`);
 console.log(`  tccutil reset Accessibility ${expectedIdentifier}`);
-console.log('  then relaunch dev and grant the new Microphone/Accessibility entries.');
+console.log(
+	'  then relaunch dev and grant the new Microphone/Accessibility entries.',
+);
 
 console.log('\nlive trust / capability / listener health:');
 console.log(

--- a/apps/whispering/src-tauri/scripts/README.md
+++ b/apps/whispering/src-tauri/scripts/README.md
@@ -26,9 +26,13 @@ binary with a stable cert and the fixed identifier `so.epicenter.whispering.dev`
 then `exec`s it. The resulting designated requirement depends only on the
 identifier and the certificate, never the cdhash, so the grant survives rebuilds.
 
-The signing cert defaults to the first Developer ID or Apple Development identity
-on the machine. Override it with `WHISPERING_DEV_SIGNING_IDENTITY`. With no cert
-the runner falls back to ad-hoc and warns that the grant will not persist.
+The signing cert is chosen in three tiers: an explicit
+`WHISPERING_DEV_SIGNING_IDENTITY` override, else the first Developer ID or Apple
+Development identity on the machine, else a persistent self-signed code-signing
+cert the runner mints once (`Whispering Dev Local Codesign`) and reuses. Every
+tier is a stable signature, so there is no ad-hoc fallback to break the grant:
+even with no Apple account and no setup, the first `bun run dev` provisions the
+self-signed cert and asks once (a keychain prompt) to let `codesign` use it.
 
 ## Granting and resetting
 

--- a/apps/whispering/src-tauri/scripts/dev-codesign-runner.sh
+++ b/apps/whispering/src-tauri/scripts/dev-codesign-runner.sh
@@ -19,11 +19,14 @@
 # requirement across relinks, so the TCC grant sticks), then `exec`s the binary
 # so Tauri's monitored PID is the app itself.
 #
-# The signing identity is the only stable code-signing cert on the machine; a
-# DISTINCT identifier (so.epicenter.whispering.dev, not the production
-# so.epicenter.whispering) keeps dev and production as separate TCC entries, so
-# granting one never touches the other. Override the cert with
-# WHISPERING_DEV_SIGNING_IDENTITY if you have a dedicated one.
+# Any STABLE code-signing cert works: a DISTINCT identifier
+# (so.epicenter.whispering.dev, not the production so.epicenter.whispering) keeps
+# dev and production as separate TCC entries, so granting one never touches the
+# other. If the machine has no real cert, the runner mints a persistent
+# self-signed one (see provision_self_signed_identity) rather than falling back
+# to ad-hoc, whose cdhash identity changes every relink and breaks the grant.
+# Override the cert with WHISPERING_DEV_SIGNING_IDENTITY if you have a dedicated
+# one.
 #
 # This runner is wired in only on macOS (see scripts/launch-dev.ts); other
 # platforms run plain `tauri dev`.
@@ -76,19 +79,90 @@ while [ "$index" -lt "${#cargo_flags[@]}" ]; do
 done
 binary="$target_dir/${triple:+$triple/}$profile/whispering"
 
-# Pick the signing identity: an explicit override, else the first real cert
-# (Developer ID or Apple Development). A stable cert is what makes the grant
-# survive rebuilds; ad-hoc ("-") cannot, so say so loudly rather than pretend.
+# A self-signed code-signing cert minted once and reused forever. The common
+# name doubles as the codesign identity string and as the lookup key for "did we
+# already mint it". Distinct from the bundle identifier: this names the signer,
+# DEV_IDENTIFIER names the signed app.
+readonly SELF_SIGNED_CN="Whispering Dev Local Codesign"
+
+# Mint (or reuse) a persistent self-signed code-signing identity in the login
+# keychain and echo its name. A self-signed cert gives the binary a STABLE
+# designated requirement across relinks (unlike ad-hoc), so the TCC grant
+# sticks, with no Apple account and no manual setup. Idempotent: the first run
+# mints, every later run reuses.
+provision_self_signed_identity() {
+	if security find-certificate -c "$SELF_SIGNED_CN" >/dev/null 2>&1; then
+		printf '%s' "$SELF_SIGNED_CN"
+		return 0
+	fi
+
+	echo "dev-codesign-runner: no stable cert found; minting a self-signed one (\"$SELF_SIGNED_CN\")." >&2
+	echo "dev-codesign-runner: macOS will ask once to let codesign use the key. Click \"Always Allow\"." >&2
+
+	local workdir key crt p12 login_kc import_err
+	workdir="$(mktemp -d)"
+	key="$workdir/key.pem"
+	crt="$workdir/cert.pem"
+	p12="$workdir/cert.p12"
+	login_kc="$HOME/Library/Keychains/login.keychain-db"
+
+	# A 10-year self-signed cert carrying the codeSigning extended key usage:
+	# the one property codesign requires of an identity.
+	openssl req -x509 -newkey rsa:2048 -nodes \
+		-keyout "$key" -out "$crt" -days 3650 \
+		-subj "/CN=$SELF_SIGNED_CN" \
+		-addext "basicConstraints=critical,CA:FALSE" \
+		-addext "keyUsage=critical,digitalSignature" \
+		-addext "extendedKeyUsage=codeSigning" >/dev/null 2>&1
+
+	# Bundle to PKCS#12 with a NON-EMPTY passphrase and the legacy SHA1-3DES PBE:
+	# Apple's Security framework fails MAC verification on empty-password p12s and
+	# is happiest with the legacy algorithms, so an empty pass or modern PBE makes
+	# `security import` reject the bundle ("MAC verification failed"). The
+	# passphrase is a throwaway that never leaves this function.
+	openssl pkcs12 -export -out "$p12" -inkey "$key" -in "$crt" \
+		-passout pass:"$SELF_SIGNED_CN" \
+		-certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES -macalg sha1 >/dev/null 2>&1
+
+	# Import into the login keychain. -T names codesign on the key's access list
+	# and -A widens that to local tooling, so the first build surfaces a GUI
+	# "Always Allow" dialog (click it once) rather than a denial. These flags do
+	# NOT by themselves suppress the prompt on modern macOS; the one-time Always
+	# Allow is what persists it. For a fully headless flow (CI), grant zero-prompt
+	# access with the login password instead:
+	#   security set-key-partition-list -S apple-tool:,apple: -s \
+	#     -k "$LOGIN_PW" "$login_kc"
+	# or skip self-signing entirely and set WHISPERING_DEV_SIGNING_IDENTITY.
+	import_err="$(security import "$p12" -k "$login_kc" \
+		-P "$SELF_SIGNED_CN" -A -T /usr/bin/codesign 2>&1)"
+	if [ -n "$import_err" ] && ! security find-certificate -c "$SELF_SIGNED_CN" >/dev/null 2>&1; then
+		# Fail loudly with the real reason rather than handing back a name whose
+		# cert isn't in the keychain (which surfaces later as a baffling codesign
+		# "item could not be found"). The usual culprit is a locked keychain in a
+		# non-GUI session: run `bun run dev` from a real Terminal/iTerm window.
+		echo "dev-codesign-runner: could not import the signing cert: $import_err" >&2
+		echo "dev-codesign-runner: is the login keychain unlocked / is this a GUI session?" >&2
+		rm -rf "$workdir"
+		return 1
+	fi
+
+	rm -rf "$workdir"
+	printf '%s' "$SELF_SIGNED_CN"
+}
+
+# Pick the signing identity, in preference order:
+#   1. an explicit override (WHISPERING_DEV_SIGNING_IDENTITY)
+#   2. a real Apple cert already on the machine (Developer ID / Apple Development)
+#   3. a persistent self-signed cert this runner mints itself
+# Every tier yields a STABLE identity, so the TCC grant survives rebuilds; the
+# old ad-hoc fallback could not, which is why it is gone.
 identity="${WHISPERING_DEV_SIGNING_IDENTITY:-}"
 if [ -z "$identity" ]; then
 	identity="$(security find-identity -v -p codesigning \
 		| awk -F'"' '/Developer ID Application|Apple Development/ { print $2; exit }')"
 fi
 if [ -z "$identity" ]; then
-	echo "dev-codesign-runner: no stable signing identity found; falling back to ad-hoc." >&2
-	echo "dev-codesign-runner: the Accessibility grant will NOT persist across rebuilds." >&2
-	echo "dev-codesign-runner: set WHISPERING_DEV_SIGNING_IDENTITY or install a codesigning cert." >&2
-	identity="-"
+	identity="$(provision_self_signed_identity)" || exit 1
 fi
 
 codesign --force \


### PR DESCRIPTION
On macOS, `tauri dev` runs the bare `target/debug/whispering` binary, which Cargo's linker leaves ad-hoc signed. An ad-hoc signature's identity is the binary's cdhash, so it changes on every relink. macOS TCC keys the microphone and Accessibility grants on that identity, so each rebuild looked like a brand-new app and the grant went stale. The visible symptom was the recorder failing to acquire the mic and the app reporting a silent "Recording failed" (the `silent-loss` dictation tier), even though transcription and everything else loaded fine.

The dev codesign runner already exists to fix this by re-signing the binary with a stable identity, but it only worked when the machine already had a Developer ID or Apple Development cert. With no cert it fell back to ad-hoc and merely warned, so a contributor with no Apple account was stuck with broken recording on every rebuild.

This adds a third tier to the runner: when there is no override and no real Apple cert, it mints a persistent self-signed code-signing certificate once (`Whispering Dev Local Codesign`) and reuses it. Every tier now produces a stable designated requirement, so the TCC grant survives rebuilds for any contributor with zero Apple account and zero manual setup. The selection order is unchanged where a real cert exists:

1. `WHISPERING_DEV_SIGNING_IDENTITY` override
2. a Developer ID / Apple Development cert already on the machine
3. the self-signed cert this runner provisions

Two correctness details the first cut got wrong and this fixes:

- The PKCS#12 is bundled with a non-empty passphrase and the legacy `PBE-SHA1-3DES` / `sha1` algorithms. Apple's Security framework fails MAC verification on empty-password or modern-PBE bundles (`SecKeychainItemImport: MAC verification failed`), so the import silently failed.
- A failed import now fails loudly with the real `security` error and aborts, instead of returning a cert name whose key isn't in the keychain, which previously surfaced downstream as a baffling codesign `The specified item could not be found in the keychain`.

`dev-doctor` follows suit: its verdict no longer tells you to install a cert by hand, and the reset hint now clears `Microphone` alongside `Accessibility` (the recorder failure is the mic grant, which the old hint never reset).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785260198&installation_id=128463665&pr_number=2221&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2221&signature=dab63d5ada637a49bf2c37c5c2ad8efd7fe75faec88c584ae24fb06c30dd4f9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->