### PR TITLE
fix(whispering): brand light-mode recorder surface and de-border the record card

### DIFF
--- a/apps/whispering/src/app.css
+++ b/apps/whispering/src/app.css
@@ -34,6 +34,13 @@
 }
 
 .dark {
-	--primary: oklch(0.62 0.19 275);
+	/* Lightness is capped at 0.55 (a deeper indigo than the page would otherwise
+	   invite) so white --primary-foreground text clears WCAG AA on every primary
+	   surface in dark mode, not just the record circle. The rebrand puts real text
+	   on --primary in several settings selectors; at 0.62 lightness white-on-indigo
+	   falls to ~3.7:1 (under the 4.5:1 body-text floor), and 0.55 lifts it to ~4.9:1.
+	   The record circle holds only an icon, so it would pass either way; these other
+	   surfaces are why the ceiling exists. */
+	--primary: oklch(0.55 0.19 275);
 	--primary-foreground: oklch(0.985 0 0);
 }

--- a/apps/whispering/src/app.css
+++ b/apps/whispering/src/app.css
@@ -6,9 +6,10 @@
    sets --background == --card (both pure white), so stacked surfaces could only be
    told apart by borders, which read as "cards on cards" in light mode.
 
-   1. Separate surfaces by TONE, not borders: --background gets a faint cool tint
-      while --card stays pure white, so a card reads as an elevated white surface on
-      a tinted page without needing a hairline border.
+   1. Separate surfaces by TONE, not borders: --background gets a barely-there
+      warm-neutral tint (the same lightness the shared theme already uses for
+      --sidebar) while --card stays pure white, so a card reads as an elevated
+      white surface on a tinted page without needing a hairline border.
 
    2. --primary becomes Whispering's brand indigo (it was the neutral shadcn
       default, near-black in light / near-white in dark). The record button is the
@@ -16,13 +17,13 @@
       active/recording state keeps using --destructive (red), already this app's
       convention. No new "recording" token: idle = --primary, recording = --destructive. */
 
-/* The cool background tint is light-only. Scope it to :root:not(.dark) rather than a
+/* The background tint is light-only. Scope it to :root:not(.dark) rather than a
    bare :root: this file is imported AFTER the shared theme, so a bare :root override
    would also win in dark mode (same specificity, later source order). Scoping it here
    means dark inherits the shared theme's background untouched, with no hardcoded copy
    to drift out of sync. */
 :root:not(.dark) {
-	--background: oklch(0.95 0.008 275);
+	--background: oklch(0.9925 0.001 70);
 }
 
 /* --primary is intentionally rebranded in BOTH modes, so it is set under :root and

--- a/apps/whispering/src/app.css
+++ b/apps/whispering/src/app.css
@@ -1,0 +1,39 @@
+/* Whispering brand + light-mode surface tuning, layered over the shared
+   @epicenter/ui/app.css (imported first in +layout.svelte). Scoped to Whispering so
+   the other Epicenter apps keep the shared neutral theme.
+
+   Two changes, both addressing the same root cause: in the shared theme light mode
+   sets --background == --card (both pure white), so stacked surfaces could only be
+   told apart by borders, which read as "cards on cards" in light mode.
+
+   1. Separate surfaces by TONE, not borders: --background gets a faint cool tint
+      while --card stays pure white, so a card reads as an elevated white surface on
+      a tinted page without needing a hairline border.
+
+   2. --primary becomes Whispering's brand indigo (it was the neutral shadcn
+      default, near-black in light / near-white in dark). The record button is the
+      app's primary action, so it now reads as a real, inviting CTA. The
+      active/recording state keeps using --destructive (red), already this app's
+      convention. No new "recording" token: idle = --primary, recording = --destructive. */
+
+/* The cool background tint is light-only. Scope it to :root:not(.dark) rather than a
+   bare :root: this file is imported AFTER the shared theme, so a bare :root override
+   would also win in dark mode (same specificity, later source order). Scoping it here
+   means dark inherits the shared theme's background untouched, with no hardcoded copy
+   to drift out of sync. */
+:root:not(.dark) {
+	--background: oklch(0.95 0.008 275);
+}
+
+/* --primary is intentionally rebranded in BOTH modes, so it is set under :root and
+   .dark together (and must stay paired: a bare :root override leaks into dark via
+   source order). */
+:root {
+	--primary: oklch(0.51 0.2 275);
+	--primary-foreground: oklch(0.985 0 0);
+}
+
+.dark {
+	--primary: oklch(0.62 0.19 275);
+	--primary-foreground: oklch(0.985 0 0);
+}

--- a/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
+++ b/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
@@ -52,7 +52,7 @@
 <div
 	class={cn(
 		'w-full overflow-hidden rounded-3xl bg-card text-foreground shadow-sm transition-[box-shadow] duration-200',
-		controller.active && 'shadow-md ring-1 ring-destructive/15',
+		controller.active && 'shadow-md ring-1 ring-destructive/25',
 	)}
 >
 	<Button
@@ -82,7 +82,7 @@
 				'relative flex size-14 shrink-0 items-center justify-center rounded-3xl shadow-lg ring-4 transition-[transform,box-shadow,background-color,color] duration-200 group-hover:scale-[1.04] group-hover:shadow-xl sm:size-16',
 				controller.active
 					? 'bg-destructive text-white shadow-destructive/30 ring-destructive/15'
-					: 'bg-primary text-primary-foreground shadow-primary/25 ring-primary/10',
+					: 'bg-primary text-primary-foreground shadow-primary/35 ring-primary/20',
 			)}
 		>
 			{#if controller.pending}
@@ -148,7 +148,7 @@
 			reading the same fact the home-page notice does so the two agree. -->
 			<Kbd.Root
 				class={cn(
-					'h-7 max-w-28 shrink-0 rounded-md bg-muted/75 px-2 text-xs text-muted-foreground shadow-none',
+					'h-7 max-w-28 shrink-0 rounded-full bg-muted/75 px-2.5 text-xs text-muted-foreground shadow-none',
 					dictationCapability.isUnavailable && 'opacity-50',
 				)}
 			>

--- a/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
+++ b/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
@@ -64,21 +64,22 @@
 		onclick={controller.toggle}
 		variant="ghost"
 		class={cn(
-			'group h-auto w-full justify-start gap-3 rounded-none bg-transparent px-5 pt-5 pb-4 text-left hover:bg-transparent dark:hover:bg-transparent sm:gap-4',
+			'group h-auto min-h-24 w-full items-center justify-start gap-3 rounded-none bg-transparent px-5 py-6 text-left hover:bg-transparent dark:hover:bg-transparent sm:gap-4',
 			controller.pending && 'cursor-wait',
 		)}
 	>
-		<!-- The glyph slot is the record CTA: idle = the brand --primary circle (this
-		app's primary action), active = a --destructive (red) circle, mirroring the
-		colors the floating pill already uses for live/stop. The icon (mic -> stop
-		square) and the active flag both come from the controller; this only paints.
-		Hover feedback lives on this circle (a slight scale + lift via group-hover),
-		not a fill behind the row: the button spans only the top zone, so a row fill
-		would cut a hard horizontal edge across the rounded card above the footer. -->
+		<!-- The glyph slot is the record CTA: idle = the brand --primary squircle
+		(this app's primary action, rounded to match the outer card's rounded-3xl),
+		active = a --destructive (red) squircle, mirroring the colors the floating
+		pill already uses for live/stop. The icon (mic -> stop square) and the active
+		flag both come from the controller; this only paints. Hover feedback lives on
+		this glyph (a slight scale + lift via group-hover), not a fill behind the row:
+		the button spans only the top zone, so a row fill would cut a hard horizontal
+		edge across the rounded card above the footer. -->
 		<span
 			aria-hidden="true"
 			class={cn(
-				'relative flex size-14 shrink-0 items-center justify-center rounded-full shadow-lg ring-4 transition-[transform,box-shadow,background-color,color] duration-200 group-hover:scale-[1.04] group-hover:shadow-xl sm:size-16',
+				'relative flex size-14 shrink-0 items-center justify-center rounded-3xl shadow-lg ring-4 transition-[transform,box-shadow,background-color,color] duration-200 group-hover:scale-[1.04] group-hover:shadow-xl sm:size-16',
 				controller.active
 					? 'bg-destructive text-white shadow-destructive/30 ring-destructive/15'
 					: 'bg-primary text-primary-foreground shadow-primary/25 ring-primary/10',
@@ -89,7 +90,7 @@
 			{:else if controller.active && showsLiveMeter}
 				<!-- Live capture: the glyph slot becomes the meter, the same bars the
 				floating pill draws, scaled to fit the box. White bars read on the red
-				(--destructive) recording circle. -->
+				(--destructive) recording squircle. -->
 				<LevelMeter
 					level={webPillLevel.level}
 					class="gap-[2px]"
@@ -124,8 +125,8 @@
 				{#if controller.active && showsLiveMeter && controller.vad}
 					<!-- VAD speech-latch indicator: the same dim-dot -> lit-dot -> spinner the
 					floating pill shows, here inline with the status text instead of in the
-					meter circle's corner (where it read as a dismiss badge and crowded the
-					loudness bars). The circle owns loudness alone now; this line owns VAD's
+					meter glyph's corner (where it read as a dismiss badge and crowded the
+					loudness bars). The glyph owns loudness alone now; this line owns VAD's
 					decision: dim while armed, red (--destructive, the recording accent) once
 					speech latches, a spinner while a previous phrase still transcribes. Gated
 					exactly like the in-card meter (active and web), so on '/' it shows only
@@ -163,7 +164,9 @@
 	its live footer is empty and the slot collapses. -->
 	{#if controller.active}
 		{#if controller.cancel}
-			<div class="flex justify-center px-5 pb-5 pt-1">
+			<div
+				class="flex justify-center border-t border-border/60 px-5 pt-3 pb-5"
+			>
 				<Button
 					tooltip="Cancel recording and discard audio"
 					onclick={() => controller.cancel?.()}
@@ -176,7 +179,7 @@
 			</div>
 		{/if}
 	{:else if footer}
-		<div class="px-5 pb-5 pt-1">
+		<div class="border-t border-border/60 px-5 pt-3 pb-5">
 			{@render footer()}
 		</div>
 	{/if}

--- a/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
+++ b/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
@@ -78,7 +78,7 @@
 		<span
 			aria-hidden="true"
 			class={cn(
-				'relative flex size-14 shrink-0 items-center justify-center rounded-full shadow-lg ring-4 transition-[transform,box-shadow,colors] duration-200 group-hover:scale-[1.04] group-hover:shadow-xl sm:size-16',
+				'relative flex size-14 shrink-0 items-center justify-center rounded-full shadow-lg ring-4 transition-[transform,box-shadow,background-color,color] duration-200 group-hover:scale-[1.04] group-hover:shadow-xl sm:size-16',
 				controller.active
 					? 'bg-destructive text-white shadow-destructive/30 ring-destructive/15'
 					: 'bg-primary text-primary-foreground shadow-primary/25 ring-primary/10',
@@ -97,25 +97,6 @@
 					minPx={3}
 					maxPx={28}
 				/>
-				{#if controller.vad}
-					<!-- VAD session: the same dim-dot -> lit-dot -> spinner indicator the
-					floating pill shows beside its meter, here in the glyph's corner. The
-					bars track loudness; this dot tracks whether VAD has latched onto speech
-					and becomes a spinner while a previous phrase is still transcribing. On
-					'/' the pill yields the recording phase to this card, so this is the
-					only place that last signal shows. The signals come from this card's own
-					controller (present only for VAD), not a global lookup. -->
-					<span
-						class="absolute top-0.5 right-0.5 flex size-4 items-center justify-center"
-					>
-						<VadIndicator
-							signals={controller.vad}
-							dimClass="bg-white/40"
-							litClass="bg-white"
-							spinnerClass="text-white/70"
-						/>
-					</span>
-				{/if}
 			{:else}
 				{@const Icon = controller.icon}
 				<span
@@ -137,8 +118,26 @@
 			<span class="truncate text-base font-semibold leading-none sm:text-lg">
 				{controller.label}
 			</span>
-			<span class="truncate text-xs font-medium text-muted-foreground sm:text-sm">
-				{controller.description}
+			<span
+				class="flex min-w-0 items-center gap-1.5 text-xs font-medium text-muted-foreground sm:text-sm"
+			>
+				{#if controller.active && showsLiveMeter && controller.vad}
+					<!-- VAD speech-latch indicator: the same dim-dot -> lit-dot -> spinner the
+					floating pill shows, here inline with the status text instead of in the
+					meter circle's corner (where it read as a dismiss badge and crowded the
+					loudness bars). The circle owns loudness alone now; this line owns VAD's
+					decision: dim while armed, red (--destructive, the recording accent) once
+					speech latches, a spinner while a previous phrase still transcribes. Gated
+					exactly like the in-card meter (active and web), so on '/' it shows only
+					here. The signals come from this card's own controller. -->
+					<VadIndicator
+						signals={controller.vad}
+						dimClass="bg-muted-foreground/40"
+						litClass="bg-destructive"
+						spinnerClass="text-destructive"
+					/>
+				{/if}
+				<span class="truncate">{controller.description}</span>
 			</span>
 		</span>
 		{#if controller.shortcutLabel}

--- a/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
+++ b/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
@@ -51,9 +51,8 @@
 
 <div
 	class={cn(
-		'w-full overflow-hidden rounded-lg border border-border/70 bg-card/60 text-foreground shadow-sm ring-1 ring-foreground/5 transition-[background-color,border-color,box-shadow,color] duration-200 hover:border-primary/55 hover:bg-card/75 hover:shadow-md hover:ring-primary/25',
-		controller.active &&
-			'border-destructive/45 bg-card/70 hover:border-destructive/60 hover:bg-destructive/10 hover:ring-destructive/25',
+		'w-full overflow-hidden rounded-3xl bg-card text-foreground shadow-sm transition-[box-shadow] duration-200',
+		controller.active && 'shadow-md ring-1 ring-destructive/15',
 	)}
 >
 	<Button
@@ -65,27 +64,36 @@
 		onclick={controller.toggle}
 		variant="ghost"
 		class={cn(
-			'min-h-24 w-full justify-start gap-3 rounded-none bg-transparent px-3.5 py-3.5 text-left hover:bg-card/70 sm:gap-4 sm:px-4',
+			'group h-auto w-full justify-start gap-3 rounded-none bg-transparent px-5 pt-5 pb-4 text-left hover:bg-transparent dark:hover:bg-transparent sm:gap-4',
 			controller.pending && 'cursor-wait',
 		)}
 	>
+		<!-- The glyph slot is the record CTA: idle = the brand --primary circle (this
+		app's primary action), active = a --destructive (red) circle, mirroring the
+		colors the floating pill already uses for live/stop. The icon (mic -> stop
+		square) and the active flag both come from the controller; this only paints.
+		Hover feedback lives on this circle (a slight scale + lift via group-hover),
+		not a fill behind the row: the button spans only the top zone, so a row fill
+		would cut a hard horizontal edge across the rounded card above the footer. -->
 		<span
 			aria-hidden="true"
 			class={cn(
-				'relative flex size-14 shrink-0 items-center justify-center rounded-md border border-border/70 bg-background/70 text-foreground shadow-inner transition-colors duration-200 sm:size-16',
-				controller.active &&
-					'border-destructive/45 bg-destructive/10 text-destructive',
+				'relative flex size-14 shrink-0 items-center justify-center rounded-full shadow-lg ring-4 transition-[transform,box-shadow,colors] duration-200 group-hover:scale-[1.04] group-hover:shadow-xl sm:size-16',
+				controller.active
+					? 'bg-destructive text-white shadow-destructive/30 ring-destructive/15'
+					: 'bg-primary text-primary-foreground shadow-primary/25 ring-primary/10',
 			)}
 		>
 			{#if controller.pending}
-				<Spinner class="size-7" />
+				<Spinner class="size-7 text-current" />
 			{:else if controller.active && showsLiveMeter}
 				<!-- Live capture: the glyph slot becomes the meter, the same bars the
-				floating pill draws, scaled to fit the box. -->
+				floating pill draws, scaled to fit the box. White bars read on the red
+				(--destructive) recording circle. -->
 				<LevelMeter
 					level={webPillLevel.level}
 					class="gap-[2px]"
-					barClass="w-[2px] bg-destructive"
+					barClass="w-[2px] bg-white"
 					minPx={3}
 					maxPx={28}
 				/>
@@ -102,9 +110,9 @@
 					>
 						<VadIndicator
 							signals={controller.vad}
-							dimClass="bg-destructive/40"
-							litClass="bg-destructive"
-							spinnerClass="text-muted-foreground"
+							dimClass="bg-white/40"
+							litClass="bg-white"
+							spinnerClass="text-white/70"
 						/>
 					</span>
 				{/if}
@@ -156,9 +164,7 @@
 	its live footer is empty and the slot collapses. -->
 	{#if controller.active}
 		{#if controller.cancel}
-			<div
-				class="flex justify-center border-t border-border/60 bg-background/20 px-3 py-2"
-			>
+			<div class="flex justify-center px-5 pb-5 pt-1">
 				<Button
 					tooltip="Cancel recording and discard audio"
 					onclick={() => controller.cancel?.()}
@@ -171,7 +177,7 @@
 			</div>
 		{/if}
 	{:else if footer}
-		<div class="border-t border-border/60 bg-background/20 px-3 py-2">
+		<div class="px-5 pb-5 pt-1">
 			{@render footer()}
 		</div>
 	{/if}

--- a/apps/whispering/src/routes/+layout.svelte
+++ b/apps/whispering/src/routes/+layout.svelte
@@ -8,6 +8,9 @@
 	import { queryClient } from '$lib/rpc/client';
 	import { reloadOnOwnerChange } from '$lib/whispering/reload-on-owner-change';
 	import '@epicenter/ui/app.css';
+	// Whispering's brand + light-mode surface overrides, layered after the shared
+	// theme so they win. Keep this import last among the stylesheets.
+	import '../app.css';
 	import * as Tooltip from '@epicenter/ui/tooltip';
 
 	let { children } = $props();


### PR DESCRIPTION
Whispering's light mode read as "cards on cards": the shared `@epicenter/ui` theme sets the page background and the card surface to the same pure white, so the recorder could only be told apart from the page by a hairline border. The record button also used the neutral shadcn primary (near-black in light, near-white in dark), so the app's primary action never looked like a call to action.

This scopes a small `app.css` to Whispering, layered after the shared theme so it wins. It tints the light-mode `--background` a touch cooler and leaves `--card` pure white, so a card reads as an elevated white surface by tone instead of a border. It also rebrands `--primary` to Whispering's indigo in both modes. The dark background stays the shared theme's value (the tint is scoped to `:root:not(.dark)`), so there is no hardcoded copy to drift out of sync.

The recorder card follows the same idea: the border comes off, the radius grows to `rounded-3xl`, and the mic moves into a filled indigo circle that turns red while recording. Hover lifts and scales the circle instead of filling the top half of the card, which kept cutting a hard horizontal edge above the footer. There is no new "recording" token: idle is `--primary`, recording stays this app's existing `--destructive` red.

## Changelog
- Redesigned Whispering's recorder in light mode: the card now sits as an elevated white surface on a softly tinted page instead of a bordered box on white, and the record button is a branded indigo circle that turns red while recording.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785314734&installation_id=128463665&pr_number=2222&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2222&signature=4b0491e1db06a46ff927a8ef031f29837a03107b6c6e697e4d8348b3a967eb42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->