### PR TITLE
fix(agent-chat): hide chat-error-banner actions when no handler is provided

### DIFF
--- a/apps/opensidian/src/lib/components/chat/AiChat.svelte
+++ b/apps/opensidian/src/lib/components/chat/AiChat.svelte
@@ -20,15 +20,6 @@
 	/>
 
 	{#if active}
-		<AgentChatThread
-			conversation={active}
-			connections={inferenceConnections}
-			onSignIn={() => {
-				// TODO: open auth popover or navigate to sign-in
-			}}
-			onUpgrade={() => {
-				// TODO: open billing / upgrade flow
-			}}
-		/>
+		<AgentChatThread conversation={active} connections={inferenceConnections} />
 	{/if}
 </div>

--- a/apps/tab-manager/src/lib/components/chat/AiChat.svelte
+++ b/apps/tab-manager/src/lib/components/chat/AiChat.svelte
@@ -40,12 +40,6 @@
 			connections={inferenceConnections}
 			resolveToolTitle={(toolName) => actionTitles[toolName]?.title}
 			onAlwaysAllow={alwaysAllowPendingToolCall}
-			onSignIn={() => {
-				// TODO: open auth popover or navigate to sign-in
-			}}
-			onUpgrade={() => {
-				// TODO: open billing / upgrade flow
-			}}
 		/>
 	{/if}
 </div>

--- a/apps/vocab/src/routes/(signed-in)/components/ConversationView.svelte
+++ b/apps/vocab/src/routes/(signed-in)/components/ConversationView.svelte
@@ -33,12 +33,6 @@
 		conversation={active}
 		connections={inferenceConnections}
 		placeholder="Ask something in English..."
-		onSignIn={() => {
-			// Vocab has no dedicated sign-in surface yet.
-		}}
-		onUpgrade={() => {
-			// Vocab has no dedicated billing surface yet.
-		}}
 	>
 		{#snippet inputAccessory()}
 			<DictationButton disabled={isGenerating} onTranscript={appendTranscript} />

--- a/packages/app-shell/src/agent-chat/agent-chat-thread.svelte
+++ b/packages/app-shell/src/agent-chat/agent-chat-thread.svelte
@@ -28,10 +28,12 @@
 		conversation: ConversationHandle;
 		/** The device connection registry (ADR-0059), for the model picker and gap. */
 		connections: InferenceConnections;
-		/** Open the app's sign-in flow (the turn failed with HTTP 401). */
-		onSignIn: () => void;
-		/** Open the app's upgrade/billing flow (the turn failed with HTTP 402). */
-		onUpgrade: () => void;
+		/** Open the app's sign-in flow (the turn failed with HTTP 401). Omit to hide
+		 * the Sign In button in the error banner. */
+		onSignIn?: () => void;
+		/** Open the app's upgrade/billing flow (the turn failed with HTTP 402). Omit
+		 * to hide the Upgrade button in the error banner. */
+		onUpgrade?: () => void;
 		/** Override how one message's content renders (vocab's pinyin pass). Omit to
 		 * use the built-in renderer (text + tool calls), wired to this conversation's
 		 * approval state and the `resolveToolTitle` / `onAlwaysAllow` seams below. The

--- a/packages/app-shell/src/agent-chat/chat-error-banner.svelte
+++ b/packages/app-shell/src/agent-chat/chat-error-banner.svelte
@@ -12,10 +12,12 @@
 	}: {
 		/** The active conversation whose error state drives the banner. */
 		conversation: ConversationHandle;
-		/** Open the app's sign-in flow (the turn failed with HTTP 401). */
-		onSignIn: () => void;
-		/** Open the app's upgrade/billing flow (the turn failed with HTTP 402). */
-		onUpgrade: () => void;
+		/** Open the app's sign-in flow (the turn failed with HTTP 401). Omit to hide
+		 * the Sign In button (apps without a sign-in surface still get the message). */
+		onSignIn?: () => void;
+		/** Open the app's upgrade/billing flow (the turn failed with HTTP 402). Omit
+		 * to hide the Upgrade button (the message still shows). */
+		onUpgrade?: () => void;
 	} = $props();
 
 	const bannerClass =
@@ -30,17 +32,21 @@
 {#if conversation.isUnauthorized}
 	<div role="alert" class={bannerClass}>
 		<span class="min-w-0 flex-1">Sign in to use AI Chat</span>
-		<Button variant="ghost" size="sm" class={actionClass} onclick={onSignIn}>
-			<LogInIcon class="size-3" />
-			Sign In
-		</Button>
+		{#if onSignIn}
+			<Button variant="ghost" size="sm" class={actionClass} onclick={onSignIn}>
+				<LogInIcon class="size-3" />
+				Sign In
+			</Button>
+		{/if}
 	</div>
 {:else if conversation.isCreditsExhausted}
 	<div role="alert" class={bannerClass}>
 		<span class="min-w-0 flex-1">You're out of credits</span>
-		<Button variant="ghost" size="sm" class={actionClass} onclick={onUpgrade}>
-			Upgrade
-		</Button>
+		{#if onUpgrade}
+			<Button variant="ghost" size="sm" class={actionClass} onclick={onUpgrade}>
+				Upgrade
+			</Button>
+		{/if}
 	</div>
 {:else if conversation.visibleError}
 	<div role="alert" class={bannerClass}>


### PR DESCRIPTION
The problem this addresses is:

`chat-error-banner.svelte` declared `onSignIn` / `onUpgrade` as **required** props, but all three consumers (opensidian, tab-manager, vocab) only passed empty TODO closures to satisfy the requirement. On a 401/402 the banner therefore rendered Sign In / Upgrade buttons that did nothing.

## Change

- Make `onSignIn` / `onUpgrade` optional in `chat-error-banner.svelte` and `agent-chat-thread.svelte` (the pass-through).
- Gate each button behind `{#if onSignIn}` / `{#if onUpgrade}` so a dead button is never rendered. The banner message text still shows regardless.
- Remove the now-unnecessary empty-closure props from the three consumers.

When an app later grows a real sign-in or billing surface, it passes a handler and the button reappears.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785314982&installation_id=128463665&pr_number=2223&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2223&signature=36f5605c0b29adb0b893534bdbf1d72775457d3b26d11261bbb33dbfeefe0fcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->