### PR TITLE
fix(sql-console): drop unreachable render branch and fix off-by-one capped detection

### DIFF
--- a/apps/matter/src/lib/mirror.svelte.ts
+++ b/apps/matter/src/lib/mirror.svelte.ts
@@ -107,8 +107,9 @@ export function createMirror(root: string) {
 	/**
 	 * Run arbitrary read-only SQL for the console and return the full result set verbatim. The console
 	 * renders `{ columns, rows }` directly: a JOIN or aggregate row has no file, so this never feeds an
-	 * editable cell (the boundary). Capped at {@link CONSOLE_LIMIT} rows so a `SELECT *` cannot hang the
-	 * UI.
+	 * editable cell (the boundary). Fetches one row past {@link CONSOLE_LIMIT} so the console can tell a
+	 * capped result from one that lands exactly on the limit, then renders only the first
+	 * {@link CONSOLE_LIMIT}, so a `SELECT *` cannot hang the UI.
 	 */
 	function runSql(
 		sql: string,
@@ -120,7 +121,7 @@ export function createMirror(root: string) {
 				invoke<{ columns: string[]; rows: unknown[][] }>('query_mirror', {
 					root,
 					sql,
-					limit: CONSOLE_LIMIT,
+					limit: CONSOLE_LIMIT + 1,
 				}),
 			catch: (cause) => Err({ message: extractErrorMessage(cause) }),
 		});

--- a/apps/matter/src/routes/(vaults)/vault/[id]/SqlConsole.svelte
+++ b/apps/matter/src/routes/(vaults)/vault/[id]/SqlConsole.svelte
@@ -114,12 +114,19 @@
 		};
 	});
 
-	/** Render one result cell: NULL as a faint dash, an object as compact JSON, everything else as text. */
+	/** Render one non-null result cell: an object as compact JSON, everything else as text. NULL and
+	 *  undefined never reach here, the template renders them as a faint dash. */
 	function renderCell(value: unknown): string {
-		if (value === null || value === undefined) return '';
 		if (typeof value === 'object') return JSON.stringify(value);
 		return String(value);
 	}
+
+	// `runSql` fetches one row past CONSOLE_LIMIT: an overflow row is the capped signal. Render only the
+	// first CONSOLE_LIMIT so a result that lands exactly on the limit is not misreported as capped.
+	const capped = $derived(!!result && result.rows.length > CONSOLE_LIMIT);
+	const rows = $derived(
+		capped ? result!.rows.slice(0, CONSOLE_LIMIT) : (result?.rows ?? []),
+	);
 </script>
 
 <div class="flex min-h-0 flex-1 flex-col">
@@ -153,7 +160,7 @@
 
 	<div class="flex-1 overflow-auto">
 		{#if result}
-			{#if result.rows.length === 0}
+			{#if rows.length === 0}
 				<Empty.Root class="min-h-48 border-0">
 					<Empty.Media variant="icon"><DatabaseIcon /></Empty.Media>
 					<Empty.Title>No rows</Empty.Title>
@@ -164,8 +171,8 @@
 					class="border-b px-4 py-1.5 text-xs text-muted-foreground"
 					role="status"
 				>
-					{result.rows.length}
-					{result.rows.length === 1 ? 'row' : 'rows'}{#if result.rows.length === CONSOLE_LIMIT}, capped at the first {CONSOLE_LIMIT}{/if}
+					{rows.length}
+					{rows.length === 1 ? 'row' : 'rows'}{#if capped}, capped at the first {CONSOLE_LIMIT}{/if}
 				</div>
 				<Table.Root class="min-w-full">
 					<Table.Header>
@@ -178,7 +185,7 @@
 						</Table.Row>
 					</Table.Header>
 					<Table.Body>
-						{#each result.rows as row, r (r)}
+						{#each rows as row, r (r)}
 							<Table.Row>
 								{#each row as cell, c (c)}
 									<Table.Cell class="max-w-80 truncate font-mono text-xs">


### PR DESCRIPTION
Cleanup from the audit of #2194 (SQL console).

## Changes

- **Dead render branch.** `renderCell` had a `value === null || value === undefined` branch that can never run: the table template guards that case itself, rendering NULL/undefined as a faint dash before `renderCell` is ever called. The branch was dead and its JSDoc claimed it renders a dash, which it does not (it returned an empty string). Dropped the branch and corrected the doc to name the template as the real owner of the dash.
- **Off-by-one capped detection.** Capped detection used `rows.length === CONSOLE_LIMIT`, which misreports a legitimate result of exactly `CONSOLE_LIMIT` rows as "capped". `runSql` now fetches `CONSOLE_LIMIT + 1`, the console renders only the first `CONSOLE_LIMIT`, and the overflow row is the capped signal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785314984&installation_id=128463665&pr_number=2224&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2224&signature=feb0a0a221d118713bef505d0148b596873463557cc006e496dd63bfd9b33f95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->