### PR TITLE
fix(local-books): report mirror fold-back honestly and drop dead status fields

### DIFF
--- a/apps/local-books/src/books/recategorize.ts
+++ b/apps/local-books/src/books/recategorize.ts
@@ -111,6 +111,14 @@ export type RecategorizeResult = {
 	id: string;
 	changed: RecategorizeChange[];
 	syncToken: string | null;
+	/**
+	 * Whether the authoritative QuickBooks response was folded into the mirror.
+	 * The write itself succeeded either way; `false` means the best-effort fold
+	 * failed (lock past busy_timeout, disk error) and the next CDC sync will
+	 * reconcile the row. Callers report this honestly instead of always claiming
+	 * the fold happened.
+	 */
+	folded: boolean;
 };
 
 type ExpenseLine = Record<string, unknown> & {
@@ -176,22 +184,27 @@ export async function recategorizeExpense({
 
 		const toName = input.account_name ?? input.account_id;
 		const changed: RecategorizeChange[] = targets.map((line) => {
-			const detail = line[LINE_DETAIL];
-			const fromRef = detail?.AccountRef;
-			const change: RecategorizeChange = {
+			const fromRef = line[LINE_DETAIL]?.AccountRef;
+			return {
 				lineId: line.Id != null ? String(line.Id) : null,
 				fromAccount: fromRef?.name ?? fromRef?.value ?? null,
 				toAccount: toName,
 			};
+		});
+
+		// Rewrite each target line's AccountRef in place. This is network-visible:
+		// `lines` is sent to QuickBooks below. Kept as an explicit loop, separate from
+		// the pure `changed` map above, so the mutation is not a side effect buried in
+		// an expression whose name promises only an audit log.
+		for (const line of targets) {
 			line[LINE_DETAIL] = {
-				...detail,
+				...line[LINE_DETAIL],
 				AccountRef: {
 					value: input.account_id,
 					...(input.account_name ? { name: input.account_name } : {}),
 				},
 			};
-			return change;
-		});
+		}
 
 		const { data: qb, error: openError } = await openQb();
 		if (openError !== null) {
@@ -217,7 +230,7 @@ export async function recategorizeExpense({
 		// monotonic CDC sync reconciles the row, and the successful QuickBooks write
 		// must not be reported as a failure (which would invite a retry that hits a
 		// 409 on the now-bumped token).
-		trySync({
+		const { error: foldError } = trySync({
 			try: () =>
 				db.ingest([{ def, objects: [updated] }], {
 					syncedAt: new Date().toISOString(),
@@ -231,6 +244,7 @@ export async function recategorizeExpense({
 			changed,
 			syncToken:
 				typeof updated.SyncToken === 'string' ? updated.SyncToken : null,
+			folded: foldError === null,
 		});
 	} finally {
 		db.close();

--- a/apps/local-books/src/commands/recategorize.ts
+++ b/apps/local-books/src/commands/recategorize.ts
@@ -65,8 +65,14 @@ export async function runRecategorize(args: ParsedArgs): Promise<number> {
 			`${data.entity} ${data.id}${line}: ${change.fromAccount ?? '(none)'} -> ${change.toAccount}`,
 		);
 	}
-	console.error(
-		`Updated in QuickBooks (SyncToken ${data.syncToken ?? '?'}) and folded into the mirror.`,
-	);
+	if (data.folded) {
+		console.error(
+			`Updated in QuickBooks (SyncToken ${data.syncToken ?? '?'}) and folded into the mirror.`,
+		);
+	} else {
+		console.error(
+			`Updated in QuickBooks (SyncToken ${data.syncToken ?? '?'}), but folding into the mirror failed. The next sync will reconcile it; do not retry recategorize (the SyncToken has already bumped).`,
+		);
+	}
 	return 0;
 }

--- a/apps/local-books/src/db.ts
+++ b/apps/local-books/src/db.ts
@@ -70,7 +70,6 @@ export type IngestCounts = Record<
 
 export type EntityStatus = {
 	entity: string;
-	table: string;
 	rows: number;
 	deleted: number;
 	/** Whether this entity has been full-pulled (its table exists). */
@@ -373,7 +372,6 @@ export function openBooksDb(
 			if (!tableExists(def.table)) {
 				return {
 					entity: def.name,
-					table: def.table,
 					rows: 0,
 					deleted: 0,
 					initialized: false,
@@ -389,7 +387,6 @@ export function openBooksDb(
 				.get();
 			return {
 				entity: def.name,
-				table: def.table,
 				rows: rows?.n ?? 0,
 				deleted: deleted?.n ?? 0,
 				initialized: true,

--- a/apps/local-books/src/sync.ts
+++ b/apps/local-books/src/sync.ts
@@ -201,11 +201,15 @@ export async function syncRealm(
 	// excluded from this pass's CDC (it is already current), while the rest ride
 	// one batched CDC call. cursorBefore is non-null here (a null cursor forces
 	// FULL above).
-	const wasInitialized = new Map(
-		names.map((name) => [name, db.isInitialized(entityDef(name))]),
-	);
-	const newNames = names.filter((name) => !wasInitialized.get(name));
-	const cdcNames = names.filter((name) => wasInitialized.get(name));
+	const newNames: string[] = [];
+	const cdcNames: string[] = [];
+	for (const name of names) {
+		if (db.isInitialized(entityDef(name))) {
+			cdcNames.push(name);
+		} else {
+			newNames.push(name);
+		}
+	}
 
 	const backfill = await fullPullEach(deps, newNames, cursorAfter, {
 		backfilled: true,


### PR DESCRIPTION
Cleanup from an audit of #2193 and #2210 (local-books mirror storage, sync, standalone CLI verbs).

## Findings fixed

- **Mirror fold-back reported honestly.** `recategorizeExpense` discarded the `trySync` Result that folds QuickBooks' authoritative response into the mirror, then the CLI unconditionally printed "folded into the mirror." If `db.ingest` throws (a concurrent sync holding the lock past `busy_timeout`, a disk error) the verb falsely claimed success. The result now carries a `folded` boolean and the CLI prints the failure case, telling the operator the next sync will reconcile and not to retry (the SyncToken has already bumped).
- **Explicit mutation.** The `targets.map(...)` that builds the `RecategorizeChange[]` audit log secretly mutated `line[LINE_DETAIL]` (network-visible: those lines are sent to QuickBooks). Split into a pure map plus an explicit rewrite loop.
- **Dead field dropped.** `EntityStatus.table` was set in both branches and read by nobody; removed. (`EntityStatus.entity` is still read by the status command and was kept.)
- **One-pass partition.** `sync.ts` built a `wasInitialized` Map only to drive two complementary `.filter`s into `newNames`/`cdcNames`. Replaced with a single loop; the Map is gone.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785315042&installation_id=128463665&pr_number=2226&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2226&signature=cf75456c59e306a0c6ffcdb23c26fbe7449dad2e7a633c3114f833fe06767c2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->