### PR TITLE
refactor(inference-picker): collapse custom+discovered into one connection store

### DIFF
--- a/packages/app-shell/src/inference-picker/connections.svelte.ts
+++ b/packages/app-shell/src/inference-picker/connections.svelte.ts
@@ -3,7 +3,7 @@
  * that owns the device's set of custom OpenAI-compatible connections plus the
  * model ids each was discovered to serve, and resolves a conversation's model to a
  * transport. Every chat app instantiates this once instead of re-deriving the same
- * two persisted stores, so the picker, the engine, and the cross-device banner all
+ * persisted store, so the picker, the engine, and the cross-device banner all
  * read one source.
  *
  * Device-local, never synced: a key is a secret on the plaintext relay and a
@@ -49,13 +49,20 @@ export type PersistFactory = <S extends StandardSchemaV1>(
  */
 export type HostedModel = { id: string; label: string; credits: number };
 
-const connectionSchema = type({
+/**
+ * One stored custom connection: the transport identity (`baseUrl` + optional
+ * `apiKey`) plus the model ids it was discovered to serve. A connection and its
+ * models are one concept, so they live in one record (not two stores joined by
+ * base URL); removing the connection drops its models with it. `models` is
+ * optional so a connection persisted before this shape still loads, then
+ * re-discovers on next open.
+ */
+const storedConnectionSchema = type({
 	baseUrl: 'string',
 	'apiKey?': 'string',
+	'models?': 'string[]',
 });
-
-/** Discovered model ids per connection, keyed by base URL. */
-const discoveredModelsSchema = type({ '[string]': 'string[]' });
+type StoredConnection = typeof storedConnectionSchema.infer;
 
 /** The reactive registry object returned by {@link createInferenceConnections}. */
 export type InferenceConnections = ReturnType<
@@ -77,15 +84,10 @@ export function createInferenceConnections({
 	/** The persistence mechanism (web: localStorage; extension: chrome.storage). */
 	persist: PersistFactory;
 }) {
-	const custom = persist(
+	const stored = persist(
 		`${storageKey}.inference-connections`,
-		connectionSchema.array(),
+		storedConnectionSchema.array(),
 		[],
-	);
-	const discovered = persist(
-		`${storageKey}.discovered-models`,
-		discoveredModelsSchema,
-		{},
 	);
 
 	/** The candidates a model resolves against, in priority order: every custom
@@ -104,9 +106,9 @@ export function createInferenceConnections({
 		models: readonly string[];
 	}[] {
 		return [
-			...custom.current.map((connection) => ({
+			...stored.current.map((connection) => ({
 				resolve: () => resolveConnection(connection),
-				models: discovered.current[connection.baseUrl] ?? [],
+				models: connection.models ?? [],
 			})),
 			{ resolve: () => hosted, models: hostedModels.map((m) => m.id) },
 		];
@@ -127,30 +129,28 @@ export function createInferenceConnections({
 	return {
 		/** The hosted catalog this app sells (for the picker's Epicenter group). */
 		hostedModels,
-		/** The device's custom connections, in display order. */
-		get custom() {
-			return custom.current;
-		},
-		/** Discovered model ids per connection, keyed by base URL. */
-		get discoveredModels() {
-			return discovered.current;
+		/**
+		 * The device's custom connections, in display order. Each carries its own
+		 * discovered `models` (see {@link StoredConnection}), so the picker reads one
+		 * list instead of joining a connection to a separate models map by base URL.
+		 */
+		get custom(): readonly StoredConnection[] {
+			return stored.current;
 		},
 
 		/** Add (or replace by base URL) a connection, optionally caching its models. */
 		add(connection: Connection, models?: string[]) {
-			custom.current = [
-				...custom.current.filter((c) => c.baseUrl !== connection.baseUrl),
-				connection,
+			const existing = stored.current.find(
+				(c) => c.baseUrl === connection.baseUrl,
+			);
+			stored.current = [
+				...stored.current.filter((c) => c.baseUrl !== connection.baseUrl),
+				{ ...connection, models: models ?? existing?.models ?? [] },
 			];
-			if (models)
-				discovered.current = {
-					...discovered.current,
-					[connection.baseUrl]: models,
-				};
 		},
-		/** Forget a connection by base URL. */
+		/** Forget a connection and its discovered models by base URL. */
 		remove(baseUrl: string) {
-			custom.current = custom.current.filter((c) => c.baseUrl !== baseUrl);
+			stored.current = stored.current.filter((c) => c.baseUrl !== baseUrl);
 		},
 
 		/** Discover the models a candidate endpoint serves (best effort, never throws). */

--- a/packages/app-shell/src/inference-picker/inference-picker.svelte
+++ b/packages/app-shell/src/inference-picker/inference-picker.svelte
@@ -253,7 +253,7 @@
 					{/if}
 
 					{#each connections.custom as connection (connection.baseUrl)}
-						{@const ids = connections.discoveredModels[connection.baseUrl] ?? []}
+						{@const ids = connection.models ?? []}
 						<Command.Group
 							heading="{connectionLabel(connection)} · {isLocal(
 								connection.baseUrl,


### PR DESCRIPTION
Stacked on #2225 (base `fix/inference-picker-bugs`). Continued cleanup from the audit of #2181.

**Finding 4: one concept split across two stores, remove() orphans half.**
A custom connection and the model ids it serves are one concept, but the registry kept them in two persisted stores (`custom` connections + a `discovered` map keyed by base URL). `remove(baseUrl)` filtered `custom` but left the matching `discovered` entry behind, orphaning it in storage.

Fix: fold the models onto each stored connection (`StoredConnection = { baseUrl, apiKey?, models?: string[] }`), back the registry with a single store, and let `remove()` drop a connection together with its models. `add()` preserves a connection's existing models when re-added without new ones. The picker now reads `connection.models` directly instead of a separate map.

Blast radius traced: the only external readers of the old `custom`/`discoveredModels` pair were inside this package (`inference-picker.svelte`); `agent-chat` and `cross-device-model-gap` only call `resolveOrHosted`/`canServe`, which are unchanged. The public read shape (`connections.custom` as a connection array) is preserved; the now-redundant `discoveredModels` getter is removed.

Migration note: `models` is optional so connections persisted under the old shape still load; their previously discovered ids (kept in the separate `discovered-models` key) are not migrated and simply re-discover on next open. Acceptable for a device-local, never-synced store.

**Finding 5 (skipped):** the audit's `createVocabEngine` / `epicenter-engine.ts` does not exist in the current tree (no such file or symbol anywhere). Nothing to change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785315153&installation_id=128463665&pr_number=2228&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2228&signature=adbd16893a0ea2b2a8d1bb6059934d4864358aa0094f0e545e9182233a2d8a8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->