### PR TITLE
refactor(local-books): move the in-memory token store to test helpers

### DIFF
--- a/apps/local-books/src/token-store.ts
+++ b/apps/local-books/src/token-store.ts
@@ -57,16 +57,3 @@ export function createFileTokenStore(filePath: string): TokenStore {
 		},
 	};
 }
-
-/** Process-lifetime in-memory store, for tests. Holds the typed set, no codec. */
-export function createMemoryTokenStore(): TokenStore {
-	const map = new Map<string, TokenSet>();
-	return {
-		async get(realmId) {
-			return map.get(realmId) ?? null;
-		},
-		async set(token) {
-			map.set(token.realmId, token);
-		},
-	};
-}

--- a/apps/local-books/test/helpers.ts
+++ b/apps/local-books/test/helpers.ts
@@ -2,6 +2,21 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { AppConfig } from '../src/config.ts';
+import type { TokenStore } from '../src/token-store.ts';
+import type { TokenSet } from '../src/tokens.ts';
+
+/** Process-lifetime in-memory token store, for tests. Holds the typed set, no codec. */
+export function createMemoryTokenStore(): TokenStore {
+	const map = new Map<string, TokenSet>();
+	return {
+		async get(realmId) {
+			return map.get(realmId) ?? null;
+		},
+		async set(token) {
+			map.set(token.realmId, token);
+		},
+	};
+}
 
 /** A full AppConfig with test defaults; override per test. Bypasses env/file. */
 export function makeConfig(over: Partial<AppConfig> = {}): AppConfig {

--- a/apps/local-books/test/sync.test.ts
+++ b/apps/local-books/test/sync.test.ts
@@ -6,9 +6,13 @@ import { openBooksDb } from '../src/db.ts';
 import { createQbClient } from '../src/qb-client.ts';
 import { repairEntities, runSyncLoop, syncRealm } from '../src/sync.ts';
 import { createTokenManager } from '../src/token-manager.ts';
-import { createMemoryTokenStore } from '../src/token-store.ts';
 import { type TokenSet, tokenSetFromGrant } from '../src/tokens.ts';
-import { makeConfig, sampleGrant, tempDir } from './helpers.ts';
+import {
+	createMemoryTokenStore,
+	makeConfig,
+	sampleGrant,
+	tempDir,
+} from './helpers.ts';
 import { makeInvoice, startMockQbServer } from './mock-qb-server.ts';
 
 /** A minimal QuickBooks Customer fixture (a name list the transactions reference). */


### PR DESCRIPTION
Stacked on #2226. Cleanup from the same audit of #2193 and #2210.

## Finding fixed

- **Test double moved out of `src/`.** `createMemoryTokenStore` is a process-lifetime in-memory `TokenStore` used only by `test/sync.test.ts`, but it shipped in `src/token-store.ts` beside the production file store. Moved to `test/helpers.ts`; the shipped module now carries only `createFileTokenStore`.

## Finding skipped

- The planned "require `openQb` and drop the mirror-only mode" change does **not** reproduce against current `main`. There is no `createBooksAgentActions`, no `mount.ts` in local-books, no optional `openQb?` parameter, and no `if (!openQb)` mirror-only branch. `openQb` is already a required field everywhere it appears (`ToolContext` in `commands/mcp.ts`, `recategorizeExpense`, `fetchReport`). Nothing to remove.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785315168&installation_id=128463665&pr_number=2229&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2229&signature=67b0a0e3439d5da754fef56f08cc1773a51c78f21035be832ee79c3a9e392243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->