### PR TITLE
refactor(matter-core): make StemQuery sort structured and stop exporting quoteIdent

### DIFF
--- a/apps/matter/src/lib/table-query.svelte.ts
+++ b/apps/matter/src/lib/table-query.svelte.ts
@@ -22,7 +22,6 @@
  * value or rebuild never lands a stale result.
  */
 
-import { quoteIdent } from '@epicenter/matter-core';
 import type { Mirror } from './mirror.svelte';
 
 /** Let a burst of keystrokes (or rapid external edits) settle before querying the mirror. */
@@ -55,20 +54,17 @@ export function createTableQuery(mirror: Mirror, tableName: () => string) {
 		void mirror.version; // re-run after the mirror is rebuilt (downstream of row edits)
 
 		// No control active: the grid renders synchronously from the in-memory rows, so issue no SQL.
-		if (!whereClause && !matchText && !currentSort) {
+		if (!isActive) {
 			orderedStems = undefined;
 			error = undefined;
 			return;
 		}
-		const orderBy = currentSort
-			? `${quoteIdent(currentSort.column)} ${currentSort.dir === 'desc' ? 'DESC' : 'ASC'}`
-			: undefined;
 		let cancelled = false;
 		const handle = setTimeout(async () => {
 			const { data, error: failure } = await mirror.runQuery(tableName(), {
 				where: whereClause || undefined,
 				match: matchText || undefined,
-				orderBy,
+				sort: currentSort,
 			});
 			if (cancelled) return; // a newer control, a rebuild, or this tab being torn down won
 			if (failure) error = failure.message;

--- a/packages/matter-core/src/core/query.test.ts
+++ b/packages/matter-core/src/core/query.test.ts
@@ -15,13 +15,13 @@ describe('buildStemQuery (the SQL shapes)', () => {
 		expect(buildStemQuery('books', { where: "status = 'reading'" })).toBe(
 			`SELECT "stem" FROM "books" WHERE status = 'reading'`,
 		);
-		expect(buildStemQuery('books', { orderBy: '"rating" DESC' })).toBe(
-			'SELECT "stem" FROM "books" ORDER BY "rating" DESC',
-		);
+		expect(
+			buildStemQuery('books', { sort: { column: 'rating', dir: 'desc' } }),
+		).toBe('SELECT "stem" FROM "books" ORDER BY "rating" DESC');
 		expect(
 			buildStemQuery('books', {
 				where: "status = 'reading'",
-				orderBy: '"rating" DESC',
+				sort: { column: 'rating', dir: 'desc' },
 			}),
 		).toBe(
 			`SELECT "stem" FROM "books" WHERE status = 'reading' ORDER BY "rating" DESC`,
@@ -44,7 +44,10 @@ describe('buildStemQuery (the SQL shapes)', () => {
 		);
 		// An explicit ORDER BY overrides the relevance rank.
 		expect(
-			buildStemQuery('books', { match: 'fox', orderBy: '"title" ASC' }),
+			buildStemQuery('books', {
+				match: 'fox',
+				sort: { column: 'title', dir: 'asc' },
+			}),
 		).toBe(
 			`SELECT "books"."stem" AS stem FROM "books" JOIN ${matched} ORDER BY "title" ASC`,
 		);
@@ -104,7 +107,10 @@ describe('buildStemQuery (executed against a real projection in bun:sqlite)', ()
 
 	test('filter plus sort returns the matching stems in order', () => {
 		expect(
-			run(freshDb(), { where: "status = 'reading'", orderBy: '"rating" DESC' }),
+			run(freshDb(), {
+				where: "status = 'reading'",
+				sort: { column: 'rating', dir: 'desc' },
+			}),
 		).toEqual(['sky', 'hobbit']);
 	});
 

--- a/packages/matter-core/src/core/query.ts
+++ b/packages/matter-core/src/core/query.ts
@@ -21,15 +21,19 @@ function ftsMatchLiteral(term: string): string {
 	return quoteString(phrase);
 }
 
-/** The grid's query controls: a SQL `WHERE` fragment, full-text search text, and a SQL `ORDER BY`
- *  fragment. All optional; an all-empty query is just `SELECT "stem" FROM <table>`. */
+/** A column sort: which column, ascending or descending. The column is a known header name (not free
+ *  text), quoted into the `ORDER BY` fragment inside {@link buildStemQuery}. */
+export type Sort = { column: string; dir: 'asc' | 'desc' };
+
+/** The grid's query controls: a SQL `WHERE` fragment, full-text search text, and a column sort. All
+ *  optional; an all-empty query is just `SELECT "stem" FROM <table>`. */
 export type StemQuery = {
 	/** A raw SQL boolean expression for the `WHERE` clause (the user's own filter box). */
 	where?: string;
 	/** Plain search text, matched full-text against the folder's FTS5 index. */
 	match?: string;
-	/** A SQL `ORDER BY` fragment built from a clicked header (a known, quoted column plus direction). */
-	orderBy?: string;
+	/** The active column sort (a clicked header), or omitted for relevance / natural order. */
+	sort?: Sort;
 };
 
 /**
@@ -37,30 +41,36 @@ export type StemQuery = {
  * select over the base table. With a `match`, the full-text search runs in a derived subquery that
  * exposes ONLY `rowid` and `rank`, joined back to the base table; that subquery is what keeps the FTS
  * index's columns (`status`, `title`, ...) from shadowing the base table's columns of the same name, so
- * the user's unqualified `where`/`orderBy` never hit an "ambiguous column" error. Relevance (`rank`)
- * orders the results unless an explicit `ORDER BY` is given. `orderBy` is a SQL fragment the caller
- * builds from a known column, so it is inlined; `where` is the user's own clause against their own
- * read-only db, where the worst a bad clause does is return an error.
+ * the user's unqualified `where`/`sort` never hit an "ambiguous column" error. Relevance (`rank`)
+ * orders the results unless an explicit `sort` is given. `sort` names a known header column, quoted
+ * into the `ORDER BY` here; `where` is the user's own clause against their own read-only db, where the
+ * worst a bad clause does is return an error.
  */
 export function buildStemQuery(
 	tableName: string,
-	{ where, match, orderBy }: StemQuery,
+	{ where, match, sort }: StemQuery,
 ): string {
 	const table = quoteIdent(tableName);
+	const orderBy = sort
+		? `${quoteIdent(sort.column)} ${sort.dir === 'desc' ? 'DESC' : 'ASC'}`
+		: undefined;
+
+	// The base select differs by mode, but the WHERE and ORDER BY tail is shared. A matched query also
+	// falls back to relevance (`rank`) when the caller gives no explicit sort.
+	let sql = `SELECT "stem" FROM ${table}`;
+	let defaultOrder: string | undefined;
 	if (match) {
 		const fts = quoteIdent(ftsTableName(tableName));
 		// The match subquery projects only rowid + rank, so its alias contributes no column that could
 		// collide with a base column in the user's where/order by. `_fts_match` is a synthetic alias.
 		const matched = `(SELECT rowid, rank FROM ${fts} WHERE ${fts} MATCH ${ftsMatchLiteral(match)})`;
-		let sql =
+		sql =
 			`SELECT ${table}."stem" AS stem FROM ${table} ` +
 			`JOIN ${matched} "_fts_match" ON ${table}.rowid = "_fts_match".rowid`;
-		if (where) sql += ` WHERE ${where}`;
-		sql += ` ORDER BY ${orderBy ?? '"_fts_match".rank'}`;
-		return sql;
+		defaultOrder = '"_fts_match".rank';
 	}
-	let sql = `SELECT "stem" FROM ${table}`;
 	if (where) sql += ` WHERE ${where}`;
-	if (orderBy) sql += ` ORDER BY ${orderBy}`;
+	const order = orderBy ?? defaultOrder;
+	if (order) sql += ` ORDER BY ${order}`;
 	return sql;
 }

--- a/packages/matter-core/src/index.ts
+++ b/packages/matter-core/src/index.ts
@@ -61,14 +61,13 @@ export {
 // Path: the folder label.
 export { basename } from './core/path';
 // Query: build the read-only SELECT the grid (and headless query verbs) run over a folder's mirror.
-export { buildStemQuery, type StemQuery } from './core/query';
+export { buildStemQuery, type Sort, type StemQuery } from './core/query';
 // Serialize: write an edited frontmatter field or body back to a `.md` file's text.
 export { editBody, editField, serializeEntry } from './core/serialize';
 // SQLite: project a typed folder's classified rows into a read-only schema + insert.
 export {
 	buildCreateTable,
 	projectToSqlite,
-	quoteIdent,
 	type SqliteProjection,
 	type SqlValue,
 } from './core/sqlite';


### PR DESCRIPTION
Cleanup from the audit of #2194 (matter SQLite query surface).

## Changes

- **Structured sort.** `StemQuery.orderBy` was a pre-assembled raw SQL string. Unlike `where` (genuine user input that must stay a raw clause), the sort fragment was *always* built in the app from a `{ column, dir }` pair via `quoteIdent`. Replace it with `sort?: Sort` where `Sort = { column: string; dir: 'asc' | 'desc' }`, and build the `ORDER BY` fragment inside `buildStemQuery` (mapping `asc`/`desc` to `ASC`/`DESC` there). The column is quoted with the `quoteIdent` already imported in `query.ts`.
- **Stop exporting `quoteIdent`.** The app's `table-query.svelte.ts` was the only external consumer of matter-core's `quoteIdent` (the workspace package has its own unrelated `quoteIdentifier`). With the sort fragment now built inside the package, the app passes its `currentSort` straight through as `sort` and drops the `quoteIdent` import, so `quoteIdent` leaves the public barrel.
- **Collapse duplicated assembly.** The `match` and non-`match` branches of `buildStemQuery` each restated the `WHERE` / `ORDER BY` tail. Share that tail; the `match` branch keeps only its relevance-rank default.
- **Early return on `isActive`.** The query effect restated the inverse of the derived `isActive`. Guard on `!isActive` instead.

`buildStemQuery`'s emitted SQL is unchanged; the test updates only swap the `orderBy` string input for the structured `sort`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785315234&installation_id=128463665&pr_number=2230&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2230&signature=a8714d4684dcff4ac829460bf19af3f537c26fc23c1944742d24376717632409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->