### PR TITLE
refactor(auth): hoist shared getProfileVia and inline the bun() adapter

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -32,6 +32,7 @@
 		"@better-auth/oauth-provider": "catalog:",
 		"@epicenter/auth": "workspace:*",
 		"@epicenter/constants": "workspace:*",
+		"@epicenter/identity": "workspace:*",
 		"@epicenter/server": "workspace:*",
 		"@epicenter/sync": "workspace:*",
 		"@epicenter/workspace": "workspace:*",

--- a/apps/api/scripts/smoke.ts
+++ b/apps/api/scripts/smoke.ts
@@ -30,6 +30,7 @@
 
 import { API_ROUTES } from '@epicenter/constants/api-routes';
 import { API_BUN_DEV_PORT } from '@epicenter/constants/apps';
+import { asOwnerId } from '@epicenter/identity';
 
 const BASE_URL = (
 	process.argv[2] ??
@@ -119,7 +120,7 @@ async function main() {
 		`epicenter blob smoke ${new Date().toISOString()} ${randHex(4)}\n`,
 	);
 	const sha256 = await sha256Hex(payload);
-	const owner = ownerId as never;
+	const owner = asOwnerId(ownerId);
 	const ticketRes = await fetch(API_ROUTES.blobs.list.url(BASE_URL, owner), {
 		method: 'POST',
 		headers: { ...authHeaders, 'content-type': 'application/json' },

--- a/apps/api/server.ts
+++ b/apps/api/server.ts
@@ -124,7 +124,8 @@ export function startBunApiServer(
 	const bunRooms = createBunRooms({ dir: dataDir });
 
 	// One pool for the process; drizzle checks a client out per query and returns
-	// it, so `bun()`'s `db.connect` hands back the shared handle with a no-op close.
+	// it, so the `mountCloudDb` connect leg below hands back the shared handle with
+	// a no-op close.
 	const pool = new pg.Pool({ connectionString: env.DATABASE_URL });
 	const db = createDb(pool);
 

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "@better-auth/oauth-provider": "catalog:",
         "@epicenter/auth": "workspace:*",
         "@epicenter/constants": "workspace:*",
+        "@epicenter/identity": "workspace:*",
         "@epicenter/server": "workspace:*",
         "@epicenter/sync": "workspace:*",
         "@epicenter/workspace": "workspace:*",

--- a/packages/auth/src/create-oauth-app-auth.ts
+++ b/packages/auth/src/create-oauth-app-auth.ts
@@ -1,14 +1,12 @@
-import { API_ROUTES } from '@epicenter/constants/api-routes';
 import { EPICENTER_API_URL } from '@epicenter/constants/apps';
 import { BEARER_SUBPROTOCOL_PREFIX } from '@epicenter/sync';
 import { defineErrors, extractErrorMessage } from 'wellcrafted/error';
 import { createLogger, type Logger } from 'wellcrafted/logger';
-import { Err, Ok, type Result, tryAsync } from 'wellcrafted/result';
+import { Err, Ok, type Result } from 'wellcrafted/result';
 import type { AuthFetch, AuthState, SyncAuthClient } from './auth-contract.js';
 import { AuthError } from './auth-errors.js';
 import {
 	ApiSessionResponse,
-	type AuthUser,
 	type OAuthTokenGrant,
 	type PersistedAuth,
 } from './auth-types.js';
@@ -20,6 +18,7 @@ import {
 import type { PersistedAuthStorage } from './persisted-auth-storage.js';
 import {
 	type ApiSessionReadError,
+	getProfileVia,
 	readApiSession,
 } from './read-api-session.js';
 
@@ -382,28 +381,6 @@ export function createOAuthAppAuth({
 		return retryResponse;
 	}
 
-	async function getProfile(): Promise<Result<AuthUser, AuthError>> {
-		const { data: response, error } = await tryAsync({
-			try: () => authedFetch(API_ROUTES.session.url(baseURL)),
-			catch: (cause) => AuthError.ProfileUnavailable({ cause }),
-		});
-		if (error) return Err(error);
-		if (!response.ok) {
-			return AuthError.ProfileUnavailable({
-				cause: {
-					message: `${API_ROUTES.session.pattern} failed with ${response.status}.`,
-					status: response.status,
-				},
-			});
-		}
-		const { data: user, error: parseError } = await tryAsync({
-			try: async () => ApiSessionResponse.assert(await response.json()).user,
-			catch: (cause) => AuthError.ProfileUnavailable({ cause }),
-		});
-		if (parseError) return Err(parseError);
-		return Ok(user);
-	}
-
 	async function completeSignInWithGrant(
 		grant: OAuthTokenGrant,
 		generation: number,
@@ -495,7 +472,7 @@ export function createOAuthAppAuth({
 			}
 		},
 		fetch: authedFetch,
-		getProfile,
+		getProfile: () => getProfileVia(authedFetch, baseURL),
 		async openWebSocket(url, protocols = []) {
 			const accessToken = await bearerForNetwork(false);
 			const authProtocols = accessToken

--- a/packages/auth/src/instance-token-auth.ts
+++ b/packages/auth/src/instance-token-auth.ts
@@ -1,12 +1,10 @@
-import { API_ROUTES } from '@epicenter/constants/api-routes';
 import { BEARER_SUBPROTOCOL_PREFIX } from '@epicenter/sync';
 import { defineErrors } from 'wellcrafted/error';
 import { createLogger, type Logger } from 'wellcrafted/logger';
-import { Err, Ok, type Result, tryAsync } from 'wellcrafted/result';
+import { Ok, type Result } from 'wellcrafted/result';
 import type { AuthFetch, AuthState, SyncAuthClient } from './auth-contract.js';
 import { AuthError } from './auth-errors.js';
-import { ApiSessionResponse, type AuthUser } from './auth-types.js';
-import { readApiSession } from './read-api-session.js';
+import { getProfileVia, readApiSession } from './read-api-session.js';
 
 type AuthFetchInput = Request | string | URL;
 
@@ -177,28 +175,6 @@ export function createInstanceTokenAuth({
 		return response;
 	}
 
-	async function getProfile(): Promise<Result<AuthUser, AuthError>> {
-		const { data: response, error } = await tryAsync({
-			try: () => authedFetch(API_ROUTES.session.url(baseURL)),
-			catch: (cause) => AuthError.ProfileUnavailable({ cause }),
-		});
-		if (error) return Err(error);
-		if (!response.ok) {
-			return AuthError.ProfileUnavailable({
-				cause: {
-					message: `${API_ROUTES.session.pattern} failed with ${response.status}.`,
-					status: response.status,
-				},
-			});
-		}
-		const { data: user, error: parseError } = await tryAsync({
-			try: async () => ApiSessionResponse.assert(await response.json()).user,
-			catch: (cause) => AuthError.ProfileUnavailable({ cause }),
-		});
-		if (parseError) return Err(parseError);
-		return Ok(user);
-	}
-
 	return {
 		get state() {
 			return state;
@@ -218,7 +194,7 @@ export function createInstanceTokenAuth({
 			return Ok(undefined);
 		},
 		fetch: authedFetch,
-		getProfile,
+		getProfile: () => getProfileVia(authedFetch, baseURL),
 		async openWebSocket(url, protocols = []) {
 			// The room URL is always built from `baseURL`, so the bearer is always
 			// addressed to its own origin; attach it unconditionally.

--- a/packages/auth/src/read-api-session.ts
+++ b/packages/auth/src/read-api-session.ts
@@ -4,9 +4,10 @@ import {
 	extractErrorMessage,
 	type InferErrors,
 } from 'wellcrafted/error';
-import { type Result, tryAsync } from 'wellcrafted/result';
+import { Ok, type Result, tryAsync } from 'wellcrafted/result';
 import type { AuthFetch } from './auth-contract.js';
-import { ApiSessionResponse } from './auth-types.js';
+import { AuthError } from './auth-errors.js';
+import { ApiSessionResponse, type AuthUser } from './auth-types.js';
 
 /**
  * The neutral outcome of one bearer `/api/session` read. The variants name the
@@ -79,4 +80,28 @@ export async function readApiSession({
 		try: async () => ApiSessionResponse.assert(await response.json()),
 		catch: (cause) => ApiSessionReadError.Malformed({ cause }),
 	});
+}
+
+/**
+ * Read `/api/session` as an {@link AuthUser} for the bearer clients' `getProfile`.
+ *
+ * `fetch` is the client's own auth-attaching fetch: it owns the Authorization
+ * header (it sets the bearer for the Epicenter origin and strips it elsewhere),
+ * so this reuses {@link readApiSession} only for the request, status branching,
+ * and body parsing. The token readApiSession is given is overwritten by `fetch`
+ * before the wire, so it is passed empty. Any read failure (unreachable,
+ * rejected, unexpected, malformed) surfaces as the single `ProfileUnavailable`
+ * the `AuthClient` contract returns.
+ */
+export async function getProfileVia(
+	fetch: AuthFetch,
+	baseURL: string,
+): Promise<Result<AuthUser, AuthError>> {
+	const { data: session, error } = await readApiSession({
+		baseURL,
+		fetch,
+		token: '',
+	});
+	if (error) return AuthError.ProfileUnavailable({ cause: error });
+	return Ok(session.user);
 }


### PR DESCRIPTION

Cleanup from an audit of #2192 (self-hostable end to end) and #2201 (one instance auth resolver).

- **Hoist `getProfileVia`.** `instance-token-auth.ts` and `create-oauth-app-auth.ts` carried byte-identical ~21-line `getProfile` bodies that hand-rolled the `/api/session` read that `readApiSession` already owns. The shared `getProfileVia(fetch, baseURL)` (in `read-api-session.ts`) is built on `readApiSession` and called from both. The client's auth-attaching `fetch` still owns the Authorization header (it sets the bearer for the Epicenter origin and strips it elsewhere), so `readApiSession` is reused only for the request, status branching, and body parsing; the token it is given is overwritten before the wire and passed empty. All read failures still surface as the single `ProfileUnavailable`, preserving the existing contract tests (success and 401-pauses-then-unavailable).
- **Brand the smoke owner.** `apps/api/scripts/smoke.ts` used `ownerId as never`, which defeats the `OwnerId` brand; switched to `asOwnerId(...)` so the blobs-route contract is checked at compile time. Added `@epicenter/identity` to `apps/api` deps for the helper.
- **Stale `bun()` comment.** The `bun()` runtime adapter named in the original finding was already dissolved on `main` (commit `fe45ded`, "dissolve RuntimeAdapter"), so there is nothing left to inline or delete. The only remnant was a comment in `apps/api/server.ts` still referencing `bun()`'s `db.connect`; it now points at the inline `mountCloudDb` connect leg.

A note for review:

The "inline the `bun()` adapter" half of the title is moot: the adapter no longer exists on `main`. Kept the title for traceability to the audit finding.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785315591&installation_id=128463665&pr_number=2231&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2231&signature=e521043ff8ab2f5debfb5b8b949ab5857aca15b77d0dc4eebb4afd9c3ffd83f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->