### PR TITLE
refactor(agent-chat): drop the generateId injection param (lazy-open deferred)

### DIFF
--- a/apps/opensidian/opensidian.ts
+++ b/apps/opensidian/opensidian.ts
@@ -21,27 +21,9 @@ import {
 	defineActions,
 	defineTable,
 	defineWorkspace,
-	generateId,
-	type Id,
 	type InferTableRow,
 	type WorkspaceFromDefinition,
 } from '@epicenter/workspace';
-import type { Brand } from 'wellcrafted/brand';
-
-/**
- * Branded chat message ID for one persisted assistant, user, or system message.
- *
- * The brand keeps message IDs distinct from conversation IDs so references
- * stay type-safe across joins and edits.
- */
-export type ChatMessageId = Id & Brand<'ChatMessageId'>;
-
-/**
- * Generate a unique {@link ChatMessageId} for a new chat message, centralizing
- * the branded id cast in one place.
- */
-export const generateChatMessageId = (): ChatMessageId =>
-	generateId<ChatMessageId>();
 
 /**
  * Tool trust: per-tool approval preferences for chat actions.

--- a/apps/opensidian/src/lib/session.ts
+++ b/apps/opensidian/src/lib/session.ts
@@ -2,7 +2,6 @@ import { createAgentChatState } from '@epicenter/app-shell/agent-chat';
 import { createSession } from '@epicenter/svelte/auth';
 import { createNodeId } from '@epicenter/workspace';
 import { createDispatchToolCatalog } from '@epicenter/workspace/agent';
-import { generateChatMessageId } from 'opensidian';
 import { openOpensidianBrowser } from 'opensidian/browser';
 import { auth } from '$platform/auth';
 import { DEFAULT_MODEL } from './chat/models';
@@ -45,7 +44,6 @@ export const session = createSession({
 			table: opensidian.tables.conversations,
 			whenLoaded: opensidian.idb.whenLoaded,
 			connections: inferenceConnections,
-			generateId: generateChatMessageId,
 			activeConversation: {
 				get current() {
 					return searchParams.chat;

--- a/apps/tab-manager/src/lib/session.svelte.ts
+++ b/apps/tab-manager/src/lib/session.svelte.ts
@@ -2,7 +2,6 @@ import { createAgentChatState } from '@epicenter/app-shell/agent-chat';
 import type { InstanceSetting, SyncAuthClient } from '@epicenter/auth';
 import { EPICENTER_TAB_MANAGER_OAUTH_CLIENT_ID } from '@epicenter/constants/oauth-clients';
 import { createAppAuthClient, createSession } from '@epicenter/svelte/auth';
-import { generateId } from '@epicenter/workspace';
 import {
 	createDispatchToolCatalog,
 	defaultApprovalDecision,
@@ -82,7 +81,6 @@ function buildSession(
 				table: tabManager.tables.conversations,
 				whenLoaded: tabManager.idb.whenLoaded,
 				connections: inferenceConnections,
-				generateId,
 				agent: {
 					buildSystemPrompts: () => [
 						buildDeviceConstraints(tabManager.nodeId),

--- a/apps/vocab/src/routes/(signed-in)/+page.svelte
+++ b/apps/vocab/src/routes/(signed-in)/+page.svelte
@@ -5,11 +5,7 @@
 	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import * as Sidebar from '@epicenter/ui/sidebar';
 	import { toast } from '@epicenter/ui/sonner';
-	import {
-		generateMessageId,
-		VOCAB_MODEL,
-		VOCAB_SYSTEM_PROMPT,
-	} from '@epicenter/vocab';
+	import { VOCAB_MODEL, VOCAB_SYSTEM_PROMPT } from '@epicenter/vocab';
 	import { onDestroy } from 'svelte';
 	import { extractErrorMessage } from 'wellcrafted/error';
 	import { requireVocab } from '$lib/session';
@@ -29,7 +25,6 @@
 		table: vocab.tables.conversations,
 		whenLoaded: vocab.idb.whenLoaded,
 		connections: inferenceConnections,
-		generateId: generateMessageId,
 		agent: {
 			buildSystemPrompts: () => [VOCAB_SYSTEM_PROMPT],
 			defaultModel: VOCAB_MODEL,

--- a/apps/vocab/vocab.ts
+++ b/apps/vocab/vocab.ts
@@ -15,22 +15,9 @@
 
 import { conversationsTable } from '@epicenter/chat';
 import type { ServableModel } from '@epicenter/constants/ai-providers';
-import {
-	defineKv,
-	defineWorkspace,
-	generateId,
-	type Id,
-} from '@epicenter/workspace';
+import { defineKv, defineWorkspace } from '@epicenter/workspace';
 import type { AgentMessage } from '@epicenter/workspace/agent';
 import { Type } from 'typebox';
-import type { Brand } from 'wellcrafted/brand';
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Branded ID Types
-// ─────────────────────────────────────────────────────────────────────────────
-
-export type MessageId = Id & Brand<'MessageId'>;
-export const generateMessageId = (): MessageId => generateId<MessageId>();
 
 /**
  * Vocab runs a single Chinese-tuned model. It is an app constant, not a
@@ -88,7 +75,7 @@ export const VOCAB_DICTATION_LANGUAGE = 'en';
 /**
  * A complete chat message: the unit Vocab persists. Each finished message is
  * written once, whole, as one JSON blob in the conversation's LWW store keyed by
- * {@link MessageId} (ADR-0046/0047), the moment a turn finishes.
+ * its message id (ADR-0046/0047), the moment a turn finishes.
  *
  * It is the shared {@link AgentMessage} so Vocab rides the one client agent loop
  * (`@epicenter/workspace/agent`). Vocab is capability-free, so every message is

--- a/packages/app-shell/src/agent-chat/agent-chat.svelte.ts
+++ b/packages/app-shell/src/agent-chat/agent-chat.svelte.ts
@@ -26,7 +26,6 @@
  * - `agent.defaultModel`        the model a brand new conversation starts on.
  * - `activeConversation`        the active-conversation source; defaults to internal
  *                               state. An app that keeps it in the URL injects its own.
- * - `generateId`                the message-id minter.
  *
  * A mutation is approval-gated by a synchronous pause: the loop waits on an
  * in-client decision, recorded per handle in `pendingApproval`. The "Always
@@ -47,7 +46,7 @@ import {
 } from '@epicenter/chat';
 import { createOpenAiAgentEngine } from '@epicenter/client';
 import { bindAgentConversation, fromTable } from '@epicenter/svelte';
-import { InstantString } from '@epicenter/workspace';
+import { generateId, InstantString } from '@epicenter/workspace';
 import {
 	type AgentToolCall,
 	type Approval,
@@ -81,8 +80,8 @@ export type ConversationHandle = NonNullable<AgentChatState['active']>;
 /**
  * What the agent can do: the persona and capabilities an app gives its chat
  * loop. Grouped because every field varies with the app, not the device or the
- * route. The workspace handles, connections, id minter, and active-conversation
- * source the loop also needs are passed separately; they have different owners.
+ * route. The workspace handles, connections, and active-conversation source the
+ * loop also needs are passed separately; they have different owners.
  */
 export type AgentKit = {
 	/** The layered system prompts an answer is generated under, read per turn. */
@@ -99,7 +98,6 @@ export function createAgentChatState({
 	table,
 	whenLoaded,
 	connections,
-	generateId,
 	activeConversation,
 	agent: {
 		buildSystemPrompts,
@@ -114,8 +112,6 @@ export function createAgentChatState({
 	whenLoaded: Promise<unknown>;
 	/** The device connection registry (ADR-0059); resolves a model to a transport. */
 	connections: InferenceConnections;
-	/** Mint a message id. */
-	generateId: () => string;
 	/** The active-conversation source; defaults to internal `$state`. */
 	activeConversation?: ActiveConversation;
 	/** What the agent can do: the app's persona and capabilities. */


### PR DESCRIPTION
This change:

**Drops the `generateId` injection param from `createAgentChatState`.**

Every app passed a brand-only rewrapper (`generateChatMessageId`, `generateMessageId`, or the bare workspace `generateId`) widened straight back to `() => string`. The brand never left the call: the loop keys the messages store by a plain string id, so the injection carried zero behavioral variation. The module now mints message ids from the workspace `generateId` directly.

Removed along with it: the now-unused `generateChatMessageId` / `ChatMessageId` (opensidian) and `generateMessageId` / `MessageId` (vocab), plus the imports each freed. `loop-repro` keeps its own `generateId`: it drives the loop (`createConversation`) directly, not `createAgentChatState`.

What is deferred (the lazy-open + denormalize-preview portion):

The original scope also asked to make conversation handles open lazily and denormalize a `lastMessageText` preview onto the row. After tracing the lifecycle I am deferring that as a coupled unit, because shipping it blind (no `node_modules` / typecheck / runtime in this pass) on the highest-risk file would be reckless. The two hard parts both need runtime verification:

### 1. Reactive handle lifecycle with URL-backed selection

Today `reconcileHandles` opens a handle for every row, and `active` just reads `handles.get(selection.current)`, which always exists. Going lazy means opening the handle for `selection.current` (plus any in-flight conversation) on demand.

The blocker: opensidian backs `activeConversation` with the URL (`?chat=`), so selection can change without going through `switchTo` (back button, a link). The only way to react to `selection.current` is reactively. But:

- Creating the handle inside the `active` getter creates the handle's `$state` / `$derived` during a component's reactive read, where they get an owner that disposes them on the next recompute. Today handles are created in the `table.observe` callback, an **unowned** context, which is exactly why they persist.
- `$effect.root` is the right tool for an unowned reactive scope, but a handle created inside its `$effect` body is owned by that effect and torn down when the effect re-runs on the next selection change.

So the lazy lifecycle needs an `$effect.root` plus careful unowned handle creation (create outside the tracked body, only read `selection.current` inside it), and the ownership/teardown behavior has to be verified in a running app before trusting it on the active chat surface.

The intended shape, once verified:
- `reconcileHandles` keeps a handle only for `selection.current` and any handle whose turn is still `isLoading` (never tear down an in-flight loop). A turn settling writes the row, which fires `table.observe`, which prunes the now-idle handle.
- `conversationList` is rebuilt by iterating the conversation **rows** (`conversationsView.all`), not `[...handles.values()]`, so the list no longer requires every loop to be live. List items become a light `{ id, title, updatedAt, isLoading, lastMessagePreview, delete() }` view (handle lookup only for `isLoading`), and `ConversationSwitcher`'s prop type changes from `ConversationHandle[]` accordingly.

### 2. Denormalized `lastMessageText` (depends on 1)

The preview only needs to leave the open `messages` doc once the list stops iterating handles. That means a `lastMessageText: string` column on the conversation row, written when a turn settles (observe the `messages` store; write back when the last message's text differs, without bumping `updatedAt`), and `lastMessagePreview` reading the row.

Adding a column to the synced `conversationsTable` (`@epicenter/chat`) requires a schema v2 + `migrate` that defaults `lastMessageText` to `''`. This would be the **first** production use of the multi-version `defineTable(...).migrate(...)` path in the repo, on shared CRDT user data, and a v2 write makes those rows `NewerWriter` to any not-yet-updated client. The field is also inert without part 1 (eager handles already supply the preview from `convo.messages`). Both reasons argue for landing it together with the lazy lifecycle, behind a live sync + load test, rather than as standalone untested groundwork.

### Net

The `generateId` removal here is independent, safe, and complete. The lazy-open + denormalize work is fully designed above and should land as a follow-up once it can be exercised in a running app (reactive handle teardown) and against a live workspace (schema v2 migration).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785315712&installation_id=128463665&pr_number=2232&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2232&signature=b6730b62ca0588dcbbbd90d58f48b0ee7ec94c452436a7a9e51f45f14acdb100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->