### PR TITLE
fix(instance-setting): surface corrupt stored bearers and resolve the onSaved seam

### DIFF
--- a/packages/app-shell/src/instance-settings/instance-settings-modal.svelte
+++ b/packages/app-shell/src/instance-settings/instance-settings-modal.svelte
@@ -10,24 +10,18 @@
 		open = $bindable(false),
 		appName,
 		setting,
-		onSaved = () => location.reload(),
 	}: {
 		open?: boolean;
 		/** The app's display name, woven into the description. */
 		appName: string;
 		/** The shared instance setting handle this app injected. */
 		setting: InstanceSetting;
-		/**
-		 * Run after a save or revert persists. Defaults to a full reload so auth
-		 * construction re-reads the new instance; an extension can inject its own
-		 * re-init.
-		 */
-		onSaved?: () => void;
 	} = $props();
 
-	// Seed the form from the snapshot once; saving runs `onSaved` (a reload by
-	// default), so there is no live value to track. `hasOverride` only gates the
-	// "Use hosted" button, so it stays a derived read of the stable handle.
+	// Seed the form from the snapshot once; saving reloads so auth construction
+	// re-reads the new instance, so there is no live value to track. `hasOverride`
+	// only gates the "Use hosted" button, so it stays a derived read of the stable
+	// handle.
 	let urlInput = $state(
 		untrack(() => (setting.isDefault() ? '' : setting.read().baseURL)),
 	);
@@ -53,12 +47,12 @@
 			return;
 		}
 		await setting.write({ baseURL, token });
-		onSaved();
+		location.reload();
 	}
 
 	async function useHosted() {
 		await setting.clear();
-		onSaved();
+		location.reload();
 	}
 </script>
 

--- a/packages/auth/src/instance-setting.ts
+++ b/packages/auth/src/instance-setting.ts
@@ -1,4 +1,19 @@
+import { defineErrors, extractErrorMessage } from 'wellcrafted/error';
+import { createLogger, type Logger } from 'wellcrafted/logger';
 import { type Instance, normalizeInstanceUrl } from './instance.js';
+
+const InstanceSettingError = defineErrors({
+	/** The stored record could not be read (a throwing `getItem`). */
+	Unreadable: ({ cause }: { cause: unknown }) => ({
+		message: `Could not read the stored instance setting; falling back to the hosted default: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	/** The stored record was present but not parseable JSON. */
+	Corrupt: ({ cause }: { cause: unknown }) => ({
+		message: `Discarding a corrupt instance setting; falling back to the hosted default: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+});
 
 /**
  * The persisted instance setting as a small handle every client shares.
@@ -30,14 +45,23 @@ export type InstanceSetting = {
  * hosted" rule, including the ADR-0071 invariant: OAuth runs only against the
  * hosted default, so a non-hosted base URL with no token cannot authenticate and
  * reads as the hosted default rather than a wedged override.
+ *
+ * A corrupt record (present but not parseable) is logged before the fallback, so
+ * a self-hoster whose stored bearer was mangled can tell it apart from "never
+ * configured" instead of silently reading as the hosted default.
  */
-function decodeInstance(raw: string | null, defaultBaseURL: string): Instance {
+function decodeInstance(
+	raw: string | null,
+	defaultBaseURL: string,
+	log: Logger,
+): Instance {
 	const hosted: Instance = { baseURL: defaultBaseURL };
 	if (raw === null) return hosted;
 	let parsed: Partial<Instance>;
 	try {
 		parsed = JSON.parse(raw) as Partial<Instance>;
-	} catch {
+	} catch (cause) {
+		log.warn(InstanceSettingError.Corrupt({ cause }));
 		return hosted;
 	}
 	// Re-normalize on read so a hand-edited record cannot smuggle in a malformed
@@ -91,27 +115,31 @@ function makeInstanceSetting({
  *
  * `storage` may be `undefined` (SSR import with no `localStorage`); the handle
  * then reports the hosted default and persists nothing. Reads are guarded so a
- * throwing `getItem` (private-mode Safari) reads as the default; writes
- * propagate so a credential that could not be persisted fails loudly, matching
- * {@link createWebStoragePersistedAuthStorage}.
+ * throwing `getItem` (private-mode Safari) reads as the default and is logged;
+ * writes propagate so a credential that could not be persisted fails loudly,
+ * matching {@link createWebStoragePersistedAuthStorage}.
  */
 export function createInstanceSetting({
 	storageKey,
 	defaultBaseURL,
 	storage,
+	log = createLogger('auth/instance-setting'),
 }: {
 	storageKey: string;
 	defaultBaseURL: string;
 	storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> | undefined;
+	/** Library logger for corrupt or unreadable stored records. */
+	log?: Logger;
 }): InstanceSetting {
 	let raw: string | null = null;
 	try {
 		raw = storage?.getItem(storageKey) ?? null;
-	} catch {
+	} catch (cause) {
+		log.warn(InstanceSettingError.Unreadable({ cause }));
 		raw = null;
 	}
 	return makeInstanceSetting({
-		initial: decodeInstance(raw, defaultBaseURL),
+		initial: decodeInstance(raw, defaultBaseURL, log),
 		defaultBaseURL,
 		persist: (serialized) => {
 			if (!storage) return;
@@ -138,13 +166,16 @@ export async function loadInstanceSetting({
 	defaultBaseURL,
 	read,
 	write,
+	log = createLogger('auth/instance-setting'),
 }: {
 	defaultBaseURL: string;
 	read: () => Promise<string | null>;
 	write: (serialized: string | null) => Promise<void>;
+	/** Library logger for corrupt stored records. */
+	log?: Logger;
 }): Promise<InstanceSetting> {
 	return makeInstanceSetting({
-		initial: decodeInstance(await read(), defaultBaseURL),
+		initial: decodeInstance(await read(), defaultBaseURL, log),
 		defaultBaseURL,
 		persist: write,
 	});


### PR DESCRIPTION

Cleanup from an audit of #2192 (self-hostable end to end) and #2201 (one instance auth resolver).

- **Surface corrupt stored bearers.** `decodeInstance`'s `JSON.parse` catch and `createInstanceSetting`'s `getItem` catch both fell back to the hosted default in silence, so a self-hoster whose stored bearer was mangled (or whose storage threw) could not tell it apart from "never configured." Threaded the same optional `log?: Logger` seam the auth clients already accept (defaulting to `createLogger('auth/instance-setting')`) and `log.warn` on a `Corrupt` (unparseable) or `Unreadable` (throwing `getItem`) record before the fallback. The fallback behavior is unchanged; it is now observable. No app call site has to change.
- **Resolve the dead `onSaved` seam.** `instance-settings-modal.svelte` exposed an `onSaved` prop ("extension can inject its own re-init"), but its only path to the modal is `SignedOutScreen`, which never forwarded it, and no app (the extension included) passes it. Deleted the prop and inlined the `location.reload()` it always ran.

A note for review:

`onSaved` was deleted, not wired: there is no re-init consumer (all five apps reach the modal through `SignedOutScreen`, which has no such prop).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785315846&installation_id=128463665&pr_number=2233&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2233&signature=b572d8d24defe400bbb1e9108b46c49117d1e8b9f86e9e44f549b4b3626db4e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->