### PR TITLE
refactor(local-books): move createMemoryTokenStore to test helpers

### DIFF
--- a/apps/local-books/src/token-store.ts
+++ b/apps/local-books/src/token-store.ts
@@ -57,16 +57,3 @@ export function createFileTokenStore(filePath: string): TokenStore {
 		},
 	};
 }
-
-/** Process-lifetime in-memory store, for tests. Holds the typed set, no codec. */
-export function createMemoryTokenStore(): TokenStore {
-	const map = new Map<string, TokenSet>();
-	return {
-		async get(realmId) {
-			return map.get(realmId) ?? null;
-		},
-		async set(token) {
-			map.set(token.realmId, token);
-		},
-	};
-}

--- a/apps/local-books/test/helpers.ts
+++ b/apps/local-books/test/helpers.ts
@@ -2,6 +2,21 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { AppConfig } from '../src/config.ts';
+import type { TokenStore } from '../src/token-store.ts';
+import type { TokenSet } from '../src/tokens.ts';
+
+/** Process-lifetime in-memory token store, for tests. Holds the typed set, no codec. */
+export function createMemoryTokenStore(): TokenStore {
+	const map = new Map<string, TokenSet>();
+	return {
+		async get(realmId) {
+			return map.get(realmId) ?? null;
+		},
+		async set(token) {
+			map.set(token.realmId, token);
+		},
+	};
+}
 
 /** A full AppConfig with test defaults; override per test. Bypasses env/file. */
 export function makeConfig(over: Partial<AppConfig> = {}): AppConfig {

--- a/apps/local-books/test/sync.test.ts
+++ b/apps/local-books/test/sync.test.ts
@@ -6,9 +6,13 @@ import { openBooksDb } from '../src/db.ts';
 import { createQbClient } from '../src/qb-client.ts';
 import { repairEntities, runSyncLoop, syncRealm } from '../src/sync.ts';
 import { createTokenManager } from '../src/token-manager.ts';
-import { createMemoryTokenStore } from '../src/token-store.ts';
 import { type TokenSet, tokenSetFromGrant } from '../src/tokens.ts';
-import { makeConfig, sampleGrant, tempDir } from './helpers.ts';
+import {
+	createMemoryTokenStore,
+	makeConfig,
+	sampleGrant,
+	tempDir,
+} from './helpers.ts';
 import { makeInvoice, startMockQbServer } from './mock-qb-server.ts';
 
 /** A minimal QuickBooks Customer fixture (a name list the transactions reference). */


### PR DESCRIPTION
Surviving piece of the local-books cleanup track (audit of #2193/#2210). The original openQb-required finding did not reproduce on current main (openQb is already required), so this is just the test-double move: `createMemoryTokenStore` leaves `src/` for `test/helpers.ts`. Grilled clean by both Claude and codex (codex ran the full local-books suite: pass). Recreated after the parent branch (C1 #2226) merged and auto-closed the stacked PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785316379&installation_id=128463665&pr_number=2234&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2234&signature=93436559e2e205aeb3e5e72b3c6b4cdaf03f21738b11e255512f1ef212ee6749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->