### PR TITLE
refactor(presence): decommission the orphaned action manifest

### DIFF
--- a/packages/workspace/src/document/open-collaboration.ts
+++ b/packages/workspace/src/document/open-collaboration.ts
@@ -1,36 +1,31 @@
 /**
  * `openCollaboration`: the one collaboration primitive on a document.
  *
- * Connects a Yjs document to the relay and derives per-peer liveness and action
- * manifests from the server-owned presence channel. An additive text-frame port
- * (`textPort`) lets the relay-channel layer ride the same socket for cross-device
- * MCP channels without coupling to sync or presence.
+ * Connects a Yjs document to the relay and derives per-peer liveness from the
+ * server-owned presence channel. An additive text-frame port (`textPort`) lets
+ * the relay-channel layer ride the same socket for cross-device MCP channels
+ * without coupling to sync or presence.
  *
  * Two wire surfaces ride one auth context:
  *
  *   binary WS frames  -> standard y-protocols SYNC.
- *   text WS frames    -> server -> client: presence (the full peer list
- *                        including each peer's action manifest, sent on
- *                        every membership or manifest change);
+ *   text WS frames    -> server -> client: presence (the full peer list, sent on
+ *                        every membership change);
  *                        client -> server: presence_publish (this node's
- *                        manifest, sent once per connect).
+ *                        identity: agent designation and exposed route names),
+ *                        sent once per connect.
  *
  * The Y.Doc holds durable workspace state; presence lives on the relay's
  * `connections` map.
  *
  * Content docs (rich-text bodies, attachments, nested independently-syncing
- * docs) use the same primitive with `actions: {}`: the published manifest is
- * empty, presence still flows in over the socket for online discovery.
+ * docs) use the same primitive with `actions: {}`; presence still flows in over
+ * the socket for online discovery.
  */
 
 import type { Logger } from 'wellcrafted/logger';
 import type * as Y from 'yjs';
-import {
-	ACTION_KEY_PATTERN,
-	type ActionManifest,
-	type ActionRegistry,
-	toActionMeta,
-} from '../shared/actions.js';
+import { ACTION_KEY_PATTERN, type ActionRegistry } from '../shared/actions.js';
 import {
 	createSyncSupervisor,
 	type OpenWebSocketFn,
@@ -92,10 +87,11 @@ export type OpenCollaborationConfig<TActions extends ActionRegistry> = {
 	connectDeadlineMs?: number;
 	log?: Logger;
 	/**
-	 * Injected local action registry. Collaboration publishes this registry to
-	 * peers as its presence manifest and exposes it as `collaboration.actions`,
-	 * but the caller remains the registry owner. Pass `{}` for content docs and
-	 * consume-only participants.
+	 * Injected local action registry. The caller remains the registry owner;
+	 * Collaboration validates the action keys and exposes it as
+	 * `collaboration.actions`, the local callable surface. It is no longer
+	 * published in presence (the action manifest is decommissioned). Pass `{}`
+	 * for content docs and consume-only participants.
 	 */
 	actions: TActions;
 	/**
@@ -184,16 +180,14 @@ export function openCollaboration<TActions extends ActionRegistry>(
 		for (const listener of presenceListeners) listener(remotePeers);
 	}
 
-	// Build the manifest once at construction time. The action registry is
-	// fixed for the lifetime of this Collaboration, so we cache the JSON form
-	// and publish it on every (re)connect.
-	const ownManifest: ActionManifest = {};
-	for (const [key, action] of Object.entries(userActions)) {
-		ownManifest[key] = toActionMeta(action);
-	}
+	// This node publishes only its identity and exposed-route names in presence.
+	// The legacy action manifest is decommissioned: nothing reads `Peer.actions`
+	// once the in-room dispatch subsystem was deleted (ADR-0073). The `actions`
+	// wire field stays required and is sent empty, so an older relay or peer sees
+	// no schema change while the device stops feeding a dead field.
 	const presencePublishFrame = JSON.stringify({
 		type: 'presence_publish',
-		actions: ownManifest,
+		actions: {},
 		agentId: config.agentId,
 		...(config.exposedRoutes !== undefined && {
 			exposedRoutes: config.exposedRoutes,
@@ -215,9 +209,9 @@ export function openCollaboration<TActions extends ActionRegistry>(
 	});
 
 	const unsubscribeStatusListener = supervisor.onStatusChange((status) => {
-		// Publish this node's action manifest on every (re)connect. The relay
-		// stores it against the new socket and rebroadcasts presence so peers
-		// see it.
+		// Publish this node's presence identity (agent designation and exposed
+		// route names) on every (re)connect. The relay stores it against the new
+		// socket and rebroadcasts presence so peers see it.
 		if (status.phase === 'connected') {
 			supervisor.send(presencePublishFrame);
 		}

--- a/packages/workspace/src/document/presence-protocol.ts
+++ b/packages/workspace/src/document/presence-protocol.ts
@@ -1,16 +1,16 @@
 /**
  * Presence wire protocol: the relay-owned peer list, plus the one frame the
- * node sends to publish its own manifest.
+ * node sends to publish its own presence identity.
  *
  * The relay owns presence (its `connections` map is the source of truth) and
- * broadcasts the FULL peer list on every membership or manifest change. The
- * client stores the latest list verbatim: there is no delta protocol and no
- * client-side reassembly, the frame IS the state.
+ * broadcasts the FULL peer list on every membership change. The client stores
+ * the latest list verbatim: there is no delta protocol and no client-side
+ * reassembly, the frame IS the state.
  *
- * The wire carries each peer's full action manifest so the receiver can
- * render affordances, validate input schemas, or hand the manifest to an AI
- * tool layer with no second round trip. Manifests are opaque to the relay: it
- * stores and forwards them as bytes, never inspects their shape.
+ * The `actions` manifest field is decommissioned: it is retained on the wire
+ * (always `{}`) for version-skew safety now that the in-room dispatch subsystem
+ * is deleted (ADR-0073), but nothing reads it. The live presence payload is each
+ * peer's `nodeId`, `connectedAt`, `agentId`, and `exposedRoutes`.
  *
  * Shared by the relay (`packages/server/src/room/core.ts`, the sender) and
  * the client (`open-collaboration.ts`, the reader).
@@ -27,8 +27,9 @@ import { ActionMetaSchema } from '../shared/actions.js';
 
 /**
  * Wire schema for an action manifest. `Record<string, ActionMeta>` where each
- * value is the metadata-only projection of a callable `Action`. Reuses
- * `ActionMetaSchema` so the wire stays in lockstep with the local registry.
+ * value is the metadata-only projection of a callable `Action`. Retained for
+ * wire compatibility but no longer populated: producers send `{}` (see the
+ * module header). Reuses `ActionMetaSchema` so the type stays valid.
  */
 export const ActionManifestSchema = Type.Record(
 	Type.String(),
@@ -38,9 +39,10 @@ export const ActionManifestSchema = Type.Record(
 /**
  * One peer's entry on the wire.
  *
- * `nodeId` routes dispatches; `connectedAt` lets receivers render an
- * "online since" affordance; `actions` is the peer's published manifest, or
- * `{}` if the peer has not (yet) published one. `agentId` is the catalog agent
+ * `nodeId` is the peer's relay routing address; `connectedAt` lets receivers
+ * render an "online since" affordance. `actions` is decommissioned (always
+ * `{}`, retained for wire compatibility; see the module header). `agentId` is
+ * the catalog agent
  * this peer answers as (ADR-0025), present only on a peer that mounted with one
  * (a resident daemon) and absent for ordinary participants. It is the join key
  * a picker uses to decorate a durable agent as live: the catalog owns the
@@ -78,12 +80,12 @@ export const PresenceFrameSchema = Type.Object({
 export type PresenceFrame = Static<typeof PresenceFrameSchema>;
 
 /**
- * Client -> server: publish this node's action manifest, and optionally the
- * catalog agent it answers as. The relay stores both against the sending
+ * Client -> server: publish this node's presence identity (its agent
+ * designation and exposed route names). The relay stores it against the sending
  * socket's nodeId and rebroadcasts presence so peers see the update. Sent once
- * on connect; re-sent if the local action registry changes. `agentId` is set
- * only by a peer that mounted as a resident agent (ADR-0025); ordinary
- * participants omit it.
+ * on connect. `actions` is decommissioned and sent as `{}` (see the module
+ * header). `agentId` is set only by a peer that mounted as a resident agent
+ * (ADR-0025); ordinary participants omit it.
  */
 export const PresencePublishFrameSchema = Type.Object({
 	type: Type.Literal('presence_publish'),


### PR DESCRIPTION
Stacks on #2237 (the dispatch deletion); merge after it.

Once the in-room dispatch subsystem is deleted, the per-peer action manifest broadcast over presence (`Peer.actions`) has no reader: the dispatch tool catalog's remote arm was its sole consumer, and it is gone. The field is dead weight on every presence frame.

This stops the client producing it. `presence_publish` now sends `actions: {}`, and the `ownManifest` build (plus its `toActionMeta` import) is removed. The live presence payload is now `nodeId` / `connectedAt` / `agentId` / `exposedRoutes`.

The reason for this shape is:

The lower-risk path. The `actions` field stays required on the wire schema and the relay keeps storing and forwarding it (now always `{}`), so there is no presence-protocol version skew: an older relay or peer validates and reads exactly the same shape, just empty. Dropping `PeerSchema.actions` / `PresencePublishFrameSchema.actions` / the server's `Connection.actions` is a genuine wire change with its own skew window, deferred until someone wants the bytes back.

`collaboration.actions` (the local callable registry read by fuji, honeycrisp, and the daemon) and the `TActions` generic are untouched: only the cross-device presence *projection* is decommissioned.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785395823&installation_id=128463665&pr_number=2238&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2238&signature=42bb8b5afff987163813be24cd6ffa0ceb9c3430f748d0c20de6c55174a50734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->