### PR TITLE
fix(whispering,fuji): harden desktop deep-link OAuth callback registration

### DIFF
--- a/apps/fuji/src-tauri/src/lib.rs
+++ b/apps/fuji/src-tauri/src/lib.rs
@@ -28,7 +28,12 @@ pub fn run() {
             {
                 use tauri_plugin_deep_link::DeepLinkExt;
 
-                _app.deep_link().register_all()?;
+                // Best-effort: a scheme-registration failure (unwritable registry
+                // or `.desktop` dir) must not abort startup, since sign-in is
+                // optional. Log and continue.
+                if let Err(err) = _app.deep_link().register_all() {
+                    eprintln!("failed to register deep-link schemes: {err}");
+                }
             }
 
             Ok(())

--- a/apps/whispering/src-tauri/capabilities/default.json
+++ b/apps/whispering/src-tauri/capabilities/default.json
@@ -98,7 +98,6 @@
     "aptabase:allow-track-event",
     "macos-permissions:default",
     "log:default",
-    "deep-link:default",
-    "opener:allow-open-url"
+    "deep-link:default"
   ]
 }

--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -216,7 +216,26 @@ pub async fn run() {
         }))
         .build();
 
-    let mut builder = tauri::Builder::default().plugin(log_plugin);
+    let mut builder = tauri::Builder::default();
+
+    // Register single-instance first, ahead of every other plugin. A second
+    // launch then forwards its args to the primary and exits before that primary
+    // initializes the rest of the plugin stack, per the plugin's documented
+    // ordering. With the `deep-link` feature this is also the path that forwards
+    // an OAuth callback URL to the already-running app on Linux/Windows; it reads
+    // deep-link state at callback time, so registering the deep-link plugin later
+    // in the chain does not affect forwarding.
+    #[cfg(desktop)]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            let _ = app
+                .get_webview_window("main")
+                .expect("no main window")
+                .set_focus();
+        }));
+    }
+
+    builder = builder.plugin(log_plugin);
 
     // Try to get APTABASE_KEY from environment, use empty string if not found
     let aptabase_key = option_env!("APTABASE_KEY").unwrap_or("");
@@ -311,17 +330,10 @@ pub async fn run() {
 
     #[cfg(desktop)]
     {
-        builder = builder
-            .plugin(tauri_plugin_autostart::init(
-                tauri_plugin_autostart::MacosLauncher::LaunchAgent,
-                None,
-            ))
-            .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
-                let _ = app
-                    .get_webview_window("main")
-                    .expect("no main window")
-                    .set_focus();
-            }));
+        builder = builder.plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            None,
+        ));
     }
 
     let builder = builder.invoke_handler(move |invoke| {

--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -287,10 +287,17 @@ pub async fn run() {
             // Register the `epicenter-whispering://` scheme at runtime on
             // Windows and Linux (macOS registers it from the bundle plist).
             // Lets the OAuth sign-in deep-link callback reach the running app.
+            // Scheme registration is best-effort: cloud sign-in is optional, so a
+            // failure here (unwritable registry/`.desktop` dir, missing
+            // `update-desktop-database`) must never abort startup. `panic = "abort"`
+            // would turn a propagated error into a hard crash. Log and continue; the
+            // only cost is that the deep-link callback may not resolve.
             #[cfg(any(windows, target_os = "linux"))]
             {
                 use tauri_plugin_deep_link::DeepLinkExt;
-                app.deep_link().register_all()?;
+                if let Err(err) = app.deep_link().register_all() {
+                    warn!("failed to register deep-link schemes; cloud sign-in deep link may not resolve: {err}");
+                }
             }
 
             Ok(())


### PR DESCRIPTION
Whispering's optional Epicenter Cloud sign-in (#2239) completes desktop OAuth by opening the system browser and catching the `epicenter-whispering://auth/callback` deep link. A fresh-eyes security + correctness review cleared the flow itself as sound (custom-scheme code injection is mitigated by PKCE S256 plus a double `state` check) and surfaced three robustness gaps in the registration path, closed here.

**Scheme registration is now best-effort.** On Linux and Windows the app registers its custom scheme at runtime (`deep_link().register_all()`), which writes to the registry or a `.desktop` file and can fail on a locked-down machine. A returned `Err` from Tauri's `setup` hook is fatal: it panics at `build().expect()`, and with `panic = "abort"` that is a hard crash. Because cloud sign-in is optional, a machine that cannot register the scheme should still launch, so the call now logs and continues. The only cost of failure is that the deep-link callback may not resolve, degrading exactly the optional feature that needed it.

**Single-instance registers first.** On Linux and Windows the OAuth callback reaches an already-running app through the single-instance plugin, which forwards the second launch's arguments to the primary. Per the plugin's documented ordering, single-instance must initialize ahead of the rest of the stack, so it now registers before every other plugin.

**Dropped a duplicate `opener:allow-open-url` capability.** It was granted twice; Tauri deduplicates the capability set, so the second grant was inert. Pure hygiene.

Mechanically verified (cargo check + typecheck). The deep-link forwarding behavior only exercises on a BUNDLED build on Linux and Windows (custom schemes don't resolve in `tauri dev`), so it still needs a manual sign-in click-through on packaged Linux + Windows builds — see the manual-verification note below.

**Manual verification still open:** on a packaged Linux build and a packaged Windows build, click Epicenter sign-in in Whispering desktop, confirm the system browser opens, sign in, and confirm the `epicenter-whispering://auth/callback` deep link returns to the running app and the session lands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785485581&installation_id=128463665&pr_number=2244&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2244&signature=567c28457669d58098b99338fde2d7ad04171c3ca612863d5314718f96b114e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->