### PR TITLE
refactor(auth): drop the inert client type from first-party OAuth seed

### DIFF
--- a/docs/adr/0087-first-party-oauth-clients-are-seeded-without-a-declared-client-type.md
+++ b/docs/adr/0087-first-party-oauth-clients-are-seeded-without-a-declared-client-type.md
@@ -1,0 +1,91 @@
+# 0087. First-party OAuth clients are seeded without a declared client type
+
+- **Status:** Proposed
+- **Date:** 2026-07-01
+
+## Context
+
+Whispering's desktop cloud sign-in (PR #2239) opens the system browser for OAuth
+and receives the code through a custom URL scheme (`epicenter-whispering://auth/callback`),
+justified in the spec only as "mirrors Fuji"
+(`apps/whispering/specs/20260602T140000-cloud-sync-and-account.md`), never against
+the standards that govern desktop OAuth. A grounding pass set out to decide the one
+implicit question the seed left open: the trusted-client projection
+(`packages/constants/src/oauth-seed.ts`) stamped each client with an OIDC `type`
+(`native` or `user-agent-based`), and it was unclear which value the Whispering and
+Fuji rows should carry. That framing was itself the bug: each of those rows is a
+single `oauth_client` whose `redirectUris` span both the app's web `/auth/callback`
+origins **and** the desktop custom scheme, so no single `type` is honest, and the
+field turned out to be dead weight regardless of its value.
+
+## Decision
+
+First-party OAuth clients declare no `type`. The `TrustedOAuthClient` shape drops
+the field, `buildTrustedOAuthClients` stops authoring it, and
+`projectTrustedOAuthClientToRow` writes `type: null`, so the `oauth_client.type`
+column is NULL for every seeded first-party row. Public-client and PKCE behavior
+are fixed by `public: true`, `tokenEndpointAuthMethod: 'none'`, and
+`requirePKCE: true`, none of which is the `type` label.
+
+This is grounded, not guessed:
+
+- **The field is inert on our write path**, verified in the pinned
+  `@better-auth/oauth-provider@1.6.18` source. The only reads of `type` are
+  `isPKCERequired` (which treats `native`, `user-agent-based`, and
+  `public === true` identically, and is null-safe) and `checkOAuthClient` (a
+  consistency check that runs only on `/oauth2/register`). Our rows are written by
+  a direct parameterized `INSERT` in `apps/api/scripts/seed-oauth-clients.ts` and
+  dynamic registration is disabled (`allowDynamicClientRegistration: false`), so no
+  read path ever branches on the value. No Epicenter code reads it either.
+- **The RFC-correct label would still be ambiguous.** RFC 8252 §3/§5/§8.12 make an
+  app that opens an external user-agent and catches a custom-scheme callback a
+  *native* client, and §7.1/§7.2 make both custom-scheme and claimed-https native
+  redirect mechanisms; the browser-based-apps BCP defers such desktop apps to
+  RFC 8252. But Whispering and Fuji ship *one* client id across a browser web build
+  and a native desktop build, so even the RFC-correct `native` would misdescribe
+  the web form factor. There is no honest single value, which is the signal that
+  the field should not be set at all.
+
+Keeping `type = EXCLUDED.type` in the seed upsert means a re-seed re-asserts NULL,
+clearing any legacy `user-agent-based` / `native` value already in a deployment.
+This ADR flips to `Accepted` when the change lands and `bun run oauth:seed:remote`
+has run against production.
+
+## Consequences
+
+- The native-vs-user-agent-based question disappears rather than being answered.
+  There is no longer a field whose value is debatable, so no recurring temptation
+  to "fix" a dual-form-factor client's type and no ADR-sized decision attached to a
+  decorative label.
+- The trusted-client config reads as pure identity + redirect surface
+  (`clientId`, `name`, `redirectUris`); the `Extract<SchemaClient['type'], ...>`
+  union and seven authored `type:` lines are deleted.
+- The justification for the desktop flow is now RFC 8252 + RFC 7636 + RFC 8707
+  (external user-agent, PKCE S256, resource-indicator audience binding), citable
+  and durable, rather than "mirrors Fuji."
+- **Cost:** the `oauth_client.type` column is NULL for first-party rows, so a
+  human inspecting the table cannot read an app's form factor from that column;
+  they read it from `public`, `redirectUris`, and the app itself. This is
+  information the column never reliably carried for a dual-form-factor client
+  anyway.
+- **Operational cost:** landing requires an `oauth:seed:remote` run (an operator
+  action, per the `:remote` blast-radius convention), idempotent and touching only
+  metadata.
+- The `epicenter-whispering://` / `epicenter-fuji://` schemes are not the
+  reverse-domain form RFC 8252 §7.1 recommends (SHOULD, e.g. `com.epicenter.*`).
+  This ADR does not change the scheme; renaming it would rewrite registered
+  redirect URIs and the bundle plists, far larger than a metadata change, for a
+  SHOULD. Recorded as a known deviation to revisit if the schemes are reworked.
+
+## Considered alternatives
+
+- **Stamp the dual-form-factor rows `native`.** Sets an inert field to the
+  security-sensitive form factor's label and needs this ADR to defend a value
+  nothing reads. Rejected: it dresses up a decorative field instead of removing it.
+- **Split each app into two client ids (web = `user-agent-based`, desktop =
+  `native`).** The only shape under which every `type` is honest. Rejected: it
+  *adds* a platform-selected client id in the app, a second seed row, and a second
+  redirect set purely to make an inert field honest, negative asymmetry. If
+  `@better-auth/oauth-provider` ever branches request-path behavior on
+  `native`-vs-`user-agent-based`, revisit both this refusal and the split then, and
+  supersede this ADR.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -154,5 +154,6 @@ Each option and the one reason it lost. Terse. This is not the spec.
 | [0084](0084-super-chat-tools-load-as-vendored-typescript-the-shell-is-a-bun-hosted-local-server.md) | Super Chat's tools load as vendored TypeScript via Bun's native dynamic import; its shell is a Bun-hosted local server, not a bundled SPA | Proposed |
 | [0085](0085-a-box-is-a-role-an-addressable-endpoint-plays-not-a-node-type.md) | A box is a role an addressable endpoint plays, not a distinct node type | Accepted |
 | [0086](0086-no-live-consumer-for-network-reachable-capability-reach-opensidian-is-superseded-not-migrated.md) | There is no live consumer for network-reachable capability reach; opensidian's cross-device tools are superseded by the super app, not migrated | Accepted |
+| [0087](0087-first-party-oauth-clients-are-seeded-without-a-declared-client-type.md) | First-party OAuth clients are seeded without a declared client type; the inert `type` field is refused | Proposed |
 
 When you add an ADR, add its row here.

--- a/packages/constants/src/oauth-seed.ts
+++ b/packages/constants/src/oauth-seed.ts
@@ -17,28 +17,29 @@ import { OAUTH_ROUTES } from './oauth-routes.js';
 /**
  * Shape of one checked-in first-party public OAuth client.
  *
- * Better Auth calls server-side confidential clients `web`. Epicenter's
- * checked-in trusted clients are public PKCE clients
- * (`tokenEndpointAuthMethod: 'none'`, `public: true`, no client secret), so
- * Better Auth only accepts `native` and `user-agent-based` for this policy.
- * The API seed layer fills in the rest (PKCE required, consent skipped,
- * authorization-code flow, Epicenter scopes).
+ * These are public PKCE clients (`tokenEndpointAuthMethod: 'none'`,
+ * `public: true`, no client secret). They deliberately carry no OIDC client
+ * `type`: the seed writes these rows directly (never through dynamic
+ * registration), and Better Auth reads `type` only on the `/oauth2/register`
+ * path and in a null-safe public-client check, so the field is inert for a
+ * directly-seeded row. Setting it would only force an unanswerable
+ * native-vs-user-agent-based question for the dual-form-factor clients:
+ * Whispering and Fuji ship one client id across a web build (browser) and a
+ * custom-scheme desktop build (native), and no single `type` is honest for a
+ * row whose redirect set spans both. Public-client and PKCE behavior are fixed
+ * by `public` + `tokenEndpointAuthMethod` + `requirePKCE`, not by this label.
+ * See ADR-0087.
  *
  * `redirectUris` is the final resolved list for a specific deployment,
  * built by {@link buildTrustedOAuthClients} from `APPS` plus the
  * deployment's API base URL.
  *
  * Field names stay spelled out instead of using `Pick` or a mapped type so
- * this file reads as config. The Better Auth indexed types keep the field
- * names tied to upstream without making the shape cryptic.
+ * this file reads as config.
  */
 export type TrustedOAuthClient = {
 	clientId: NonNullable<SchemaClient['clientId']>;
 	name: NonNullable<SchemaClient['name']>;
-	type: Extract<
-		NonNullable<SchemaClient['type']>,
-		'native' | 'user-agent-based'
-	>;
 	redirectUris: readonly string[];
 };
 
@@ -82,7 +83,6 @@ export function buildTrustedOAuthClients(apiBaseURL: string) {
 		{
 			clientId: EPICENTER_FUJI_OAUTH_CLIENT_ID,
 			name: 'Fuji',
-			type: 'user-agent-based',
 			redirectUris: [
 				...appCallbacks(APPS.FUJI),
 				EPICENTER_FUJI_TAURI_OAUTH_REDIRECT_URI,
@@ -91,7 +91,6 @@ export function buildTrustedOAuthClients(apiBaseURL: string) {
 		{
 			clientId: EPICENTER_WHISPERING_OAUTH_CLIENT_ID,
 			name: 'Whispering',
-			type: 'user-agent-based',
 			redirectUris: [
 				...appCallbacks(APPS.WHISPERING),
 				EPICENTER_WHISPERING_TAURI_OAUTH_REDIRECT_URI,
@@ -100,31 +99,26 @@ export function buildTrustedOAuthClients(apiBaseURL: string) {
 		{
 			clientId: EPICENTER_HONEYCRISP_OAUTH_CLIENT_ID,
 			name: 'Honeycrisp',
-			type: 'user-agent-based',
 			redirectUris: appCallbacks(APPS.HONEYCRISP),
 		},
 		{
 			clientId: EPICENTER_OPENSIDIAN_OAUTH_CLIENT_ID,
 			name: 'Opensidian',
-			type: 'user-agent-based',
 			redirectUris: appCallbacks(APPS.OPENSIDIAN),
 		},
 		{
 			clientId: EPICENTER_TAB_MANAGER_OAUTH_CLIENT_ID,
 			name: 'Tab Manager extension',
-			type: 'user-agent-based',
 			redirectUris: ['chrome-extension://mkbnicfhpacdofmoocppnjjmdfmkkgda/'],
 		},
 		{
 			clientId: EPICENTER_VOCAB_OAUTH_CLIENT_ID,
 			name: 'Vocab',
-			type: 'user-agent-based',
 			redirectUris: appCallbacks(APPS.VOCAB),
 		},
 		{
 			clientId: EPICENTER_CLI_OAUTH_CLIENT_ID,
 			name: 'Epicenter CLI',
-			type: 'native',
 			redirectUris: [OAUTH_ROUTES.cliCallback.url(apiBaseURL)],
 		},
 	] as const satisfies readonly TrustedOAuthClient[];
@@ -162,7 +156,12 @@ export function projectTrustedOAuthClientToRow(
 		grantTypes: ['authorization_code'],
 		responseTypes: ['code'],
 		public: true,
-		type: client.type,
+		// First-party seeded rows declare no OIDC client type; the column is
+		// NULL. NULL is null-safe in Better Auth's public-client checks, and
+		// keeping `type = EXCLUDED.type` in the seed upsert re-asserts NULL on
+		// every run, so a re-seed also clears any legacy value. See ADR-0087 and
+		// the {@link TrustedOAuthClient} doc.
+		type: null,
 		requirePKCE: true,
 	};
 }

--- a/packages/server/src/auth/plugins.test.ts
+++ b/packages/server/src/auth/plugins.test.ts
@@ -31,7 +31,6 @@ import { authPlugins } from './plugins.js';
 const trustedClientFixture = {
 	clientId: EPICENTER_FUJI_OAUTH_CLIENT_ID,
 	name: 'Fuji',
-	type: 'user-agent-based',
 	redirectUris: [
 		'http://localhost:5174/auth/callback',
 		'https://fuji.epicenter.so/auth/callback',
@@ -52,7 +51,6 @@ test('trusted OAuth clients project to public PKCE client rows', () => {
 	const row = projectTrustedOAuthClientToRow({
 		clientId: 'trusted-client-1',
 		name: 'Trusted Client',
-		type: 'user-agent-based',
 		redirectUris: [redirectUri],
 	});
 
@@ -66,7 +64,7 @@ test('trusted OAuth clients project to public PKCE client rows', () => {
 		responseTypes: ['code'],
 		scopes: [...EPICENTER_OAUTH_SCOPES],
 		public: true,
-		type: 'user-agent-based',
+		type: null,
 		requirePKCE: true,
 		skipConsent: true,
 	});
@@ -215,7 +213,6 @@ function createTrustedClientTestAuth({
 		...projectTrustedOAuthClientToRow({
 			clientId: 'registered-client-1',
 			name: 'Registered Client',
-			type: 'user-agent-based',
 			redirectUris: [redirectUri],
 		}),
 		skipConsent: false,

--- a/packages/server/src/test-helpers/oauth.ts
+++ b/packages/server/src/test-helpers/oauth.ts
@@ -94,7 +94,6 @@ export async function issueOAuthTokens(
 		projectTrustedOAuthClientToRow({
 			clientId,
 			name: clientName,
-			type: 'user-agent-based',
 			redirectUris: [OAUTH_TEST_REDIRECT_URI],
 		}),
 	);


### PR DESCRIPTION
A grounding pass on Whispering's desktop cloud sign-in (#2239) set out to decide whether the Whispering and Fuji `oauth_client` rows should be typed `native` or `user-agent-based`. The framing was the bug: each of those rows is one client id whose redirect URIs span both the app's web `/auth/callback` origins **and** a custom scheme (`epicenter-whispering://auth/callback`), so no single OIDC `type` is honest, and the field turned out to be dead weight regardless of its value.

So this refuses the field instead of picking a value. First-party OAuth clients declare no `type`: the column is `NULL` for every seeded row, and public-client + PKCE behavior is fixed by `public` + `token_endpoint_auth_method: 'none'` + `requirePKCE: true`.

This is grounded, not guessed:

- **The field is inert on our write path**, verified in the pinned `@better-auth/oauth-provider@1.6.18` source. The only reads of `type` are `isPKCERequired` (treats `native`, `user-agent-based`, and `public === true` identically, and is null-safe) and `checkOAuthClient` (runs only on `/oauth2/register`, which the direct seed bypasses; dynamic registration is disabled). No Epicenter code reads it either.
- **The RFC-correct label would still be ambiguous.** RFC 8252 makes an app that opens an external user-agent and catches a custom-scheme callback a *native* client, but Whispering and Fuji ship one client id across a browser web build and a native desktop build, so even `native` misdescribes the web form factor. There is no honest single value, which is the signal not to set it.

The change deletes the `TrustedOAuthClient.type` union and seven authored `type:` lines; the client array now reads as pure `{clientId, name, redirectUris}`. Keeping `type = EXCLUDED.type` in the seed upsert means a re-seed re-asserts `NULL`, clearing any legacy value already in a deployment.

```ts
// before
{ clientId: EPICENTER_WHISPERING_OAUTH_CLIENT_ID, name: 'Whispering', type: 'user-agent-based', redirectUris: [...] }
// after
{ clientId: EPICENTER_WHISPERING_OAUTH_CLIENT_ID, name: 'Whispering', redirectUris: [...] }
```

Full rationale, the RFC 8252 / 7636 / 8707 grounding, and the declined `native` and split-client-id alternatives are in `docs/adr/0087`.

**Operational follow-up:** no behavior change, but the column is only re-asserted to `NULL` in a live deployment after `bun run oauth:seed:remote` runs. That is the operator step that flips ADR-0087 to Accepted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785491630&installation_id=128463665&pr_number=2246&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2246&signature=bf7cde01a575fd8e5cd271eadddee4e4d5aea52d2a9596d863a9301ade9ddeec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->