### PR TITLE
fix(ui): polish light-mode card surfaces

### DIFF
--- a/apps/whispering/src/app.css
+++ b/apps/whispering/src/app.css
@@ -34,6 +34,13 @@
 }
 
 .dark {
-	--primary: oklch(0.62 0.19 275);
+	/* Lightness is capped at 0.55 (a deeper indigo than the page would otherwise
+	   invite) so white --primary-foreground text clears WCAG AA on every primary
+	   surface in dark mode, not just the record circle. The rebrand puts real text
+	   on --primary in several settings selectors; at 0.62 lightness white-on-indigo
+	   falls to ~3.7:1 (under the 4.5:1 body-text floor), and 0.55 lifts it to ~4.9:1.
+	   The record circle holds only an icon, so it would pass either way; these other
+	   surfaces are why the ceiling exists. */
+	--primary: oklch(0.55 0.19 275);
 	--primary-foreground: oklch(0.985 0 0);
 }

--- a/apps/whispering/src/app.css
+++ b/apps/whispering/src/app.css
@@ -6,9 +6,10 @@
    sets --background == --card (both pure white), so stacked surfaces could only be
    told apart by borders, which read as "cards on cards" in light mode.
 
-   1. Separate surfaces by TONE, not borders: --background gets a faint cool tint
-      while --card stays pure white, so a card reads as an elevated white surface on
-      a tinted page without needing a hairline border.
+   1. Separate surfaces by TONE, not borders: --background gets a barely-there
+      warm-neutral tint (the same lightness the shared theme already uses for
+      --sidebar) while --card stays pure white, so a card reads as an elevated
+      white surface on a tinted page without needing a hairline border.
 
    2. --primary becomes Whispering's brand indigo (it was the neutral shadcn
       default, near-black in light / near-white in dark). The record button is the
@@ -16,13 +17,13 @@
       active/recording state keeps using --destructive (red), already this app's
       convention. No new "recording" token: idle = --primary, recording = --destructive. */
 
-/* The cool background tint is light-only. Scope it to :root:not(.dark) rather than a
+/* The background tint is light-only. Scope it to :root:not(.dark) rather than a
    bare :root: this file is imported AFTER the shared theme, so a bare :root override
    would also win in dark mode (same specificity, later source order). Scoping it here
    means dark inherits the shared theme's background untouched, with no hardcoded copy
    to drift out of sync. */
 :root:not(.dark) {
-	--background: oklch(0.95 0.008 275);
+	--background: oklch(0.9925 0.001 70);
 }
 
 /* --primary is intentionally rebranded in BOTH modes, so it is set under :root and

--- a/apps/whispering/src/app.css
+++ b/apps/whispering/src/app.css
@@ -1,32 +1,15 @@
-/* Whispering brand + light-mode surface tuning, layered over the shared
-   @epicenter/ui/app.css (imported first in +layout.svelte). Scoped to Whispering so
-   the other Epicenter apps keep the shared neutral theme.
+/* Whispering brand rebrand, layered over the shared @epicenter/ui/app.css (imported
+   first in +layout.svelte). The light-mode --background/--card separation now lives
+   in the shared theme (packages/ui/src/app.css) since dark mode already had it; this
+   file only carries Whispering-specific branding.
 
-   Two changes, both addressing the same root cause: in the shared theme light mode
-   sets --background == --card (both pure white), so stacked surfaces could only be
-   told apart by borders, which read as "cards on cards" in light mode.
+   --primary becomes Whispering's brand indigo (it was the neutral shadcn default,
+   near-black in light / near-white in dark). The record button is the app's primary
+   action, so it now reads as a real, inviting CTA. The active/recording state keeps
+   using --destructive (red), already this app's convention. No new "recording"
+   token: idle = --primary, recording = --destructive.
 
-   1. Separate surfaces by TONE, not borders: --background gets a barely-there
-      warm-neutral tint (the same lightness the shared theme already uses for
-      --sidebar) while --card stays pure white, so a card reads as an elevated
-      white surface on a tinted page without needing a hairline border.
-
-   2. --primary becomes Whispering's brand indigo (it was the neutral shadcn
-      default, near-black in light / near-white in dark). The record button is the
-      app's primary action, so it now reads as a real, inviting CTA. The
-      active/recording state keeps using --destructive (red), already this app's
-      convention. No new "recording" token: idle = --primary, recording = --destructive. */
-
-/* The background tint is light-only. Scope it to :root:not(.dark) rather than a
-   bare :root: this file is imported AFTER the shared theme, so a bare :root override
-   would also win in dark mode (same specificity, later source order). Scoping it here
-   means dark inherits the shared theme's background untouched, with no hardcoded copy
-   to drift out of sync. */
-:root:not(.dark) {
-	--background: oklch(0.9925 0.001 70);
-}
-
-/* --primary is intentionally rebranded in BOTH modes, so it is set under :root and
+   --primary is intentionally rebranded in BOTH modes, so it is set under :root and
    .dark together (and must stay paired: a bare :root override leaks into dark via
    source order). */
 :root {

--- a/apps/whispering/src/app.css
+++ b/apps/whispering/src/app.css
@@ -28,3 +28,23 @@
 	--primary: oklch(0.55 0.19 275);
 	--primary-foreground: oklch(0.985 0 0);
 }
+
+/* Native audio players (home result, recordings row, detail modal). The controls
+   live in engine shadow DOM, so this is the whole styling surface we get.
+
+   color-scheme is pinned per theme class rather than inherited: Chromium skins
+   media controls at mount time and does not reliably reskin them when the
+   inherited scheme flips, so a player mounted under the dark default stayed a
+   black bar after switching to light. Pinning to the theme class gives the
+   element a computed-style change on toggle.
+
+   border-radius clips the control chrome to the same radius as the inputs and
+   buttons it sits beside; engines that draw their own tighter shape inside the
+   box (Safari's pill) are unaffected. */
+audio {
+	border-radius: var(--radius-md);
+	color-scheme: light;
+}
+.dark audio {
+	color-scheme: dark;
+}

--- a/apps/whispering/src/app.css
+++ b/apps/whispering/src/app.css
@@ -1,0 +1,39 @@
+/* Whispering brand + light-mode surface tuning, layered over the shared
+   @epicenter/ui/app.css (imported first in +layout.svelte). Scoped to Whispering so
+   the other Epicenter apps keep the shared neutral theme.
+
+   Two changes, both addressing the same root cause: in the shared theme light mode
+   sets --background == --card (both pure white), so stacked surfaces could only be
+   told apart by borders, which read as "cards on cards" in light mode.
+
+   1. Separate surfaces by TONE, not borders: --background gets a faint cool tint
+      while --card stays pure white, so a card reads as an elevated white surface on
+      a tinted page without needing a hairline border.
+
+   2. --primary becomes Whispering's brand indigo (it was the neutral shadcn
+      default, near-black in light / near-white in dark). The record button is the
+      app's primary action, so it now reads as a real, inviting CTA. The
+      active/recording state keeps using --destructive (red), already this app's
+      convention. No new "recording" token: idle = --primary, recording = --destructive. */
+
+/* The cool background tint is light-only. Scope it to :root:not(.dark) rather than a
+   bare :root: this file is imported AFTER the shared theme, so a bare :root override
+   would also win in dark mode (same specificity, later source order). Scoping it here
+   means dark inherits the shared theme's background untouched, with no hardcoded copy
+   to drift out of sync. */
+:root:not(.dark) {
+	--background: oklch(0.95 0.008 275);
+}
+
+/* --primary is intentionally rebranded in BOTH modes, so it is set under :root and
+   .dark together (and must stay paired: a bare :root override leaks into dark via
+   source order). */
+:root {
+	--primary: oklch(0.51 0.2 275);
+	--primary-foreground: oklch(0.985 0 0);
+}
+
+.dark {
+	--primary: oklch(0.62 0.19 275);
+	--primary-foreground: oklch(0.985 0 0);
+}

--- a/apps/whispering/src/lib/recording-overlay/LevelMeter.svelte
+++ b/apps/whispering/src/lib/recording-overlay/LevelMeter.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
 	import { cn } from '@epicenter/ui/utils';
 
-	// The live mic meter: a fixed bank of bars whose heights ride the smoothed
-	// `level`. Shared by the floating recording pill and the in-window recording
-	// card so both speak one visual language by construction, rather than keeping
-	// two copies of the envelope and height math in sync by hand (ADR-0039). The
-	// caller styles the bars (width, color) and the container (height, gap); the
-	// defaults render the pill's 3px white bar.
+	// The pill's live mic meter: a fixed bank of bars whose heights ride the
+	// smoothed `level`. The pill styles the bars (width, color) and the container
+	// (height, gap); the defaults render its 3px white bar, and a VAD session
+	// tints the bars via `barClass` when speech latches.
 	let {
 		level,
 		minPx = 3,

--- a/apps/whispering/src/lib/recording-overlay/RecordingPill.svelte
+++ b/apps/whispering/src/lib/recording-overlay/RecordingPill.svelte
@@ -7,12 +7,12 @@
 	import SquareIcon from '@lucide/svelte/icons/square';
 	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 	import XIcon from '@lucide/svelte/icons/x';
-	import LevelMeter from '$lib/components/LevelMeter.svelte';
 	import type { DeliveryReach } from '$lib/operations/delivery';
 	import {
 		FAILURE_LABEL,
 		type RecordingOverlayStatus,
 	} from '$lib/recording-overlay/events';
+	import LevelMeter from '$lib/recording-overlay/LevelMeter.svelte';
 	import VadIndicator from '$lib/recording-overlay/VadIndicator.svelte';
 
 	// The floating dictation pill, presentational and platform-free. It renders
@@ -189,17 +189,12 @@
 				{:else}
 					<!-- VAD has no per-utterance cancel, so the slot holds the capture
 					     indicator at the cancel button's width, keeping the cluster
-					     balanced. The same dim-dot -> lit-dot -> spinner the home capture
-					     card shows: the bars track raw level, this mark tracks whether VAD
-					     has latched onto speech (with its detection delay) and then the
-					     previous phrase's transcribe. -->
+					     balanced. The dim-dot -> lit-dot -> spinner mark: the bars track
+					     raw level, this mark tracks whether VAD has latched onto speech
+					     (with its detection delay) and then the previous phrase's
+					     transcribe. -->
 					<div class="flex size-6 items-center justify-center">
-						<VadIndicator
-							signals={recording}
-							dimClass="bg-white/40"
-							litClass="bg-pink-300"
-							spinnerClass="text-white/50"
-						/>
+						<VadIndicator signals={recording} />
 					</div>
 				{/if}
 

--- a/apps/whispering/src/lib/recording-overlay/RecordingPillHost.svelte
+++ b/apps/whispering/src/lib/recording-overlay/RecordingPillHost.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { page } from '$app/state';
 	import { tauri } from '#platform/tauri';
 	import { dispatchPillAction } from '$lib/recording-overlay/pill-actions';
 	import RecordingPill from '$lib/recording-overlay/RecordingPill.svelte';
@@ -15,15 +14,10 @@
 	// front, and a failure is surfaced by the notification and the recordings row.
 	const status = $derived(projectLifecycleToStatus(dictationLifecycle.current));
 
-	// The home route's recording card carries its own live meter and stop/cancel,
-	// so the floating pill would only double it there. Yield the recording phase to
-	// the card on '/', but keep the pill for the outcome phases (transcribing,
-	// delivered, failed) the card never shows, and for every phase on the other app
-	// routes (recordings, settings, ...), which have no in-window capture card.
-	const isHomeRoute = $derived(page.url.pathname === '/');
-	const showPill = $derived(
-		!!status && !(isHomeRoute && status.phase === 'recording'),
-	);
+	// The pill is the sole live recording surface on web, mirroring the desktop
+	// overlay: it shows on every route, with no home-route special case. The home
+	// card only paints a static glyph and defers all live feedback here.
+	const showPill = $derived(!!status);
 </script>
 
 {#if !tauri && showPill}

--- a/apps/whispering/src/lib/recording-overlay/VadIndicator.svelte
+++ b/apps/whispering/src/lib/recording-overlay/VadIndicator.svelte
@@ -2,42 +2,32 @@
 	import { cn } from '@epicenter/ui/utils';
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 
-	// A VAD session's capture state, shown beside the live meter as one small mark:
-	// a dot that is dim while merely listening (armed, hearing sound but not yet
-	// latched) and lights up the instant capture latches onto speech, then becomes
-	// a spinner while a previous phrase is still transcribing. The bars next to it
-	// track raw loudness; this mark tracks VAD's decision, which lags loudness by a
-	// detection delay, so the two are deliberately separate signals. Shared by the
-	// floating pill and the home capture card so the three states read identically
-	// on both; each surface passes its own palette.
+	// A VAD session's capture state, shown beside the pill's live meter as one
+	// small mark: a dot that is dim while merely listening (armed, hearing sound
+	// but not yet latched) and lights up the instant capture latches onto speech,
+	// then becomes a spinner while a previous phrase is still transcribing. The
+	// bars next to it track raw loudness; this mark tracks VAD's decision, which
+	// lags loudness by a detection delay, so the two are deliberately separate
+	// signals. The pill is the only surface that renders it, so the palette is
+	// fixed here rather than passed in.
 	//
 	// `speaking` and `transcribing` are orthogonal at the source; this mark shows
 	// one of three states, so transcribing wins (the spinner replaces the dot).
 	// That precedence lives here, the one place this mark is rendered.
 	let {
 		signals,
-		dimClass,
-		litClass,
-		spinnerClass,
 	}: {
 		/**
 		 * The two orthogonal VAD signals this mark renders: `speaking` (latched onto
 		 * speech, past mere loudness) and `transcribing` (a previous phrase still
-		 * transcribing). They arrive as one object because they are produced together
-		 * (by the status projection and by the VAD controller) and this is the only
-		 * place they render together; a surface that also needs `speaking` alone (the
-		 * pill tints its bars with it) reads it off the same object.
+		 * transcribing). They arrive as one object because the status projection
+		 * produces them together; the pill also reads `speaking` off the same object
+		 * to tint its meter bars.
 		 */
 		signals: { speaking: boolean; transcribing: boolean };
-		/** Dot color while listening (armed, not yet latched onto speech). */
-		dimClass: string;
-		/** Dot color once speech is latched. */
-		litClass: string;
-		/** Spinner color while a previous phrase transcribes. */
-		spinnerClass: string;
 	} = $props();
 
-	// One title for whichever state shows, identical on every surface.
+	// One title for whichever state shows.
 	const title = $derived(
 		signals.transcribing
 			? 'Transcribing previous phrase'
@@ -49,12 +39,12 @@
 
 <span class="inline-flex items-center justify-center" {title} aria-hidden="true">
 	{#if signals.transcribing}
-		<LoaderCircleIcon class={cn('size-3.5 animate-spin', spinnerClass)} />
+		<LoaderCircleIcon class="size-3.5 animate-spin text-white/50" />
 	{:else}
 		<span
 			class={cn(
 				'size-2 rounded-full transition-colors duration-150',
-				signals.speaking ? litClass : dimClass,
+				signals.speaking ? 'bg-pink-300' : 'bg-white/40',
 			)}
 		></span>
 	{/if}

--- a/apps/whispering/src/routes/(app)/(config)/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/+layout.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { Button } from '@epicenter/ui/button';
 	import { cn } from '@epicenter/ui/utils';
-	import XIcon from '@lucide/svelte/icons/x';
 	import { commandRunners } from '$lib/commands';
 	import ImportFileButton from '$lib/components/ImportFileButton.svelte';
 	import {
@@ -38,89 +37,61 @@
 		<span class="text-lg font-bold">whispering</span>
 	</Button>
 
+	<!-- The row hides while a capture is live: the pill owns stop and cancel on
+	every route, and the state-derived toggle here would just duplicate them. -->
 	<div class="flex items-center gap-1.5">
-		{#if captureSurface.current === 'manual'}
-			{#if manualRecorder.state === 'RECORDING'}
+		{#if captureSurface.current === 'manual' && manualRecorder.state !== 'RECORDING'}
+			<ManualDeviceSelector
+				iconViewTransitionName={viewTransition.pipeline.device}
+			/>
+			<TranscriptionSelector
+				variant="standalone"
+				iconViewTransitionName={viewTransition.pipeline.transcription}
+			/>
+			<TransformationSelector />
+			<div class="flex">
 				<Button
-					tooltip="Cancel recording"
-					onclick={() => commandRunners.cancelRecording()}
-					variant="ghost"
-					size="icon"
-				>
-					<XIcon class="size-4" />
-				</Button>
-				<Button
-					tooltip="Stop recording"
+					tooltip="Start recording"
 					onclick={() => commandRunners.toggleManualRecording()}
 					variant="ghost"
 					size="icon"
+					class="rounded-r-none border-r-0"
 				>
-					<ManualButtonIcon class="size-4" />
+					<span
+						class="inline-flex shrink-0"
+						style:view-transition-name={viewTransition.recordingMode('manual')}
+					>
+						<ManualButtonIcon class="size-4" />
+					</span>
 				</Button>
-			{:else}
-				<ManualDeviceSelector
-					iconViewTransitionName={viewTransition.pipeline.device}
-				/>
-				<TranscriptionSelector
-					variant="standalone"
-					iconViewTransitionName={viewTransition.pipeline.transcription}
-				/>
-				<TransformationSelector />
-				<div class="flex">
-					<Button
-						tooltip="Start recording"
-						onclick={() => commandRunners.toggleManualRecording()}
-						variant="ghost"
-						size="icon"
-						class="rounded-r-none border-r-0"
-					>
-						<span
-							class="inline-flex shrink-0"
-							style:view-transition-name={viewTransition.recordingMode('manual')}
-						>
-							<ManualButtonIcon class="size-4" />
-						</span>
-					</Button>
-					<CaptureSurfaceSelector class="rounded-l-none" />
-				</div>
-			{/if}
-		{:else if captureSurface.current === 'vad'}
-			{#if vadRecorder.state === 'IDLE'}
-				<VadDeviceSelector
-					iconViewTransitionName={viewTransition.pipeline.device}
-				/>
-				<TranscriptionSelector
-					variant="standalone"
-					iconViewTransitionName={viewTransition.pipeline.transcription}
-				/>
-				<TransformationSelector />
-				<div class="flex">
-					<Button
-						tooltip="Start voice activated recording"
-						onclick={() => commandRunners.toggleVadRecording()}
-						variant="ghost"
-						size="icon"
-						class="rounded-r-none border-r-0"
-					>
-						<span
-							class="inline-flex shrink-0"
-							style:view-transition-name={viewTransition.recordingMode('vad')}
-						>
-							<VadButtonIcon class="size-4" />
-						</span>
-					</Button>
-					<CaptureSurfaceSelector class="rounded-l-none" />
-				</div>
-			{:else}
+				<CaptureSurfaceSelector class="rounded-l-none" />
+			</div>
+		{:else if captureSurface.current === 'vad' && vadRecorder.state === 'IDLE'}
+			<VadDeviceSelector
+				iconViewTransitionName={viewTransition.pipeline.device}
+			/>
+			<TranscriptionSelector
+				variant="standalone"
+				iconViewTransitionName={viewTransition.pipeline.transcription}
+			/>
+			<TransformationSelector />
+			<div class="flex">
 				<Button
-					tooltip="Stop voice activated recording"
+					tooltip="Start voice activated recording"
 					onclick={() => commandRunners.toggleVadRecording()}
 					variant="ghost"
 					size="icon"
+					class="rounded-r-none border-r-0"
 				>
-					<VadButtonIcon class="size-4" />
+					<span
+						class="inline-flex shrink-0"
+						style:view-transition-name={viewTransition.recordingMode('vad')}
+					>
+						<VadButtonIcon class="size-4" />
+					</span>
 				</Button>
-			{/if}
+				<CaptureSurfaceSelector class="rounded-l-none" />
+			</div>
 		{:else if captureSurface.current === 'import'}
 			<TranscriptionSelector
 				variant="standalone"

--- a/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
+++ b/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
@@ -52,7 +52,7 @@
 <div
 	class={cn(
 		'w-full overflow-hidden rounded-3xl bg-card text-foreground shadow-sm transition-[box-shadow] duration-200',
-		controller.active && 'shadow-md ring-1 ring-destructive/15',
+		controller.active && 'shadow-md ring-1 ring-destructive/25',
 	)}
 >
 	<Button
@@ -82,7 +82,7 @@
 				'relative flex size-14 shrink-0 items-center justify-center rounded-3xl shadow-lg ring-4 transition-[transform,box-shadow,background-color,color] duration-200 group-hover:scale-[1.04] group-hover:shadow-xl sm:size-16',
 				controller.active
 					? 'bg-destructive text-white shadow-destructive/30 ring-destructive/15'
-					: 'bg-primary text-primary-foreground shadow-primary/25 ring-primary/10',
+					: 'bg-primary text-primary-foreground shadow-primary/35 ring-primary/20',
 			)}
 		>
 			{#if controller.pending}
@@ -148,7 +148,7 @@
 			reading the same fact the home-page notice does so the two agree. -->
 			<Kbd.Root
 				class={cn(
-					'h-7 max-w-28 shrink-0 rounded-md bg-muted/75 px-2 text-xs text-muted-foreground shadow-none',
+					'h-7 max-w-28 shrink-0 rounded-full bg-muted/75 px-2.5 text-xs text-muted-foreground shadow-none',
 					dictationCapability.isUnavailable && 'opacity-50',
 				)}
 			>

--- a/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
+++ b/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
@@ -5,11 +5,7 @@
 	import { cn } from '@epicenter/ui/utils';
 	import XIcon from '@lucide/svelte/icons/x';
 	import type { Snippet } from 'svelte';
-	import LevelMeter from '$lib/components/LevelMeter.svelte';
-	import VadIndicator from '$lib/recording-overlay/VadIndicator.svelte';
-	import { webPillLevel } from '$lib/recording-overlay/web-pill.svelte';
 	import { dictationCapability } from '$lib/state/dictation-capability.svelte';
-	import { tauri } from '#platform/tauri';
 	import type { RecordingActionController } from './recording-action-controller';
 
 	// The controller owns the state machine and every derived label/icon. The card
@@ -25,9 +21,9 @@
 		/**
 		 * When set, names the action glyph for a cross-page view transition while
 		 * the card is at rest. Suppressed automatically while `active`, because the
-		 * live glyph (a stop square, a waveform) is a different object and must not
-		 * morph from the resting mode glyph. Callers pass the name unconditionally;
-		 * the card owns the at-rest gate.
+		 * live glyph (a stop square) is a different object and must not morph from
+		 * the resting mode glyph. Callers pass the name unconditionally; the card
+		 * owns the at-rest gate.
 		 */
 		iconViewTransitionName?: string;
 	} = $props();
@@ -37,21 +33,11 @@
 			? `${controller.label} (${controller.shortcutLabel})`
 			: controller.label,
 	);
-
-	// Exactly one live meter shows at a time, on the surface holding your
-	// attention. On desktop the always-on-top overlay is that meter: it floats over
-	// even the focused app for the whole recording, so the card defers to it with a
-	// static glyph and a second meter here would only double the overlay's. On web
-	// there is no floating overlay, so the in-window surface carries the meter: this
-	// card on the home route (where the in-page pill stands down), the pill on the
-	// other routes. The smoothed level is already in this window on web
-	// (`webPillLevel`); on desktop it is emitted straight to the overlay, not here.
-	const showsLiveMeter = !tauri;
 </script>
 
 <div
 	class={cn(
-		'w-full overflow-hidden rounded-3xl bg-card text-foreground shadow-sm transition-[box-shadow] duration-200',
+		'w-full overflow-hidden rounded-xl bg-card text-foreground shadow-sm transition-[box-shadow] duration-200',
 		controller.active && 'shadow-md ring-1 ring-destructive/25',
 	)}
 >
@@ -64,40 +50,26 @@
 		onclick={controller.toggle}
 		variant="ghost"
 		class={cn(
-			'group h-auto min-h-24 w-full items-center justify-start gap-3 rounded-none bg-transparent px-5 py-6 text-left hover:bg-transparent dark:hover:bg-transparent sm:gap-4',
+			'h-auto min-h-24 w-full items-center justify-start gap-3 rounded-none bg-transparent px-5 py-6 text-left hover:bg-transparent dark:hover:bg-transparent sm:gap-4',
 			controller.pending && 'cursor-wait',
 		)}
 	>
-		<!-- The glyph slot is the record CTA: idle = the brand --primary squircle
-		(this app's primary action, rounded to match the outer card's rounded-3xl),
-		active = a --destructive (red) squircle, mirroring the colors the floating
-		pill already uses for live/stop. The icon (mic -> stop square) and the active
-		flag both come from the controller; this only paints. Hover feedback lives on
-		this glyph (a slight scale + lift via group-hover), not a fill behind the row:
-		the button spans only the top zone, so a row fill would cut a hard horizontal
-		edge across the rounded card above the footer. -->
+		<!-- The controller owns the state machine and the icon (mic -> stop square);
+		this glyph only paints it. The floating pill, not this card, is the live
+		recording surface on every platform and route, so the glyph never animates
+		or meters: it is a static brand-primary CTA that turns tinted destructive
+		while active. -->
 		<span
 			aria-hidden="true"
 			class={cn(
-				'relative flex size-14 shrink-0 items-center justify-center rounded-3xl shadow-lg ring-4 transition-[transform,box-shadow,background-color,color] duration-200 group-hover:scale-[1.04] group-hover:shadow-xl sm:size-16',
+				'relative flex size-14 shrink-0 items-center justify-center rounded-lg shadow-sm transition-colors duration-200 sm:size-16',
 				controller.active
-					? 'bg-destructive text-white shadow-destructive/30 ring-destructive/15'
-					: 'bg-primary text-primary-foreground shadow-primary/35 ring-primary/20',
+					? 'bg-destructive/10 text-destructive'
+					: 'bg-primary text-primary-foreground',
 			)}
 		>
 			{#if controller.pending}
 				<Spinner class="size-7" />
-			{:else if controller.active && showsLiveMeter}
-				<!-- Live capture: the glyph slot becomes the meter, the same bars the
-				floating pill draws, scaled to fit the box. White bars read on the red
-				(--destructive) recording squircle. -->
-				<LevelMeter
-					level={webPillLevel.level}
-					class="gap-[2px]"
-					barClass="w-[2px] bg-white"
-					minPx={3}
-					maxPx={28}
-				/>
 			{:else}
 				{@const Icon = controller.icon}
 				<span
@@ -119,26 +91,8 @@
 			<span class="truncate text-base font-semibold leading-none sm:text-lg">
 				{controller.label}
 			</span>
-			<span
-				class="flex min-w-0 items-center gap-1.5 text-xs font-medium text-muted-foreground sm:text-sm"
-			>
-				{#if controller.active && showsLiveMeter && controller.vad}
-					<!-- VAD speech-latch indicator: the same dim-dot -> lit-dot -> spinner the
-					floating pill shows, here inline with the status text instead of in the
-					meter glyph's corner (where it read as a dismiss badge and crowded the
-					loudness bars). The glyph owns loudness alone now; this line owns VAD's
-					decision: dim while armed, red (--destructive, the recording accent) once
-					speech latches, a spinner while a previous phrase still transcribes. Gated
-					exactly like the in-card meter (active and web), so on '/' it shows only
-					here. The signals come from this card's own controller. -->
-					<VadIndicator
-						signals={controller.vad}
-						dimClass="bg-muted-foreground/40"
-						litClass="bg-destructive"
-						spinnerClass="text-destructive"
-					/>
-				{/if}
-				<span class="truncate">{controller.description}</span>
+			<span class="truncate text-xs font-medium text-muted-foreground sm:text-sm">
+				{controller.description}
 			</span>
 		</span>
 		{#if controller.shortcutLabel}
@@ -148,7 +102,7 @@
 			reading the same fact the home-page notice does so the two agree. -->
 			<Kbd.Root
 				class={cn(
-					'h-7 max-w-28 shrink-0 rounded-full bg-muted/75 px-2.5 text-xs text-muted-foreground shadow-none',
+					'h-7 max-w-28 shrink-0 rounded-md bg-muted/75 px-2 text-xs text-muted-foreground shadow-none',
 					dictationCapability.isUnavailable && 'opacity-50',
 				)}
 			>

--- a/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
+++ b/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
@@ -64,21 +64,22 @@
 		onclick={controller.toggle}
 		variant="ghost"
 		class={cn(
-			'group h-auto w-full justify-start gap-3 rounded-none bg-transparent px-5 pt-5 pb-4 text-left hover:bg-transparent dark:hover:bg-transparent sm:gap-4',
+			'group h-auto min-h-24 w-full items-center justify-start gap-3 rounded-none bg-transparent px-5 py-6 text-left hover:bg-transparent dark:hover:bg-transparent sm:gap-4',
 			controller.pending && 'cursor-wait',
 		)}
 	>
-		<!-- The glyph slot is the record CTA: idle = the brand --primary circle (this
-		app's primary action), active = a --destructive (red) circle, mirroring the
-		colors the floating pill already uses for live/stop. The icon (mic -> stop
-		square) and the active flag both come from the controller; this only paints.
-		Hover feedback lives on this circle (a slight scale + lift via group-hover),
-		not a fill behind the row: the button spans only the top zone, so a row fill
-		would cut a hard horizontal edge across the rounded card above the footer. -->
+		<!-- The glyph slot is the record CTA: idle = the brand --primary squircle
+		(this app's primary action, rounded to match the outer card's rounded-3xl),
+		active = a --destructive (red) squircle, mirroring the colors the floating
+		pill already uses for live/stop. The icon (mic -> stop square) and the active
+		flag both come from the controller; this only paints. Hover feedback lives on
+		this glyph (a slight scale + lift via group-hover), not a fill behind the row:
+		the button spans only the top zone, so a row fill would cut a hard horizontal
+		edge across the rounded card above the footer. -->
 		<span
 			aria-hidden="true"
 			class={cn(
-				'relative flex size-14 shrink-0 items-center justify-center rounded-full shadow-lg ring-4 transition-[transform,box-shadow,background-color,color] duration-200 group-hover:scale-[1.04] group-hover:shadow-xl sm:size-16',
+				'relative flex size-14 shrink-0 items-center justify-center rounded-3xl shadow-lg ring-4 transition-[transform,box-shadow,background-color,color] duration-200 group-hover:scale-[1.04] group-hover:shadow-xl sm:size-16',
 				controller.active
 					? 'bg-destructive text-white shadow-destructive/30 ring-destructive/15'
 					: 'bg-primary text-primary-foreground shadow-primary/25 ring-primary/10',
@@ -89,7 +90,7 @@
 			{:else if controller.active && showsLiveMeter}
 				<!-- Live capture: the glyph slot becomes the meter, the same bars the
 				floating pill draws, scaled to fit the box. White bars read on the red
-				(--destructive) recording circle. -->
+				(--destructive) recording squircle. -->
 				<LevelMeter
 					level={webPillLevel.level}
 					class="gap-[2px]"
@@ -124,8 +125,8 @@
 				{#if controller.active && showsLiveMeter && controller.vad}
 					<!-- VAD speech-latch indicator: the same dim-dot -> lit-dot -> spinner the
 					floating pill shows, here inline with the status text instead of in the
-					meter circle's corner (where it read as a dismiss badge and crowded the
-					loudness bars). The circle owns loudness alone now; this line owns VAD's
+					meter glyph's corner (where it read as a dismiss badge and crowded the
+					loudness bars). The glyph owns loudness alone now; this line owns VAD's
 					decision: dim while armed, red (--destructive, the recording accent) once
 					speech latches, a spinner while a previous phrase still transcribes. Gated
 					exactly like the in-card meter (active and web), so on '/' it shows only
@@ -163,7 +164,9 @@
 	its live footer is empty and the slot collapses. -->
 	{#if controller.active}
 		{#if controller.cancel}
-			<div class="flex justify-center px-5 pb-5 pt-1">
+			<div
+				class="flex justify-center border-t border-border/60 px-5 pt-3 pb-5"
+			>
 				<Button
 					tooltip="Cancel recording and discard audio"
 					onclick={() => controller.cancel?.()}
@@ -176,7 +179,7 @@
 			</div>
 		{/if}
 	{:else if footer}
-		<div class="px-5 pb-5 pt-1">
+		<div class="border-t border-border/60 px-5 pt-3 pb-5">
 			{@render footer()}
 		</div>
 	{/if}

--- a/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
+++ b/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
@@ -3,14 +3,13 @@
 	import * as Kbd from '@epicenter/ui/kbd';
 	import { Spinner } from '@epicenter/ui/spinner';
 	import { cn } from '@epicenter/ui/utils';
-	import XIcon from '@lucide/svelte/icons/x';
 	import type { Snippet } from 'svelte';
 	import { dictationCapability } from '$lib/state/dictation-capability.svelte';
 	import type { RecordingActionController } from './recording-action-controller';
 
 	// The controller owns the state machine and every derived label/icon. The card
 	// only decides presentation: a spinner while pending, the destructive "filled"
-	// treatment while active, and a footer shown only at rest.
+	// treatment while active, and the pipeline footer below the toggle.
 	let {
 		controller,
 		footer,
@@ -111,28 +110,11 @@
 		{/if}
 	</Button>
 
-	<!-- The footer slot is the card's secondary zone: at rest it configures the
-	pipeline; while live it discards the take. Keeping the slot filled in both
-	states keeps the discard control tethered to the card (not orphaned below it)
-	and holds the card's height steady across start/stop. VAD has no discard, so
-	its live footer is empty and the slot collapses. -->
-	{#if controller.active}
-		{#if controller.cancel}
-			<div
-				class="flex justify-center border-t border-border/60 px-5 pt-3 pb-5"
-			>
-				<Button
-					tooltip="Cancel recording and discard audio"
-					onclick={() => controller.cancel?.()}
-					variant="ghost-destructive"
-					size="sm"
-				>
-					<XIcon class="size-4" />
-					Cancel recording
-				</Button>
-			</div>
-		{/if}
-	{:else if footer}
+	<!-- The footer stays put across start/stop, so there is no height jump by
+	construction. Cancel lives on the pill, the sole live recording surface. The
+	pipeline controls stay useful mid-take: model and transformation are read at
+	stop time. -->
+	{#if footer}
 		<div class="border-t border-border/60 px-5 pt-3 pb-5">
 			{@render footer()}
 		</div>

--- a/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
+++ b/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
@@ -86,7 +86,7 @@
 			)}
 		>
 			{#if controller.pending}
-				<Spinner class="size-7 text-current" />
+				<Spinner class="size-7" />
 			{:else if controller.active && showsLiveMeter}
 				<!-- Live capture: the glyph slot becomes the meter, the same bars the
 				floating pill draws, scaled to fit the box. White bars read on the red

--- a/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
+++ b/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
@@ -78,7 +78,7 @@
 		<span
 			aria-hidden="true"
 			class={cn(
-				'relative flex size-14 shrink-0 items-center justify-center rounded-full shadow-lg ring-4 transition-[transform,box-shadow,colors] duration-200 group-hover:scale-[1.04] group-hover:shadow-xl sm:size-16',
+				'relative flex size-14 shrink-0 items-center justify-center rounded-full shadow-lg ring-4 transition-[transform,box-shadow,background-color,color] duration-200 group-hover:scale-[1.04] group-hover:shadow-xl sm:size-16',
 				controller.active
 					? 'bg-destructive text-white shadow-destructive/30 ring-destructive/15'
 					: 'bg-primary text-primary-foreground shadow-primary/25 ring-primary/10',
@@ -97,25 +97,6 @@
 					minPx={3}
 					maxPx={28}
 				/>
-				{#if controller.vad}
-					<!-- VAD session: the same dim-dot -> lit-dot -> spinner indicator the
-					floating pill shows beside its meter, here in the glyph's corner. The
-					bars track loudness; this dot tracks whether VAD has latched onto speech
-					and becomes a spinner while a previous phrase is still transcribing. On
-					'/' the pill yields the recording phase to this card, so this is the
-					only place that last signal shows. The signals come from this card's own
-					controller (present only for VAD), not a global lookup. -->
-					<span
-						class="absolute top-0.5 right-0.5 flex size-4 items-center justify-center"
-					>
-						<VadIndicator
-							signals={controller.vad}
-							dimClass="bg-white/40"
-							litClass="bg-white"
-							spinnerClass="text-white/70"
-						/>
-					</span>
-				{/if}
 			{:else}
 				{@const Icon = controller.icon}
 				<span
@@ -137,8 +118,26 @@
 			<span class="truncate text-base font-semibold leading-none sm:text-lg">
 				{controller.label}
 			</span>
-			<span class="truncate text-xs font-medium text-muted-foreground sm:text-sm">
-				{controller.description}
+			<span
+				class="flex min-w-0 items-center gap-1.5 text-xs font-medium text-muted-foreground sm:text-sm"
+			>
+				{#if controller.active && showsLiveMeter && controller.vad}
+					<!-- VAD speech-latch indicator: the same dim-dot -> lit-dot -> spinner the
+					floating pill shows, here inline with the status text instead of in the
+					meter circle's corner (where it read as a dismiss badge and crowded the
+					loudness bars). The circle owns loudness alone now; this line owns VAD's
+					decision: dim while armed, red (--destructive, the recording accent) once
+					speech latches, a spinner while a previous phrase still transcribes. Gated
+					exactly like the in-card meter (active and web), so on '/' it shows only
+					here. The signals come from this card's own controller. -->
+					<VadIndicator
+						signals={controller.vad}
+						dimClass="bg-muted-foreground/40"
+						litClass="bg-destructive"
+						spinnerClass="text-destructive"
+					/>
+				{/if}
+				<span class="truncate">{controller.description}</span>
 			</span>
 		</span>
 		{#if controller.shortcutLabel}

--- a/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
+++ b/apps/whispering/src/routes/(app)/_components/RecordingActionCard.svelte
@@ -51,9 +51,8 @@
 
 <div
 	class={cn(
-		'w-full overflow-hidden rounded-lg border border-border/70 bg-card/60 text-foreground shadow-sm ring-1 ring-foreground/5 transition-[background-color,border-color,box-shadow,color] duration-200 hover:border-primary/55 hover:bg-card/75 hover:shadow-md hover:ring-primary/25',
-		controller.active &&
-			'border-destructive/45 bg-card/70 hover:border-destructive/60 hover:bg-destructive/10 hover:ring-destructive/25',
+		'w-full overflow-hidden rounded-3xl bg-card text-foreground shadow-sm transition-[box-shadow] duration-200',
+		controller.active && 'shadow-md ring-1 ring-destructive/15',
 	)}
 >
 	<Button
@@ -65,27 +64,36 @@
 		onclick={controller.toggle}
 		variant="ghost"
 		class={cn(
-			'min-h-24 w-full justify-start gap-3 rounded-none bg-transparent px-3.5 py-3.5 text-left hover:bg-card/70 sm:gap-4 sm:px-4',
+			'group h-auto w-full justify-start gap-3 rounded-none bg-transparent px-5 pt-5 pb-4 text-left hover:bg-transparent dark:hover:bg-transparent sm:gap-4',
 			controller.pending && 'cursor-wait',
 		)}
 	>
+		<!-- The glyph slot is the record CTA: idle = the brand --primary circle (this
+		app's primary action), active = a --destructive (red) circle, mirroring the
+		colors the floating pill already uses for live/stop. The icon (mic -> stop
+		square) and the active flag both come from the controller; this only paints.
+		Hover feedback lives on this circle (a slight scale + lift via group-hover),
+		not a fill behind the row: the button spans only the top zone, so a row fill
+		would cut a hard horizontal edge across the rounded card above the footer. -->
 		<span
 			aria-hidden="true"
 			class={cn(
-				'relative flex size-14 shrink-0 items-center justify-center rounded-md border border-border/70 bg-background/70 text-foreground shadow-inner transition-colors duration-200 sm:size-16',
-				controller.active &&
-					'border-destructive/45 bg-destructive/10 text-destructive',
+				'relative flex size-14 shrink-0 items-center justify-center rounded-full shadow-lg ring-4 transition-[transform,box-shadow,colors] duration-200 group-hover:scale-[1.04] group-hover:shadow-xl sm:size-16',
+				controller.active
+					? 'bg-destructive text-white shadow-destructive/30 ring-destructive/15'
+					: 'bg-primary text-primary-foreground shadow-primary/25 ring-primary/10',
 			)}
 		>
 			{#if controller.pending}
-				<Spinner class="size-7" />
+				<Spinner class="size-7 text-current" />
 			{:else if controller.active && showsLiveMeter}
 				<!-- Live capture: the glyph slot becomes the meter, the same bars the
-				floating pill draws, scaled to fit the box. -->
+				floating pill draws, scaled to fit the box. White bars read on the red
+				(--destructive) recording circle. -->
 				<LevelMeter
 					level={webPillLevel.level}
 					class="gap-[2px]"
-					barClass="w-[2px] bg-destructive"
+					barClass="w-[2px] bg-white"
 					minPx={3}
 					maxPx={28}
 				/>
@@ -102,9 +110,9 @@
 					>
 						<VadIndicator
 							signals={controller.vad}
-							dimClass="bg-destructive/40"
-							litClass="bg-destructive"
-							spinnerClass="text-muted-foreground"
+							dimClass="bg-white/40"
+							litClass="bg-white"
+							spinnerClass="text-white/70"
 						/>
 					</span>
 				{/if}
@@ -156,9 +164,7 @@
 	its live footer is empty and the slot collapses. -->
 	{#if controller.active}
 		{#if controller.cancel}
-			<div
-				class="flex justify-center border-t border-border/60 bg-background/20 px-3 py-2"
-			>
+			<div class="flex justify-center px-5 pb-5 pt-1">
 				<Button
 					tooltip="Cancel recording and discard audio"
 					onclick={() => controller.cancel?.()}
@@ -171,7 +177,7 @@
 			</div>
 		{/if}
 	{:else if footer}
-		<div class="border-t border-border/60 bg-background/20 px-3 py-2">
+		<div class="px-5 pb-5 pt-1">
 			{@render footer()}
 		</div>
 	{/if}

--- a/apps/whispering/src/routes/(app)/_components/RecordingResult.svelte
+++ b/apps/whispering/src/routes/(app)/_components/RecordingResult.svelte
@@ -27,7 +27,7 @@
 		transcript: string;
 		/** Visible rows of the transcript preview before it scrolls/expands. */
 		rows?: number;
-		/** When provided, a delete button is shown below the preview. */
+		/** When provided, a delete button is shown at the end of the audio row. */
 		onDelete?: () => void;
 	} = $props();
 
@@ -49,23 +49,32 @@
 		{rows}
 		disabled={!transcript.trim()}
 	/>
-	{#if audioQuery.data}
-		<audio
-			style:view-transition-name={viewTransition.recording(recordingId).audio}
-			src={audioQuery.data}
-			controls
-			class="h-8 w-full"
-		></audio>
-	{/if}
-	{#if onDelete}
-		<Button
-			class="self-end"
-			variant="ghost-destructive"
-			size="sm"
-			onclick={onDelete}
-		>
-			<TrashIcon class="size-4" />
-			Delete
-		</Button>
+	<!-- Delete is a companion action on the audio row, mirroring the copy button
+	     on the transcript row above: content stretches, its action caps the row.
+	     Icon-only with a tooltip; the confirmation dialog carries the words. -->
+	{#if audioQuery.data || onDelete}
+		<div class="flex w-full items-center gap-2">
+			{#if audioQuery.data}
+				<audio
+					style:view-transition-name={viewTransition.recording(recordingId)
+						.audio}
+					src={audioQuery.data}
+					controls
+					class="h-8 min-w-0 flex-1"
+				></audio>
+			{/if}
+			{#if onDelete}
+				<Button
+					class="ml-auto"
+					variant="ghost-destructive"
+					size="icon-sm"
+					tooltip="Delete recording"
+					aria-label="Delete recording"
+					onclick={onDelete}
+				>
+					<TrashIcon class="size-4" />
+				</Button>
+			{/if}
+		</div>
 	{/if}
 </div>

--- a/apps/whispering/src/routes/(app)/_components/manual-recording-controller.svelte.ts
+++ b/apps/whispering/src/routes/(app)/_components/manual-recording-controller.svelte.ts
@@ -1,7 +1,6 @@
 import { createMutation } from '@tanstack/svelte-query';
 import { MANUAL_RECORDING_BUTTON } from '$lib/constants/audio';
 import {
-	cancelRecording,
 	startManualRecording,
 	stopManualRecording,
 } from '$lib/operations/recording';
@@ -76,10 +75,6 @@ export function createManualRecordingController(): RecordingActionController {
 		toggle() {
 			if (isRecording) stopMutation.mutate();
 			else startMutation.mutate();
-		},
-		cancel() {
-			// Self-reports failures and plays the discard sound; fire-and-forget.
-			void cancelRecording();
 		},
 	};
 }

--- a/apps/whispering/src/routes/(app)/_components/recording-action-controller.ts
+++ b/apps/whispering/src/routes/(app)/_components/recording-action-controller.ts
@@ -22,11 +22,4 @@ export type RecordingActionController = {
 	readonly shortcutLabel: string;
 	/** Start when idle, stop when active. */
 	toggle(): void;
-	/**
-	 * Discard the in-progress capture without keeping its audio. Present only
-	 * when the recorder has a discard-vs-finalize split (manual). Absent for VAD,
-	 * where stopping the session is the only way to abort it, so a separate cancel
-	 * would just duplicate the toggle.
-	 */
-	cancel?(): void;
 };

--- a/apps/whispering/src/routes/(app)/_components/recording-action-controller.ts
+++ b/apps/whispering/src/routes/(app)/_components/recording-action-controller.ts
@@ -29,17 +29,4 @@ export type RecordingActionController = {
 	 * would just duplicate the toggle.
 	 */
 	cancel?(): void;
-	/**
-	 * The live voice-activation signals, drawn as the small dim-dot -> lit-dot ->
-	 * spinner mark beside the meter. Present only for a voice-activated controller;
-	 * absent for manual, which has no listening/speech/transcribe states. So the
-	 * card shows the mark exactly when this is present, instead of asking a global
-	 * "is the current capture a VAD one". Like `cancel`, optional by mode.
-	 */
-	vad?: {
-		/** VAD has latched onto speech: light the mark past mere loudness. */
-		readonly speaking: boolean;
-		/** A previous phrase is still transcribing beside the live meter. */
-		readonly transcribing: boolean;
-	};
 };

--- a/apps/whispering/src/routes/(app)/_components/vad-recording-controller.svelte.ts
+++ b/apps/whispering/src/routes/(app)/_components/vad-recording-controller.svelte.ts
@@ -1,7 +1,6 @@
 import { createMutation } from '@tanstack/svelte-query';
 import { VAD_RECORDING_BUTTON } from '$lib/constants/audio';
 import { toggleVadRecording } from '$lib/operations/recording';
-import { dictationLifecycle } from '$lib/state/dictation-lifecycle.svelte';
 import { vadRecorder } from '$lib/state/vad-recorder.svelte';
 import { getRecordingShortcutLabel } from '$lib/utils/recording-shortcut';
 import type { RecordingActionController } from './recording-action-controller';
@@ -21,23 +20,12 @@ export function createVadRecordingController(): RecordingActionController {
 	}));
 
 	const isListening = $derived(vadRecorder.state !== 'IDLE');
-	const isSpeechDetected = $derived(vadRecorder.state === 'SPEECH_DETECTED');
-	// The live VAD signals the card draws beside its meter, as one memoized object
-	// so `get vad()` returns a stable reference like every other member instead of
-	// building a fresh object per read. `transcribing` is a previous phrase still
-	// transcribing while this session keeps listening (the continuous-VAD overlap),
-	// gated on listening so it only reads as "ours" while this session is live.
-	const vad = $derived({
-		speaking: isSpeechDetected,
-		transcribing:
-			isListening && dictationLifecycle.current.outcome.kind === 'transcribing',
-	});
 	const button = $derived(VAD_RECORDING_BUTTON[vadRecorder.state]);
 	const shortcutLabel = $derived(getRecordingShortcutLabel('vad'));
 
 	const description = $derived.by(() => {
 		if (toggleMutation.isPending) return 'Updating voice activation';
-		if (isSpeechDetected) return 'Speech detected';
+		if (vadRecorder.state === 'SPEECH_DETECTED') return 'Speech detected';
 		if (isListening) return 'Listening for speech';
 		return 'Listen for speech';
 	});
@@ -68,9 +56,6 @@ export function createVadRecordingController(): RecordingActionController {
 		},
 		get shortcutLabel() {
 			return shortcutLabel;
-		},
-		get vad() {
-			return vad;
 		},
 		toggle() {
 			toggleMutation.mutate();

--- a/apps/whispering/src/routes/+layout.svelte
+++ b/apps/whispering/src/routes/+layout.svelte
@@ -8,8 +8,8 @@
 	import { queryClient } from '$lib/rpc/client';
 	import { reloadOnOwnerChange } from '$lib/whispering/reload-on-owner-change';
 	import '@epicenter/ui/app.css';
-	// Whispering's brand + light-mode surface overrides, layered after the shared
-	// theme so they win. Keep this import last among the stylesheets.
+	// Whispering's brand overrides, layered after the shared theme so they win.
+	// Keep this import last among the stylesheets.
 	import '../app.css';
 	import * as Tooltip from '@epicenter/ui/tooltip';
 

--- a/apps/whispering/src/routes/+layout.svelte
+++ b/apps/whispering/src/routes/+layout.svelte
@@ -8,6 +8,9 @@
 	import { queryClient } from '$lib/rpc/client';
 	import { reloadOnOwnerChange } from '$lib/whispering/reload-on-owner-change';
 	import '@epicenter/ui/app.css';
+	// Whispering's brand + light-mode surface overrides, layered after the shared
+	// theme so they win. Keep this import last among the stylesheets.
+	import '../app.css';
 	import * as Tooltip from '@epicenter/ui/tooltip';
 
 	let { children } = $props();

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",
@@ -953,7 +952,6 @@
       "name": "@epicenter/ui",
       "version": "0.3.0",
       "dependencies": {
-        "@fontsource-variable/manrope": "^5.2.6",
         "@lucide/svelte": "^1.7.0",
         "@tanstack/svelte-table": "catalog:",
         "bits-ui": "^2.16.5",
@@ -1477,8 +1475,6 @@
     "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
-
-    "@fontsource-variable/manrope": ["@fontsource-variable/manrope@5.2.8", "", {}, "sha512-nc9lOuCRz73UHnovDE2bwXUdghE2SEOc7Aii0qGe3CLyE03W1a7VnY5Z6euRiapiKbCkGS+eXbY3s/kvWeGeSw=="],
 
     "@google/generative-ai": ["@google/generative-ai@0.24.1", "", {}, "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q=="],
 

--- a/packages/server/src/auth-pages/styles.ts
+++ b/packages/server/src/auth-pages/styles.ts
@@ -3,9 +3,9 @@
  * cli-callback).
  *
  * Matches the Epicenter design system tokens from `packages/ui/src/app.css`
- * using oklch equivalents. System-ui font stack (brand font Manrope is not
- * loaded on these standalone pages). No external dependencies. This string is
- * inlined in the `<style>` tag by the layout component.
+ * using oklch equivalents, including its system-ui font stack. No external
+ * dependencies. This string is inlined in the `<style>` tag by the layout
+ * component.
  */
 export const AUTH_STYLES = `
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,7 +30,6 @@
 		"typecheck": "svelte-check --tsconfig ./tsconfig.json"
 	},
 	"dependencies": {
-		"@fontsource-variable/manrope": "^5.2.6",
 		"@lucide/svelte": "^1.7.0",
 		"@tanstack/svelte-table": "catalog:",
 		"bits-ui": "^2.16.5",

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -40,6 +40,10 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
+	/* One stack for both modes; dark must not redeclare a shorter one. A stack
+	   that bottoms out at bare sans-serif renders Helvetica on macOS, whose
+	   vertical metrics sit text ink ~2px high in a line box, so every icon
+	   beside a label reads as drooping. system-ui (SF Pro, Segoe UI) centers. */
 	--font-sans:
 		"Manrope Variable", system-ui, -apple-system, BlinkMacSystemFont,
 		"Segoe UI", Roboto, sans-serif;
@@ -83,7 +87,6 @@
 }
 
 .dark {
-	--font-sans: "Manrope Variable", sans-serif;
 	--background: oklch(0.129 0.042 264.695);
 	--foreground: oklch(0.984 0.003 247.858);
 	--card: oklch(0.208 0.042 265.755);

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -44,8 +44,7 @@
 	   vertical metrics sit text ink ~2px high in a line box, so every icon
 	   beside a label reads as drooping. system-ui (SF Pro, Segoe UI) centers. */
 	--font-sans:
-		system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		sans-serif;
+		system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 	--radius: 0.625rem;
 	/* Dark mode already separates --background from --card (0.129 vs 0.208); light mode
 	   collapsing both to pure white is the asymmetry. This barely-there warm-neutral tint

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -1,5 +1,4 @@
 @import "tailwindcss";
-/* @import '@fontsource-variable/manrope'; */
 
 @import "tw-animate-css";
 
@@ -45,8 +44,8 @@
 	   vertical metrics sit text ink ~2px high in a line box, so every icon
 	   beside a label reads as drooping. system-ui (SF Pro, Segoe UI) centers. */
 	--font-sans:
-		"Manrope Variable", system-ui, -apple-system, BlinkMacSystemFont,
-		"Segoe UI", Roboto, sans-serif;
+		system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+		sans-serif;
 	--radius: 0.625rem;
 	/* Dark mode already separates --background from --card (0.129 vs 0.208); light mode
 	   collapsing both to pure white is the asymmetry. This barely-there warm-neutral tint

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -44,7 +44,10 @@
 		"Manrope Variable", system-ui, -apple-system, BlinkMacSystemFont,
 		"Segoe UI", Roboto, sans-serif;
 	--radius: 0.625rem;
-	--background: oklch(1 0 0);
+	/* Dark mode already separates --background from --card (0.129 vs 0.208); light mode
+	   collapsing both to pure white is the asymmetry. This barely-there warm-neutral tint
+	   restores that separation so a --card surface reads as elevated without a border. */
+	--background: oklch(0.9925 0.001 70);
 	--foreground: oklch(0.129 0.042 264.695);
 	--card: oklch(1 0 0);
 	--card-foreground: oklch(0.129 0.042 264.695);

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -60,7 +60,11 @@
 	--primary-foreground: oklch(0.984 0.003 247.858);
 	--secondary: oklch(0.968 0.007 247.896);
 	--secondary-foreground: oklch(0.208 0.042 265.755);
-	--muted: oklch(0.968 0.007 247.896);
+	/* --muted is the selected/hover fill (toggle-group items, ghost hovers). At
+	   the shadcn default 0.968 it sat 0.025 L above --background, nearly
+	   invisible as a selection; 0.945 keeps it soft but clearly separates a
+	   selected tab from the page (dark mode's pair is 0.15 L apart). */
+	--muted: oklch(0.945 0.007 247.896);
 	--muted-foreground: oklch(0.554 0.046 257.417);
 	--accent: oklch(0.968 0.007 247.896);
 	--accent-foreground: oklch(0.208 0.042 265.755);


### PR DESCRIPTION
Light mode was flattening white cards into white pages. The shared theme set `--background` and `--card` to pure white, while dark mode already separated those surfaces. This gives the shared light background a barely-there warm-neutral tint, keeps cards pure white, and leaves dark mode unchanged.

Whispering also gets the focused recording-surface polish from this branch: the idle record control uses the app's indigo primary color, the shortcut chip is softer, the active recording ring is clearer, and the VAD indicator now sits with the status text instead of crowding the meter.

This supersedes #2222: it keeps that Whispering recorder polish, expands the surface separation into the shared light theme, and leaves #2222 as the narrower earlier cut.

## Changelog

- Separate light-mode page backgrounds from card surfaces in the shared UI theme.
- Polish Whispering's light-mode recording card, idle CTA, shortcut chip, and active recording state.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785531258&installation_id=128463665&pr_number=2249&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2249&signature=cb3606e1ca6d56427b1ba699bbad28d08d09b4b06f82996faf1feb0d326afb6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
