### PR TITLE
feat(app-shell): collapse sign-in surfaces into one panel with self-host as a real mode

### DIFF
--- a/packages/app-shell/src/account-popover/account-popover.svelte
+++ b/packages/app-shell/src/account-popover/account-popover.svelte
@@ -20,7 +20,7 @@
 	import { extractErrorMessage } from 'wellcrafted/error';
 	import { mutationOptions, queryOptions } from 'wellcrafted/query';
 	import InstanceSettingsModal from '../instance-settings/instance-settings-modal.svelte';
-	import InstanceSignIn from '../instance-settings/instance-sign-in.svelte';
+	import SignInPanel from '../instance-settings/sign-in-panel.svelte';
 
 	const accountProfileQueryClient = new QueryClient({
 		defaultOptions: {
@@ -78,10 +78,10 @@
 		onForgetDevice?: () => void | Promise<void>;
 		/**
 		 * When set, the signed-out panel also offers connecting to a self-hosted
-		 * Epicenter instance, via the shared {@link InstanceSignIn} (a hosted sign-in
-		 * button plus a "Connect to a self-hosted instance" link that opens the
-		 * settings modal), the same affordance the full-page `SignedOutScreen` uses.
-		 * Omit to keep the plain hosted-only sign-in button.
+		 * Epicenter instance, via the shared sign-in panel (a hosted sign-in button
+		 * plus a "Connect to a self-hosted instance" link that opens the settings
+		 * modal), the same affordance the full-page `SignedOutScreen` uses. Omit to
+		 * keep the hosted-only sign-in panel.
 		 */
 		instanceConnect?: {
 			/** The app's display name, woven into the modal's description. */
@@ -113,17 +113,6 @@
 	// now; the reason is shown and those actions are disabled. Reconnect is safe
 	// (it never reloads), so it stays enabled.
 	const accountLocked = $derived(!!disabledReason);
-	// When the injected instance is a self-host override, the signed-out heading
-	// names the box instead of pitching hosted cross-device sync, mirroring
-	// SignedOutScreen. InstanceSignIn already flips its button and link copy.
-	const instanceUsesSelfHost = $derived(
-		instanceConnect ? !instanceConnect.setting.isDefault() : false,
-	);
-	const instanceHost = $derived(
-		instanceConnect && instanceUsesSelfHost
-			? new URL(instanceConnect.setting.read().baseURL).host
-			: undefined,
-	);
 	const accountCacheKey = $derived(
 		auth.state.status === 'signed-out' ? null : auth.state.ownerId,
 	);
@@ -155,14 +144,6 @@
 				onError: (error) => {
 					toastOnError(error, 'Failed to sign out');
 				},
-			}),
-		() => accountProfileQueryClient,
-	);
-	const startSignIn = createMutation(
-		() =>
-			mutationOptions({
-				mutationKey: ['account', 'startSignIn'],
-				mutationFn: () => auth.startSignIn(),
 			}),
 		() => accountProfileQueryClient,
 	);
@@ -336,56 +317,17 @@
 					</div>
 				{/if}
 			</div>
-		{:else if instanceConnect}
-			<div class="p-4 space-y-3">
-				<div class="space-y-1">
-					<p class="text-sm font-medium">
-						{instanceUsesSelfHost ? `Connect to ${instanceHost}` : 'Sign in'}
-					</p>
-					<p class="text-xs text-muted-foreground">
-						{instanceUsesSelfHost
-							? 'Sign in to your self-hosted instance.'
-							: `Sign in to sync your ${syncNoun} across devices.`}
-					</p>
-				</div>
-				{#if disabledReason}
-					<p class="text-xs text-muted-foreground">{disabledReason}</p>
-				{/if}
-				<InstanceSignIn
-					{auth}
-					setting={instanceConnect.setting}
-					{disabledReason}
-					onConfigure={openInstanceModal}
-				/>
-			</div>
 		{:else}
-			<div class="p-4 space-y-3">
-				<div class="space-y-1">
-					<p class="text-sm font-medium">Sign in</p>
-					<p class="text-xs text-muted-foreground">
-						Sign in to sync your {syncNoun} across devices.
-					</p>
-				</div>
-				{#if disabledReason}
-					<p class="text-xs text-muted-foreground">{disabledReason}</p>
-				{/if}
-				{#if startSignIn.error}
-					<p class="text-xs text-destructive">{startSignIn.error.message}</p>
-				{/if}
-				<Button
-					class="w-full"
-					onclick={() => startSignIn.mutate()}
-					disabled={startSignIn.isPending || accountLocked}
-				>
-					{#if startSignIn.isPending}
-						<Spinner />
-						Signing in…
-					{:else if auth.state.status === 'reauth-required'}
-						Reconnect
-					{:else}
-						Sign in with Epicenter
-					{/if}
-				</Button>
+			<div class="p-4">
+				<SignInPanel
+					{auth}
+					title="Sign in"
+					description={`Sign in to sync your ${syncNoun} across devices.`}
+					{disabledReason}
+					instance={instanceConnect
+						? { setting: instanceConnect.setting, onConfigure: openInstanceModal }
+						: undefined}
+				/>
 			</div>
 		{/if}
 	</Popover.Content>

--- a/packages/app-shell/src/account-popover/account-popover.svelte
+++ b/packages/app-shell/src/account-popover/account-popover.svelte
@@ -116,6 +116,14 @@
 	const accountCacheKey = $derived(
 		auth.state.status === 'signed-out' ? null : auth.state.ownerId,
 	);
+	// Which star this account lives on: a configured self-host override names the
+	// box, and the host IS the identity there (the instance session's email is a
+	// canned placeholder, not an account).
+	const selfHostHost = $derived(
+		instanceConnect && !instanceConnect.setting.isDefault()
+			? new URL(instanceConnect.setting.read().baseURL).host
+			: undefined,
+	);
 	// Identity lives on the auth client: `state` carries the capability id
 	// (`ownerId`), and `getProfile()` reads presentational identity (the email)
 	// on demand. TanStack Query owns the reactive cache here, keyed by owner, and
@@ -125,7 +133,7 @@
 			queryOptions({
 				queryKey: ['account-profile', accountCacheKey],
 				queryFn: () => auth.getProfile(),
-				enabled: auth.state.status !== 'signed-out',
+				enabled: auth.state.status !== 'signed-out' && !selfHostHost,
 				staleTime: Infinity,
 			}),
 		() => accountProfileQueryClient,
@@ -257,7 +265,12 @@
 		{#if auth.state.status === 'signed-in'}
 			<div class="p-4 space-y-3">
 				<div class="space-y-1">
-					<p class="text-sm font-medium">{accountLabel}</p>
+					{#if selfHostHost}
+						<p class="text-sm font-medium">{selfHostHost}</p>
+						<p class="text-xs text-muted-foreground">Self-hosted instance</p>
+					{:else}
+						<p class="text-sm font-medium">{accountLabel}</p>
+					{/if}
 				</div>
 				{#if disabledReason}
 					<p class="text-xs text-muted-foreground">{disabledReason}</p>

--- a/packages/app-shell/src/instance-settings/sign-in-panel.svelte
+++ b/packages/app-shell/src/instance-settings/sign-in-panel.svelte
@@ -4,33 +4,61 @@
 	import { Spinner } from '@epicenter/ui/spinner';
 	import { cn } from '@epicenter/ui/utils';
 
-	let {
-		auth,
-		setting,
-		disabledReason,
-		onConfigure,
-		class: className,
-	}: {
+	/**
+	 * One shared signed-out sign-in panel.
+	 *
+	 * Renders the hosted primary action plus an optional self-host instance
+	 * connect affordance. Used by the account popover and the signed-out screen.
+	 */
+	type SignInPanelProps = {
 		/** The app's auth client; its `startSignIn` drives the primary button. */
 		auth: AuthClient;
-		/** The shared instance setting handle this app injected. */
-		setting: InstanceSetting;
+		/**
+		 * Hosted-mode heading. When a self-host override is configured, the panel
+		 * replaces it with "Connect to {host}", so parents supply only the hosted
+		 * copy and cannot forget the flip.
+		 */
+		title: string;
+		/**
+		 * Hosted-mode subheading (e.g. "Sign in to sync your recordings across
+		 * devices."), replaced alongside title when an override is configured.
+		 */
+		description: string;
+		/**
+		 * Optional self-host instance controls. When present, the panel offers
+		 * connecting to a self-hosted instance; grouping means a configure
+		 * affordance cannot ship without the setting that gives it meaning. Omit
+		 * for a hosted-only panel.
+		 */
+		instance?: {
+			/** The shared instance setting handle this app injected. */
+			setting: InstanceSetting;
+			/**
+			 * Open the instance-settings modal. The shell owns that modal, not this
+			 * component, because its lifetime differs: inline on a full-page screen, but
+			 * root-mounted beside a popover (so closing the popover cannot tear an open
+			 * modal down).
+			 */
+			onConfigure: () => void;
+		};
 		/**
 		 * When set, the primary sign-in and the "connect/change" link are disabled.
 		 * Lets a host block a page-reloading account change at an unsafe moment, e.g.
 		 * Whispering during a recording. Omit to leave the actions enabled.
 		 */
 		disabledReason?: string;
-		/**
-		 * Open the instance-settings modal. The shell owns that modal, not this
-		 * component, because its lifetime differs: inline on a full-page screen, but
-		 * root-mounted beside a popover (so closing the popover cannot tear an open
-		 * modal down).
-		 */
-		onConfigure: () => void;
 		/** Layout classes for the action column (width, alignment). */
 		class?: string;
-	} = $props();
+	};
+
+	let {
+		auth,
+		title,
+		description,
+		instance,
+		disabledReason,
+		class: className,
+	}: SignInPanelProps = $props();
 
 	let signingIn = $state(false);
 	let signInError = $state<string | null>(null);
@@ -38,12 +66,16 @@
 	// A self-host override is configured (a non-hosted star with a token is
 	// persisted, ADR-0071), which flips the labels from "sign in / connect" to
 	// "retry / change". Reads the boot snapshot, which only changes across a reload.
-	const configured = $derived(!setting.isDefault());
+	const configured = $derived(instance ? !instance.setting.isDefault() : false);
 
 	// The self-host token client reports why it is not connected; hosted OAuth has
 	// no such channel (`auth.connection` is undefined) and falls back to the
 	// generic startSignIn error rendered below.
-	const host = $derived(new URL(setting.read().baseURL).host);
+	const host = $derived(
+		instance && configured
+			? new URL(instance.setting.read().baseURL).host
+			: undefined,
+	);
 	const connectionState = $derived(auth.connection?.state);
 	const connectionNotice = $derived.by(() => {
 		const c = connectionState;
@@ -86,6 +118,15 @@
 </script>
 
 <div class={cn('flex flex-col gap-3', className)}>
+	<div class="space-y-1">
+		<p class="text-sm font-medium">{configured ? `Connect to ${host}` : title}</p>
+		<p class="text-xs text-muted-foreground">
+			{configured ? 'Sign in to your self-hosted instance.' : description}
+		</p>
+	</div>
+	{#if disabledReason}
+		<p class="text-xs text-muted-foreground">{disabledReason}</p>
+	{/if}
 	{#if connectionNotice}
 		<p class="text-xs {connectionNotice.tone}">{connectionNotice.text}</p>
 	{:else if signInError}
@@ -101,13 +142,15 @@
 			{configured ? 'Retry connection' : 'Sign in with Epicenter'}
 		{/if}
 	</Button>
-	<Button
-		variant="link"
-		size="sm"
-		class="text-muted-foreground"
-		disabled={accountLocked}
-		onclick={onConfigure}
-	>
-		{configured ? 'Change instance' : 'Connect to a self-hosted instance'}
-	</Button>
+	{#if instance}
+		<Button
+			variant="link"
+			size="sm"
+			class="text-muted-foreground"
+			disabled={accountLocked}
+			onclick={instance.onConfigure}
+		>
+			{configured ? 'Change instance' : 'Connect to a self-hosted instance'}
+		</Button>
+	{/if}
 </div>

--- a/packages/app-shell/src/instance-settings/sign-in-panel.svelte
+++ b/packages/app-shell/src/instance-settings/sign-in-panel.svelte
@@ -3,6 +3,9 @@
 	import { Button } from '@epicenter/ui/button';
 	import { Spinner } from '@epicenter/ui/spinner';
 	import { cn } from '@epicenter/ui/utils';
+	import Cloud from '@lucide/svelte/icons/cloud';
+	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
+	import Server from '@lucide/svelte/icons/server';
 
 	/**
 	 * One shared signed-out sign-in panel.
@@ -42,9 +45,10 @@
 			onConfigure: () => void;
 		};
 		/**
-		 * When set, the primary sign-in and the "connect/change" link are disabled.
-		 * Lets a host block a page-reloading account change at an unsafe moment, e.g.
-		 * Whispering during a recording. Omit to leave the actions enabled.
+		 * When set, the primary sign-in and the connect/change actions are
+		 * disabled, and the reason is shown as a muted line. Lets a host block a
+		 * page-reloading account change at an unsafe moment, e.g. Whispering during
+		 * a recording. Omit to leave the actions enabled.
 		 */
 		disabledReason?: string;
 		/** Layout classes for the action column (width, alignment). */
@@ -138,18 +142,23 @@
 			{configured ? 'Connecting…' : 'Signing in…'}
 		{:else if auth.state.status === 'reauth-required'}
 			Reconnect
+		{:else if configured}
+			<RefreshCw class="size-4" />
+			Retry connection
 		{:else}
-			{configured ? 'Retry connection' : 'Sign in with Epicenter'}
+			<Cloud class="size-4" />
+			Sign in with Epicenter
 		{/if}
 	</Button>
 	{#if instance}
+		<!-- Self-host is a real mode, so it gets a real button; Cloud vs Server names the two modes. -->
 		<Button
-			variant="link"
-			size="sm"
-			class="text-muted-foreground"
+			variant="outline"
+			class="w-full"
 			disabled={accountLocked}
 			onclick={instance.onConfigure}
 		>
+			<Server class="size-4" />
 			{configured ? 'Change instance' : 'Connect to a self-hosted instance'}
 		</Button>
 	{/if}

--- a/packages/app-shell/src/instance-settings/signed-out-screen.svelte
+++ b/packages/app-shell/src/instance-settings/signed-out-screen.svelte
@@ -2,7 +2,7 @@
 	import type { InstanceSetting, SyncAuthClient } from '@epicenter/auth';
 	import { cn } from '@epicenter/ui/utils';
 	import InstanceSettingsModal from './instance-settings-modal.svelte';
-	import InstanceSignIn from './instance-sign-in.svelte';
+	import SignInPanel from './sign-in-panel.svelte';
 
 	let {
 		appName,
@@ -28,12 +28,8 @@
 	} = $props();
 
 	let modalOpen = $state(false);
-
-	// A token override flips the heading from "sign in" to "connect". Derived reads
-	// of the stable handle; saving the modal reloads, so nothing changes live. The
-	// sign-in actions themselves live in the shared {@link InstanceSignIn}.
-	const usingToken = $derived(!setting.isDefault());
-	const instanceHost = $derived(new URL(setting.read().baseURL).host);
+	// SignInPanel owns the hosted/self-host heading flip; this wrapper owns the
+	// centered page shell and the settings modal lifetime.
 </script>
 
 <div
@@ -42,18 +38,11 @@
 		className,
 	)}
 >
-	<div class="space-y-1">
-		<p class="text-sm font-medium">
-			{usingToken ? `Connect to ${instanceHost}` : `Sign in to ${appName}`}
-		</p>
-		<p class="text-xs text-muted-foreground">
-			{usingToken ? 'Sign in to your self-hosted instance.' : tagline}
-		</p>
-	</div>
-	<InstanceSignIn
+	<SignInPanel
 		{auth}
-		{setting}
-		onConfigure={() => (modalOpen = true)}
+		title={`Sign in to ${appName}`}
+		description={tagline}
+		instance={{ setting, onConfigure: () => (modalOpen = true) }}
 		class="w-full max-w-xs"
 	/>
 </div>


### PR DESCRIPTION
Follow-up to #2247, which added the self-host connect UI to the account popover. That PR left the shell with three renderings of the primary sign-in action: the popover's plain signed-out branch (a TanStack mutation), its instance-connect branch (InstanceSignIn), and the signed-out screen (InstanceSignIn again), plus two copies of the heading flip that names a configured self-host box. A new surface could forget the flip, and two error mechanisms coexisted for one button.

Old shape:

```
account-popover.svelte
  signed-out (plain)      -> own heading + createMutation + button
  signed-out (instance)   -> own heading flip + <InstanceSignIn>
signed-out-screen.svelte  -> own heading flip + <InstanceSignIn>
```

New shape:

```
sign-in-panel.svelte (renamed from instance-sign-in.svelte)
  owns: heading flip, disabled reason, connection notice, both actions
account-popover.svelte    -> one signed-out branch: <SignInPanel>
signed-out-screen.svelte  -> centering shell + modal lifetime: <SignInPanel>
```

Parents supply only hosted copy (title, description) and layout; the panel replaces them with "Connect to {host}" when a self-host override is configured, so the flip cannot be forgotten. The instance controls stay a grouped optional prop (instance: { setting, onConfigure }), so a configure affordance cannot ship without the setting that gives it meaning, and the modal stays shell-owned and root-mounted (the popover teardown/focus fix from #2247 is untouched).

Two user-visible changes ride along. Hosted Epicenter and a self-hosted instance are the two real ways to connect an app, so the panel now renders them as two full-width actions with Cloud and Server icons naming the modes; the self-host affordance was previously a muted fine-print link that read like an error path. And when an app is signed in to a self-hosted instance, the popover identity block now shows the instance host with a "Self-hosted instance" caption instead of the server's placeholder email (owner@instance.local), skipping the profile fetch that would only return that placeholder.

## Changelog
- Show self-hosted instance connection as a real option next to hosted sign-in, not a fine-print link
- Show which self-hosted instance you are connected to in the account menu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785534042&installation_id=128463665&pr_number=2250&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2250&signature=f502b4e11926832ba72deeb1be420c0030e6a759948e878d39903338b2e9f685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->