### PR TITLE
docs: tighten handoff skill

### DIFF
--- a/.agents/skills/handoff/SKILL.md
+++ b/.agents/skills/handoff/SKILL.md
@@ -1,46 +1,43 @@
 ---
 name: handoff
-description: Draft a cold-start, copy-pasteable continuation prompt so a fresh agent can resume without this thread, even if the current chat is closed. Use when the user says "hand this off", "compact this", "wrap up for the next session", "resume this later", "continue in a new chat", "write a continuation prompt", "draft a prompt", "make a prompt I can copy-paste", "create a delegation brief", or invokes /handoff.
+description: 'Draft a cold-start, copy-pasteable prompt so a fresh agent can continue, review, or implement this work without reading this thread. Use when the user says "hand this off", "wrap up for the next session", "resume this later", "continue in a new chat", "write a continuation prompt", "make a prompt I can copy-paste", "create a delegation brief", "prompt for an orchestrator", or invokes /handoff. Not for /goal lines (use agent-goal) or for prompts that ship inside product code.'
 argument-hint: "What should the next agent accomplish?"
 metadata:
   author: epicenter
-  version: '2.0'
+  version: '3.0'
 ---
 
 # Handoff
 
-Draft a cold-start continuation prompt that can be pasted into a fresh agent thread or separate session.
+Write the prompt for a competent stranger: a fresh agent with no thread context, possibly starting after this chat is closed. The test: pasted into a blank thread, the recipient can start working without reading this thread or asking what happened.
 
-Return the prompt directly in the conversation. The user can copy it from there.
+Return the prompt directly in the conversation so the user can copy it. This skill produces the prompt only; do not launch, supervise, or automate the recipient.
 
-The recipient has no thread context and may be starting after this chat is closed. Include only what they need to continue correctly.
+## What The Prompt Must Answer
 
-Do not launch, supervise, or automate the recipient. This skill produces the prompt only.
+Write one prompt regardless of recipient type, and cover these points. They are content requirements, not headings: a bounded review ask can cover them in a dozen lines, a multi-day continuation may need a section each.
 
-## Include
+1. Mission: one concrete outcome and the exact artifact wanted (diff, review memo, updated spec, ADR draft, summary).
+2. State: branch, dirty versus committed work, checks already run, and what remains open.
+3. Reading list: exact paths, commands, and snippets to read first, with why each matters.
+4. Decisions: what is settled and must not be reopened, what is known fact, what is only a recommendation, and which questions are open and whose call they are. Mixing these makes the recipient treat taste as evidence.
+5. Boundaries: what may change, what must not, and what adjacent work is out of scope.
+6. Plan: ordered next steps concrete enough to start without asking for context.
+7. Proof and stop: verification commands, the evidence expected in the final answer, and where to stop instead of continuing into the next phase.
 
-- Goal: what the next agent should accomplish.
-- Current state: what is done, what is dirty, what is committed, and what is still open.
-- Important files: exact paths and why they matter.
-- Decisions: choices already made and choices not to reopen.
-- Constraints: repo rules, commands, style rules, and things to avoid.
-- Next steps: ordered, concrete actions.
-- Verification: commands already run and commands still needed.
+## Rules
 
-For a bounded review prompt, make the goal one concrete question. Include exact
-file paths, short snippets, or the diff command to run, and say what answer shape
-will be useful.
+- Paste real code or command output when it is shorter than explaining it. Use real paths, never vague references.
+- Do not duplicate specs, plans, commits, or diffs. Link the stable path and summarize the decision it carries.
+- Use absolute dates. "Today", "yesterday", and "recently" rot.
+- Do not imply the recipient has tools, credentials, apps, or subagents unless the user said so. Write "when available" when a step depends on the harness.
+- Bound the work. If the recipient should not implement, say so; if implementation may follow, ask for a separate execution handoff after the decision pass.
 
-If the prompt asks the recipient to edit files, direct that work to a disposable
-git worktree on its own branch. The final diff still needs local review before
-it lands.
+## Shape It To The Job
 
-## Write It For A Cold Reader
+- Edits: send the recipient to a disposable git worktree on its own branch, break work into commit-sized waves, and note that the final diff still gets local review.
+- Review: one concrete question with exact paths or a diff command. Ask for findings, risks, and gaps, not approval.
+- Delegation: a recipient that can spawn subagents keeps synthesis and the final artifact; each delegated piece gets one question, bounded sources, and one deliverable. Name specific models or agents only when the user did.
+- Adversarial rework: for a grill, greenfield pass, or clean break, tell the recipient not to defer to prior conclusions, to state what would falsify the current direction, and to name refusals with the value each gives up.
 
-Paste real code or command output when it is shorter than explaining it. Use real file paths instead of vague references.
-
-Do not duplicate full specs, plans, decision docs, commits, or diffs. Link to stable paths and summarize the decision they contain.
-
-Close decisions the recipient should not spend time reopening. If a choice is still genuinely open, name the owner and the exact question.
-
-A good handoff can be pasted into a blank agent thread and executed without reading this thread or asking what happened.
+For a `/goal` one-liner, use [agent-goal](../agent-goal/SKILL.md). For a human-facing progress summary, use [progress-summary](../progress-summary/SKILL.md).


### PR DESCRIPTION
The handoff skill was still shaped like a checklist-heavy continuation template, which made it easy to over-trigger and easy for future agents to copy mechanically. This tightens the trigger description, removes "compact this" and generic product-prompt language, and adds the near-miss boundaries for /goal lines and product code prompts.

The body now uses one mental model: write a prompt for a competent stranger. The old include list and cold-reader section become seven content requirements, a small rule set, and a short job-shaping section for edits, reviews, delegation, and adversarial rework.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785535045&installation_id=128463665&pr_number=2252&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2252&signature=d94ef5c3949f1e6520596fa85db23b6e7f5604dc86c88d2bc01c540f0cebf265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->