### PR TITLE
docs(adr): renumber the sign-in ADR to 0088 and reconcile the same-day decision streams

### DIFF
--- a/docs/adr/0087-honeycrisp-is-the-maintained-notes-product-from-one-isomorphic-workspace-surface.md
+++ b/docs/adr/0087-honeycrisp-is-the-maintained-notes-product-from-one-isomorphic-workspace-surface.md
@@ -9,7 +9,7 @@ Fuji has been removed, and Honeycrisp is the notes app that still has a live wor
 
 ## Decision
 
-Honeycrisp is the maintained Epicenter notes product. It ships from one SvelteKit codebase on web and desktop, with one package root export that exposes the isomorphic workspace definition. Runtime-specific concerns live behind `#platform/*` imports and environment factories under `src/lib/workspace/`; the auth lifecycle stays Shape A through `createSession` and `WorkspaceGate`. Honeycrisp does not regain Fuji, a daemon mount, or a `./mount` export.
+Honeycrisp is the maintained Epicenter notes product. It ships from one SvelteKit codebase on web and desktop, with one package root export that exposes the isomorphic workspace definition. Runtime-specific concerns live behind `#platform/*` imports and environment factories under `src/lib/workspace/`; the auth lifecycle follows the repo-wide composition in [ADR-0088](0088-sign-in-is-an-enhancement-never-a-door.md): sign-in is an enhancement over a local-first boot, not a gate. Honeycrisp does not regain Fuji, a daemon mount, or a `./mount` export.
 
 ## Consequences
 
@@ -19,4 +19,4 @@ The `@epicenter/honeycrisp` package root remains the integration contract for co
 
 - **Restore Fuji or the daemon mount surface.** Rejected. Fuji was removed deliberately, and ADR-0080 makes the Super App an in-process workspace composer rather than a per-app daemon consumer.
 - **Fork Honeycrisp into separate web and desktop apps.** Rejected. That would split the workspace contract and duplicate the product surface for no benefit.
-- **Adopt Whispering's module singleton shape.** Rejected. Honeycrisp is auth-gated with one route tree, so Shape A keeps owner changes and first paint simpler.
+- **Adopt Whispering's module singleton shape.** Initially rejected here, then adopted repo-wide the same day by [ADR-0088](0088-sign-in-is-an-enhancement-never-a-door.md), which answers this bullet's concerns with `reloadOnOwnerChange` and the hydration gate. The product-surface decision above is independent of that lifecycle choice.

--- a/docs/adr/0088-sign-in-is-an-enhancement-never-a-door.md
+++ b/docs/adr/0088-sign-in-is-an-enhancement-never-a-door.md
@@ -1,4 +1,4 @@
-# 0087. Sign-in is an enhancement, never a door
+# 0088. Sign-in is an enhancement, never a door
 
 - **Status:** Proposed
 - **Date:** 2026-07-01

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -155,5 +155,6 @@ Each option and the one reason it lost. Terse. This is not the spec.
 | [0085](0085-a-box-is-a-role-an-addressable-endpoint-plays-not-a-node-type.md) | A box is a role an addressable endpoint plays, not a distinct node type | Accepted |
 | [0086](0086-no-live-consumer-for-network-reachable-capability-reach-opensidian-is-superseded-not-migrated.md) | There is no live consumer for network-reachable capability reach; opensidian's cross-device tools are superseded by the super app, not migrated | Accepted |
 | [0087](0087-honeycrisp-is-the-maintained-notes-product-from-one-isomorphic-workspace-surface.md) | Honeycrisp is the maintained notes product from one isomorphic workspace surface | Proposed |
+| [0088](0088-sign-in-is-an-enhancement-never-a-door.md) | Sign-in is an enhancement, never a door | Proposed |
 
 When you add an ADR, add its row here.

--- a/specs/20260701T151347-progressive-sign-in-collapse.md
+++ b/specs/20260701T151347-progressive-sign-in-collapse.md
@@ -4,7 +4,7 @@
 **Status**: Draft
 **Owner**: Braden
 **Branch**: progressive-sign-in (waves branch off main as they start)
-**Relates**: [ADR-0087](../docs/adr/0087-sign-in-is-an-enhancement-never-a-door.md) (the decision this spec executes), [ADR-0071](../docs/adr/0071-oauth-is-hosted-only-a-custom-instance-requires-a-token.md), [ADR-0075](../docs/adr/0075-self-host-is-a-single-partition-instance-behind-one-operator-supplied-bearer.md), [ADR-0079](../docs/adr/0079-whispering-authenticates-with-an-oauth-bearer-on-every-surface.md), `specs/20260627T221642-whispering-optional-unified-auth.md` (the vault session that keeps `createSession` alive)
+**Relates**: [ADR-0088](../docs/adr/0088-sign-in-is-an-enhancement-never-a-door.md) (the decision this spec executes), [ADR-0071](../docs/adr/0071-oauth-is-hosted-only-a-custom-instance-requires-a-token.md), [ADR-0075](../docs/adr/0075-self-host-is-a-single-partition-instance-behind-one-operator-supplied-bearer.md), [ADR-0079](../docs/adr/0079-whispering-authenticates-with-an-oauth-bearer-on-every-surface.md), `specs/20260627T221642-whispering-optional-unified-auth.md` (the vault session that keeps `createSession` alive)
 **Prompts**: `specs/20260701T151347-progressive-sign-in-collapse.prompt.md` (per-wave executor kickoffs, grill prompts, check-in protocol)
 
 ## One Sentence
@@ -153,6 +153,14 @@ small inline affordance instead of gating the app.
 as a concept (null workspace, `require*()`, redirect routes, two documented
 shapes).
 
+**Drift note (post `450f488854`, PR #2253)**: honeycrisp's workspace nested
+under `$lib/workspace/` and auth moved behind `#platform/auth`; the gate and
+Shape A session are unchanged, so the recipe holds. ADR-0087 (honeycrisp is
+the maintained notes product) stands; its Shape A auth-lifecycle clause is
+superseded by ADR-0088. ADR-0086 retires opensidian's chat and cross-device
+surfaces (superseded by the super app), which rescopes opensidian's
+conversion to minimal (see per-app judgment points).
+
 ### The break is compatibility-free
 
 - Gated apps never wrote unowned local data (the workspace did not exist
@@ -186,7 +194,7 @@ lifecycle), not deleted. Do not remove it in Wave 4.
 
 | Decision | Class | Choice | Rationale |
 | --- | --- | --- | --- |
-| Refuse app-level sign-in gates | 2 coherence | Delete all four gates | ADR-0087; the local-first product sentence. |
+| Refuse app-level sign-in gates | 2 coherence | Delete all four gates | ADR-0088; the local-first product sentence. |
 | One composition shape | 1 evidence | Whispering's boot-branch + reload | Shipped and live in `whispering.active.ts`; census confirms every keying invariant holds. |
 | Identity change handling | 1 evidence | `location.reload()`, never in-place doc swap | Whispering's Option A decision, re-verified: reload deletes hot-swap, rebinding, and reactive re-auth machinery. `reloadOnOwnerChange` keys on `ownerId`, so token expiry never reloads. |
 | Boot-branch helper home | 2 coherence | `@epicenter/svelte/auth` (`packages/svelte-utils/src/`) | Sibling of `createSession`; already imports `@epicenter/auth`; MIT `packages/workspace` cannot (license firewall). |
@@ -263,7 +271,7 @@ deleted):
 	import { WorkspaceGate } from '@epicenter/app-shell/workspace-gate';
 	import * as Tooltip from '@epicenter/ui/tooltip';
 	import { honeycrisp } from '$lib/honeycrisp';
-	import { auth } from '$platform/auth';
+	import { auth } from '#platform/auth';
 	import { onMount } from 'svelte';
 	import { reloadOnOwnerChange } from '@epicenter/svelte/auth';
 
@@ -290,10 +298,10 @@ the gate no longer branches on auth at all.
 ```ts
 import { connectLocalFirst } from '@epicenter/svelte/auth';
 import { createNodeId } from '@epicenter/workspace';
-import { auth } from '$platform/auth';
-import { createHoneycrispDoc } from './workspace';  // the existing iso factory
+import { auth } from '#platform/auth';
+import { createHoneycrisp } from '$lib/workspace';  // the iso factory (package root export, ADR-0087)
 
-const workspace = createHoneycrispDoc();
+const workspace = createHoneycrisp();
 const { whenReady, collaboration } = connectLocalFirst({
 	auth,
 	ydoc: workspace.ydoc,
@@ -353,8 +361,12 @@ For each app, in this order, as standalone commits:
 
 Per-app judgment points (executor decides, PR body records):
 
-- **opensidian** (biggest sweep, ~20 files): cross-device tools and terminal
-  are signed-in-only; chat needs a configured connection or sign-in.
+- **opensidian** (biggest sweep, ~20 files, but MINIMAL conversion): ADR-0086
+  retired its chat and cross-device surfaces (the super app supersedes them),
+  so prefer deleting those surfaces over gating them, do not invest in
+  affordance polish, and keep the conversion to recipe steps 1-4 and 6-7. The
+  point of converting opensidian at all is unblocking Wave 4's
+  `SignedOutScreen` deletion while the app still has to typecheck.
 - **tab-manager**: keep the outer `{#await}` (async storage); the singleton
   is built after storage resolves, then everything else follows the recipe.
   `window.location.reload()` works in the sidepanel.
@@ -366,7 +378,7 @@ One wave = one PR = one merged unit before the next starts.
 
 ### Wave 0: decision records (this PR)
 
-- [x] **0.1** ADR-0087 recorded as Proposed.
+- [x] **0.1** ADR-0088 recorded as Proposed.
 - [x] **0.2** This spec + the companion prompt file.
 
 ### Wave 1: extract the kit from Whispering (refactor-only, zero behavior change)
@@ -405,7 +417,7 @@ One wave = one PR = one merged unit before the next starts.
 - [ ] **4.3** Rewrite the `workspace-app-composition` skill (both
       `.agents/skills/` and the `.claude/skills/` mirror) to one shape;
       delete Shape A / Shape B language.
-- [ ] **4.4** Flip ADR-0087 to Accepted; delete this spec and the prompt
+- [ ] **4.4** Flip ADR-0088 to Accepted; delete this spec and the prompt
       file; add the spec-history entry.
 - [ ] **4.5** Run `bun scripts/check-doc-hygiene.ts`.
 
@@ -433,14 +445,14 @@ rg -l "SignedOutScreen|connectLocalFirst" apps/api/ui   # empty: dashboard untou
 1. User migrated local rows (bare doc cleared), works signed in, signs out.
 2. Next boot opens the bare doc, which is empty.
 3. Expected: empty local app; owner data is invisible until re-sign-in;
-   nothing was deleted. This is doctrine (ADR-0087), not a bug.
+   nothing was deleted. This is doctrine (ADR-0088), not a bug.
 
 ### "Keep for now", forever
 
 1. User declines migration; local rows persist.
 2. Every signed-in boot re-offers the dialog (flag-free by design).
 3. Expected: acceptable; the data itself is the state. Do not add a
-   "don't ask again" flag without reopening ADR-0087's flag-free stance.
+   "don't ask again" flag without reopening ADR-0088's flag-free stance.
 
 ### reauth-required
 
@@ -494,7 +506,7 @@ rg -l "SignedOutScreen|connectLocalFirst" apps/api/ui   # empty: dashboard untou
 - [ ] Sign-out reloads to the local doc; owner replica remains on disk.
 - [ ] All Invariants greps pass; repo typecheck and test suites pass.
 - [ ] Whispering behavior is unchanged after Wave 1 (its own smoke passes).
-- [ ] ADR-0087 flipped to Accepted; this spec deleted; doc hygiene passes.
+- [ ] ADR-0088 flipped to Accepted; this spec deleted; doc hygiene passes.
 
 ## References
 

--- a/specs/20260701T151347-progressive-sign-in-collapse.prompt.md
+++ b/specs/20260701T151347-progressive-sign-in-collapse.prompt.md
@@ -1,7 +1,7 @@
 # Progressive sign-in collapse: execution prompts
 
 Companion to `specs/20260701T151347-progressive-sign-in-collapse.md` (the
-canonical plan; if this file disagrees with the spec or ADR-0087, they win).
+canonical plan; if this file disagrees with the spec or ADR-0088, they win).
 Three sections: kickoff prompts for the executing agent, grill prompts to run
 against each finished wave, and the check-in protocol for the coordinating
 reviewer. Delete this file with the spec in Wave 4.
@@ -17,7 +17,7 @@ fresh branch off `main`. Fill `<...>` slots.
 
 ```txt
 Read specs/20260701T151347-progressive-sign-in-collapse.md and
-docs/adr/0087-sign-in-is-an-enhancement-never-a-door.md in full before
+docs/adr/0088-sign-in-is-an-enhancement-never-a-door.md in full before
 touching code. Load the skills: workspace-app-composition, svelte, auth,
 git, writing-voice.
 
@@ -43,7 +43,7 @@ Open a PR titled against main and list every judgment call in the body.
 ```txt
 Read specs/20260701T151347-progressive-sign-in-collapse.md (especially "The
 per-app conversion recipe" and the honeycrisp before/after call sites) and
-docs/adr/0087-sign-in-is-an-enhancement-never-a-door.md. Load the skills:
+docs/adr/0088-sign-in-is-an-enhancement-never-a-door.md. Load the skills:
 workspace-app-composition, svelte, sveltekit, auth, git, writing-voice.
 Wave 1 must already be merged; verify connectLocalFirst exists in
 @epicenter/svelte/auth before starting, and stop if it does not.
@@ -85,7 +85,7 @@ all be merged; verify with the Invariants block before starting.
 
 Execute Wave 4: delete SignedOutScreen, make AccountPopover.instanceConnect
 required, rewrite the workspace-app-composition skill (both .agents/skills
-and .claude/skills copies) to one composition shape, flip ADR-0087 to
+and .claude/skills copies) to one composition shape, flip ADR-0088 to
 Accepted, delete the spec and its .prompt.md companion, add the
 docs/spec-history.md entry, and run bun scripts/check-doc-hygiene.ts.
 Do NOT delete createSession (demoted, kept for the vault session).
@@ -127,7 +127,7 @@ per item.
 
 ```txt
 You are reviewing the conversion of apps/<app> from an auth-gated app to a
-local-first app per docs/adr/0087. The claim: the app is fully usable signed
+local-first app per docs/adr/0088. The claim: the app is fully usable signed
 out, and sign-in only adds sync. Attack:
 
 1. Boot signed out (mentally or by running it): trace the singleton from
@@ -158,7 +158,7 @@ passes it and the JSDoc no longer says optional; (3) the
 workspace-app-composition skill: no Shape A/Shape B language survives, the
 one documented shape matches what the five apps actually do, and both skill
 copies are identical; (4) createSession still exists and its JSDoc forbids
-owning a workspace lifecycle; (5) ADR-0087 is Accepted, the spec and prompt
+owning a workspace lifecycle; (5) ADR-0088 is Accepted, the spec and prompt
 files are gone, spec-history has the entry, and check-doc-hygiene passes.
 ```
 


### PR DESCRIPTION
PR #2253 and #2254 merged minutes apart and both minted ADR-0087. The sign-in ADR landed second, so it renumbers to 0088, with its spec and prompt references updated and both index rows now present in the ADR README.

The two same-day decision streams also touched: ADR-0087 (honeycrisp) declared the auth lifecycle "stays Shape A through createSession and WorkspaceGate" and rejected the module-singleton shape, which ADR-0088 decides the other way repo-wide. Since both are Proposed, ADR-0087's auth-lifecycle clause now defers to ADR-0088; its actual decision (one isomorphic workspace surface, no daemon mount, no Fuji) is untouched. The collapse spec picks up the #2253 path drift (`#platform/auth`, `$lib/workspace/`) and rescopes opensidian to a minimal conversion per ADR-0086, which retired its chat and cross-device surfaces.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785537063&installation_id=128463665&pr_number=2256&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2256&signature=ca38bac0ac9b7f469c046ff7925bed2cd81d1af3bfc1603f13187f01433ea6de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->