### PR TITLE
docs(whispering): repoint the boot-selection comment at connectLocalFirst

### DIFF
--- a/apps/whispering/src/routes/+layout.svelte
+++ b/apps/whispering/src/routes/+layout.svelte
@@ -12,7 +12,7 @@
 
 	let { children } = $props();
 
-	// Option A: the active doc is picked once at boot (openActiveWhispering); an
+	// Option A: the active doc is picked once at boot (connectLocalFirst); an
 	// owner-identity change reloads so the next boot rebuilds the right doc.
 	onMount(() => reloadOnOwnerChange(auth));
 


### PR DESCRIPTION
One-line straggler from #2259: the root layout's comment still named the deleted openActiveWhispering; the boot selection lives in connectLocalFirst now. (The original fix commit lost a push race with the autofix bot and the PR merged without it.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785558897&installation_id=128463665&pr_number=2260&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2260&signature=fe158d2192a01af09a1d2170fde80f8e5617684dce711c71ddfc5292c081d55c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->