### PR TITLE
docs(skills): execute detectors 5-9 across the library (audit wave 2)

### DIFF
--- a/.agents/skills/arktype/SKILL.md
+++ b/.agents/skills/arktype/SKILL.md
@@ -12,8 +12,6 @@ Patterns for composing arktype schemas, naming runtime schema values alongside i
 
 ## When to Apply This Skill
 
-- Defining a discriminated union schema (e.g., commands, events, actions)
-- Composing a base type with per-variant fields
 - Working with `defineTable()` schemas that use union types
 - Importing or exporting schema values that share a name with inferred types
 

--- a/.agents/skills/auth/SKILL.md
+++ b/.agents/skills/auth/SKILL.md
@@ -31,24 +31,17 @@ Better Auth remains the auth server and session engine. Epicenter extends it
 through plugins and options; it does not replace Better Auth's server-side
 session model.
 
-Use this composition sentence when explaining the architecture:
+The composition: Better Auth provides the auth-server machinery, OAuth covers
+the app/resource boundary, and `AuthState{ownerId}` drives workspace boot.
+Better Auth owns users, account cookies, login, consent, token issuing,
+revocation, JWKS, and metadata. Epicenter clients store `PersistedAuth`, not
+Better Auth sessions. `/api/session` is the adapter that verifies an OAuth
+access token, resolves the request to an `ownerId`, and returns
+`ApiSessionResponse`.
 
-```txt
-Epicenter uses Better Auth for auth-server machinery, OAuth for the app/resource boundary, and AuthState{ownerId} for workspace boot.
-```
-
-That means Better Auth owns users, account cookies, login, consent, token
-issuing, revocation, JWKS, and metadata. Epicenter clients store
-`PersistedAuth`, not Better Auth sessions. `/api/session` is the adapter that
-verifies an OAuth access token, resolves the request to an `ownerId`, and
-returns `ApiSessionResponse`.
-
-When the user asks whether this is idiomatic Better Auth, be precise:
-
-```txt
-It is not the shortest Better Auth browser-cookie path.
-It is an idiomatic composition of Better Auth as the auth server beneath a cross-client OAuth runtime.
-```
+This is not the shortest Better Auth browser-cookie path; it is an idiomatic
+composition of Better Auth as the auth server beneath a cross-client OAuth
+runtime.
 
 Do not suggest removing Better Auth unless the user has a concrete blocker that
 cannot be handled with configuration, a small adapter, or an upstream fix.
@@ -121,8 +114,8 @@ There are no bearer, device-authorization, or custom-session plugins. Local
 email/password is disabled (`emailAndPassword: { enabled: false }`): enabling
 unverified local credentials reopens an account-linking takeover on
 better-auth 1.5.6 (no `requireLocalEmailVerified` gate). Only Google is a
-trusted linking provider; see the `better-auth-security` skill's Account
-Linking note.
+trusted linking provider; see the `better-auth-security-best-practices`
+skill's Account Linking note.
 
 ## Public Surface
 
@@ -518,21 +511,9 @@ mode flag on it.
 
 ## Common Pitfalls
 
-- Do not add `auth.bearerToken` or any token reader. Token reading leaks
-  transport details back into app code.
-- Do not reintroduce cookie-vs-bearer app factories. Better Auth still uses
-  cookies for hosted sign-in pages, but app resources use OAuth access tokens
-  through the one `createOAuthAppAuth` factory.
-- Do not treat `startSignIn()` resolving as signed-in. State is the source of
-  truth; `startSignIn` takes no args.
-- Do not clear local workspace data on refresh failure. Move to
-  `reauth-required` (the runtime pauses network auth) and keep `ownerId`
-  available for local partition selection.
 - Do not let `accessTokenExpiresAt` decide local identity state. It is a
   transport refresh hint only; the resource server is the source of truth for
   token validity.
-- Do not send both cookies and bearer tokens to resource routes.
-  `singleCredential` rejects ambiguity before Better Auth sees it.
 - Do not hide persistence failures in storage adapters. If `set` cannot save
   the refreshed cell, the failure must propagate, not silently look saved.
 - Do not import `requireSignedIn`, `InferSignedIn`, `openFuji`,

--- a/.agents/skills/autumn/SKILL.md
+++ b/.agents/skills/autumn/SKILL.md
@@ -8,29 +8,11 @@ metadata:
 
 # Autumn Billing Integration Guide
 
-## Reference Repositories
-
-- [Autumn](https://github.com/useautumn/autumn): Usage-based billing platform
-- [Autumn TypeScript SDK + CLI](https://github.com/useautumn/typescript): `autumn-js` SDK and `atmn` CLI
-- [Autumn Docs](https://docs.useautumn.com)
-
 ## Upstream Grounding
 
-When Autumn Product, ProductItem, Feature, Entitlement, Customer, CustomerProduct, pricing, credit checks, SDK calls, CLI behavior, or usage-event semantics affect correctness, use source-backed grounding before relying on memory. If DeepWiki MCP is available, ask a narrow question against `useautumn/autumn`; if it is unavailable or the repo is not indexed, use upstream source or official docs directly. For `autumn-js` SDK or `atmn` CLI behavior, verify against the installed package, `useautumn/typescript`, or official docs. Treat DeepWiki as orientation, then verify decisive details against local billing code, installed types, source, or official docs before changing code.
-
-Skip DeepWiki for hosted-only Epicenter billing boundaries already documented in `AGENTS.md` and below.
+Grounding repos: `useautumn/autumn` for billing platform semantics; `useautumn/typescript` for the `autumn-js` SDK and `atmn` CLI. Official docs: https://docs.useautumn.com.
 
 ---
-
-## When to Apply This Skill
-
-Use this when you need to:
-
-- Define or modify features, credit systems, or plans in `autumn.config.ts`.
-- Add credit checks or usage tracking via the `autumn-js` SDK.
-- Gate API endpoints behind billing (free tier limits, paid plan access).
-- Push/pull billing config with the `atmn` CLI.
-- Debug billing issues (insufficient credits, customer sync, refunds).
 
 ## Domain Model Checks
 

--- a/.agents/skills/better-auth-best-practices/SKILL.md
+++ b/.agents/skills/better-auth-best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: better-auth-best-practices
-description: 'Better Auth server/client setup: `auth.ts`, generated schema, DB adapters, sessions, cookies, env vars, and plugins. Use when mentioning Better Auth, betterauth, auth handlers, OAuth, email/password, or session configuration.'
+description: 'Better Auth library setup: server `auth.ts`, `createAuthClient`, generated schema, DB adapters, Better Auth session and cookie options, env vars, and plugins. Use when mentioning Better Auth, betterauth, or configuring Better Auth handlers, adapters, or plugins. For Epicenter auth clients, `/api/session`, session state, or OAuth app sign-in, use the auth skill instead.'
 metadata:
   author: epicenter
   version: '1.0'

--- a/.agents/skills/cloudflare-workers/SKILL.md
+++ b/.agents/skills/cloudflare-workers/SKILL.md
@@ -8,25 +8,15 @@ metadata:
 
 # Cloudflare Workers
 
-## Reference Repositories
-
-- [Cloudflare Docs](https://github.com/cloudflare/cloudflare-docs) - Workers, Durable Objects, KV, R2, D1, Queues, WebSockets, bindings, and deployment docs
-- [Hono](https://github.com/honojs/hono) - TypeScript web framework commonly used on Workers
-
 ## Upstream Grounding
 
-When Worker runtime behavior, bindings, Durable Objects, WebSockets, streaming, cache APIs, service bindings, compatibility dates, limits, or wrangler configuration affect correctness, ask DeepWiki a narrow question against `cloudflare/cloudflare-docs` before relying on memory. Use `honojs/hono` as the grounding repo when the question is about Hono on Workers.
-
-Verify decisive details against local generated Worker types, source, or official Cloudflare docs before changing code. Skip DeepWiki for stable Web API basics and repo-local deployment patterns already visible in the code.
+Grounding repos: `cloudflare/cloudflare-docs` for Workers, Durable Objects, KV, R2, D1, Queues, WebSockets, bindings, wrangler, and limits; `honojs/hono` for Hono on Workers.
 
 ## When to Apply This Skill
 
 Use this pattern when you need to:
 
 - Work on `apps/api` Worker code, bindings, or `wrangler` configuration.
-- Implement or debug Durable Objects, KV, R2, D1, Queues, or WebSockets.
-- Handle streaming responses, SSE, CORS, cache behavior, or request lifecycle limits.
-- Check Cloudflare-specific runtime behavior or deployment constraints.
 
 ## Request Lifecycle Rules
 

--- a/.agents/skills/code-audit/SKILL.md
+++ b/.agents/skills/code-audit/SKILL.md
@@ -16,8 +16,6 @@ Recurring smell categories worth hunting periodically. Each category has a grep 
 
 Use when:
 
-- Doing a periodic code-quality review pass.
-- Scoping a cleanup PR.
 - After a major refactor, hunting for stale boundaries the new design exposes.
 - Reviewing a PR that touches a primitive: these patterns indicate where new contracts may be leaking into consumers.
 

--- a/.agents/skills/cohesion-over-testability/SKILL.md
+++ b/.agents/skills/cohesion-over-testability/SKILL.md
@@ -45,8 +45,6 @@ Trigger when any of these hold:
   invokes it, and that caller is the obvious "outer" (a handler, a
   component, a wrapper). The other caller is a test file in the same
   directory.
-- A function accepts an optional `deps` / `overrides` / `injected`
-  parameter whose only non-default value appears in a test file.
 - A helper takes a paired getter and setter (`getX` + `setX`) over the
   same value. The pair describes one slot, not a boundary.
 - A `.test.ts` file is comparable to or larger than the SUT in LOC, and
@@ -56,11 +54,6 @@ Trigger when any of these hold:
   function without naming the outer ("returns rows for the `ps`
   command", "reconciles state for `createSession`"). The inner has no
   product sentence; it's a slice of one.
-
-User phrases that trigger this skill: "is this earning its keep", "why
-is this exported", "trace the callers", "is this split for the test",
-"the test is shaping the API", "could this be one function", "is there
-a better way to structure this", "we extracted this for tests".
 
 ## The Signal vs The Reason
 

--- a/.agents/skills/comparable-apps/SKILL.md
+++ b/.agents/skills/comparable-apps/SKILL.md
@@ -102,36 +102,15 @@ Asymmetric win surfaced: refusing the feature of "email in chrome" lets the runt
 
 ## Worked example: local model pickers (Whispering)
 
-Question: how should a settings screen present downloadable local models (Whisper, Parakeet, Moonshine) when each is a 0.03 to 1.6 GB download?
+Question: how should a settings screen present downloadable local models when each is a 0.03 to 1.6 GB download?
 
-| App | Category | Picker pattern | Size on action? |
-| --- | --- | --- | --- |
-| Ollama desktop | Local LLM runtime | Picks a default model, downloads on first use; library is secondary | Yes |
-| LM Studio | Local LLM catalog | Full catalog browser with search; "Staff pick" badge | Yes, on every download button |
-| Jan | Local LLM app | Hub with "Recommended" tags | Yes |
-| superwhisper | Local dictation | Onboarding recommends one model with its size; others in a secondary list | Yes |
-| MacWhisper | Local dictation | Model tiers with sizes; recommended default | Yes |
-| Handy | Local dictation (OSS) | Flat model list, recommended default preselected | Yes |
-| VoiceInk | Local dictation | Reference target for the next local-dictation pass; model-picker details not yet captured in-repo | Verify before relying on it |
-| Wispr Flow | Dictation (cloud) | No model picker at all; the surface does not exist | n/a |
-
-Implication: local-model apps converge on default-first (one recommended model per engine, size visible on the download action, full catalog secondary). Whispering borrowed default-first plus size-on-action and refused LM Studio's catalog browser, since its largest catalog is four models. Wispr Flow is the refusal boundary: going cloud deletes the surface entirely, which is not Whispering's category. VoiceInk is in the reference set now, but not yet evidence for the model-picker claim until someone captures its current picker behavior. Resulting design: a status hero plus one "All models" disclosure (first built in PR #1922, then rebuilt on the folder-backed selector from PR #1923; see `specs/20260612T164300-local-model-recommended-defaults-rebuild.md`).
+The comparison spanned local LLM runtimes (Ollama, LM Studio, Jan), local dictation apps (superwhisper, MacWhisper, Handy), and one cloud dictation app (Wispr Flow) as the refusal boundary. The pattern converged on default-first: one recommended model per engine, size visible on the download action, full catalog secondary. Whispering borrowed default-first plus size-on-action and refused the full catalog browser, since its largest catalog is four models. Going cloud would delete the surface entirely, which is not Whispering's category.
 
 ## Worked example: macOS Accessibility onboarding (Whispering)
 
-Question: how should Whispering help users recover when macOS Accessibility is missing or stale after install/update?
+Question: how should Whispering help users recover when macOS Accessibility is missing or stale after install or update?
 
-| App | Category | Surface to inspect | Repo-local status |
-| --- | --- | --- | --- |
-| Apple System Settings | Platform convention | Privacy & Security > Accessibility, including remove/re-add behavior after app changes | Current source of truth for the settings path |
-| Whispering | Local dictation | In-app guide with written steps, "Open System Settings", and optional hosted video | Implemented in `MacosAccessibilityGuide.svelte` and `MacosAccessibilityGuideDialog.svelte` |
-| Handy | Local dictation (OSS) | Permission, recorder, shortcut, and local transcription architecture | Already used as a technical reference in Whispering specs and comments |
-| superwhisper | Local dictation | Permission onboarding and recovery flow | Existing comparable-apps reference only |
-| MacWhisper | Local transcription | Permission onboarding and recovery flow | Existing comparable-apps reference only |
-| VoiceInk | Local dictation | Permission onboarding and recovery flow | New reference target; no previous repo references |
-| Wispr Flow | Dictation (cloud) | Permission onboarding and recovery flow | Existing comparable-apps reference only |
-
-Implication: Apple owns the canonical permission path; dictation apps are UX references for how to make that platform requirement survivable. Whispering's current shape is a good baseline: text steps, an explicit System Settings action, granted-state feedback, and an optional video loaded from release assets rather than bundled into the app. Before changing the onboarding or recovery flow, capture what VoiceInk does alongside superwhisper, MacWhisper, Handy, and Wispr Flow in the relevant spec.
+The comparison put the platform vendor in the table alongside the category: Apple System Settings owns the canonical permission path, and comparable dictation apps (superwhisper, MacWhisper, Handy, VoiceInk, Wispr Flow) are UX references for making that platform requirement survivable. The pattern converged on: written steps, an explicit "Open System Settings" action, granted-state feedback, and optional rich media loaded on demand rather than bundled into the app. The durable lesson is that when the platform owns the surface, the vendor row is the source of truth and peer apps only calibrate the recovery UX.
 
 ## Other questions this lens answers well
 

--- a/.agents/skills/control-flow/SKILL.md
+++ b/.agents/skills/control-flow/SKILL.md
@@ -12,15 +12,6 @@ When refactoring complex control flow, mirror natural human reasoning patterns:
 
 > **Related Skills**: See `refactoring` for systematic code audit methodology including branch collapsing and caller counting.
 
-## When to Apply This Skill
-
-Use this pattern when you need to:
-
-- Refactor nested conditionals into linear guard-clause control flow.
-- Replace mixed `throw`/`return` try-catch logic with readable early returns.
-- Name booleans and branches to read like natural human reasoning.
-- Restructure handlers so failure paths are explicit before the happy path.
-
 1. **Ask the human question first**: "Can I use what I already have?" -> early return for happy path
 2. **Assess the situation**: "What's my current state and what do I need to do?" -> clear, mutually exclusive conditions
 3. **Take action**: "Get what I need" -> consolidated logic at the end

--- a/.agents/skills/define-errors/SKILL.md
+++ b/.agents/skills/define-errors/SKILL.md
@@ -33,28 +33,28 @@ import {
 
 ## Core Rules
 
-1. All variants for a domain live in **one `defineErrors` call** : never spread them across multiple calls
-2. The factory function **returns `{ message, ...fields }`** : that is the entire API; no `.withMessage()`, `.withContext()`, or `.withCause()` chains
-3. **`cause: unknown`** is just a field like any other : accept it in the input and forward it in the return object
+1. All variants for a domain live in **one `defineErrors` call**: never spread them across multiple calls
+2. The factory function **returns `{ message, ...fields }`**: that is the entire API; no `.withMessage()`, `.withContext()`, or `.withCause()` chains
+3. **`cause: unknown`** is just a field like any other: accept it in the input and forward it in the return object
 4. **Call `extractErrorMessage(cause)` inside the factory**, never at the call site
-5. Each call like `MyError.Variant({ ... })` **returns `Err(...)` automatically** : no separate `FooErr` pair
-6. **Shadow the const with a same-name type** using `InferErrors` : `const FooError` / `type FooError`
+5. Each call like `MyError.Variant({ ... })` **returns `Err(...)` automatically**: no separate `FooErr` pair
+6. **Shadow the const with a same-name type** using `InferErrors`: `const FooError` / `type FooError`
 7. Use `InferError<typeof FooError.Variant>` to extract a single variant's type when needed
-8. **Variant names describe the specific failure mode** : never use generic names like `Service`, `Error`, or `Failed`
+8. **Variant names describe the specific failure mode**: never use generic names like `Service`, `Error`, or `Failed`
 9. Aim for 2-5 variants per domain, each named by failure mode
-10. **Write `.message` for end-user readability** : `toastOnError` shows `.message` as the muted toast description below the bold title. Write messages that make sense to users, not just developers. Avoid raw paths, status codes, or stack traces as the primary message. Include them after a human-readable prefix:
+10. **Write `.message` for end-user readability**: `toastOnError` shows `.message` as the muted toast description below the bold title. Write messages that make sense to users, not just developers. Avoid raw paths, status codes, or stack traces as the primary message. Include them after a human-readable prefix:
 
 ```typescript
-// ✅ GOOD : human-readable prefix, technical detail after
+// ✅ GOOD: human-readable prefix, technical detail after
 message: `Could not save recording: ${extractErrorMessage(cause)}`
 
-// ❌ BAD : raw technical output as the entire message
+// ❌ BAD: raw technical output as the entire message
 message: `POST /api/recordings 500: ${extractErrorMessage(cause)}`
 ```
 
 ## Patterns
 
-### 1. Simple variant : no input, static message
+### 1. Simple variant: no input, static message
 
 ```typescript
 export const RecorderError = defineErrors({
@@ -68,7 +68,7 @@ export type RecorderError = InferErrors<typeof RecorderError>;
 return RecorderError.AlreadyRecording();
 ```
 
-### 2. Variant with structured fields : message computed from input
+### 2. Variant with structured fields: message computed from input
 
 ```typescript
 export const DbError = defineErrors({
@@ -87,28 +87,7 @@ return DbError.NotFound({ table: 'users', id: '123' });
 // error.id      -> "123"
 ```
 
-### 3. Variant with cause : extractErrorMessage inside the factory
-
-```typescript
-import { extractErrorMessage } from 'wellcrafted/error';
-
-export const FfmpegError = defineErrors({
-  CompressFailed: ({ cause }: { cause: unknown }) => ({
-    message: `Failed to compress audio: ${extractErrorMessage(cause)}`,
-    cause,
-  }),
-  VerifyFailed: ({ cause }: { cause: unknown }) => ({
-    message: `Failed to verify temp file: ${extractErrorMessage(cause)}`,
-    cause,
-  }),
-});
-export type FfmpegError = InferErrors<typeof FfmpegError>;
-
-// Call site : pass the raw caught error, never call extractErrorMessage here
-catch: (error) => FfmpegError.CompressFailed({ cause: error }),
-```
-
-### 4. Multiple variants in one object : discriminated union built-in
+### 3. Multiple variants in one object: discriminated union built-in
 
 ```typescript
 export const DeviceStreamError = defineErrors({
@@ -136,32 +115,6 @@ export type DeviceStreamError = InferErrors<typeof DeviceStreamError>;
 
 // Extracting a single variant type
 type NoDevicesFoundError = InferError<typeof DeviceStreamError.NoDevicesFound>;
-```
-
-### 5. Domain errors with specific operation failures
-
-```typescript
-export const FsError = defineErrors({
-  ReadFailed: ({ path, cause }: { path: string; cause: unknown }) => ({
-    message: `Failed to read '${path}': ${extractErrorMessage(cause)}`,
-    path,
-    cause,
-  }),
-  WriteFailed: ({ path, cause }: { path: string; cause: unknown }) => ({
-    message: `Failed to write '${path}': ${extractErrorMessage(cause)}`,
-    path,
-    cause,
-  }),
-  DeleteFailed: ({ path, cause }: { path: string; cause: unknown }) => ({
-    message: `Failed to delete '${path}': ${extractErrorMessage(cause)}`,
-    path,
-    cause,
-  }),
-});
-export type FsError = InferErrors<typeof FsError>;
-
-// Call site
-return FsError.ReadFailed({ path: '/tmp/foo.txt', cause: error });
 ```
 
 ## Type Extraction
@@ -227,55 +180,37 @@ The smell is specifically the **total fold**: every branch consumes the union in
 ## Anti-Patterns
 
 ```typescript
-// WRONG : old createTaggedError API
+// WRONG: old createTaggedError API
 import { createTaggedError } from 'wellcrafted/error';
 const { FooError, FooErr } = createTaggedError('FooError')
   .withContext<{ id: string }>()
   .withMessage(({ context }) => `Not found: ${context.id}`);
 
-// WRONG : calling extractErrorMessage at the call site
+// WRONG: calling extractErrorMessage at the call site
 catch: (error) => MyError.Failed({ message: extractErrorMessage(error) });
-// CORRECT : pass raw cause, call extractErrorMessage inside the factory
+// CORRECT: pass raw cause, call extractErrorMessage inside the factory
 catch: (error) => MyError.Failed({ cause: error });
 
-// WRONG : one defineErrors per variant (defeats the namespace grouping)
+// WRONG: one defineErrors per variant (defeats the namespace grouping)
 const BusyError = defineErrors({ BusyError: () => ({ message: 'Busy' }) });
 const PermError = defineErrors({ PermError: () => ({ message: 'No perm' }) });
-// CORRECT : all variants for a domain in one call
+// CORRECT: all variants for a domain in one call
 const RecorderError = defineErrors({
   Busy: () => ({ message: 'A recording is already in progress' }),
   PermissionDenied: () => ({ message: 'Microphone permission denied' }),
 });
 
-// WRONG : using ReturnType instead of InferErrors
+// WRONG: using ReturnType instead of InferErrors
 type FooError = ReturnType<typeof FooError>;
 // CORRECT
 type FooError = InferErrors<typeof FooError>;
 
-// WRONG : using separate Err/FooErr pair (old API)
+// WRONG: using separate Err/FooErr pair (old API)
 FooErr({ context: { id: '1' } });
-// CORRECT : each variant call returns Err(...) automatically
+// CORRECT: each variant call returns Err(...) automatically
 FooError.NotFound({ id: '1' });
 
-// WRONG : generic "Service" variant name (says nothing about the failure mode)
-const RecorderError = defineErrors({
-  Service: ({ message }: { message: string }) => ({ message }),
-});
-// RecorderError.Service({ message: '...' }) : "Service" is not a failure mode
-// CORRECT : name each variant by what actually went wrong
-const RecorderError = defineErrors({
-  AlreadyRecording: () => ({ message: 'A recording is already in progress' }),
-  PermissionDenied: ({ cause }: { cause: unknown }) => ({
-    message: `Microphone permission denied. ${extractErrorMessage(cause)}`,
-    cause,
-  }),
-  DeviceNotFound: ({ deviceId }: { deviceId: string }) => ({
-    message: `Device not found: ${deviceId}`,
-    deviceId,
-  }),
-});
-
-// WRONG : generic catch-all with operation string (hides failure modes behind a parameter)
+// WRONG: generic catch-all with operation string (hides failure modes behind a parameter)
 const FfmpegError = defineErrors({
   Service: ({ operation, cause }: { operation: string; cause: unknown }) => ({
     message: `Failed to ${operation}: ${extractErrorMessage(cause)}`,
@@ -283,8 +218,8 @@ const FfmpegError = defineErrors({
     cause,
   }),
 });
-// FfmpegError.Service({ operation: 'compress audio', cause }) : variant name is meaningless
-// CORRECT : each operation is its own variant
+// FfmpegError.Service({ operation: 'compress audio', cause }): variant name is meaningless
+// CORRECT: each operation is its own variant
 const FfmpegError = defineErrors({
   CompressFailed: ({ cause }: { cause: unknown }) => ({
     message: `Failed to compress audio: ${extractErrorMessage(cause)}`,
@@ -295,31 +230,14 @@ const FfmpegError = defineErrors({
     cause,
   }),
 });
-
-// WRONG : monolithic single-variant error for a domain with many failure modes
-const RecorderError = defineErrors({
-  Error: ({ message }: { message: string }) => ({ message }), // Too vague
-});
-// CORRECT : split by failure mode
-const RecorderError = defineErrors({
-  AlreadyRecording: () => ({ message: 'A recording is already in progress' }),
-  InitFailed: ({ cause }: { cause: unknown }) => ({
-    message: `Failed to initialize recorder: ${extractErrorMessage(cause)}`,
-    cause,
-  }),
-  StreamAcquisition: ({ cause }: { cause: unknown }) => ({
-    message: `Failed to acquire recording stream: ${extractErrorMessage(cause)}`,
-    cause,
-  }),
-});
 ```
 
 ## Anti-pattern: ad-hoc `{ ok, ... }` discriminated unions
 
-When a function (especially across an RPC/IPC/HTTP boundary) needs to signal success or failure, do **not** invent a parallel `{ ok: true, data } | { ok: false, error }` shape. This codebase already uses wellcrafted's `Result<T, E>` (`{ data: T, error: null } | { data: null, error: E }`) : a parallel `{ ok }` invention duplicates a stable shape that already has tooling around it.
+When a function (especially across an RPC/IPC/HTTP boundary) needs to signal success or failure, do **not** invent a parallel `{ ok: true, data } | { ok: false, error }` shape. This codebase already uses wellcrafted's `Result<T, E>` (`{ data: T, error: null } | { data: null, error: E }`): a parallel `{ ok }` invention duplicates a stable shape that already has tooling around it.
 
 ```ts
-// ❌ ad-hoc : parallel invention to Result<T, E>
+// ❌ ad-hoc: parallel invention to Result<T, E>
 type CallResult<T> =
   | { ok: true;  data: T }
   | { ok: false; error: { name: string; message: string } };
@@ -344,7 +262,7 @@ type CallResult<T> = Result<T, CallError>;
 
 **Why**: every wellcrafted helper (`isOk`/`isErr`, `tryAsync`/`trySync`, `unwrap`, `tapErr`, the logger's `"name" in err` discriminator) operates on `{ data, error }`. `{ ok }` returns can't compose with any of it. Each ad-hoc invention loses ecosystem leverage and forces every consumer to learn one more shape.
 
-**Wire-format corollary**: when a `Result` crosses a serialization boundary (RPC, IPC, HTTP), the `defineErrors` `{ name, message, ...fields }` shape **is** the wire form. The receiver reconstructs by reading `error.name` to dispatch : no `{ ok }` wrapper needed.
+**Wire-format corollary**: when a `Result` crosses a serialization boundary (RPC, IPC, HTTP), the `defineErrors` `{ name, message, ...fields }` shape **is** the wire form. The receiver reconstructs by reading `error.name` to dispatch; no `{ ok }` wrapper needed.
 
 ## Whispering RPC Boundary
 
@@ -352,14 +270,14 @@ In Whispering, `$lib/rpc` preserves tagged errors. Do not convert service or ope
 
 Define an RPC-local `defineErrors` namespace only when the adapter itself owns a failure that no lower layer can own, such as a missing state lookup before calling an operation.
 
-**Note : state machines are not Results**: discriminated unions like `{ state: 'in-use' | 'orphan' | 'clean' }` for a startup gate, or `{ outcome: 'graceful' | 'sigterm' }` for a shutdown, are genuine state enums and should stay as discriminated unions. The smell is *errors* dressed as `{ ok }` flags, not state-enums.
+**Note: state machines are not Results**: discriminated unions like `{ state: 'in-use' | 'orphan' | 'clean' }` for a startup gate, or `{ outcome: 'graceful' | 'sigterm' }` for a shutdown, are genuine state enums and should stay as discriminated unions. The smell is *errors* dressed as `{ ok }` flags, not state-enums.
 
 ## Reserved field name: `name`
 
-`name` is reserved at the type level : TypeScript errors if you return it from a factory, because the factory stamps it from the variant key.
+`name` is reserved at the type level: TypeScript errors if you return it from a factory, because the factory stamps it from the variant key.
 
 ```ts
-// ❌ Type error : factory would overwrite this anyway
+// ❌ Type error: factory would overwrite this anyway
 defineErrors({
   Bad: () => ({ message: 'x', name: 'override' }),
 });
@@ -376,13 +294,13 @@ defineErrors({
 
 ### Soft convention: avoid `data` as a field name
 
-`Err<E>` carries a `data: null` at the wrapper level (it's how the shape distinguishes `Err` from `Ok`). A variant body with its own `data` field is visually confusing : `err.data` (the wrapper's null) shadows `err.error.data` (your field) in every reader's head.
+`Err<E>` carries a `data: null` at the wrapper level (it's how the shape distinguishes `Err` from `Ok`). A variant body with its own `data` field is visually confusing: `err.data` (the wrapper's null) shadows `err.error.data` (your field) in every reader's head.
 
-This is **not** type-enforced (an earlier wellcrafted PR tried to reserve `data` and reverted : the logger's `"name" in err` discriminator doesn't depend on the reservation, so the breaking change was dropped). Prefer `payload`, `body`, `value`, or a domain-specific name like `path`, `response`, `input`.
+This is **not** type-enforced (an earlier wellcrafted PR tried to reserve `data` and reverted; the logger's `"name" in err` discriminator doesn't depend on the reservation, so the breaking change was dropped). Prefer `payload`, `body`, `value`, or a domain-specific name like `path`, `response`, `input`.
 
-## Related: don't call `Err(null)` : wrap caught values in a tagged error
+## Related: don't call `Err(null)`; wrap caught values in a tagged error
 
-`wellcrafted`'s Result shape can't distinguish `Err(null)` from `Ok(null)` : both produce `{ data: null, error: null }`, and `isErr` reads both as success. The `Err` constructor accepts any `E`; there's no type-level ban (one was tried and reverted because it was bypassable by casts and taught the wrong fix).
+`wellcrafted`'s Result shape can't distinguish `Err(null)` from `Ok(null)`: both produce `{ data: null, error: null }`, and `isErr` reads both as success. The `Err` constructor accepts any `E`; there's no type-level ban (one was tried and reverted because it was bypassable by casts and taught the wrong fix).
 
 The rule lives in idiom: **at every `catch (error: unknown)` boundary, wrap the caught value in a tagged error from `defineErrors`, don't pass it straight to `Err`.**
 
@@ -400,4 +318,4 @@ const Errors = defineErrors({
 catch: (error) => Errors.Unexpected({ cause: error })
 ```
 
-See [docs/articles/ok-null-is-fine-err-null-is-a-lie.md](../../../docs/articles/ok-null-is-fine-err-null-is-a-lie.md) for the full rationale : and the wellcrafted philosophy doc at `docs/philosophy/err-null-is-ok-null.md` for the deep dive on why the type-level ban failed.
+See [docs/articles/ok-null-is-fine-err-null-is-a-lie.md](../../../docs/articles/ok-null-is-fine-err-null-is-a-lie.md) for the full rationale, and the wellcrafted philosophy doc at `docs/philosophy/err-null-is-ok-null.md` for the deep dive on why the type-level ban failed.

--- a/.agents/skills/documentation/SKILL.md
+++ b/.agents/skills/documentation/SKILL.md
@@ -17,8 +17,6 @@ Documentation explains **why**, not **what**. Users can read code to see what it
 
 Use this pattern when you need to:
 
-- Write or update folder `README.md` files with architecture intent.
-- Add JSDoc to public APIs with usage context and examples.
 - Review docs/comments that currently restate code without rationale.
 - Add code comments for non-obvious decisions, constraints, or workarounds.
 

--- a/.agents/skills/drizzle-orm/SKILL.md
+++ b/.agents/skills/drizzle-orm/SKILL.md
@@ -7,26 +7,15 @@ metadata:
 ---
 
 # Drizzle ORM Guidelines
-## Reference Repositories
-
-- [Drizzle ORM](https://github.com/drizzle-team/drizzle-orm) : TypeScript ORM with SQL-like query builder
-- [Turso](https://github.com/tursodatabase/turso) : Edge-hosted LibSQL database (Epicenter's database)
-
 ## Upstream Grounding
 
-When Drizzle schema definitions, migration snapshots, query builder APIs, column typing, custom types, or driver integration affect correctness, use source-backed grounding before relying on memory. If DeepWiki MCP is available, ask a narrow question against `drizzle-team/drizzle-orm`; for libSQL, Turso sync, embedded replicas, D1 compatibility, or remote SQLite behavior, ask against `tursodatabase/turso`. If DeepWiki is unavailable or the repo is not indexed, use upstream source or official docs directly. Treat DeepWiki as orientation, then verify decisive details against local installed types, generated migrations, source, driver versions, or official docs before changing code.
-
-Skip DeepWiki for repo-local schema naming and storage-boundary conventions already documented below.
+Grounding repos: `drizzle-team/drizzle-orm` for schema, migrations, and query builder APIs; `tursodatabase/turso` for libSQL, Turso sync, embedded replicas, and D1 compatibility.
 
 ## When to Apply This Skill
 
 Use this pattern when you need to:
 
-- Define Drizzle schemas, relations, indexes, migrations, or query code.
-- Define Drizzle columns that use branded TypeScript string types.
 - Choose between `$type<T>()` and `customType` for column definitions.
-- Configure Drizzle Kit and understand generated migration snapshots.
-- Choose a SQLite-compatible driver boundary: `bun:sqlite`, `better-sqlite3`, D1, or libSQL/Turso.
 - Remove identity `toDriver`/`fromDriver` conversions that add runtime overhead.
 - Keep data serialized through the storage layer and parse at UI edges.
 

--- a/.agents/skills/epicenter-ui/SKILL.md
+++ b/.agents/skills/epicenter-ui/SKILL.md
@@ -206,16 +206,7 @@ Use different copy for true empty data and filtered empty data:
 
 ## Avoid
 
-- Plain `Loading...` text.
-- Hand-composed full-page `Empty.Root` plus `Spinner` when the standard `Loading` caption shell fits.
 - Raw `Loader2Icon`, `LoaderCircleIcon`, or custom `animate-spin` outside `packages/ui`. Use `Spinner`.
-- Raw `animate-pulse` placeholder blocks. Use `Skeleton`.
-- Loading dots outside chat messages.
-- Empty state copy inside an unstructured centered `div` when `Empty.*` would fit.
-- Tooltip wrappers around `Button` or `Link` when the `tooltip` prop is enough.
-- Extra wrapper `div`s around `Empty.Root` just to center or stack content.
-- Duplicating component internals from shadcn-svelte or extras instead of importing the local `@epicenter/ui` wrapper.
-- App imports from `packages/ui/src` or aliases that bypass `@epicenter/ui/*`.
 
 ## Boundary With Svelte
 

--- a/.agents/skills/error-handling/SKILL.md
+++ b/.agents/skills/error-handling/SKILL.md
@@ -8,16 +8,6 @@ metadata:
 
 # Error Handling with wellcrafted trySync and tryAsync
 
-## When to Apply This Skill
-
-Use this pattern when you need to:
-
-- Replace recoverable `try-catch` blocks with `trySync` or `tryAsync`.
-- Handle fallback success paths via `Ok(...)` and propagate failures with `Err(...)`.
-- Wrap caught exceptions as `cause` for typed domain error constructors.
-- Refactor nested error branches into immediate-return linear control flow.
-- Convert handler failures into HTTP status responses with explicit guards.
-
 ## References
 
 Load these on demand based on what you're working on:

--- a/.agents/skills/error-handling/SKILL.md
+++ b/.agents/skills/error-handling/SKILL.md
@@ -32,7 +32,7 @@ Load these on demand based on what you're working on:
 
 When handling errors that can be gracefully recovered from, use `trySync` (for synchronous code) or `tryAsync` (for asynchronous code) from wellcrafted instead of traditional try-catch blocks. This provides better type safety and explicit error handling.
 
-> **Related Skills**: See `services-layer` skill for `defineErrors` patterns and service architecture. See `query-layer` skill for RPC error pass-through and report-boundary presentation.
+> **Related Skills**: See `define-errors` skill for `defineErrors` patterns, `services-layer` skill for service architecture, and `query-layer` skill for RPC error pass-through and report-boundary presentation.
 
 ### The Pattern
 

--- a/.agents/skills/factory-function-composition/SKILL.md
+++ b/.agents/skills/factory-function-composition/SKILL.md
@@ -17,7 +17,6 @@ This skill helps you apply factory function patterns for clean dependency inject
 Use this pattern when you see:
 
 - A function that takes a client/resource as its first argument
-- Options from different layers (client, service, method) mixed together
 - Client creation happening inside functions that shouldn't own it
 - Functions that are hard to test because they create their own dependencies
 

--- a/.agents/skills/factory-function-composition/references/single-or-array-pattern.md
+++ b/.agents/skills/factory-function-composition/references/single-or-array-pattern.md
@@ -15,7 +15,7 @@ function create(itemOrItems: T | T[]): Promise<Result<void, E>> {
 
 1. **Accept `T | T[]`** as the parameter type
 2. **Normalize** with `Array.isArray()` at the top of the function
-3. **All logic** works against the array : one code path
+3. **All logic** works against the array: one code path
 
 ```typescript
 function createServer(clientOrClients: Client | Client[], options?: Options) {
@@ -157,4 +157,4 @@ function create(itemOrItems: T | T[]) {
 
 ## References
 
-- [Full article](../../../../docs/articles/single-or-array-overload-pattern.md) : detailed explanation with more examples
+- [Full article](../../../../docs/articles/single-or-array-overload-pattern.md): detailed explanation with more examples

--- a/.agents/skills/factory-function-composition/references/sync-construction-render-gate.md
+++ b/.agents/skills/factory-function-composition/references/sync-construction-render-gate.md
@@ -99,7 +99,7 @@ In Svelte, gate once at the root using `@epicenter/ui/spinner` for the loading s
 
 The gate guarantees: by the time any child component's script runs, the async work is complete. Children use sync access without checking readiness.
 
-**Always include `{:catch}`** : if the async seed fails (e.g. `browser.windows.getAll` throws), the user sees an actionable error instead of an infinite spinner.
+**Always include `{:catch}`**: if the async seed fails (e.g. `browser.windows.getAll` throws), the user sees an actionable error instead of an infinite spinner.
 
 ## Implementation
 
@@ -169,11 +169,11 @@ Use `whenReady` when your client has sync methods that depend on initialized sta
 
 ## Related Patterns
 
-- [Lazy Singleton](../../../../docs/articles/lazy-singleton-pattern.md) : when you need race-condition-safe lazy initialization
-- [Don't Use Parallel Maps](../../../../docs/articles/instance-state-attachment-pattern.md) : attach state to instances instead of tracking separately
+- [Lazy Singleton](../../../../docs/articles/lazy-singleton-pattern.md): when you need race-condition-safe lazy initialization
+- [Don't Use Parallel Maps](../../../../docs/articles/instance-state-attachment-pattern.md): attach state to instances instead of tracking separately
 
 ## References
 
-- [Full article](/docs/articles/sync-construction-async-property-ui-render-gate-pattern.md) : detailed explanation with diagrams
-- [Comprehensive guide](/docs/articles/sync-client-initialization.md) : 480-line deep dive with idb example
-- [idb await-in-every-method](/docs/articles/idb-await-every-method-pattern.md) : the sibling pattern for purely async APIs
+- [Full article](/docs/articles/sync-construction-async-property-ui-render-gate-pattern.md): detailed explanation with diagrams
+- [Comprehensive guide](/docs/articles/sync-client-initialization.md): 480-line deep dive with idb example
+- [idb await-in-every-method](/docs/articles/idb-await-every-method-pattern.md): the sibling pattern for purely async APIs

--- a/.agents/skills/frontend-design/SKILL.md
+++ b/.agents/skills/frontend-design/SKILL.md
@@ -54,7 +54,7 @@ Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
 Focus on:
 - **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
 - **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
-- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
+- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. In Svelte components, reach for `svelte/transition` and `svelte/motion` when CSS alone can't express it. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
 - **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
 - **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
 
@@ -63,5 +63,3 @@ NEVER use generic AI-generated aesthetics like overused font families (Inter, Ro
 Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
 
 **IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
-
-Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.

--- a/.agents/skills/git/SKILL.md
+++ b/.agents/skills/git/SKILL.md
@@ -20,10 +20,7 @@ If the task asks for a PR title, PR body, changelog entry, issue link, username 
 
 Use this pattern when you need to:
 
-- Write commit messages that follow conventional commit rules.
-- Check whether a staged commit is reviewable as a standalone unit.
 - Decide commit type/scope formatting and breaking-change notation.
-- Create or switch branches.
 - Review commit text for anti-patterns like AI/tool attribution.
 
 ## References

--- a/.agents/skills/github-issues/SKILL.md
+++ b/.agents/skills/github-issues/SKILL.md
@@ -8,16 +8,6 @@ metadata:
 
 # GitHub Issue & PR Comment Guidelines
 
-## When to Apply This Skill
-
-Use this pattern when you need to:
-
-- Reply to GitHub issues, PR threads, or feature/bug discussions.
-- Write acknowledgments, follow-up questions, and troubleshooting replies.
-- Announce fixes with clear credit and community-friendly tone.
-- Offer direct debugging help with scheduling links when needed.
-- Avoid over-structured, corporate-style comment responses.
-
 ## Anti-Patterns (Avoid These)
 
 - **Over-structured responses**: Don't use headers, numbered sections, or bullet lists for simple replies. A conversational paragraph is usually better.

--- a/.agents/skills/hono/SKILL.md
+++ b/.agents/skills/hono/SKILL.md
@@ -8,25 +8,9 @@ metadata:
 
 # Hono
 
-## Reference Repositories
-
-- [Hono](https://github.com/honojs/hono) - TypeScript web framework for edge runtimes and Cloudflare Workers
-- [Cloudflare Docs](https://github.com/cloudflare/cloudflare-docs) - Workers, Durable Objects, WebSockets, KV, R2, and deployment docs
-
 ## Upstream Grounding
 
-When Hono route typing, middleware order, context variables, response helpers, streaming, WebSockets, or Cloudflare Worker runtime behavior affects correctness, ask DeepWiki a narrow question against `honojs/hono` or `cloudflare/cloudflare-docs` before relying on memory. Use it to orient, then verify decisive details against local installed types, source, or official docs before changing code.
-
-Skip DeepWiki for stable HTTP basics and repo-local API conventions already visible in the code.
-
-## When to Apply This Skill
-
-Use this pattern when you need to:
-
-- Write or refactor Hono route handlers and middleware.
-- Type request params, query values, context variables, or response bodies.
-- Adapt Hono handlers to Cloudflare Workers runtime constraints.
-- Debug streaming, WebSockets, CORS, auth middleware, or per-route bindings.
+Grounding repos: `honojs/hono` for route typing, middleware, streaming, and WebSockets; `cloudflare/cloudflare-docs` for Worker runtime behavior.
 
 ## Middleware And Context
 

--- a/.agents/skills/logging/SKILL.md
+++ b/.agents/skills/logging/SKILL.md
@@ -12,7 +12,7 @@ Structured, level-keyed, field-oriented logging for library code. Modeled on Rus
 
 ## Where it lives
 
-All of it ships from **`wellcrafted/logger`** : `createLogger`, `consoleSink`, `memorySink`, `composeSinks`, and the types. Runtime-agnostic, browser-safe. No file sink in-process: durability is a *host* concern (shell redirect, systemd journal, Cloudflare tail). The library emits to `consoleSink`; the operator decides where stdout/stderr go.
+All of it ships from **`wellcrafted/logger`**: `createLogger`, `consoleSink`, `memorySink`, `composeSinks`, and the types. Runtime-agnostic, browser-safe. No file sink in-process: durability is a *host* concern (shell redirect, systemd journal, Cloudflare tail). The library emits to `consoleSink`; the operator decides where stdout/stderr go.
 
 ## Quickstart
 
@@ -27,22 +27,22 @@ log.warn(MarkdownError.TableWrite({ path, cause }));
 
 ## The 5 levels
 
-`trace | debug | info | warn | error`. No `fatal` : process termination is the app's call, not the library's.
+`trace | debug | info | warn | error`. No `fatal`: process termination is the app's call, not the library's.
 
 | Level | Signature | Use for |
 |---|---|---|
 | `trace` | `(message, data?)` | Per-token / per-message noise; off in prod |
 | `debug` | `(message, data?)` | Internal state transitions (handshakes, cache loads) |
 | `info`  | `(message, data?)` | Lifecycle events (connected, loaded, flushed) |
-| `warn`  | `(err)` | Recoverable failure : retry, fallback, partial result |
+| `warn`  | `(err)` | Recoverable failure: retry, fallback, partial result |
 | `error` | `(err)` | Unrecoverable at this layer; the operation has given up |
 
-**Shape split is intentional.** `warn` / `error` take a typed error unary : the variant carries `message`, `name`, and captured fields. `trace` / `debug` / `info` are free-form because free-running diagnostic events don't need enumeration.
+**Shape split is intentional.** `warn` / `error` take a typed error unary: the variant carries `message`, `name`, and captured fields. `trace` / `debug` / `info` are free-form because free-running diagnostic events don't need enumeration.
 
 ## Level is a call-site decision, not a variant property
 
 ```ts
-// Right : same error, different levels in different contexts
+// Right: same error, different levels in different contexts
 log.warn(SyncError.ConnectionFailed({ cause }));  // inside retry loop
 log.error(SyncError.ConnectionFailed({ cause })); // last attempt, giving up
 ```
@@ -75,7 +75,7 @@ You can also mint-and-log a tagged variant directly inside a `.catch` tail when 
 
 ## Sinks
 
-A sink is `((event) => void) & Partial<AsyncDisposable>` : a callable with optional resource cleanup.
+A sink is `((event) => void) & Partial<AsyncDisposable>`: a callable with optional resource cleanup.
 
 ```ts
 import {
@@ -98,7 +98,7 @@ systemd-run --user bun run start       # journal (structured queries via journal
 
 This used to be `jsonlFileSink`; that primitive was removed because owning a file writer in-process bought complexity (backpressure, dispose semantics, error fallbacks) that shell redirection already solves.
 
-### `composeSinks(...)` : fan out
+### `composeSinks(...)`: fan out
 
 ```ts
 const sink = composeSinks(consoleSink, myCustomSink);
@@ -107,7 +107,7 @@ const log = createLogger('source', sink);
 
 `composeSinks` forwards disposal to members that implement it (via `sink[Symbol.asyncDispose]?.()`). `consoleSink` is a no-op on dispose; stateful sinks flush and close.
 
-### `memorySink()` : for tests
+### `memorySink()`: for tests
 
 ```ts
 const { sink, events } = memorySink();
@@ -150,7 +150,7 @@ type LogEvent = {
   ts:      number;    // epoch millis
   level:   LogLevel;  // 'trace' | 'debug' | 'info' | 'warn' | 'error'
   source:  string;    // from createLogger()
-  message: string;    // human text : for warn/error, inherited from the typed error
+  message: string;    // human text: for warn/error, inherited from the typed error
   data?:   unknown;   // the typed error for warn/error; free-form for info/debug/trace
 };
 ```
@@ -159,7 +159,7 @@ Custom sinks that serialize for the wire should convert `ts` to ISO-8601 and fla
 
 ## See also
 
-- `error-handling` skill : the `trySync`/`tryAsync` patterns the logger consumes
-- `define-errors` skill : how to mint the typed error variants the logger consumes
-- `rust-errors` skill : full `tracing` ↔ `Logger` mapping
-- `tapErr` (from `wellcrafted/result`) : Result-chain combinator that logs on the Err branch and passes the Result through. Rare in epicenter, since most call sites branch on `result.error` directly to use the data on the Ok branch. Reach for it only when the Result flows out of the function in a `.then(...)` chain.
+- `error-handling` skill: the `trySync`/`tryAsync` patterns the logger consumes
+- `define-errors` skill: how to mint the typed error variants the logger consumes
+- `rust-errors` skill: full `tracing` ↔ `Logger` mapping
+- `tapErr` (from `wellcrafted/result`): Result-chain combinator that logs on the Err branch and passes the Result through. Rare in epicenter, since most call sites branch on `result.error` directly to use the data on the Ok branch. Reach for it only when the Result flows out of the function in a `.then(...)` chain.

--- a/.agents/skills/method-shorthand-jsdoc/SKILL.md
+++ b/.agents/skills/method-shorthand-jsdoc/SKILL.md
@@ -137,7 +137,6 @@ function createService(client) {
 Use this pattern when:
 
 - Helper functions are ONLY used by methods in the return object
-- You want JSDoc visible when consumers hover over the method
 - The helper doesn't need to be called before the return statement
 
 Keep helpers separate when:

--- a/.agents/skills/monorepo/SKILL.md
+++ b/.agents/skills/monorepo/SKILL.md
@@ -8,27 +8,11 @@ metadata:
 
 # Script Commands
 
-## Reference Repositories
-
-- [jsrepo](https://github.com/jsrepojs/jsrepo) : Package distribution for monorepos
-- [WXT](https://github.com/wxt-dev/wxt) : Browser extension framework (used by tab-manager app)
-
 ## Upstream Grounding
 
-When jsrepo configuration, publish behavior, block layout, or package distribution affects correctness, use source-backed grounding before relying on memory. If DeepWiki MCP is available, ask a narrow question against `jsrepojs/jsrepo`; for browser-extension build behavior, prefer the `wxt` skill, or ask against `wxt-dev/wxt` if this skill owns the script or package boundary. If DeepWiki is unavailable or the repo is not indexed, use upstream source or official docs directly. Treat DeepWiki as orientation, then verify decisive details against local package scripts, config files, installed types, generated output, or official docs before changing code.
-
-Skip DeepWiki for repo-local Bun script conventions already documented below.
+Grounding repos: `jsrepojs/jsrepo` for package distribution and publish behavior; `wxt-dev/wxt` for browser-extension builds (prefer the `wxt` skill unless this skill owns the script or package boundary).
 
 The monorepo uses consistent script naming conventions:
-
-## When to Apply This Skill
-
-Use this pattern when you need to:
-
-- Run formatting, linting, or type-check scripts in this monorepo.
-- Choose between auto-fix commands and `:check` CI-only variants.
-- Verify final changes with the repo-standard `bun typecheck` workflow.
-- Scaffold a new package in `packages/`.
 
 | Command            | Purpose                                        | When to use |
 | ------------------ | ---------------------------------------------- | ----------- |
@@ -46,7 +30,7 @@ Use this pattern when you need to:
 - `:check` suffix = check only (for CI, no modifications)
 - `typecheck` alone = type checking (separate concern, cannot auto-fix)
 - `test` runs only `*.test.ts`; `bench` runs only `*.bench.ts`. A file is
-  one or the other : never both. Benchmarks print reports; tests assert.
+  one or the other, never both. Benchmarks print reports; tests assert.
 
 ## Dev Scripts
 

--- a/.agents/skills/query-layer/SKILL.md
+++ b/.agents/skills/query-layer/SKILL.md
@@ -8,15 +8,9 @@ metadata:
 
 # Query Layer Patterns
 
-## Reference Repositories
-
-- [TanStack Query](https://github.com/tanstack/query): async state management for data fetching
-
 ## Upstream Grounding
 
-When TanStack Query behavior, Svelte adapter types, cache invalidation semantics, optimistic updates, or mutation lifecycle callbacks affect correctness, ask DeepWiki a narrow question against `TanStack/query` before relying on memory. Use it to orient, then verify decisive details against local installed types, source, or official docs before changing code.
-
-Skip DeepWiki for stable basics and repo-local patterns already documented below.
+Grounding repo: `TanStack/query` for query behavior, Svelte adapter types, cache invalidation, optimistic updates, and mutation lifecycle.
 
 The query/RPC layer is the reactive bridge between UI components and the service layer. It wraps service functions or observable operations with caching, mutation lifecycle state, invalidation, and direct imperative access using TanStack Query and WellCrafted factories.
 
@@ -26,12 +20,8 @@ The query/RPC layer is the reactive bridge between UI components and the service
 
 Use this pattern when you need to:
 
-- Create queries or mutations that consume services
-- Define canonical query and mutation keys with `defineKeys`
 - Decide whether work belongs in `$lib/rpc`, `$lib/operations`, or `$lib/services`
-- Implement runtime service selection based on user settings
 - Add optimistic cache updates for instant UI feedback
-- Understand hook-local adapters and reusable query definitions
 
 ## Core Architecture
 

--- a/.agents/skills/refactoring/SKILL.md
+++ b/.agents/skills/refactoring/SKILL.md
@@ -16,10 +16,6 @@ Systematic approach to auditing and improving code. Every change is evidence-bas
 
 Use this methodology when you need to:
 
-- Audit a module for code smells or unnecessary abstractions
-- Inline single-use helper functions
-- Eliminate raw/untyped access that bypasses a typed boundary
-- Collapse duplicate switch/if branches that do the same thing
 - Refactor function signatures (positional params → parameter objects)
 - Derive types instead of duplicating fields
 

--- a/.agents/skills/rust-errors/SKILL.md
+++ b/.agents/skills/rust-errors/SKILL.md
@@ -7,24 +7,14 @@ metadata:
 ---
 
 # Rust to TypeScript Error Handling
-## Reference Repositories
-
-- [Tauri](https://github.com/tauri-apps/tauri): Desktop app framework (source of Rust-to-TypeScript error patterns)
-
 ## Upstream Grounding
 
-When Rust error serialization, Tauri command error transport, IPC payload shape, generated bindings, or frontend invoke error behavior affects correctness, use source-backed grounding before relying on memory. If DeepWiki MCP is available, ask a narrow question against `tauri-apps/tauri`; if it is unavailable or the repo is not indexed, use upstream source or official docs directly. Treat DeepWiki as orientation, then verify decisive details against local Rust code, generated bindings, installed crates, TypeScript types, source, or official docs before changing code.
-
-Skip DeepWiki for local error naming conventions already documented below.
+Grounding repo: `tauri-apps/tauri` for error serialization, command error transport, and IPC payload shape.
 
 ## When to Apply This Skill
 
 Use this pattern when you need to:
 
-- Send Rust errors through Tauri commands to TypeScript clients.
-- Define Rust enums that serialize into discriminated union error shapes.
-- Validate unknown error payloads in TypeScript before switching on variants.
-- Keep cross-language error payloads consistent with `name` and `message` fields.
 - Avoid serde tagging patterns that produce nested, awkward TypeScript shapes.
 
 ## Discriminated Union Pattern for Errors

--- a/.agents/skills/services-layer/SKILL.md
+++ b/.agents/skills/services-layer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: services-layer
-description: 'Service layer patterns: defineErrors, namespace exports, Result types. Use when: "create a service", "service layer", creating services, defining domain-specific errors.'
+description: 'Service layer patterns: UI-free business logic, namespace exports, Result return types, platform-specific service variants. Use when: "create a service", "service layer", creating or organizing services. For defining error types with defineErrors, use the define-errors skill instead.'
 metadata:
   author: epicenter
   version: '2.0'
@@ -17,7 +17,6 @@ This skill documents how to implement services in the Whispering architecture. S
 Use this pattern when you need to:
 
 - Create a new service with domain-specific error handling
-- Add error types with structured context (like HTTP status codes)
 - Understand how services are organized and exported
 - Implement platform-specific service variants (desktop vs web)
 
@@ -41,108 +40,7 @@ Services follow a three-layer architecture: **Service** -> **RPC/Query** -> **UI
 
 ## Creating Errors with defineErrors
 
-Every service defines domain-specific errors using `defineErrors` from wellcrafted. Errors are grouped into a namespace object where each key becomes a variant.
-
-```typescript
-import { defineErrors, type InferError, type InferErrors, extractErrorMessage } from 'wellcrafted/error';
-import { Err, Ok, type Result, tryAsync, trySync } from 'wellcrafted/result';
-
-// Namespace-style error definition : name describes the domain
-const CompletionError = defineErrors({
-  ConnectionFailed: ({ cause }: { cause: unknown }) => ({
-    message: `Connection failed: ${extractErrorMessage(cause)}`,
-    cause,
-  }),
-  EmptyResponse: ({ providerLabel }: { providerLabel: string }) => ({
-    message: `${providerLabel} API returned an empty response`,
-    providerLabel,
-  }),
-  MissingParam: ({ param }: { param: string }) => ({
-    message: `${param} is required`,
-    param,
-  }),
-});
-
-// Type derivation : shadow the const with a type of the same name
-type CompletionError = InferErrors<typeof CompletionError>;
-type ConnectionFailedError = InferError<typeof CompletionError.ConnectionFailed>;
-
-// Call sites : each variant returns Err<...> directly
-return CompletionError.ConnectionFailed({ cause: error });
-return CompletionError.EmptyResponse({ providerLabel: 'OpenAI' });
-return CompletionError.MissingParam({ param: 'apiKey' });
-```
-
-### How defineErrors Works
-
-`defineErrors({ ... })` takes an object of factory functions and returns a namespace object. Each key becomes a variant:
-
-- **`name` is auto-stamped** from the key (e.g., key `NotFound` -> `error.name === 'NotFound'`)
-- **The factory function IS the message generator** : it returns `{ message, ...fields }`
-- **Each variant returns `Err<...>` directly** : no separate `FooErr` constructor needed
-- **Types use `InferError` / `InferErrors`** : not `ReturnType`
-
-```typescript
-// No-input variant (static message)
-const RecorderError = defineErrors({
-  Busy: () => ({
-    message: 'A recording is already in progress',
-  }),
-});
-
-// Usage : no arguments needed
-return RecorderError.Busy();
-
-// Variant with derived fields : constructor extracts from raw input
-const HttpError = defineErrors({
-  Response: ({ response, body }: { response: { status: number }; body: unknown }) => ({
-    message: `HTTP ${response.status}: ${extractErrorMessage(body)}`,
-    status: response.status,
-    body,
-  }),
-});
-
-// Usage : pass raw objects, constructor derives fields
-return HttpError.Response({ response, body: await response.json() });
-// error.message -> "HTTP 401: Unauthorized"
-// error.status  -> 401 (derived from response, flat on the object)
-// error.name    -> "Response"
-```
-
-### Error Type Examples from the Codebase
-
-```typescript
-// Static message, no input needed
-const RecorderError = defineErrors({
-  Busy: () => ({
-    message: 'A recording is already in progress',
-  }),
-});
-RecorderError.Busy()
-
-// Multiple related errors in a single namespace
-const HttpError = defineErrors({
-  Connection: ({ cause }: { cause: unknown }) => ({
-    message: `Failed to connect to the server: ${extractErrorMessage(cause)}`,
-    cause,
-  }),
-  Response: ({ response, body }: { response: { status: number }; body: unknown }) => ({
-    message: `HTTP ${response.status}: ${extractErrorMessage(body)}`,
-    status: response.status,
-    body,
-  }),
-  Parse: ({ cause }: { cause: unknown }) => ({
-    message: `Failed to parse response body: ${extractErrorMessage(cause)}`,
-    cause,
-  }),
-});
-
-// Union type for the whole namespace
-type HttpError = InferErrors<typeof HttpError>;
-
-// Individual variant type
-type ConnectionError = InferError<typeof HttpError.Connection>;
-```
+Every service defines its domain-specific errors in a `defineErrors` namespace, colocated with the service and exported alongside it (const and type share the name). The `defineErrors` API itself (variant factories, `InferErrors`/`InferError`, call-site patterns) is owned by [define-errors](../define-errors/SKILL.md); read it there.
 
 ## Key Rules
 
@@ -151,11 +49,7 @@ type ConnectionError = InferError<typeof HttpError.Connection>;
 3. **Always return Result types** - Never throw errors
 4. **Use trySync/tryAsync** - See the error-handling skill for details
 5. **Export factory + Live instance** - Factory for testing, Live for production
-6. **Use defineErrors namespaces** - Group related errors under a single namespace
-7. **Derive types with InferError/InferErrors** - Not `ReturnType`
-8. **Variant names describe the failure mode** - Never use generic names like `Service`, `Error`, or `Failed`. The namespace provides domain context (`RecorderError`), so the variant must say *what went wrong* (`AlreadyRecording`, `InitFailed`, `StreamAcquisition`). `RecorderError.Service` is meaningless : `RecorderError.AlreadyRecording` tells you exactly what happened.
-9. **Split discriminated union inputs** - Each variant gets its own name and shape. If the constructor branches on its inputs (if/switch/ternary) to decide the message, each branch should be its own variant
-10. **Transform cause in the constructor, not the call site** - Accept `cause: unknown` and call `extractErrorMessage(cause)` inside the factory's message template. Call sites pass the raw error: `{ cause: error }`. This centralizes message extraction where the message is composed and keeps call sites clean.
+6. **Split discriminated union inputs** - Each variant gets its own name and shape. If the constructor branches on its inputs (if/switch/ternary) to decide the message, each branch should be its own variant
 
 ## References
 

--- a/.agents/skills/social-media/SKILL.md
+++ b/.agents/skills/social-media/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: social-media
-description: 'Social media post guidelines for LinkedIn, Reddit, Twitter/X. Use when: "post on LinkedIn", "write a tweet", "draft a Reddit post", "share this", drafting announcements.'
+description: 'Post copy guidelines for LinkedIn, Reddit, Twitter/X. Use when: "post on LinkedIn", "write a tweet", "draft a Reddit post", drafting final announcement copy. For turning an artifact into multi-platform content, use content-distribution; this skill owns the final post copy.'
 metadata:
   author: epicenter
   version: '1.0'
@@ -9,16 +9,6 @@ metadata:
 # Social Media Post Guidelines
 
 Follow [writing-voice](../writing-voice/SKILL.md) for tone.
-
-## When to Apply This Skill
-
-Use this pattern when you need to:
-
-- Draft LinkedIn, Twitter/X, or Reddit posts about product or technical updates.
-- Announce features without hashtags, hype language, or template sections.
-- Share implementation details developers actually care about.
-- Reshape AI-sounding copy into concise, platform-native writing.
-- Build short threads where each post carries a concrete standalone point.
 
 ## Platform-Specific Brevity
 
@@ -40,35 +30,14 @@ Use this pattern when you need to:
 - Specific technical details that developers care about
 - Actual implementation challenges and solutions
 - Links to relevant libraries/APIs used
-- One unique feature detail ("with your model of choice")
-- Disclaimers when recommending tools ("Not affiliated, it just...")
-- Personal standards/opinions ("by my standards", "slated for cleanup")
+- One concrete detail that makes the feature distinct
+- A non-affiliation disclaimer when recommending someone else's tool
+- Honest personal opinions, including admissions that code is rough or unfinished
 - Proper punctuation for transitions (semicolons, periods; not space-hyphens)
 
 ## Examples: Twitter/X
 
-### Single Tweet (Feature Announcement)
-
-Good:
-
-```
-Whispering now does file uploads. Drag audio/video files in, get transcription out. Works with any OpenAI-compatible API.
-
-Open source: github.com/EpicenterHQ/epicenter
-```
-
-Bad:
-
-```
-🚀 Exciting news! Whispering now supports file uploads!
-
-Drag and drop your files for instant AI-powered transcription. This is a game-changer for productivity! 🎯
-
-Try it now 👇
-github.com/EpicenterHQ/epicenter
-
-#OpenSource #AI #Productivity
-```
+For a feature announcement, one tweet is the whole post: what shipped, what it does in plain verbs, one link. No emoji framing, no hashtags, no "try it now."
 
 ### Single Tweet (Technical Insight)
 
@@ -137,6 +106,8 @@ The good thread: each tweet has a concrete fact. The bad thread: tweet 1 is a ho
 
 ### Good (Actual Human Post)
 
+This is one past Whispering post, kept as an example of the shape (feature, plain mechanics, link, done), not a template to reuse.
+
 ```
 Whispering now supports direct file uploads!
 
@@ -168,34 +139,7 @@ GitHub: https://github.com/EpicenterHQ/epicenter
 
 ### Good (Focused on Implementation)
 
-````
-Hey r/sveltejs! Just shipped a file upload feature for Whispering and wanted to share how I implemented drag-and-drop files.
-
-I used the [FileDropZone component from shadcn-svelte-extras](https://www.shadcn-svelte-extras.com/components/file-drop-zone), which provided a clean abstraction that allows users to drop and click to upload files:
-
-```svelte
-<FileDropZone
-  accept="{ACCEPT_AUDIO}, {ACCEPT_VIDEO}"
-  maxFiles={10}
-  maxFileSize={25 * MEGABYTE}
-  onUpload={(files) => {
-    if (files.length > 0) {
-      handleFileUpload(files);
-    }
-  }}
-/>
-```
-
-The component handles web drag-and-drop, but since Whispering is a Tauri desktop app, drag-and-drop functionality didn't work on the desktop (click-to-select still worked fine). So I reached for Tauri's [onDragDropEvent](https://tauri.app/reference/javascript/api/namespacewebviewwindow/#ondragdropevent) to add native support for dragging files anywhere into the application.
-
-You can see the [full implementation here](link) (note that the code is still somewhat messy by my standards; it is slated for cleanup!).
-
-Whispering is a large, open-source, production Svelte 5 + Tauri app: https://github.com/EpicenterHQ/epicenter
-
-Feel free to check it out for more patterns! If you're building Svelte 5 apps and need file uploads, definitely check out shadcn-svelte-extras. Not affiliated, it just saved me hours of implementation time.
-
-Happy to answer any questions about the implementation!
-````
+Write it like a build log from a peer, not an announcement. Greet the sub, say what you shipped and how: name the exact library or component, show one short real code snippet, link the upstream docs, and describe the problem you hit and the fix. Admit honest caveats about the code's state, link the full implementation, disclose non-affiliation when recommending a tool, and close by inviting implementation questions.
 
 ### Bad (Marketing-Focused)
 

--- a/.agents/skills/spec-execution/SKILL.md
+++ b/.agents/skills/spec-execution/SKILL.md
@@ -12,16 +12,6 @@ When handed a specification document (a `specs/*.md` file), execute it methodica
 
 Commits should follow the shape of the work. Commit after a wave when that wave is a natural review unit. Combine waves into one larger commit when the changes are tightly coupled. Break a large wave into smaller commits when that makes the history easier to audit. The goal is working checkpoints first, readable git history second.
 
-## When to Apply This Skill
-
-Use this pattern when you need to:
-
-- Implement a `specs/*.md` plan end-to-end in structured waves.
-- Decide which spec tasks run in parallel vs sequentially.
-- Update spec checkboxes and implementation notes after each wave.
-- Commit code changes together with spec progress at sensible review boundaries.
-- Finish execution by running `post-implementation-review`, harvesting durable decisions into `docs/adr/`, and deleting the spent spec.
-
 ## The Execution Loop
 
 ```

--- a/.agents/skills/specification-writing/SKILL.md
+++ b/.agents/skills/specification-writing/SKILL.md
@@ -17,16 +17,6 @@ A specification gives an agent or maintainer the context they need to implement 
 
 > **Note**: This guide uses `[PLACEHOLDER]` markers for content you must fill in. Code blocks show templates; replace all bracketed content with your feature's details.
 
-## When to Apply This Skill
-
-Use this pattern when you need to:
-
-- Plan a feature with a spec that enables autonomous implementation.
-- Document research findings, trade-offs, and design rationale.
-- Define phased implementation tasks with trackable checkboxes.
-- Capture open questions and recommendations without over-prescribing.
-- Lay out architecture with tables/diagrams instead of wall-of-prose plans.
-
 ## References
 
 Load these on demand based on the spec's decision surface:

--- a/.agents/skills/styling/SKILL.md
+++ b/.agents/skills/styling/SKILL.md
@@ -8,27 +8,17 @@ metadata:
 
 # Styling Guidelines
 
-## Reference Repositories
-
-- [shadcn-svelte](https://github.com/huntabyte/shadcn-svelte): Port of shadcn/ui for Svelte with Bits UI primitives
-- [shadcn-svelte-extras](https://github.com/ieedan/shadcn-svelte-extras): Additional components for shadcn-svelte
-- [Svelte](https://github.com/sveltejs/svelte): Svelte 5 framework
-
 ## Upstream Grounding
 
-When styling behavior depends on shadcn-svelte component structure, class merging, variants, or Bits UI composition, use source-backed grounding before relying on memory. If DeepWiki MCP is available, ask a narrow question against `huntabyte/shadcn-svelte`; for extras component behavior, ask against `ieedan/shadcn-svelte-extras`. If DeepWiki is unavailable or the repo is not indexed, use upstream source or official docs directly. Treat DeepWiki as orientation, then verify decisive details against local `@epicenter/ui` wrappers, installed types, source, or official docs before changing code.
-
-Skip DeepWiki for ordinary Tailwind utilities and repo-local layout rules already documented below.
+Grounding repos: `huntabyte/shadcn-svelte` for component structure, variants, and Bits UI composition; `ieedan/shadcn-svelte-extras` for extras components; `sveltejs/svelte` for framework behavior.
 
 ## When to Apply This Skill
 
 Use this pattern when you need to:
 
-- Write Tailwind/CSS for UI components in this repo.
 - Decide whether a wrapper element is necessary or can be removed.
 - Style interactive disabled states using HTML `disabled` and Tailwind variants.
 - Replace JS click guards with semantic disabled behavior.
-- Build scrollable content areas inside flex columns, resizable panes, or split layouts.
 
 ## Minimize Wrapper Elements
 

--- a/.agents/skills/svelte/SKILL.md
+++ b/.agents/skills/svelte/SKILL.md
@@ -7,12 +7,6 @@ description: Svelte 5 component and state-module patterns for Epicenter apps. Us
 
 Use this skill for Svelte 5 components and Svelte state modules in Epicenter apps. Keep the first pass focused on Svelte runes, component lifecycle, workspace-backed state, TanStack Query usage, and local UI composition.
 
-## Reference Repositories
-
-- [Svelte](https://github.com/sveltejs/svelte): Svelte 5 framework with runes and fine-grained reactivity
-- [shadcn-svelte](https://github.com/huntabyte/shadcn-svelte): Port of shadcn/ui for Svelte with Bits UI primitives
-- [shadcn-svelte-extras](https://github.com/ieedan/shadcn-svelte-extras): Additional components for shadcn-svelte
-
 ## Source Checks
 
 - Check [Svelte `$props`](https://svelte.dev/docs/svelte/$props), [`$bindable`](https://svelte.dev/docs/svelte/$bindable), and [snippets](https://svelte.dev/docs/svelte/snippet) before changing prop ownership, `bind:` APIs, or `children` snippet typing rules.
@@ -24,9 +18,7 @@ Use this skill for Svelte 5 components and Svelte state modules in Epicenter app
 
 ## Upstream Grounding
 
-When Svelte 5 runes, compiler behavior, lifecycle, reactivity, snippets, or template behavior affect correctness, use source-backed grounding before relying on memory. If DeepWiki MCP is available, ask a narrow question against `sveltejs/svelte`; for SvelteKit integration, ask against `sveltejs/kit`; for shadcn-svelte or extras component APIs, ask against `huntabyte/shadcn-svelte` or `ieedan/shadcn-svelte-extras`. If DeepWiki is unavailable or the repo is not indexed, use upstream source or official docs directly. Treat DeepWiki as orientation, then verify decisive details against local installed types, source, or official docs before changing code.
-
-Skip DeepWiki for stable basics and repo-local patterns already documented here or in references.
+Grounding repos: `sveltejs/svelte` for runes, compiler behavior, and reactivity; `sveltejs/kit` for SvelteKit integration; `huntabyte/shadcn-svelte` and `ieedan/shadcn-svelte-extras` for component APIs.
 
 ## Related Skills
 
@@ -39,12 +31,7 @@ Skip DeepWiki for stable basics and repo-local patterns already documented here 
 
 Use this skill when you need to:
 
-- Build or refactor Svelte 5 components using runes.
-- Choose between `$state`, `$derived`, `$effect`, snippets, and keyed blocks.
-- Wire TanStack Query mutations from `.svelte` or `.ts` files.
-- Convert workspace table or KV data into reactive Svelte state.
 - Refactor shallow aliases, repetitive markup, or unstable reactive data sources.
-- Follow shadcn-svelte import and composition patterns.
 - Fix template gotchas such as unicode escapes in HTML context.
 
 ## Svelte 5 Baseline

--- a/.agents/skills/sveltekit/SKILL.md
+++ b/.agents/skills/sveltekit/SKILL.md
@@ -8,14 +8,9 @@ metadata:
 
 # SvelteKit
 
-## Reference Repositories
-
-- [SvelteKit](https://github.com/sveltejs/kit) - Svelte application framework for routing, server rendering, form actions, and adapters
-- [Svelte](https://github.com/sveltejs/svelte) - Svelte 5 compiler and runtime
-
 ## Upstream Grounding
 
-When SvelteKit load behavior, invalidation, cookies, hooks, env handling, server-only modules, generated `$types`, or adapter behavior affects correctness, ask DeepWiki a narrow question against `sveltejs/kit` before relying on memory. Verify decisive details against local installed types and source.
+Grounding repos: `sveltejs/kit` for load, invalidation, hooks, env, `$types`, and adapters; `sveltejs/svelte` for the compiler and runtime.
 
 Use the `svelte` skill for component runes and template mechanics.
 

--- a/.agents/skills/tanstack-table/SKILL.md
+++ b/.agents/skills/tanstack-table/SKILL.md
@@ -8,14 +8,9 @@ metadata:
 
 # TanStack Table
 
-## Reference Repositories
-
-- [TanStack Table](https://github.com/TanStack/table) - Headless table state and row models
-- [Svelte](https://github.com/sveltejs/svelte) - Svelte 5 component and reactivity model
-
 ## Upstream Grounding
 
-When TanStack Table adapter APIs, row models, controlled state, sorting, filtering, pagination, or Svelte rendering helpers affect correctness, ask DeepWiki a narrow question against `TanStack/table`. Verify against the installed `@tanstack/svelte-table` and `@tanstack/table-core` versions.
+Grounding repos: `TanStack/table` for row models, controlled state, and Svelte rendering helpers; `sveltejs/svelte` for the component and reactivity model.
 
 This skill is for UI table state. Use `workspace-api` for Epicenter CRDT table storage and migrations.
 

--- a/.agents/skills/tauri/SKILL.md
+++ b/.agents/skills/tauri/SKILL.md
@@ -7,25 +7,16 @@ metadata:
 ---
 
 # Tauri Patterns
-## Reference Repositories
-
-- [Tauri](https://github.com/tauri-apps/tauri): Desktop app framework with Rust backend and web frontend
-
 ## Upstream Grounding
 
-When Tauri command behavior, permissions, capabilities, CSP, asset protocols, path APIs, plugin filesystem behavior, or IPC semantics affect correctness, use source-backed grounding before relying on memory. If DeepWiki MCP is available, ask a narrow question against `tauri-apps/tauri`; if it is unavailable or the repo is not indexed, use upstream source or official docs directly. Treat DeepWiki as orientation, then verify decisive details against local generated bindings, installed Rust crates, TypeScript types, source, or official docs before changing code.
-
-Skip DeepWiki for repo-local command naming and app-specific wrapper conventions already visible in the code.
+Grounding repo: `tauri-apps/tauri` for commands, permissions, capabilities, CSP, path APIs, plugin filesystem behavior, and IPC semantics.
 
 ## When to Apply This Skill
 
 Use this pattern when you need to:
 
-- Add or change Tauri commands, permissions, capabilities, or security config.
-- Build file paths in Tauri frontend code running in the webview.
 - Choose correctly between `@tauri-apps/api/path` and Node/Bun `path` APIs.
 - Replace manual slash concatenation with `join()`, `dirname()`, and related helpers.
-- Handle cross-platform filesystem behavior for desktop apps.
 - Combine Tauri path APIs with `@tauri-apps/plugin-fs` operations.
 
 ## Commands, Permissions, And Security

--- a/.agents/skills/technical-articles/SKILL.md
+++ b/.agents/skills/technical-articles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-articles
-description: 'Technical articles and blog posts with honest trade-offs. Use when: "write a blog post", "draft an article", "write about this", creating articles in docs/articles/.'
+description: 'Technical articles and blog posts with honest trade-offs. Use when: "write a blog post", "draft an article", "turn this into an article", creating articles in docs/articles/.'
 metadata:
   author: epicenter
   version: '1.0'
@@ -9,16 +9,6 @@ metadata:
 # Technical Articles
 
 All articles must follow [writing-voice](../writing-voice/SKILL.md) rules. This skill owns article shape; `writing-voice` owns house voice and punctuation.
-
-## When to Apply This Skill
-
-Use this pattern when you need to:
-
-- Write technical articles in `docs/articles/` or blog-style engineering posts.
-- Turn headings and titles into arguments instead of neutral topic labels.
-- Structure prose, code, and visuals with deliberate rhythm and pacing.
-- Open with the core insight first instead of announcing the topic.
-- Edit drafts to remove AI tell patterns and keep writing concrete.
 
 ## Core Principles
 
@@ -78,7 +68,7 @@ ASCII diagrams, tables, and before/after code blocks are tools to reach for when
 
 Use a diagram when showing flow or architecture that's hard to describe linearly. Use a table when there's a genuine comparison with 3+ items. Use before/after code when the contrast IS the point. Skip all of them when the article doesn't need them.
 
-When you have multiple independent reasons for something, write them as regular prose with natural transitions. Don't use numbered bold headings (`**1. Bold heading**` followed by explanation):that pattern is one of the most recognizable AI writing tells.
+When you have multiple independent reasons for something, write them as regular prose with natural transitions. Don't use numbered bold headings (`**1. Bold heading**` followed by explanation). That pattern is one of the most recognizable AI writing tells.
 
 ## Architecture Article Composition
 
@@ -103,7 +93,7 @@ This is the most important section. Good articles alternate between prose and vi
 3. **After a code block, one sentence of explanation is often enough.** If the code is self-explanatory, skip it entirely and bridge to the next idea.
 4. **Use line breaks between distinct thoughts.** Don't pack three ideas into one paragraph. Each paragraph: one idea.
 
-### Good rhythm : prose and code alternate:
+### Good rhythm: prose and code alternate
 
 ```
 [1-2 sentences: what the problem is]
@@ -123,7 +113,7 @@ const result = index.get(id);   // O(1) lookup
 [1-2 sentences: what this means for the reader]
 ```
 
-### Bad rhythm : wall of prose, code at the end:
+### Bad rhythm: wall of prose, code at the end
 
 ```
 [Paragraph explaining the problem]
@@ -154,17 +144,17 @@ The bad version tells the reader what the article is about. The good version tel
 
 ## When the User Gave You the Voice, Use It
 
-If the article originates from a voice transcript, chat brainstorm, or spoken-out-loud reasoning, the user's own phrases ARE the voice of the article. Reconstructing them in "better" English strips out the cadence that made the insight land in the first place : and the user won't recognize their own thought on the page. They'll bounce.
+If the article originates from a voice transcript, chat brainstorm, or spoken-out-loud reasoning, the user's own phrases ARE the voice of the article. Reconstructing them in "better" English strips out the cadence that made the insight land in the first place, and the user won't recognize their own thought on the page. They'll bounce.
 
 The test: would the user, skimming their own article a week later, feel the impetus that made them want to write it? If the opening is polished into generic technical prose, no.
 
 ### Rules
 
-1. **Use the user's exact phrases in the first paragraph.** Not paraphrased, not smoothed. The raw phrase : lightly cleaned for grammar, never for cadence. Even mildly awkward phrasing ("I knew it was a smell because…") is better than a cleaner rewrite, because it's what the user actually thinks and how they'll remember the article.
+1. **Use the user's exact phrases in the first paragraph.** Not paraphrased, not smoothed. The raw phrase, lightly cleaned for grammar, never for cadence. Even mildly awkward phrasing ("I knew it was a smell because…") is better than a cleaner rewrite, because it's what the user actually thinks and how they'll remember the article.
 
 2. **If there's a core code transformation, it lands in the first ~100 words.** Before / after, both visible in the first scroll. The prose explains; the code IS the article. Burying the code transformation below context-setting paragraphs means the reader never reaches it.
 
-3. **Lift specific phrases verbatim from the transcript.** If the user said "I knew I had made a Svelte-specific version" : use that line, don't rewrite it to "I had created a framework-specific adapter." The specificity of the original phrasing is the voice.
+3. **Lift specific phrases verbatim from the transcript.** If the user said "I knew I had made a Svelte-specific version": use that line, don't rewrite it to "I had created a framework-specific adapter." The specificity of the original phrasing is the voice.
 
 4. **Fidelity beats polish.** When you're drafting from a transcript, err on the side of preserving the user's phrasing even when a more elegant sentence is available. The user wrote the insight in their head once; the article should match that mental version so they can still feel it when they re-read.
 
@@ -174,7 +164,7 @@ The test: would the user, skimming their own article a week later, feel the impe
 
 ### Good (the user's actual phrases)
 
-> I realized I had made a Svelte-specific version. I knew it was a smell because I was calling `$effect` just to track `auth.token`. That suggested to me I actually wanted an imperative `onTokenChange` : and the only reason that API didn't exist was that I'd been wrapping Svelte on Svelte.
+> I realized I had made a Svelte-specific version. I knew it was a smell because I was calling `$effect` just to track `auth.token`. That suggested to me I actually wanted an imperative `onTokenChange`, and the only reason that API didn't exist was that I'd been wrapping Svelte on Svelte.
 
 The first version is publishable. The second version sounds like someone thinking out loud, which is what the user was doing when they handed you the transcript.
 
@@ -235,7 +225,7 @@ The shape emerges from the content. If you find yourself adding a diagram or tab
 - Numbered bold headings for multi-part arguments (`**1. Bold heading**` pattern)
 - Summary tables tacked on at the end that restate what the prose already said
 - Marketing language or AI giveaways
-- More than 4-5 sentences of prose without a visual break
+- Long stretches of prose with no visual break (Rhythm and Pacing owns the calibration)
 - Opening that announces the topic instead of delivering the insight
 - Closing that reaches for a grand summary or call to action
 

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -12,13 +12,8 @@ metadata:
 
 Use this pattern when you need to:
 
-- Write or refactor `*.test.ts` files in this codebase.
 - Structure tests with `setup()` functions instead of mutable `beforeEach` setup.
-- Split large test files into focused behavior/type/scenario files.
-- Enforce behavior-based test naming and clear failure intent.
-- Add or review negative type tests using `@ts-expect-error`.
 - Audit a test file for assertions that cannot fail or fakes that don't earn their lines.
-- Prune tests that cannot name a real regression they would catch.
 
 ## References
 
@@ -32,11 +27,11 @@ Load these on demand based on what you're working on:
 
 External reading:
 
-- Kent C. Dodds, ["Avoid Nesting When You're Testing"](https://kentcdodds.com/blog/avoid-nesting-when-youre-testing) : setup functions over beforeEach, flat tests
-- Kent C. Dodds, ["AHA Testing"](https://kentcdodds.com/blog/aha-testing) : avoid hasty abstractions in tests
-- Kent C. Dodds, [Testing JavaScript](https://testingjavascript.com) : Test Object Factory Pattern
-- Matt Pocock, ["How to test your types"](https://www.totaltypescript.com/how-to-test-your-types) : vitest `expectTypeOf` for type testing
-- Matt Pocock, [`shoehorn`](https://github.com/total-typescript/shoehorn) : partial mocks for test ergonomics
+- Kent C. Dodds, ["Avoid Nesting When You're Testing"](https://kentcdodds.com/blog/avoid-nesting-when-youre-testing): setup functions over beforeEach, flat tests
+- Kent C. Dodds, ["AHA Testing"](https://kentcdodds.com/blog/aha-testing): avoid hasty abstractions in tests
+- Kent C. Dodds, [Testing JavaScript](https://testingjavascript.com): Test Object Factory Pattern
+- Matt Pocock, ["How to test your types"](https://www.totaltypescript.com/how-to-test-your-types): vitest `expectTypeOf` for type testing
+- Matt Pocock, [`shoehorn`](https://github.com/total-typescript/shoehorn): partial mocks for test ergonomics
 
 > **Related Skills**: See `services-layer` for the service patterns being tested. See `typescript` for type testing conventions.
 
@@ -44,10 +39,10 @@ External reading:
 
 Two distinct file extensions, two distinct purposes:
 
-- **`*.test.ts`** : asserts behavior with `expect()`. Runs under `bun test`
+- **`*.test.ts`**: asserts behavior with `expect()`. Runs under `bun test`
   (repo default, CI). A test file without at least one `expect()` call does
   not belong under this extension.
-- **`*.bench.ts`** : measures and reports. Prints tables, timings, or
+- **`*.bench.ts`**: measures and reports. Prints tables, timings, or
   storage sizes. Runs under `bun bench` only. No assertions required
   (perf thresholds on shared hardware flake; prefer visual trends).
 

--- a/.agents/skills/turso/SKILL.md
+++ b/.agents/skills/turso/SKILL.md
@@ -8,14 +8,9 @@ metadata:
 
 # Turso And libSQL
 
-## Reference Repositories
-
-- [Turso](https://github.com/tursodatabase/turso) - SQLite-compatible database platform and libSQL ecosystem
-- [Drizzle ORM](https://github.com/drizzle-team/drizzle-orm) - ORM commonly used with libSQL and Turso
-
 ## Upstream Grounding
 
-When Turso sync behavior, libSQL driver behavior, embedded replicas, partial sync, concurrency, compatibility, or CLI behavior affects correctness, use source-backed grounding before relying on memory. If DeepWiki MCP is available, ask a narrow question against `tursodatabase/turso`; for Drizzle's libSQL adapter or typed query surface, ask against `drizzle-team/drizzle-orm`. If DeepWiki is unavailable or the repo is not indexed, use upstream source or official docs directly. Treat DeepWiki as orientation, then verify decisive details against local driver versions, installed types, source, or official docs before changing code.
+Grounding repos: `tursodatabase/turso` for sync, embedded replicas, partial sync, and libSQL driver behavior; `drizzle-team/drizzle-orm` for the libSQL adapter.
 
 Use the `drizzle-orm` skill for schema and query builder decisions.
 

--- a/.agents/skills/type-level-error-messages/SKILL.md
+++ b/.agents/skills/type-level-error-messages/SKILL.md
@@ -14,7 +14,6 @@ metadata:
 
 Use this pattern when you need to:
 
-- Constrain object keys, string literals, or other literal-type inputs in a helper function and surface a readable error at the call site.
 - Replace a `never` or `string` return in a constraint type with something that points at the bad value.
 - Match the way `arktype`'s internal `ErrorMessage<M>` types behave: visible message, invisible brand.
 - Give app authors edit-site feedback on shape/format rules (snake_case keys, slug formats, semver strings) without forcing every consumer to call a separate `validate()` step.

--- a/.agents/skills/typescript/SKILL.md
+++ b/.agents/skills/typescript/SKILL.md
@@ -10,16 +10,6 @@ metadata:
 
 Use this skill for project-wide TypeScript conventions before loading narrower skills such as `arktype`, `typebox`, `testing`, or `method-shorthand-jsdoc`.
 
-## When To Apply This Skill
-
-Use this skill when you need to:
-
-- Write or refactor TypeScript with Epicenter naming and style conventions.
-- Decide whether to derive, import, or declare a type.
-- Review type ownership, copied shapes, factory return types, brands, casts, and generic names.
-- Choose clear value-mapping and control-flow patterns for unions and discriminated values.
-- Organize type tests, runtime schemas, or factory-focused refactors.
-
 ## Core Rules
 
 - Try to derive or import a type before declaring a new named type. New named types must earn their place as a real contract, protocol vocabulary, discriminated result union, capability port, or multi-implementation shape.

--- a/.agents/skills/web-design-guidelines/SKILL.md
+++ b/.agents/skills/web-design-guidelines/SKILL.md
@@ -11,15 +11,6 @@ metadata:
 
 Review files for compliance with Web Interface Guidelines.
 
-## When to Apply This Skill
-
-Use this pattern when you need to:
-
-- Audit UI code against Web Interface Guidelines.
-- Review a site for accessibility, UX, or design best-practice compliance.
-- Return terse `file:line` findings from a guidelines-driven review.
-- Re-check interfaces using the latest upstream guideline rules before reporting.
-
 ## How It Works
 
 1. Fetch the latest guidelines from the source URL below

--- a/.agents/skills/workspace-api/SKILL.md
+++ b/.agents/skills/workspace-api/SKILL.md
@@ -10,16 +10,9 @@ metadata:
 
 Use this skill for Epicenter workspace definitions, table and KV access, inline action registries, attachment composition, collaboration setup, and workspace connections.
 
-## Reference Repositories
-
-- [Yjs](https://github.com/yjs/yjs): CRDT framework used by the workspace data layer
-- [Yjs Protocols](https://github.com/yjs/y-protocols): sync, awareness, and protocol helpers used around collaboration
-
 ## Upstream Grounding
 
-When workspace behavior depends on Yjs transactions, shared types, update encoding, document lifecycle, or conflict semantics, use source-backed grounding before relying on memory. If DeepWiki MCP is available, ask a narrow question against `yjs/yjs`; for collaboration sync or awareness protocol behavior, ask against `yjs/y-protocols`. If DeepWiki is unavailable or the repo is not indexed, use upstream source or official docs directly. Treat DeepWiki as orientation, then verify decisive details against local workspace code, installed types, tests, or official docs before changing code.
-
-Skip DeepWiki for Epicenter schema, action, migration, and attachment conventions already documented below.
+Grounding repos: `yjs/yjs` for transactions, shared types, update encoding, and conflict semantics; `yjs/y-protocols` for sync and awareness protocol behavior.
 
 ## Related Skills
 
@@ -27,19 +20,6 @@ Skip DeepWiki for Epicenter schema, action, migration, and attachment convention
 - `svelte`: reactive wrappers such as `fromTable` and `fromKv`, plus commit-on-blur workspace inputs
 - `attach-primitive`: the full contract and invariants every `attach*` function must follow
 - `typebox`: TypeBox primitives used by `field.*`, `defineKv`, and action input schemas
-
-## When To Apply This Skill
-
-Use this skill when you are:
-
-- Defining a table or KV store with `defineTable()` or `defineKv()`.
-- Adding a version or migration to an existing table definition.
-- Reading, writing, or observing table or KV data.
-- Creating actions with `defineMutation` or `defineQuery`.
-- Composing a live document with `createWorkspace` and surrounding `attach*` primitives (persistence, sync, materializers).
-- Adding `createDisposableCache(builder)` for per-row or fan-out documents.
-- Attaching persistence, collaboration, or materializers around a workspace.
-- Writing server-side Bun scripts with `connectWorkspace()`.
 
 ## Core Rules
 

--- a/.agents/skills/workspace-app-composition/SKILL.md
+++ b/.agents/skills/workspace-app-composition/SKILL.md
@@ -302,28 +302,6 @@ lifecycle command is `epicenter daemon up`, not `epicenter serve`.
 
 ## Anti-Patterns
 
-- Putting auth, `createPersistedState`, `auth.onStateChange`, or HMR disposal in
-  the browser/extension/tauri factory. Those belong in `src/lib/session.ts`.
-- Naming the singleton `session.svelte.ts`. It is a plain `src/lib/session.ts`.
-- Adding a second singleton home (`client.ts`) to a Shape A app. The singleton
-  already lives in `src/lib/session.ts`.
-- Putting auth subscriptions or workspace construction in a Svelte component.
-  They belong in the session singleton.
-- Branching on platform at a `#platform/*` call site. Import the bare specifier
-  and let the build select the impl.
-- Using `satisfies` on a `#platform/*` impl instead of a `: Contract` annotation.
-- Importing a `.tauri.ts`-only symbol through `#platform/*` (it is `null` on web);
-  import it directly from the `.tauri` module inside another `.tauri.ts` file.
-- Reintroducing `resolve.extensions` suffixes or tsconfig `moduleSuffixes` for
-  platform selection.
-- Dropping `...defaultClientConditions` from the Tauri `conditions` array.
-- Adding a `./browser` package export to honeycrisp/vocab for symmetry
-  with opensidian. Keep the asymmetry; only opensidian has a consumer for it.
-- Adding `./mount` back to honeycrisp. Honeycrisp's integration contract is the
-  package `.` isomorphic workspace export.
-- Placing `daemon.ts` or `script.ts` inside the app package. They live under a
-  project's `workspaces/<app>/` and are registered via `epicenter.config.ts`.
-- Restoring `serve` as the public lifecycle command (it is `epicenter daemon up`).
 - Load-gating a post-auth workspace (its `idb.whenLoaded` does not exist at
   `load` time), or showing a `<Loading>` skeleton for a fast eager-workspace gate
   (the spinner just flashes). Gate where the readiness promise is first

--- a/.agents/skills/writing-voice/SKILL.md
+++ b/.agents/skills/writing-voice/SKILL.md
@@ -27,17 +27,6 @@ Use the narrow artifact skill when the user asks for that artifact:
 
 For PR and commit text, the voice rules here still apply, but the product and personal-voice sections further down (landing-page framing, "end with an invitation", first-person story openers) are for marketing and community writing, not for reviewer-facing PRs or commits.
 
-## When to Apply This Skill
-
-Use this pattern when you need to:
-
-- Write user-facing text like UI copy, tooltips, error messages, or prose.
-- Rewrite text that sounds corporate, stilted, or AI-generated.
-- Decide punctuation style in prose, comments, JSDoc, markdown, or commit messages.
-- Explain technical concepts with concrete mechanisms instead of abstract claims.
-- Match the user's tone and pacing in responses.
-- Draft product/open-source writing with honest trade-offs and specifics.
-
 ## The Test
 
 Read it out loud. If it:

--- a/.agents/skills/wxt/SKILL.md
+++ b/.agents/skills/wxt/SKILL.md
@@ -8,13 +8,9 @@ metadata:
 
 # WXT Browser Extensions
 
-## Reference Repositories
-
-- [WXT](https://github.com/wxt-dev/wxt) - Browser extension framework used by `apps/tab-manager`
-
 ## Upstream Grounding
 
-When WXT entrypoint discovery, manifest generation, browser targets, storage, content scripts, background service worker lifecycle, or build output affects correctness, ask DeepWiki a narrow question against `wxt-dev/wxt`. Verify decisive details against local `wxt.config.ts` and generated output.
+Grounding repo: `wxt-dev/wxt` for entrypoint discovery, manifest generation, storage, content scripts, and background service worker lifecycle.
 
 ## Epicenter Shape
 

--- a/.agents/skills/yjs/SKILL.md
+++ b/.agents/skills/yjs/SKILL.md
@@ -7,17 +7,9 @@ metadata:
 ---
 
 # Yjs CRDT Patterns
-## Reference Repositories
-
-- [Yjs](https://github.com/yjs/yjs): CRDT framework for shared editing and offline-first data
-- [Yjs Protocols](https://github.com/yjs/y-protocols) - Sync, awareness, and auth protocol helpers
-- [Y IndexedDB](https://github.com/yjs/y-indexeddb) - Browser persistence provider for Y.Doc updates
-
 ## Upstream Grounding
 
-When conflict semantics, transaction origins, shared-type behavior, update encoding, storage growth, or shared-type APIs affect correctness, use source-backed grounding before relying on memory. If DeepWiki MCP is available, ask a narrow question against `yjs/yjs`; for sync, awareness, auth protocol helpers, or provider interoperability, ask against `yjs/y-protocols`; for browser persistence behavior, ask against `yjs/y-indexeddb`. If DeepWiki is unavailable or the repo is not indexed, use upstream source or official docs directly. Treat DeepWiki as orientation, then verify decisive details against local installed types, source, or official docs before changing code.
-
-Skip DeepWiki for stable basics and repo-local patterns already documented below.
+Grounding repos: `yjs/yjs` for shared types, transactions, and conflict semantics; `yjs/y-protocols` for sync, awareness, and protocol helpers; `yjs/y-indexeddb` for browser persistence.
 
 > **Related Skills**: See `workspace-api` for the workspace abstraction built on Yjs.
 
@@ -25,8 +17,6 @@ Skip DeepWiki for stable basics and repo-local patterns already documented below
 
 Use this pattern when you need to:
 
-- Design collaborative data models with Y.Map, Y.Array, or Y.Text.
-- Handle conflict-prone updates with single-writer keys or nested maps.
 - Implement drag-and-drop reordering with fractional indexing.
 - Optimize Yjs storage for high-churn key-value workloads.
 - Review boundaries to prevent raw Yjs type leaks into consumer code.


### PR DESCRIPTION
Stacked on #2257; review only the commits above its base. This branch executes the detectors that #2257 encoded, across the whole library: the audit's "fix next" tier plus the three cross-cutting boilerplate batches. Net effect is roughly 700 lines deleted with no rule losing its single owner.

## Per-skill fixes (one commit each)

The biggest ownership move: services-layer embedded a second ~100-line defineErrors tutorial that drifted from the define-errors skill. define-errors now owns error-type teaching (itself cut from three same-shape worked examples to one per unique shape); services-layer keeps only service structure and points across. Cross-references elsewhere were updated to match.

The rest of the tier: auth loses five pitfalls that main's recent edits had already absorbed into its body, plus two scripted-quote blocks harvested from one grilling conversation; workspace-app-composition and epicenter-ui lose anti-pattern lists that restated their own sections nearly item for item; comparable-apps and social-media lose transcript residue (pasted PR numbers, dangling spec paths, one Whispering post canonized as rules on three platforms); technical-articles resolves its self-contradiction (body said 3-4 sentences per paragraph, closer said 4-5) by leaving one owner; frontend-design drops pep-talk residue and its React motion pointer in a Svelte repo; better-auth-best-practices (an unmodified upstream import otherwise) gets a description-only narrow so it stops shadowing the repo-truth auth skill on "OAuth" and "session configuration".

## The mechanical sweep (one commit)

Three homogeneous batch passes, combined because they overlap on 12 files:

- "When to Apply This Skill" sections that restated the frontmatter description were deleted in 30 skills; where a section carried real recognition cues the description cannot hold (concrete code smells, near-miss boundaries), only those bullets survive.
- "Upstream Grounding" and "Reference Repositories" boilerplate compressed to the skill-specific repo pointers in 16 skills (~109 lines); AGENTS.md owns the grounding rule itself. Every repo slug was preserved verbatim.
- Dash-strip colon artifacts (" : ", glued colons) repaired in prose across 8 files; ternaries and conditional types in code fences were left alone.

Validation: the skills CLI still finds and validates all 80 skills, the detector-3 dead-link check is clean, and no em or en dash characters were added anywhere in the diff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785559405&installation_id=128463665&pr_number=2261&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2261&signature=3a100ea480f1dd8d0fdf20229c145863a858af2b1989fc2f3e2f85f948d1012d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->