### PR TITLE
docs(skills): single-source the keep-vs-inline criteria in radical-options

### DIFF
--- a/.agents/skills/cohesive-clean-breaks/SKILL.md
+++ b/.agents/skills/cohesive-clean-breaks/SKILL.md
@@ -418,22 +418,5 @@ Before finishing, grep for old vocabulary, old shapes, old filenames, removed
 exports, fallback parsers, stale comments, and examples. If old names still
 appear outside historical specs or migration notes, the break is incomplete.
 
-Ask:
-
-```txt
-Can I explain the new API without saying "or"?
-Does one layer own each invariant?
-Would a new caller find only one obvious path?
-Are examples free of compatibility shapes?
-Are side effects injected as policy instead of imported as hidden globals?
-Did I move the boundary that caused the smell, or only wrap it?
-Did I delete stale names instead of leaving aliases?
-Did I delete dead paths instead of leaving them unreachable?
-Did the file tree change to match the new ownership?
-Did every validation move to the earliest layer that can know the truth?
-Would mentally inlining each new helper make the code clearer?
-Did I run the asymmetric wins pass before adding another invariant?
-Does Go-to-Def from a typical call site land on the real definition, or on an alias, re-export, or wrapper?
-```
-
-If any answer is no, keep simplifying.
+Then re-run the applicable section checks above instead of a recap list. If
+any check fails, keep simplifying.

--- a/.agents/skills/fresh-eyes-grill/SKILL.md
+++ b/.agents/skills/fresh-eyes-grill/SKILL.md
@@ -64,9 +64,9 @@ Ask these questions in order:
 10. Are tests asserting public behavior or implementation trivia?
 
 Do not accept "it is explicit" as a sufficient answer. Explicit code can still
-be the wrong boundary. A state, helper, or type earns its place only when it
-prevents misuse, names real domain vocabulary, isolates unsafe input, or removes
-more confusion than it adds.
+be the wrong boundary. Judge whether a state, helper, or type earns its place
+with the [radical-options](../radical-options/SKILL.md) keep list rather than
+an ad hoc standard.
 
 ## Type Shape Rules
 
@@ -149,15 +149,9 @@ makeInitialState                 1        keep if it names boot semantics
 normalizeResult                  1        inline unless it isolates unsafe input
 ```
 
-Keep one-caller helpers only when they do one of these jobs:
-
-- name a lifecycle transition
-- isolate a parse or network boundary
-- prevent stale async work
-- keep a long method readable
-- match a deliberate family of operations
-
-Inline helpers that only rename simple control flow.
+Judge each one-caller helper with the [refactoring](../refactoring/SKILL.md)
+caller-count table and single-caller reasons; inline helpers that only rename
+simple control flow.
 
 ## Output Shape
 

--- a/.agents/skills/post-implementation-review/SKILL.md
+++ b/.agents/skills/post-implementation-review/SKILL.md
@@ -120,15 +120,10 @@ Which calls need `untrack`, and would moving ownership remove that need?
 ```
 
 Count callers for every new or changed helper, component, factory, wrapper, and
-export. A one-caller boundary is guilty until it proves it owns one of these:
-
-```txt
-a lifecycle that must be isolated from parent rerenders
-an unsafe parse, network, storage, or external-library boundary
-a repeated domain operation with several real callers
-a public contract that downstream code imports
-a long imperative block whose helper name explains the phase
-```
+export. A one-caller boundary is guilty until it proves it earns its place;
+judge it with the radical-options keep list cited above and the
+[refactoring](../refactoring/SKILL.md) caller-count table, not a from-memory
+paraphrase of either.
 
 If a boundary only passes a stable handle, callback, or raw library object to
 another one-call wrapper, collapse it. In particular, treat `untrack` inside an

--- a/.agents/skills/refactoring/SKILL.md
+++ b/.agents/skills/refactoring/SKILL.md
@@ -52,6 +52,11 @@ Not every 1-caller function should be inlined. Keep it when:
 - **Complex logic worth naming**: Deep-clone operations, recursive tree walks, or multi-step parsing where the name documents intent.
 - **The calling method is already long**: Inlining 15 lines into a 50-line method hurts readability.
 
+These reasons are about helpers. For whether an abstraction layer earns its
+existence at all (invariants, unsafe interop, domain naming), use the
+[radical-options](../radical-options/SKILL.md) keep list; it is the single
+owner of those criteria.
+
 ## Type Safety Boundaries
 
 All raw/untyped access should go through a single parsing boundary. Everything downstream uses typed results.


### PR DESCRIPTION
Stacked on #2261; review only the single commit above its base.

The review/simplify cluster carried six drifted calibrations of one rule, "when does an abstraction or helper earn its keep": radical-options' keep list, refactoring's caller-count table and single-caller reasons, post-implementation-review's guilty-until-proven list, fresh-eyes-grill's earns-its-place sentence plus its own five-job helper list, and cohesive-clean-breaks' 13-question Final Check recap. Each copy had drifted to a slightly different standard, so which criteria you applied depended on which skill happened to load.

The ownership decision: radical-options owns the layer-level criteria (does the abstraction earn its existence), and refactoring owns the helper-level mechanics (caller-count triage and single-caller reasons); those two answer different questions, so both stay, each citing the other's altitude. The other three skills now point at the owners instead of paraphrasing them. cohesive-clean-breaks' Final Check keeps its grep exit gate, which verifies artifacts rather than restating rules, and drops the recap questions; every deleted question was owned by a body section above it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785559468&installation_id=128463665&pr_number=2262&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2262&signature=d20eb677589eef01ad43c746380e6b1f6896082cdbbe89a972e312eec11ab0b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->