### PR TITLE
fix(svelte): scope the bare broadcast channel to the signed-out branch

### DIFF
--- a/packages/svelte-utils/src/connect-local-first.ts
+++ b/packages/svelte-utils/src/connect-local-first.ts
@@ -31,10 +31,12 @@ type WorkspaceDoc = Parameters<typeof connectDoc>[0];
  * re-runs this selection. Construction is synchronous; data still loads
  * async behind `whenReady`.
  *
- * The cross-tab BroadcastChannel is attached unconditionally under the doc
- * guid, mirroring the shipped Whispering wiring this was extracted from
- * (signed-in docs additionally get the owner-keyed channel inside
- * `connectDoc`).
+ * The cross-tab BroadcastChannel is scoped to the branch: signed-out docs get
+ * the bare guid channel, signed-in docs get only the owner-keyed channel that
+ * `connectDoc` attaches internally. A signed-in doc on the bare channel would
+ * let a signed-out tab (a DIFFERENT doc with the same guid) cross-pollinate
+ * updates into the owner doc, bypassing the sign-in migration, and would let
+ * two signed-in owners on one profile exchange plaintext.
  */
 export function connectLocalFirst({
 	auth,
@@ -57,9 +59,9 @@ export function connectLocalFirst({
 	collaboration: Collaboration | undefined;
 } {
 	const state = auth.state;
-	attachBroadcastChannel(ydoc);
 
 	if (state.status === 'signed-out') {
+		attachBroadcastChannel(ydoc);
 		const idb = attachIndexedDb(ydoc);
 		return { whenReady: idb.whenLoaded, collaboration: undefined };
 	}


### PR DESCRIPTION
Surfaced by the Wave 2 honeycrisp grill (per-note body docs adopt `connectLocalFirst`, multiplying the exposure). The helper attached the bare guid-keyed BroadcastChannel unconditionally, faithful to the shipped Whispering wiring it was extracted from in #2259, but that wiring was itself a latent isolation hole once signed-out usability exists:

- A signed-in tab and a signed-out tab run DIFFERENT docs with the same guid. Both on the bare channel means local rows cross-pollinate into the owner doc, silently bypassing the Add / Delete / Keep sign-in migration.
- Two signed-in owners on one browser profile both attach the same bare channel, exchanging plaintext across owners: the exact scenario `attach-broadcast-channel`'s contract warns about and owner-keyed channels exist to prevent.

Signed-out docs keep the bare channel (cross-tab sync of the local doc); signed-in docs keep only the owner-keyed channel `connectDoc` attaches internally, which they always had. The one behavior removed is guid-channel delivery to signed-in docs, which no correct flow relied on.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785561056&installation_id=128463665&pr_number=2265&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2265&signature=1b634b07bbc3ab636fd69ece32e501928f49c04e9ac8ec3fa5e780762df3d690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->