### PR TITLE
refactor(blobs): collapse pass over the blob surface, plus the paste-a-URL ergonomics

### DIFF
--- a/packages/cli/src/commands/blobs.ts
+++ b/packages/cli/src/commands/blobs.ts
@@ -3,11 +3,12 @@
  * content-addressed URL. The sha256 rides inside the URL, so the documents
  * that cite it are the only manifest; nothing is recorded anywhere else.
  *
- *   add <file|url>  upload the bytes (hash -> ticket -> presigned PUT straight
- *                   to the store) and print the URL; writes nothing to disk
- *   ls              list the owner's stored blobs (the store is the index)
- *   get <sha256>    download one blob by content address to a file
- *   rm  <sha256>    delete one blob from the store (breaks every citation)
+ *   add <file|url>      upload the bytes (hash -> ticket -> presigned PUT
+ *                       straight to the store) and print the URL; writes
+ *                       nothing to disk
+ *   ls                  list the owner's stored blobs (the store is the index)
+ *   get <sha256|url>    download one blob by content address to a file
+ *   rm  <sha256|url>    delete one blob from the store (breaks every citation)
  *
  * Every subcommand is a direct cloud round-trip built from the resolved machine
  * auth client (the persisted OAuth cell, or a configured instance token for a
@@ -99,14 +100,14 @@ const lsCommand = cmd({
 });
 
 const getCommand = cmd({
-	command: 'get <sha256>',
+	command: 'get <blob>',
 	describe: 'Download a blob by content address and write it to a file',
 	builder: (yargs) =>
 		yargs
-			.positional('sha256', {
+			.positional('blob', {
 				type: 'string',
 				demandOption: true,
-				describe: 'The lowercase-hex sha256 content address',
+				describe: 'A lowercase-hex sha256 content address, or a blob URL',
 			})
 			.option('output', {
 				alias: 'o',
@@ -116,10 +117,16 @@ const getCommand = cmd({
 			.options(formatOptions)
 			.strict(),
 	handler: async (argv) => {
+		const { data: sha256, error: parseError } = parseSha256(argv.blob);
+		if (parseError !== null) {
+			fail(parseError);
+			return;
+		}
+
 		const epicenter = await connectCloud();
 		if (!epicenter) return;
 
-		const { data: res, error } = await epicenter.blobs.get(argv.sha256);
+		const { data: res, error } = await epicenter.blobs.get(sha256);
 		if (error !== null) {
 			fail(error.message, { code: 2 });
 			return;
@@ -130,9 +137,9 @@ const getCommand = cmd({
 		// The store enforces the hash on write, but a download can still be
 		// truncated mid-flight; verify before we trust the bytes on disk.
 		const actual = createHash('sha256').update(bytes).digest('hex');
-		if (actual !== argv.sha256) {
+		if (actual !== sha256) {
 			fail(
-				`downloaded bytes do not match their content address: expected ${argv.sha256}, got ${actual}`,
+				`downloaded bytes do not match their content address: expected ${sha256}, got ${actual}`,
 				{ code: 2 },
 			);
 			return;
@@ -144,14 +151,14 @@ const getCommand = cmd({
 			res.headers.get('content-type') ?? 'application/octet-stream';
 		const ext = mime.getExtension(contentType);
 		const outputPath = path.resolve(
-			argv.output ?? (ext ? `${argv.sha256}.${ext}` : argv.sha256),
+			argv.output ?? (ext ? `${sha256}.${ext}` : sha256),
 		);
 		await fs.mkdir(path.dirname(outputPath), { recursive: true });
 		await fs.writeFile(outputPath, bytes);
 
 		output(
 			{
-				sha256: argv.sha256,
+				sha256,
 				output: path.relative(process.cwd(), outputPath),
 				size_bytes: bytes.byteLength,
 				content_type: contentType,
@@ -163,28 +170,34 @@ const getCommand = cmd({
 
 // Removes the cloud object only; local files are yours to manage.
 const rmCommand = cmd({
-	command: 'rm <sha256>',
+	command: 'rm <blob>',
 	describe:
 		'Delete a blob from the store by content address; every URL citing it breaks forever (idempotent)',
 	builder: (yargs) =>
 		yargs
-			.positional('sha256', {
+			.positional('blob', {
 				type: 'string',
 				demandOption: true,
-				describe: 'The lowercase-hex sha256 content address',
+				describe: 'A lowercase-hex sha256 content address, or a blob URL',
 			})
 			.options(formatOptions)
 			.strict(),
 	handler: async (argv) => {
+		const { data: sha256, error: parseError } = parseSha256(argv.blob);
+		if (parseError !== null) {
+			fail(parseError);
+			return;
+		}
+
 		const epicenter = await connectCloud();
 		if (!epicenter) return;
 
-		const { error } = await epicenter.blobs.delete(argv.sha256);
+		const { error } = await epicenter.blobs.delete(sha256);
 		if (error !== null) {
 			fail(error.message, { code: 2 });
 			return;
 		}
-		output({ sha256: argv.sha256, deleted: true }, { format: argv.format });
+		output({ sha256, deleted: true }, { format: argv.format });
 	},
 });
 
@@ -225,6 +238,21 @@ async function connectCloud(): Promise<EpicenterClient | null> {
 		fetch: (input, init) => auth.fetch(input, init),
 		ownerId: auth.state.ownerId,
 	});
+}
+
+/**
+ * Accept a bare content address or a pasted blob URL and return the
+ * lowercase-hex sha256. The URL form matches the read-URL shape
+ * (`.../blobs/<sha256>`), so a citation can be pasted back verbatim to `get`
+ * or `rm` without extracting the hash by hand.
+ */
+function parseSha256(input: string): Result<string, string> {
+	if (/^[a-f0-9]{64}$/.test(input)) return Ok(input);
+	const fromUrl = input.match(/\/blobs\/([a-f0-9]{64})(?:[/?#]|$)/);
+	if (fromUrl?.[1]) return Ok(fromUrl[1]);
+	return Err(
+		`expected a 64-character lowercase-hex sha256 or a blob URL containing one, got: ${input}`,
+	);
 }
 
 /**

--- a/packages/cli/src/commands/blobs.ts
+++ b/packages/cli/src/commands/blobs.ts
@@ -54,7 +54,7 @@ const addCommand = cmd({
 				type: 'string',
 				choices: ['json', 'jsonl', 'plain'] as const,
 				describe:
-					"Output format (default: json; 'plain' prints the bare URL)",
+					"Output format (default: json, auto-pretty for TTY; 'plain' prints the bare URL)",
 			})
 			.strict(),
 	handler: async (argv) => {

--- a/packages/cli/src/commands/blobs.ts
+++ b/packages/cli/src/commands/blobs.ts
@@ -48,7 +48,14 @@ const addCommand = cmd({
 				type: 'string',
 				describe: 'Override the content type (else inferred from the source)',
 			})
-			.options(formatOptions)
+			// The shared json/jsonl pair plus a plain mode: the bare URL on stdout,
+			// so `$(epicenter blobs add x.png)` drops straight into a document.
+			.option('format', {
+				type: 'string',
+				choices: ['json', 'jsonl', 'plain'] as const,
+				describe:
+					"Output format (default: json; 'plain' prints the bare URL)",
+			})
 			.strict(),
 	handler: async (argv) => {
 		const epicenter = await connectCloud();
@@ -74,6 +81,10 @@ const addCommand = cmd({
 			return;
 		}
 
+		if (argv.format === 'plain') {
+			console.log(result.url);
+			return;
+		}
 		output(
 			{ sha256: result.sha256, url: result.url, duplicate: result.duplicate },
 			{ format: argv.format },

--- a/packages/cli/src/commands/blobs.ts
+++ b/packages/cli/src/commands/blobs.ts
@@ -26,7 +26,8 @@ import { Err, Ok, type Result, tryAsync } from 'wellcrafted/result';
 import { cmd } from '../util/cmd.js';
 import { fail, formatOptions, output } from '../util/format-output.js';
 
-/** A source is fetched when it looks like an http(s) URL, else read from disk. */
+/** An `add` source that looks like an http(s) URL is handed to the SDK to
+ * fetch; anything else is read from disk. */
 const HTTP_URL = /^https?:\/\//i;
 
 const addCommand = cmd({
@@ -49,21 +50,20 @@ const addCommand = cmd({
 		const epicenter = await connectCloud();
 		if (!epicenter) return;
 
-		// Hold the bytes locally so we hand the SDK a Blob (no second fetch of a
-		// URL we already downloaded).
-		const { data: resolved, error: resolveError } = await resolveSource(
-			argv.source,
-			argv.contentType,
-		);
-		if (resolveError !== null) {
-			fail(resolveError);
+		// A URL source goes to the SDK as-is: it fetches the bytes once and takes
+		// the content type from the response. A local file is read here and typed
+		// by its extension; `--content-type` overrides either.
+		const { data: source, error: readError } = HTTP_URL.test(argv.source)
+			? Ok(argv.source)
+			: await readLocalFile(argv.source);
+		if (readError !== null) {
+			fail(readError);
 			return;
 		}
-		const { bytes, contentType } = resolved;
 
 		const { data: result, error: uploadError } = await epicenter.blobs.add(
-			new Blob([new Uint8Array(bytes)], { type: contentType }),
-			{ contentType },
+			source,
+			{ contentType: argv.contentType },
 		);
 		if (uploadError !== null) {
 			fail(uploadError.message, { code: 2 });
@@ -154,7 +154,7 @@ const getCommand = cmd({
 
 		// The store enforces the hash on write, but a download can still be
 		// truncated mid-flight; verify before we trust the bytes on disk.
-		const actual = sha256Of(bytes);
+		const actual = createHash('sha256').update(bytes).digest('hex');
 		if (actual !== argv.sha256) {
 			fail(
 				`downloaded bytes do not match their content address: expected ${argv.sha256}, got ${actual}`,
@@ -177,7 +177,7 @@ const getCommand = cmd({
 		output(
 			{
 				sha256: argv.sha256,
-				output: rel(outputPath),
+				output: path.relative(process.cwd(), outputPath),
 				size_bytes: bytes.byteLength,
 				content_type: contentType,
 			},
@@ -225,40 +225,12 @@ async function connectCloud(): Promise<EpicenterClient | null> {
 	});
 }
 
-/** The bytes to upload plus the content type that rides with them. */
-type ResolvedSource = {
-	bytes: Buffer;
-	contentType: string;
-};
-
 /**
- * Read a source into bytes. An http(s) URL is downloaded (content type from the
- * response); a local path is read (content type inferred from the extension via
- * `mime`). The error channel is a ready-to-print message so the handler has one
- * failure path.
+ * Read a local file into a Blob typed by its extension (via `mime`; the SDK
+ * defaults an untyped Blob to `application/octet-stream`). The error channel
+ * is a ready-to-print message so the handler has one failure path.
  */
-async function resolveSource(
-	source: string,
-	contentTypeOverride: string | undefined,
-): Promise<Result<ResolvedSource, string>> {
-	if (HTTP_URL.test(source)) {
-		const { data: res, error } = await tryAsync({
-			try: () => fetch(source),
-			catch: (cause) =>
-				Err(`could not fetch ${source}: ${extractErrorMessage(cause)}`),
-		});
-		if (error !== null) return Err(error);
-		if (!res.ok) return Err(`could not fetch ${source}: ${res.status}`);
-		const bytes = Buffer.from(await res.arrayBuffer());
-		return Ok({
-			bytes,
-			contentType:
-				contentTypeOverride ??
-				res.headers.get('content-type') ??
-				'application/octet-stream',
-		});
-	}
-
+async function readLocalFile(source: string): Promise<Result<Blob, string>> {
 	const localPath = path.resolve(source);
 	const { data: bytes, error } = await tryAsync({
 		try: () => fs.readFile(localPath),
@@ -266,21 +238,7 @@ async function resolveSource(
 			Err(`could not read ${source}: ${extractErrorMessage(cause)}`),
 	});
 	if (error !== null) return Err(error);
-	return Ok({
-		bytes,
-		contentType:
-			contentTypeOverride ??
-			mime.getType(localPath) ??
-			'application/octet-stream',
-	});
-}
-
-/** Lowercase-hex sha256 of bytes, to verify a download against its address. */
-function sha256Of(bytes: Buffer): string {
-	return createHash('sha256').update(bytes).digest('hex');
-}
-
-/** A path relative to the cwd, for terse output. */
-function rel(p: string): string {
-	return path.relative(process.cwd(), p);
+	return Ok(
+		new Blob([new Uint8Array(bytes)], { type: mime.getType(localPath) ?? '' }),
+	);
 }

--- a/packages/cli/src/commands/blobs.ts
+++ b/packages/cli/src/commands/blobs.ts
@@ -13,6 +13,9 @@
  * auth client (the persisted OAuth cell, or a configured instance token for a
  * self-hosted star); none route through the local daemon, unlike `run`. See
  * `docs/adr/0091-blobs-trade-a-file-for-a-durable-content-addressed-url-documents-are-the-only-manifest.md`.
+ *
+ * Exit codes: 1 for a local problem (auth, reading a source file), 2 when the
+ * cloud round-trip itself fails.
  */
 
 import { createHash } from 'node:crypto';
@@ -95,34 +98,6 @@ const lsCommand = cmd({
 	},
 });
 
-const rmCommand = cmd({
-	command: 'rm <sha256>',
-	// Removes the cloud object only; local files are yours to manage. Every
-	// document URL citing this hash 404s from now on.
-	describe:
-		'Delete a blob from the store by content address; every URL citing it breaks forever (idempotent)',
-	builder: (yargs) =>
-		yargs
-			.positional('sha256', {
-				type: 'string',
-				demandOption: true,
-				describe: 'The lowercase-hex sha256 content address',
-			})
-			.options(formatOptions)
-			.strict(),
-	handler: async (argv) => {
-		const epicenter = await connectCloud();
-		if (!epicenter) return;
-
-		const { error } = await epicenter.blobs.delete(argv.sha256);
-		if (error !== null) {
-			fail(error.message, { code: 2 });
-			return;
-		}
-		output({ sha256: argv.sha256, deleted: true }, { format: argv.format });
-	},
-});
-
 const getCommand = cmd({
 	command: 'get <sha256>',
 	describe: 'Download a blob by content address and write it to a file',
@@ -183,6 +158,33 @@ const getCommand = cmd({
 			},
 			{ format: argv.format },
 		);
+	},
+});
+
+// Removes the cloud object only; local files are yours to manage.
+const rmCommand = cmd({
+	command: 'rm <sha256>',
+	describe:
+		'Delete a blob from the store by content address; every URL citing it breaks forever (idempotent)',
+	builder: (yargs) =>
+		yargs
+			.positional('sha256', {
+				type: 'string',
+				demandOption: true,
+				describe: 'The lowercase-hex sha256 content address',
+			})
+			.options(formatOptions)
+			.strict(),
+	handler: async (argv) => {
+		const epicenter = await connectCloud();
+		if (!epicenter) return;
+
+		const { error } = await epicenter.blobs.delete(argv.sha256);
+		if (error !== null) {
+			fail(error.message, { code: 2 });
+			return;
+		}
+		output({ sha256: argv.sha256, deleted: true }, { format: argv.format });
 	},
 });
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -212,9 +212,12 @@ export function createEpicenterClient(opts: EpicenterClientOptions) {
 					});
 				}
 				bytes = await source.arrayBuffer();
+				// `||`, matching the Blob branch below: an empty-string content type
+				// (an override of '' or a bare header) falls through to the default
+				// instead of being pinned into the stored object verbatim.
 				contentType =
-					params.contentType ??
-					source.headers.get('content-type') ??
+					params.contentType ||
+					source.headers.get('content-type') ||
 					'application/octet-stream';
 			} else {
 				bytes = await fileOrUrl.arrayBuffer();

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -87,15 +87,12 @@ export type AddBlobResult = {
  * headers the client must echo verbatim (`upload`). Internal to `blobs.add`.
  */
 type BlobTicket =
-	| { status: 'duplicate'; sha256: string; key: string; url: string }
+	| { status: 'duplicate'; url: string }
 	| {
 			status: 'upload';
-			sha256: string;
-			key: string;
 			url: string;
 			uploadUrl: string;
 			requiredHeaders: Record<string, string>;
-			expiresInSeconds: number;
 	  };
 
 /** Failure modes of the Result-returning client surfaces (`blobs.*`). */

--- a/packages/constants/src/blob-errors.ts
+++ b/packages/constants/src/blob-errors.ts
@@ -9,9 +9,9 @@ import { defineErrors, type InferErrors } from 'wellcrafted/error';
  * Worker decides at ticket-mint and read time. See
  * ADR-0089 (the blob store is a presigned-S3 kernel and the bucket is its only index).
  *
- * Mirrors `AssetError`'s contract: defined once in the shared constants
- * package so the server runtime and any blob client SDK reference the same
- * discriminated union; the serialized envelope is `wellcrafted`'s
+ * Defined once in the shared constants package so the server runtime and any
+ * blob client SDK reference the same discriminated union; the serialized
+ * envelope is `wellcrafted`'s
  * `{ data: null, error: { name, message, ...fields } }`; each variant bakes
  * in its own HTTP `status`.
  *

--- a/packages/server/src/routes/blobs.ts
+++ b/packages/server/src/routes/blobs.ts
@@ -167,7 +167,7 @@ const blobsApp = new Hono<BlobEnv>()
 			// upload is a no-op. Content addressing makes this safe and cheap (one
 			// HEAD).
 			if (await c.var.blobStore.exists(key)) {
-				return c.json({ status: 'duplicate' as const, sha256, key, url });
+				return c.json({ status: 'duplicate' as const, url });
 			}
 
 			const { url: uploadUrl, requiredHeaders } =
@@ -178,14 +178,15 @@ const blobsApp = new Hono<BlobEnv>()
 					expiresInSeconds: PUT_TTL_SECONDS,
 				});
 
+			// The ticket carries only what the uploader acts on: the read URL (which
+			// ends in the sha256 the caller sent), the presigned PUT, and the signed
+			// headers to echo. The PUT's TTL rides inside `uploadUrl` as the standard
+			// `X-Amz-Expires` query param.
 			return c.json({
 				status: 'upload' as const,
-				sha256,
-				key,
 				url,
 				uploadUrl,
 				requiredHeaders,
-				expiresInSeconds: PUT_TTL_SECONDS,
 			});
 		},
 	)

--- a/specs/20260701T150659-blobs-are-a-url-machine.md
+++ b/specs/20260701T150659-blobs-are-a-url-machine.md
@@ -137,12 +137,21 @@ The middle row has an honest catch: v1 blobs are private, so a blob URL resolves
 
 **Before** (`packages/cli/src/commands/blobs.ts:101-151`): after upload, ~50 lines compute `blobPath`, guard it against escaping the root, write bytes to disk, load and upsert the manifest, and print five fields including `path` and `manifest`.
 
-**After**:
+**After** (as landed; the collapse pass then went one step further and hands a
+URL source to the SDK as a string, so the CLI only builds a Blob for local
+files):
 
 ```ts
+const { data: source, error: readError } = HTTP_URL.test(argv.source)
+	? Ok(argv.source)
+	: await readLocalFile(argv.source);
+if (readError !== null) {
+	fail(readError);
+	return;
+}
 const { data: result, error: uploadError } = await epicenter.blobs.add(
-	new Blob([new Uint8Array(bytes)], { type: contentType }),
-	{ contentType },
+	source,
+	{ contentType: argv.contentType },
 );
 if (uploadError !== null) {
 	fail(uploadError.message, { code: 2 });

--- a/specs/20260701T150659-blobs-are-a-url-machine.md
+++ b/specs/20260701T150659-blobs-are-a-url-machine.md
@@ -179,8 +179,8 @@ output(
 
 ### Phase 2: agent ergonomics
 
-- [ ] **2.1** `get` and `rm` accept a full blob URL and extract the hash (regex on `/blobs/([a-f0-9]{64})`).
-- [ ] **2.2** Plain (non-JSON) `add` output prints the URL alone on stdout, so `$(epicenter blobs add x.png)` composes.
+- [x] **2.1** `get` and `rm` accept a full blob URL and extract the hash (regex on `/blobs/([a-f0-9]{64})`).
+- [x] **2.2** Plain (non-JSON) `add` output prints the URL alone on stdout, so `$(epicenter blobs add x.png)` composes (`--format plain`).
 
 ### Phase 3: trigger-gated, not scheduled
 


### PR DESCRIPTION
PR #2264 collapsed `epicenter blobs` to four store verbs. This is the collapse pass over the surface it left behind: every boundary in the blob path was probed by fresh-context reviewers, the ones that failed to defend themselves were deleted, and the spec's Phase 2 ergonomics landed on the cleaned surface.

## The ticket carries only what the uploader acts on

The upload-ticket response sent three fields no consumer reads. `key` is reconstructable from the ownerId in the URL and the sha256 in the body, and returning it invites clients to touch raw bucket keys the presigned design exists to hide. `expiresInSeconds` duplicates the `X-Amz-Expires` query param already inside `uploadUrl`. The `sha256` echo repeats the request body and the trailing segment of `url`.

```jsonc
// Before
{ "status": "upload", "sha256": "...", "key": "owners/.../blobs/...", "url": "...",
  "uploadUrl": "...", "requiredHeaders": { ... }, "expiresInSeconds": 300 }

// After
{ "status": "upload", "url": "...", "uploadUrl": "...", "requiredHeaders": { ... } }
```

Raw-wire consumers that read the dropped fields would break; none exist (client, CLI, smoke script, and tests were all traced). The surface shipped days ago in #2264.

## The CLI stops re-implementing the SDK's URL fetch

`blobs add <url>` pre-fetched the URL into a local buffer behind a comment claiming it avoided "a second fetch of a URL we already downloaded". There is no second fetch under either design; the comment was a fossil of the deleted manifest era, when `add` wrote downloaded bytes to disk. The URL branch of `resolveSource` duplicated `client.blobs.add`'s own fetch and content-type fallback line for line, and copied the bytes three times where the SDK path copies once.

```ts
// Before: fetch here, buffer, wrap, hand the SDK a Blob
const { data: resolved } = await resolveSource(argv.source, argv.contentType);
await epicenter.blobs.add(new Blob([...], { type: resolved.contentType }), { contentType });

// After: the SDK already accepts a URL string and fetches it once
const { data: source } = HTTP_URL.test(argv.source)
	? Ok(argv.source)
	: await readLocalFile(argv.source);
await epicenter.blobs.add(source, { contentType: argv.contentType });
```

A URL-fetch failure now exits 2 instead of 1, matching the file's convention (1 for local problems, 2 for network operations). One real client fix came along for the ride: `add`'s URL branch resolved the content type with `??` while the Blob branch used `||`, so an empty-string override was pinned verbatim into the stored object on one branch and fell through to `application/octet-stream` on the other. One operator now.

## Paste a citation back (spec Phase 2)

The read URL carries its own content address, so a citation copied out of a document is enough to act on:

```sh
epicenter blobs get "https://api.epicenter.so/api/owners/o/blobs/1caf81cd..."   # extracts the hash
epicenter blobs rm  "https://api.epicenter.so/api/owners/o/blobs/1caf81cd..."
epicenter blobs add --format plain talk.mp4    # bare URL on stdout: $(...) composes
```

`specs/20260701T150659-blobs-are-a-url-machine.md` Phase 2 boxes are checked; Phase 3 (public tier, gc) stays trigger-gated and untouched.

## Probed and deliberately left alone

- `client.blobs.get`'s hand-followed 302: the only caller with a genuinely different success predicate; folding redirect-following into the shared `request()` helper would be a mode discriminator consumed by one of four call sites.
- `connectCloud()` vs `up.ts`'s auth seam: both already call the single `resolveMachineAuthClient` choke point; what differs is lifecycle (one-shot round trip vs daemon-lifetime disposable).
- `apps/api/scripts/smoke.ts`: the runtime-parity instrument, not a blob test. It asserts raw wire shapes the SDK deliberately hides (302 + Location, ticket discriminant, 503 contract) and covers health/session/rooms the blob CLI never touches.
- Unifying `add`'s branches through `Response.blob()`: refuted by experiment. `Blob.type` diverges by runtime (Bun fabricates `;charset=utf-8` and preserves case; Node lowercases and empties invalid values), which would make the permanently-stored content type depend on which engine ran the upload.
- `requireBlobStore`, the `owner.ts` key helpers, and the S3 config struct: judged cohesive by the June grill; not reopened.

7 commits, 5 files, +132/-123 against main (the collapse commits are net negative; the two Phase 2 feature commits are additive by design).

## Changelog

- `epicenter blobs get` and `rm` now accept a pasted blob URL and extract the content address from it.
- `epicenter blobs add --format plain` prints the bare URL on stdout so `$(epicenter blobs add x.png)` composes.
- The blob upload-ticket response no longer includes `key`, `sha256`, or `expiresInSeconds`; act on `url`, `uploadUrl`, and `requiredHeaders`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785563568&installation_id=128463665&pr_number=2267&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2267&signature=a4a6dad15f770c4ab583ec6768527cb2fc66454b1085836d99b7f25f843869db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->