### PR TITLE
fix(vocab): guard account actions during dictation and wire the chat sign-in CTA

### DIFF
--- a/apps/vocab/src/routes/components/ConversationView.svelte
+++ b/apps/vocab/src/routes/components/ConversationView.svelte
@@ -6,6 +6,7 @@
 	import { Markdown } from '@epicenter/ui/markdown';
 	import { agentMessageText } from '@epicenter/workspace/agent';
 	import { pinyinRomanizer } from '$lib/romanize/pinyin';
+	import { auth } from '$platform/auth';
 	import { inferenceConnections } from '$lib/state/inference-connections.svelte';
 	import DictationButton from './DictationButton.svelte';
 
@@ -33,6 +34,7 @@
 		conversation={active}
 		connections={inferenceConnections}
 		placeholder="Ask something in English..."
+		onSignIn={() => void auth.startSignIn()}
 	>
 		{#snippet inputAccessory()}
 			<DictationButton disabled={isGenerating} onTranscript={appendTranscript} />

--- a/apps/vocab/src/routes/components/VocabSidebar.svelte
+++ b/apps/vocab/src/routes/components/VocabSidebar.svelte
@@ -8,6 +8,7 @@
 	import TrashIcon from '@lucide/svelte/icons/trash';
 	import { instanceSetting } from '$lib/instance';
 	import { auth } from '$platform/auth';
+	import { dictation } from '$lib/state/dictation.svelte';
 	import { vocab } from '$lib/vocab';
 
 	let {
@@ -33,6 +34,9 @@
 				{auth}
 				collaboration={vocab.collaboration}
 				syncNoun="conversations"
+				disabledReason={dictation.status !== 'idle'
+					? 'Finish dictating to change your account'
+					: undefined}
 				onForgetDevice={() => vocab.wipe()}
 				instanceConnect={{ appName: 'Vocab', setting: instanceSetting }}
 			/>


### PR DESCRIPTION
Two adversarial-review findings on #2268 that missed its merge window: the account popover now disables its page-reloading actions while a dictation is in flight (a reload cannot survive a MediaRecorder, so the guard lives at the source per the reload contract), and AgentChatThread gets onSignIn so the signed-out chat error banner's Sign In button actually renders now that vocab has a sign-in surface.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785564285&installation_id=128463665&pr_number=2270&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2270&signature=c35775ea3a04a415a85952fe5e648f0651225d8af8eede05e3b6757b6388fb6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->