### PR TITLE
refactor(tab-manager): boot into a working local doc, delete the sign-in gate

### DIFF
--- a/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
+++ b/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
@@ -1,20 +1,32 @@
 <script lang="ts">
+	import { SignInMigrationDialog } from '@epicenter/app-shell/sign-in-migration';
 	import { WorkspaceGate } from '@epicenter/app-shell/workspace-gate';
 	import * as Empty from '@epicenter/ui/empty';
 	import { Loading } from '@epicenter/ui/loading';
 	import { Toaster } from '@epicenter/ui/sonner';
 	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 	import { ModeWatcher } from 'mode-watcher';
+	import { onMount } from 'svelte';
 	import { tabManagerBoot } from '$lib/session.svelte';
 	import TabManagerApp from './TabManagerApp.svelte';
+
+	// The outer await is async `chrome.storage`, not auth (ADR-0088's
+	// tab-manager judgment point): once it resolves, the workspace bundle is
+	// never null, so the app renders unconditionally.
+	onMount(() => {
+		void tabManagerBoot.whenReady.then(() => {
+			// Signed-in only: prompt to migrate this device's local tabs and
+			// bookmarks into the account (no-op when signed out or when there is
+			// no local data). Fire and forget: `check()` owns its own
+			// once-per-boot guard.
+			void tabManagerBoot.signInMigration.check();
+		});
+	});
 </script>
 
 {#await tabManagerBoot.whenReady}
 	<Loading class="h-full" label="Loading tabs…" />
 {:then}
-	<!-- The outer await above is async `chrome.storage`, not auth (ADR-0088's
-	     tab-manager judgment point): once it resolves, the workspace bundle is
-	     never null, so the app renders unconditionally. -->
 	<WorkspaceGate
 		pending={tabManagerBoot.tabManager.whenReady}
 		onForgetDevice={() => tabManagerBoot.tabManager.wipe()}
@@ -22,6 +34,7 @@
 	>
 		<TabManagerApp />
 	</WorkspaceGate>
+	<SignInMigrationDialog migration={tabManagerBoot.signInMigration} />
 {:catch}
 	<Empty.Root class="h-full border-0">
 		<Empty.Media>

--- a/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
+++ b/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
@@ -1,40 +1,27 @@
 <script lang="ts">
-	import { SignedOutScreen } from '@epicenter/app-shell/instance-settings';
+	import { WorkspaceGate } from '@epicenter/app-shell/workspace-gate';
 	import * as Empty from '@epicenter/ui/empty';
 	import { Loading } from '@epicenter/ui/loading';
 	import { Toaster } from '@epicenter/ui/sonner';
 	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 	import { ModeWatcher } from 'mode-watcher';
-	import { tabManagerSession } from '$lib/session.svelte';
-	import SignedInApp from './SignedInApp.svelte';
+	import { tabManagerBoot } from '$lib/session.svelte';
+	import TabManagerApp from './TabManagerApp.svelte';
 </script>
 
-{#await tabManagerSession.whenReady}
+{#await tabManagerBoot.whenReady}
 	<Loading class="h-full" label="Loading tabs…" />
 {:then}
-	{#if tabManagerSession.current}
-		{#await tabManagerSession.current.idb.whenLoaded}
-			<Loading class="h-full" label="Loading tabs…" />
-		{:then}
-			<SignedInApp />
-		{:catch}
-			<Empty.Root class="h-full border-0">
-				<Empty.Media>
-					<TriangleAlertIcon class="size-8 text-muted-foreground" />
-				</Empty.Media>
-				<Empty.Title>Failed to load workspace</Empty.Title>
-				<Empty.Description> Try reopening the side panel. </Empty.Description>
-			</Empty.Root>
-		{/await}
-	{:else}
-		<SignedOutScreen
-			appName="Epicenter"
-			tagline="Sync your tabs across devices."
-			auth={tabManagerSession.auth}
-			setting={tabManagerSession.instanceSetting}
-			class="h-full bg-background"
-		/>
-	{/if}
+	<!-- The outer await above is async `chrome.storage`, not auth (ADR-0088's
+	     tab-manager judgment point): once it resolves, the workspace bundle is
+	     never null, so the app renders unconditionally. -->
+	<WorkspaceGate
+		pending={tabManagerBoot.tabManager.whenReady}
+		onForgetDevice={() => tabManagerBoot.tabManager.wipe()}
+		onSignOut={() => tabManagerBoot.auth.signOut()}
+	>
+		<TabManagerApp />
+	</WorkspaceGate>
 {:catch}
 	<Empty.Root class="h-full border-0">
 		<Empty.Media>

--- a/apps/tab-manager/src/entrypoints/sidepanel/TabManagerApp.svelte
+++ b/apps/tab-manager/src/entrypoints/sidepanel/TabManagerApp.svelte
@@ -22,11 +22,11 @@
 	import AiDrawer from '$lib/components/AiDrawer.svelte';
 	import { createCommandPaletteItems } from '$lib/components/command-palette-items';
 	import UnifiedTabList from '$lib/components/tabs/UnifiedTabList.svelte';
-	import { requireTabManager, tabManagerSession } from '$lib/session.svelte';
+	import { tabManagerBoot } from '$lib/session.svelte';
 	import { browserState } from '$lib/state/browser-state.svelte';
 
-	const tabManager = requireTabManager();
-	const auth = tabManagerSession.auth;
+	const tabManager = tabManagerBoot.tabManager;
+	const auth = tabManagerBoot.auth;
 	const items = createCommandPaletteItems(tabManager.state.savedTabs);
 	let searchInputRef = $state<HTMLInputElement | null>(null);
 	let commandPaletteOpen = $state(false);
@@ -205,6 +205,7 @@
 					collaboration={tabManager.collaboration}
 					syncNoun="tabs"
 					onForgetDevice={() => tabManager.wipe()}
+					instanceConnect={{ appName: 'Epicenter', setting: tabManagerBoot.instanceSetting }}
 				/>
 			</div>
 		</header>

--- a/apps/tab-manager/src/lib/components/chat/AiChat.svelte
+++ b/apps/tab-manager/src/lib/components/chat/AiChat.svelte
@@ -3,10 +3,10 @@
 		AgentChatThread,
 		ConversationSwitcher,
 	} from '@epicenter/app-shell/agent-chat';
-	import { requireTabManager } from '$lib/session.svelte';
+	import { tabManagerBoot } from '$lib/session.svelte';
 	import { inferenceConnections } from '$lib/state/inference-connections.svelte';
 
-	const tabManager = requireTabManager();
+	const tabManager = tabManagerBoot.tabManager;
 	const aiChat = $derived(tabManager.state.aiChat);
 	const active = $derived(aiChat.active);
 

--- a/apps/tab-manager/src/lib/components/chat/AiChat.svelte
+++ b/apps/tab-manager/src/lib/components/chat/AiChat.svelte
@@ -7,6 +7,7 @@
 	import { inferenceConnections } from '$lib/state/inference-connections.svelte';
 
 	const tabManager = tabManagerBoot.tabManager;
+	const auth = tabManagerBoot.auth;
 	const aiChat = $derived(tabManager.state.aiChat);
 	const active = $derived(aiChat.active);
 
@@ -40,6 +41,7 @@
 			connections={inferenceConnections}
 			resolveToolTitle={(toolName) => actionTitles[toolName]?.title}
 			onAlwaysAllow={alwaysAllowPendingToolCall}
+			onSignIn={() => auth.startSignIn()}
 		/>
 	{/if}
 </div>

--- a/apps/tab-manager/src/lib/components/chat/TrustSettings.svelte
+++ b/apps/tab-manager/src/lib/components/chat/TrustSettings.svelte
@@ -3,9 +3,9 @@
 	import * as Popover from '@epicenter/ui/popover';
 	import { Switch } from '@epicenter/ui/switch';
 	import SettingsIcon from '@lucide/svelte/icons/settings';
-	import { requireTabManager } from '$lib/session.svelte';
+	import { tabManagerBoot } from '$lib/session.svelte';
 
-	const tabManager = requireTabManager();
+	const tabManager = tabManagerBoot.tabManager;
 	const trustedTools = $derived(tabManager.state.toolTrust.trustedToolNames);
 	const actionTitles = $derived(
 		tabManager.actions as Record<string, { title?: string }>,

--- a/apps/tab-manager/src/lib/components/tabs/TabItem.svelte
+++ b/apps/tab-manager/src/lib/components/tabs/TabItem.svelte
@@ -13,7 +13,7 @@
 	import Volume2Icon from '@lucide/svelte/icons/volume-2';
 	import VolumeXIcon from '@lucide/svelte/icons/volume-x';
 	import XIcon from '@lucide/svelte/icons/x';
-	import { requireTabManager } from '$lib/session.svelte';
+	import { tabManagerBoot } from '$lib/session.svelte';
 	import {
 		type BrowserTab,
 		browserState,
@@ -21,7 +21,7 @@
 	import { getDomain } from '$lib/utils/format';
 	import TabFavicon from './TabFavicon.svelte';
 
-	const tabManager = requireTabManager();
+	const tabManager = tabManagerBoot.tabManager;
 	let { tab }: { tab: BrowserTab } = $props();
 
 	const domain = $derived(tab.url ? getDomain(tab.url) : '');

--- a/apps/tab-manager/src/lib/components/tabs/UnifiedTabList.svelte
+++ b/apps/tab-manager/src/lib/components/tabs/UnifiedTabList.svelte
@@ -13,13 +13,13 @@
 	import SearchIcon from '@lucide/svelte/icons/search';
 	import Trash2Icon from '@lucide/svelte/icons/trash-2';
 	import { VList } from 'virtua/svelte';
-	import { requireTabManager } from '$lib/session.svelte';
+	import { tabManagerBoot } from '$lib/session.svelte';
 	import { browserState } from '$lib/state/browser-state.svelte';
 	import { getDomain, getRelativeTime } from '$lib/utils/format';
 	import TabFavicon from './TabFavicon.svelte';
 	import TabItem from './TabItem.svelte';
 
-	const tabManager = requireTabManager();
+	const tabManager = tabManagerBoot.tabManager;
 </script>
 
 {#if tabManager.state.unifiedView.flatItems.length === 0}

--- a/apps/tab-manager/src/lib/migration/sign-in-migration.ts
+++ b/apps/tab-manager/src/lib/migration/sign-in-migration.ts
@@ -1,0 +1,106 @@
+/**
+ * Tab Manager's wiring of the shared first-sign-in migration
+ * (`@epicenter/app-shell/sign-in-migration`): the local-source opener and the
+ * words are app-side; the probe / Add / Delete / Keep mechanics, including
+ * the crash-safe conversation-message phases, are the kit's (`childDocs`).
+ *
+ * Unlike Honeycrisp's static singleton, this is a factory
+ * (`createTabManagerSignInMigration`), not a module-level `export const`:
+ * the auth client and the live workspace bundle are both deferred-init
+ * behind async `chrome.storage.local` (see `$lib/session.svelte.ts`), so
+ * there is no synchronous `auth` or `tabManager` to close over at module
+ * load. `session.svelte.ts` calls this once, right after it builds the
+ * workspace bundle.
+ */
+
+import { createSignInMigration } from '@epicenter/app-shell/sign-in-migration';
+import type { AuthClient } from '@epicenter/auth';
+import { attachIndexedDb } from '@epicenter/workspace';
+import type { TabManagerBundle } from '$lib/session.svelte';
+import { tabManagerWorkspace } from '$lib/workspace/definition';
+
+/**
+ * Open a throwaway handle to the signed-out plaintext local doc (the
+ * migration source). This opens the same `epicenter-tab-manager` IndexedDB
+ * the signed-out extension uses; the owner doc's storage is partitioned, so
+ * this never collides with the active synced doc. `dispose()` tears down the
+ * connection without deleting data (`clearLocal` does the deletion).
+ *
+ * Only the rows a person actually creates are staged for copy: `devices`
+ * self-registers fresh in whichever doc is active (same node id either way)
+ * and `toolTrust` is a small local preference, so both are left out of the
+ * copy set. Add still clears the WHOLE bare root afterward (`idb.clearLocal`
+ * has no per-table granularity), so any local device or tool-trust rows are
+ * dropped too; that is the intended "local device state does not follow
+ * you" behavior, not a leak.
+ */
+function openLocalSource() {
+	const workspace = tabManagerWorkspace.create();
+	const idb = attachIndexedDb(workspace.ydoc);
+	return {
+		tables: {
+			savedTabs: workspace.tables.savedTabs,
+			bookmarks: workspace.tables.bookmarks,
+			conversations: workspace.tables.conversations,
+		},
+		whenLoaded: idb.whenLoaded,
+		clearLocal: idb.clearLocal,
+		dispose: () => workspace.ydoc.destroy(),
+	};
+}
+
+/**
+ * Oxford-comma join for the dialog summary line: `["3 tabs"]` -> "3 tabs",
+ * `["3 tabs", "2 bookmarks"]` -> "3 tabs and 2 bookmarks",
+ * `["3 tabs", "2 bookmarks", "1 conversation"]` -> "3 tabs, 2 bookmarks, and
+ * 1 conversation".
+ */
+function joinPhrase(parts: string[]): string {
+	if (parts.length <= 1) return parts[0] ?? 'data';
+	if (parts.length === 2) return parts.join(' and ');
+	return `${parts.slice(0, -1).join(', ')}, and ${parts.at(-1)}`;
+}
+
+/**
+ * Human phrase for what is staged locally, e.g. "3 tabs", "2 bookmarks", or
+ * "3 tabs, 2 bookmarks, and 1 conversation".
+ */
+function describeLocalContents(counts: Record<string, number>): string {
+	const parts: string[] = [];
+	const tabs = counts.savedTabs ?? 0;
+	if (tabs > 0) parts.push(`${tabs} tab${tabs === 1 ? '' : 's'}`);
+	const bookmarks = counts.bookmarks ?? 0;
+	if (bookmarks > 0)
+		parts.push(`${bookmarks} bookmark${bookmarks === 1 ? '' : 's'}`);
+	const conversations = counts.conversations ?? 0;
+	if (conversations > 0)
+		parts.push(
+			`${conversations} conversation${conversations === 1 ? '' : 's'}`,
+		);
+	return parts.length > 0 ? joinPhrase(parts) : 'data';
+}
+
+/**
+ * Build the sign-in migration state for one boot. `session.svelte.ts` calls
+ * this exactly once, right after `auth` and `tabManager` both exist.
+ */
+export function createTabManagerSignInMigration(
+	auth: AuthClient,
+	tabManager: TabManagerBundle,
+) {
+	return createSignInMigration({
+		auth,
+		openLocalSource,
+		target: tabManager,
+		describe: describeLocalContents,
+		errorNoun: 'tabs and bookmarks',
+		childDocs: {
+			// A conversation's turns live in its own per-row Y.Doc; the kit
+			// merges these into owner storage before the row copy.
+			guids: (tables) =>
+				tables.conversations
+					.scan()
+					.rows.map((row) => tables.conversations.docs.messages.guid(row.id)),
+		},
+	});
+}

--- a/apps/tab-manager/src/lib/session.svelte.ts
+++ b/apps/tab-manager/src/lib/session.svelte.ts
@@ -36,6 +36,7 @@ import {
 	TAB_MANAGER_SYSTEM_PROMPT,
 } from './chat/system-prompt';
 import { createDeviceProfile, registerDevice } from './device';
+import { createTabManagerSignInMigration } from './migration/sign-in-migration';
 import {
 	instanceSettingPromise,
 	oauthLauncher,
@@ -63,6 +64,9 @@ export type TabManagerBundle = ReturnType<typeof buildTabManager>;
 let authClient: SyncAuthClient | undefined;
 let instanceSettingValue: InstanceSetting | undefined;
 let bundle: TabManagerBundle | undefined;
+let signInMigrationValue:
+	| ReturnType<typeof createTabManagerSignInMigration>
+	| undefined;
 
 const whenReady = Promise.all([
 	persistedAuthStoragePromise,
@@ -80,6 +84,7 @@ const whenReady = Promise.all([
 	authClient = auth;
 	instanceSettingValue = instanceSetting;
 	bundle = buildTabManager(auth, profile);
+	signInMigrationValue = createTabManagerSignInMigration(auth, bundle);
 	// Option A (ADR-0088): the doc is picked once at boot (the preset branch
 	// inside `openTabManagerBrowser`); an owner-identity change reloads the
 	// sidepanel document so the next boot rebuilds the right doc.
@@ -167,6 +172,16 @@ export const tabManagerBoot = {
 			);
 		}
 		return bundle;
+	},
+	get signInMigration(): ReturnType<typeof createTabManagerSignInMigration> {
+		if (!signInMigrationValue) {
+			throw new Error(
+				'[tab-manager] tabManagerBoot.signInMigration read before storage ' +
+					'readiness. Components must mount under ' +
+					'`{#await tabManagerBoot.whenReady}`.',
+			);
+		}
+		return signInMigrationValue;
 	},
 	whenReady,
 	[Symbol.dispose]() {

--- a/apps/tab-manager/src/lib/session.svelte.ts
+++ b/apps/tab-manager/src/lib/session.svelte.ts
@@ -1,7 +1,31 @@
+/**
+ * Boot-time Tab Manager client (ADR-0088: sign-in is an enhancement, never a
+ * door).
+ *
+ * `chrome.storage.local` is async, so unlike Honeycrisp's synchronous
+ * top-level singleton, everything here is deferred-init: the reactive auth
+ * client, the workspace bundle (`openTabManagerBrowser`'s preset branch, see
+ * `tab-manager/extension.ts`), and the composed app state (savedTabs,
+ * bookmarks, toolTrust, unifiedView, aiChat) are all built exactly once,
+ * inside `whenReady`, after the persisted auth cell, the instance setting,
+ * and the device profile have resolved. `reloadOnOwnerChange` is wired the
+ * moment the auth client exists, so an identity change reloads the sidepanel
+ * document and the next boot re-runs the preset branch.
+ *
+ * The workspace is never `null` once ready: there is no `require*()`
+ * accessor. `App.svelte` mounts its whole tree under
+ * `{#await tabManagerBoot.whenReady}`, so by the time a descendant reads
+ * `tabManagerBoot.tabManager` the bundle is guaranteed to exist; the getter's
+ * throw is a boot-order guard, not a signed-out branch.
+ */
+
 import { createAgentChatState } from '@epicenter/app-shell/agent-chat';
 import type { InstanceSetting, SyncAuthClient } from '@epicenter/auth';
 import { EPICENTER_TAB_MANAGER_OAUTH_CLIENT_ID } from '@epicenter/constants/oauth-clients';
-import { createAppAuthClient, createSession } from '@epicenter/svelte/auth';
+import {
+	createAppAuthClient,
+	reloadOnOwnerChange,
+} from '@epicenter/svelte/auth';
 import {
 	createLocalToolCatalog,
 	defaultApprovalDecision,
@@ -24,20 +48,21 @@ import { createToolTrustState } from './state/tool-trust.svelte';
 import { createUnifiedViewState } from './state/unified-view-state.svelte';
 import { openTabManagerBrowser } from './tab-manager/extension';
 
-/**
- * Deferred-init values: set exactly once when `persistedAuthStoragePromise`
- * AND the peer identity have resolved. They are plain `let`, not `$state`,
- * because nothing needs the assignment itself to drive reactivity; consumers
- * await `tabManagerSession.whenReady` before reading.
- *
- * Once storage and peer are ready, `session` is the synchronous
- * `createSession()` return value. Its `current` getter is `null` when signed
- * out and the augmented tab-manager binding (binding fields + `state`) when
- * signed in.
- */
+/** The composed app state layered onto the connected workspace bundle. */
+type TabManagerState = {
+	savedTabs: ReturnType<typeof createSavedTabState>;
+	bookmarks: ReturnType<typeof createBookmarkState>;
+	toolTrust: ReturnType<typeof createToolTrustState>;
+	unifiedView: ReturnType<typeof createUnifiedViewState>;
+	aiChat: ReturnType<typeof createAgentChatState>;
+};
+
+/** Everything a component reads once the boot promise resolves. */
+export type TabManagerBundle = ReturnType<typeof buildTabManager>;
+
 let authClient: SyncAuthClient | undefined;
 let instanceSettingValue: InstanceSetting | undefined;
-let session: ReturnType<typeof buildSession> | undefined;
+let bundle: TabManagerBundle | undefined;
 
 const whenReady = Promise.all([
 	persistedAuthStoragePromise,
@@ -54,67 +79,71 @@ const whenReady = Promise.all([
 	});
 	authClient = auth;
 	instanceSettingValue = instanceSetting;
-	session = buildSession(auth, profile);
+	bundle = buildTabManager(auth, profile);
+	// Option A (ADR-0088): the doc is picked once at boot (the preset branch
+	// inside `openTabManagerBrowser`); an owner-identity change reloads the
+	// sidepanel document so the next boot rebuilds the right doc.
+	reloadOnOwnerChange(auth);
 });
 
-function buildSession(
+function buildTabManager(
 	auth: SyncAuthClient,
 	profile: Awaited<ReturnType<typeof createDeviceProfile>>,
 ) {
-	return createSession({
-		auth,
-		build: (signedIn) => {
-			const tabManager = openTabManagerBrowser({
-				signedIn,
-				nodeId: profile.nodeId,
-			});
+	const tabManager = openTabManagerBrowser({ auth, nodeId: profile.nodeId });
 
-			const savedTabs = createSavedTabState(tabManager);
-			const bookmarks = createBookmarkState(tabManager);
-			const toolTrust = createToolTrustState(tabManager);
-			const unifiedView = createUnifiedViewState({ bookmarks, savedTabs });
-			// The shared chat registry (ADR-0047/0059) with tab-manager's variation
-			// injected: device-constraint + base prompts read per turn, its in-process
-			// browser actions as the tool surface, and the "Always Allow" trust set
-			// folded into the approval policy.
-			const aiChat = createAgentChatState({
-				table: tabManager.tables.conversations,
-				whenLoaded: tabManager.idb.whenLoaded,
-				connections: inferenceConnections,
-				agent: {
-					buildSystemPrompts: () => [
-						buildDeviceConstraints(tabManager.nodeId),
-						TAB_MANAGER_SYSTEM_PROMPT,
-					],
-					defaultModel: DEFAULT_MODEL,
-					toolCatalog: createLocalToolCatalog(tabManager.actions),
-					// A tool the user chose to "Always Allow" auto-approves; otherwise a
-					// query runs unattended and a mutation asks (ADR-0044).
-					decideApproval: (call, definition) =>
-						toolTrust.shouldAutoApprove(call.toolName)
-							? 'auto'
-							: defaultApprovalDecision(call, definition),
-				},
-			});
-			const state = { savedTabs, bookmarks, toolTrust, unifiedView, aiChat };
-
-			void tabManager.idb.whenLoaded.then(() =>
-				registerDevice(tabManager, profile.defaultName),
-			);
-
-			return {
-				...tabManager,
-				state,
-				[Symbol.dispose]() {
-					aiChat[Symbol.dispose]();
-					tabManager[Symbol.dispose]();
-				},
-			};
+	const savedTabs = createSavedTabState(tabManager);
+	const bookmarks = createBookmarkState(tabManager);
+	const toolTrust = createToolTrustState(tabManager);
+	const unifiedView = createUnifiedViewState({ bookmarks, savedTabs });
+	// The shared chat registry (ADR-0047/0059) with tab-manager's variation
+	// injected: device-constraint + base prompts read per turn, its in-process
+	// browser actions as the tool surface, and the "Always Allow" trust set
+	// folded into the approval policy.
+	const aiChat = createAgentChatState({
+		table: tabManager.tables.conversations,
+		whenLoaded: tabManager.idb.whenLoaded,
+		connections: inferenceConnections,
+		agent: {
+			buildSystemPrompts: () => [
+				buildDeviceConstraints(tabManager.nodeId),
+				TAB_MANAGER_SYSTEM_PROMPT,
+			],
+			defaultModel: DEFAULT_MODEL,
+			toolCatalog: createLocalToolCatalog(tabManager.actions),
+			// A tool the user chose to "Always Allow" auto-approves; otherwise a
+			// query runs unattended and a mutation asks (ADR-0044).
+			decideApproval: (call, definition) =>
+				toolTrust.shouldAutoApprove(call.toolName)
+					? 'auto'
+					: defaultApprovalDecision(call, definition),
 		},
 	});
+	const state: TabManagerState = {
+		savedTabs,
+		bookmarks,
+		toolTrust,
+		unifiedView,
+		aiChat,
+	};
+
+	void tabManager.idb.whenLoaded.then(() =>
+		registerDevice(tabManager, profile.defaultName),
+	);
+
+	return {
+		...tabManager,
+		state,
+		/** Resolves when local persistence has hydrated the root doc. */
+		whenReady: tabManager.idb.whenLoaded,
+		[Symbol.dispose]() {
+			aiChat[Symbol.dispose]();
+			tabManager[Symbol.dispose]();
+		},
+	};
 }
 
-export const tabManagerSession = {
+export const tabManagerBoot = {
 	get auth(): SyncAuthClient {
 		if (!authClient) {
 			throw new Error('[tab-manager] auth read before storage readiness.');
@@ -129,31 +158,23 @@ export const tabManagerSession = {
 		}
 		return instanceSettingValue;
 	},
-	get current() {
-		if (!session) {
+	get tabManager(): TabManagerBundle {
+		if (!bundle) {
 			throw new Error(
-				'[tab-manager] tabManagerSession.current read before storage readiness.',
+				'[tab-manager] tabManagerBoot.tabManager read before storage ' +
+					'readiness. Components must mount under ' +
+					'`{#await tabManagerBoot.whenReady}`.',
 			);
 		}
-		return session.current;
+		return bundle;
 	},
 	whenReady,
 	[Symbol.dispose]() {
-		session?.[Symbol.dispose]();
+		bundle?.[Symbol.dispose]();
 		authClient?.[Symbol.dispose]();
 	},
 };
 
 if (import.meta.hot) {
-	import.meta.hot.dispose(() => tabManagerSession[Symbol.dispose]());
-}
-
-export function requireTabManager() {
-	if (!session) {
-		throw new Error(
-			'[tab-manager] requireTabManager() called before storage readiness. ' +
-				'Components must mount under `{#await tabManagerSession.whenReady}`.',
-		);
-	}
-	return session.require();
+	import.meta.hot.dispose(() => tabManagerBoot[Symbol.dispose]());
 }

--- a/apps/tab-manager/src/lib/state/bookmark-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/bookmark-state.svelte.ts
@@ -3,7 +3,9 @@
  *
  * Read-only reactive layer backed by `fromTable()`: a stateless
  * `ReadonlyTableView` whose reads track the underlying CRDT table. All write
- * operations are delegated to workspace actions owned by the signed-in session.
+ * operations are delegated to workspace actions on the boot-time workspace
+ * bundle (ADR-0088: bookmarks exist on the local doc whether signed in or
+ * not; there is no signed-in-only gate here).
  *
  * The public API exposes a `$derived` sorted array (access pattern is
  * always "render the full sorted list") plus a URL lookup set for O(1)

--- a/apps/tab-manager/src/lib/state/inference-connections.svelte.ts
+++ b/apps/tab-manager/src/lib/state/inference-connections.svelte.ts
@@ -14,7 +14,7 @@ import { API_ROUTES } from '@epicenter/constants/api-routes';
 import { APP_URLS } from '@epicenter/constants/vite';
 import type { StorageItemKey } from '@wxt-dev/storage';
 import { APP_MODELS } from '$lib/chat/models';
-import { tabManagerSession } from '$lib/session.svelte';
+import { tabManagerBoot } from '$lib/session.svelte';
 import { createStorageState } from './storage-state.svelte';
 
 export const inferenceConnections = createInferenceConnections({
@@ -24,7 +24,7 @@ export const inferenceConnections = createInferenceConnections({
 		// The extension's auth client is deferred-init (it throws before storage
 		// readiness), so read it at turn time inside this closure, never at module
 		// load. The hosted transport is only resolved when a hosted turn generates.
-		fetch: (input, init) => tabManagerSession.auth.fetch(input, init),
+		fetch: (input, init) => tabManagerBoot.auth.fetch(input, init),
 		baseURL: API_ROUTES.ai.completions.baseUrl(APP_URLS.API),
 	},
 	persist: (key, schema, fallback) =>

--- a/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
@@ -3,7 +3,9 @@
  *
  * Read-only reactive layer backed by `fromTable()`: a stateless
  * `ReadonlyTableView` whose reads track the underlying CRDT table. All write
- * operations are delegated to workspace actions owned by the signed-in session.
+ * operations are delegated to workspace actions on the boot-time workspace
+ * bundle (ADR-0088: saved tabs exist on the local doc whether signed in or
+ * not; there is no signed-in-only gate here).
  *
  * The public API exposes a `$derived` sorted array since the access
  * pattern is always "render the full sorted list."

--- a/apps/tab-manager/src/lib/state/unified-view-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/unified-view-state.svelte.ts
@@ -2,9 +2,9 @@
  * Reactive unified view state for the side panel.
  *
  * Manages section expansion (open tabs, saved for later, bookmarks) and
- * derives a single flat item array from browser state plus the session-owned
- * saved tab and bookmark states. The flat array feeds a single VList that
- * renders all sections in one scrollable view.
+ * derives a single flat item array from browser state plus the saved tab and
+ * bookmark states built alongside it. The flat array feeds a single VList
+ * that renders all sections in one scrollable view.
  *
  * Section expand/collapse works identically to how window expand/collapse
  * already works in the original `FlatTabList`: a `SvelteSet` tracks expanded
@@ -64,8 +64,8 @@ export function createUnifiedViewState({
 	/**
 	 * Which windows are expanded within the open tabs section.
 	 *
-	 * Starts empty because the session creates this before browser state is
-	 * ready. The focused window is seeded once browser data is available.
+	 * Starts empty because boot creates this before browser state is ready.
+	 * The focused window is seeded once browser data is available.
 	 */
 	const expandedWindows = new SvelteSet<number>();
 

--- a/apps/tab-manager/src/lib/tab-manager/extension.ts
+++ b/apps/tab-manager/src/lib/tab-manager/extension.ts
@@ -1,12 +1,14 @@
 /**
- * Tab-manager browser composition.
+ * Tab-manager browser composition: the one boot branch (ADR-0088).
  *
- * Single source of truth for "how Tab Manager mounts in a browser extension."
- * `tabManagerWorkspace.connect()` is the browser preset: it builds the root
- * Y.Doc, attaches IndexedDB persistence and the relay sync transport, and wires
- * the per-row child-doc openers (`tables.conversations.docs.messages.open(id)`).
- * The `compose` callback wires tab and bookmark actions against the connected
- * tables, with Y.Doc transaction batching.
+ * Reads `auth.state` once and picks a preset: `connectLocal(compose)` signed
+ * out (bare guid-named IndexedDB, cross-tab channel, no relay) or
+ * `connect({ ...projectSignedIn(auth), nodeId }, compose)` signed in. Both
+ * presets take the SAME `compose` callback and return the same bundle shape
+ * (per-row conversation child-doc openers from `@epicenter/chat` included),
+ * so nothing downstream branches on auth again. `compose` wires tab and
+ * bookmark actions against the connected tables, with Y.Doc transaction
+ * batching.
  *
  * Live browser state (tabs, windows, tab groups) is NOT stored here. Chrome is
  * the sole authority for ephemeral browser state. See `browser-state.svelte.ts`.
@@ -15,9 +17,11 @@
  * tears down the root Y.Doc, which cascades to persistence and sync.
  */
 
+import type { SyncAuthClient } from '@epicenter/auth';
 import { InstantString } from '@epicenter/field';
-import type { SignedIn } from '@epicenter/svelte/auth';
+import { projectSignedIn } from '@epicenter/svelte/auth';
 import {
+	type ConnectedWorkspaceContext,
 	defineActions,
 	defineMutation,
 	defineQuery,
@@ -77,18 +81,24 @@ export type SaveCloseFailed = Extract<TabError, { name: 'SaveCloseFailed' }>;
 /**
  * Build the tab-manager binding. Synchronous: callers must resolve the
  * node id before invoking (the extension's node id comes from
- * `chrome.storage.local` via `createDeviceProfile()` in `device.ts`).
+ * `chrome.storage.local` via `createDeviceProfile()` in `device.ts`). Reads
+ * `auth.state` exactly once, at call time, to pick the preset branch.
  *
  * Consumers gate UI render on `tabManager.idb.whenLoaded`.
  */
 export function openTabManagerBrowser({
-	signedIn,
+	auth,
 	nodeId,
 }: {
-	signedIn: SignedIn;
+	auth: SyncAuthClient;
 	nodeId: NodeId;
 }) {
-	return tabManagerWorkspace.connect({ ...signedIn, nodeId }, (workspace) => {
+	function compose(
+		workspace: ConnectedWorkspaceContext<
+			typeof tabManagerWorkspace.tables,
+			typeof tabManagerWorkspace.kv
+		>,
+	) {
 		const { tables } = workspace;
 		const batch = (fn: () => void) => workspace.ydoc.transact(fn);
 		return {
@@ -471,7 +481,14 @@ export function openTabManagerBrowser({
 				}),
 			}),
 		};
-	});
+	}
+
+	return auth.state.status === 'signed-out'
+		? tabManagerWorkspace.connectLocal(compose)
+		: tabManagerWorkspace.connect(
+				{ ...projectSignedIn(auth), nodeId },
+				compose,
+			);
 }
 
 export type TabManagerBrowser = ReturnType<typeof openTabManagerBrowser>;


### PR DESCRIPTION
Tab Manager used to hard-gate its whole sidepanel behind a signed-in session: `App.svelte`'s inner `{#if tabManagerSession.current}` rendered `SignedOutScreen` for anyone without an account, and a Shape A `createSession` singleton (`requireTabManager()`) meant the workspace could be `null`. ADR-0088 says sign-in is an enhancement, never a door, and this is Wave 3.3 of `specs/20260701T151347-progressive-sign-in-collapse.md`: convert tab-manager to the boot-branch shape Honeycrisp (Wave 2) already proved, adapted for the one thing tab-manager has that Honeycrisp doesn't: async `chrome.storage` before anything (auth included) can even be constructed.

## Old shape vs new shape

```txt
before                                       after
entrypoints/sidepanel/App.svelte
  {#await session.whenReady}                   {#await tabManagerBoot.whenReady}
    Loading                                      Loading
  {:then}                                      {:then}
    {#if session.current}                        WorkspaceGate pending={tabManagerBoot.tabManager.whenReady}
      WorkspaceGate ... SignedInApp                 (auth-independent, gates on IDB hydration only)
    {:else}                                       SignInMigrationDialog
      SignedOutScreen                            {/await}
    {/if}
  {/await}

lib/session.svelte.ts                        lib/session.svelte.ts
  createSession(auth, build)                    no createSession; a deferred-init boot object
  session.current (nullable)                    tabManagerBoot.tabManager (throws only before
  requireTabManager()                             storage readiness, never null once ready)
```

The outer `{#await}` stays: it gates on `chrome.storage.local`, not auth, so forcing it into the same shape as Honeycrisp's synchronous top-level singleton would be fake symmetry. What's gone is the *inner* branch: once storage resolves, the sidepanel renders unconditionally. `SignedInApp.svelte` is renamed to `TabManagerApp.svelte` since signed-in is no longer the condition that renders it.

## `openTabManagerBrowser` becomes the preset branch

It used to take `{ signedIn, nodeId }` and always call `tabManagerWorkspace.connect(...)` with a signed-in payload, so it could never run signed out. It now takes `{ auth, nodeId }` and picks `connectLocal(compose)` or `connect({ ...projectSignedIn(auth), nodeId }, compose)` off `auth.state.status`, with the *same* `compose` callback (the tab/bookmark/device actions) passed to both branches, so nothing downstream has to know which one ran.

## Deferred-init, not a nullable session

`chrome.storage.local` is async, so tab-manager can't build a synchronous top-level singleton the way Honeycrisp does. `tabManagerBoot` keeps that constraint but drops the Shape A shape around it: `.auth`, `.instanceSetting`, and `.tabManager` are getters that throw only before `whenReady` resolves (a boot-order guard), never a signed-out branch. `session.current` (nullable) and `requireTabManager()` (the throw-on-signed-out accessor) collapse into the one `.tabManager` getter, since there's no longer a "signed out" case to distinguish from "not ready yet." `reloadOnOwnerChange` is wired the moment the auth client exists, inside the same `whenReady` resolution.

## Migration is a factory, not a singleton

Honeycrisp's `sign-in-migration.ts` is a module-level `export const signInMigration = createSignInMigration({ auth, ... })`, built at import time because `honeycrisp`'s `auth` is synchronous. Tab-manager's `auth` isn't available until `chrome.storage` resolves, so `createTabManagerSignInMigration(auth, tabManager)` is a factory `session.svelte.ts` calls once, right after it builds the workspace bundle, inside the same `whenReady` resolution.

`openLocalSource()` only stages `savedTabs`, `bookmarks`, and `conversations` for copy, deliberately excluding `devices` and `toolTrust`: `registerDevice()` runs on every boot regardless of auth state, so the bare local doc's `devices` table would always have at least one row, which would make the migration dialog nag on every first sign-in even for someone who never saved a tab. Add still clears the whole bare root afterward (`idb.clearLocal` has no per-table granularity), so any local device/tool-trust rows get dropped too, which is the "local device state doesn't follow you" behavior, not a leak. A conversation's turns live in a per-row child `Y.Doc` (`@epicenter/chat`'s `.docs.messages`), wired through the kit's `childDocs.guids` for the crash-safe merge phase.

## Signed-in-only features: the AI chat

The AI chat used to render only behind the sign-in gate, so a hosted turn could never fail from being signed out. Now a signed-out visitor can open the AI drawer and send a message; the hosted transport (`auth.fetch` with no bearer) fails with 401. `AgentChatThread` already ships a "Sign in to use AI Chat" banner for that case (`isUnauthorized`); tab-manager just wires `onSignIn={() => auth.startSignIn()}` so the banner's button does something, matching the small-inline-affordance guidance over building a `<FeatureGate>`. No other signed-in-only surface exists in tab-manager: saved tabs, bookmarks, and search all work identically against the local doc whether signed in or not.

## Other judgment calls

- **Renamed the boot singleton from `tabManagerSession` to `tabManagerBoot`.** `.current`/`.require()` are gone, and keeping the "session" name on a deferred-init object that has nothing to do with auth-gating felt like it'd invite the next reader to assume Shape A was still alive.
- **`WorkspaceGate` replaces the hand-rolled `{#await tabManager.idb.whenLoaded}` + `Empty.Root` error branch** that used to live inline in `App.svelte`; the shared gate's default error state already offers Reload / Forget device / Sign out, so the bespoke "Failed to load workspace" message was pure duplication.
- **`AccountPopover` gains `instanceConnect={{ appName: 'Epicenter', setting: tabManagerBoot.instanceSetting }}`**, the same `appName` `SignedOutScreen` used, so self-host connect is reachable from the popover for the first time.

For verification:

Repo-scoped to `apps/tab-manager`: `bun run typecheck` (svelte-check, 0 errors), `bun test` (the one existing test), and `bun run check:doc-paths` all pass clean. `bun run build` fails, but identically on `main` before this branch (confirmed by stashing and re-running): a pre-existing Rollup resolution error for `wxt/utils/storage` from `packages/workspace/src/document/node-id.ts`, unrelated to this change. Not verified: a live sidepanel smoke (loading the unpacked extension, boot signed out, save a tab, sign in, see the migration dialog, Add, sign out) — expected-unverified for this environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785564317&installation_id=128463665&pr_number=2271&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2271&signature=212ff2b71405d46027678adf16c659946e7bb6083f99f9cce0efcf7567bf48d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->