### PR TITLE
refactor(whispering): use ad-hoc dev signing requirement

### DIFF
--- a/apps/whispering/scripts/dev-doctor.ts
+++ b/apps/whispering/scripts/dev-doctor.ts
@@ -5,12 +5,13 @@
  *   bun run dev:doctor
  *
  * It reports the STATIC identity facts that decide whether the TCC grant will
- * stick: where the dev binary is, its code-signing Identifier and authority,
- * whether that matches the dev identifier, and the reset command to copy. The
- * LIVE facts (AXIsProcessTrusted, the current DictationCapability, the rdev
- * listener's last stop reason) are owned by the running app's Rust supervisor
- * and surface in the app itself plus the Tauri log, so this script points there
- * rather than guessing them from outside the process.
+ * stick: where the dev binary is, its code-signing Identifier, signature,
+ * designated requirement, whether those match the dev identity, and the reset
+ * command to copy. The LIVE facts (AXIsProcessTrusted, the current
+ * DictationCapability, the rdev listener's last stop reason) are owned by the
+ * running app's Rust supervisor and surface in the app itself plus the Tauri
+ * log, so this script points there rather than guessing them from outside the
+ * process.
  */
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -25,14 +26,11 @@ function run(command: string, args: string[]): string {
 	).trim();
 }
 
-function readDevIdentity(): { identifier: string; productName: string } {
-	const config = JSON.parse(
-		readFileSync(join(SRC_TAURI, 'tauri.dev.conf.json'), 'utf8'),
-	);
-	return { identifier: config.identifier, productName: config.productName };
-}
-
-const { identifier: expectedIdentifier, productName } = readDevIdentity();
+const devConfig = JSON.parse(
+	readFileSync(join(SRC_TAURI, 'tauri.dev.conf.json'), 'utf8'),
+);
+const expectedIdentifier = devConfig.identifier;
+const productName = devConfig.productName;
 
 console.log('Whispering dev Accessibility doctor');
 console.log('==================================');
@@ -45,51 +43,58 @@ if (process.platform !== 'darwin') {
 	process.exit(0);
 }
 
-const binary = join(SRC_TAURI, 'target', 'debug', 'whispering');
+// Mirror the runner's binary path: honor CARGO_TARGET_DIR like cargo does.
+const targetDir = process.env.CARGO_TARGET_DIR ?? join(SRC_TAURI, 'target');
+const binary = join(targetDir, 'debug', 'whispering');
 console.log(`\ndev binary:         ${binary}`);
 if (!existsSync(binary)) {
-	console.log('  (not built yet — run `bun run dev:local` first)');
+	console.log('  (not built yet; run `bun run dev` first)');
 	process.exit(0);
 }
 
-const codesign = run('codesign', ['-dv', '--verbose=2', binary]);
+const codesign = run('codesign', ['-dv', '--verbose=4', binary]);
+const requirements = run('codesign', ['-d', '-r-', binary]);
 const identifierLine = codesign.match(/^Identifier=(.*)$/m)?.[1] ?? '(none)';
-const authority = codesign.match(/^Authority=(.*)$/m)?.[1] ?? '(none)';
+const signature = codesign.match(/^Signature=(.*)$/m)?.[1] ?? '(none)';
+const teamIdentifier =
+	codesign.match(/^TeamIdentifier=(.*)$/m)?.[1] ?? '(none)';
+const cdhash = codesign.match(/^CDHash=(.*)$/m)?.[1] ?? '(none)';
 const flags = codesign.match(/flags=(\S+)/)?.[1] ?? '(none)';
+const requirementLine =
+	requirements.match(/designated =>.*$/m)?.[0] ?? '(none)';
+const expectedRequirement = `designated => identifier "${expectedIdentifier}"`;
 
 console.log(`  signed Identifier: ${identifierLine}`);
-console.log(`  authority:         ${authority}`);
+console.log(`  signature:         ${signature}`);
+console.log(`  team identifier:   ${teamIdentifier}`);
+console.log(`  cdhash:            ${cdhash}`);
 console.log(`  flags:             ${flags}`);
+console.log(`  requirement:       ${requirementLine}`);
 
-const isAdhoc = /adhoc/.test(flags);
+const isAdhoc = signature === 'adhoc' || /\badhoc\b/.test(flags);
 const identifierMatches = identifierLine === expectedIdentifier;
+const requirementMatches = requirementLine === expectedRequirement;
 
 console.log('\nverdict:');
-if (isAdhoc) {
+if (!identifierMatches) {
 	console.log(
-		'  ✗ ad-hoc signature — the grant will NOT survive rebuilds. The runner',
+		`  x signed identifier is "${identifierLine}", expected "${expectedIdentifier}".`,
 	);
+	console.log('    The runner may not be wired in. Re-run `bun run dev`.');
+} else if (!isAdhoc) {
+	console.log(`  x signature is "${signature}", expected ad-hoc.`);
+	console.log('    The runner should sign with `codesign --sign -`.');
+} else if (!requirementMatches) {
+	console.log('  x designated requirement is not identifier-only.');
+	console.log(`    Expected requirement: ${expectedRequirement}`);
 	console.log(
-		'    normally mints a self-signed cert instead; re-run `bun run dev:local`',
-	);
-	console.log('    (or set WHISPERING_DEV_SIGNING_IDENTITY) and rebuild.');
-} else if (!identifierMatches) {
-	console.log(
-		`  ✗ signed identifier is "${identifierLine}", expected "${expectedIdentifier}".`,
-	);
-	console.log(
-		'    The runner may not be wired in; re-run `bun run dev:local`.',
+		'    Re-run `bun run dev` so the runner can overwrite the signature.',
 	);
 } else {
 	console.log(
-		'  ✓ stable signature with the dev identifier. Grant should persist.',
+		'  ok: ad-hoc signature uses the fixed identifier-only requirement. Grant should persist.',
 	);
 }
-
-console.log('\navailable codesigning identities:');
-console.log(
-	`  ${run('security', ['find-identity', '-v', '-p', 'codesigning']).replace(/\n/g, '\n  ')}`,
-);
 
 console.log(
 	'\nreset the dev grants (after the app has launched at least once):',

--- a/apps/whispering/src-tauri/scripts/README.md
+++ b/apps/whispering/src-tauri/scripts/README.md
@@ -19,20 +19,30 @@ relink. macOS Accessibility (TCC) keys the grant on that identity, so each Rust
 rebuild looked like a brand-new app and the grant went stale. The Rust
 supervisor then reported `DictationCapability::Broken`.
 
-The fix is a stable signature, not a bundle id. Tauri's `build.runner` hook
-(`tauri.dev.macos.conf.json`) points `tauri dev` at
-[`dev-codesign-runner.sh`](./dev-codesign-runner.sh), which builds, re-signs the
-binary with a stable cert and the fixed identifier `so.epicenter.whispering.dev`,
-then `exec`s it. The resulting designated requirement depends only on the
-identifier and the certificate, never the cdhash, so the grant survives rebuilds.
+The fix is a stable designated requirement, not a certificate. Tauri's
+`build.runner` hook (`tauri.dev.macos.conf.json`) points `tauri dev` at
+[`dev-codesign-runner.sh`](./dev-codesign-runner.sh), which builds the binary,
+overwrites its signature, and then `exec`s it:
 
-The signing cert is chosen in three tiers: an explicit
-`WHISPERING_DEV_SIGNING_IDENTITY` override, else the first Developer ID or Apple
-Development identity on the machine, else a persistent self-signed code-signing
-cert the runner mints once (`Whispering Dev Local Codesign`) and reuses. Every
-tier is a stable signature, so there is no ad-hoc fallback to break the grant:
-even with no Apple account and no setup, the first `bun run dev` provisions the
-self-signed cert and asks once (a keychain prompt) to let `codesign` use it.
+```sh
+codesign --force \
+	--sign - \
+	--identifier so.epicenter.whispering.dev \
+	--requirements '=designated => identifier "so.epicenter.whispering.dev"' \
+	--entitlements src-tauri/entitlements.plist \
+	target/debug/whispering
+```
+
+The `--sign -` identity is still ad-hoc, but the embedded designated requirement
+is explicit and identifier-only. TCC keys the dev grant to that requirement, so
+the grant survives relinks even though the binary's cdhash changes.
+
+This is intentionally local-only. Any local process could sign itself ad-hoc
+with `so.epicenter.whispering.dev` and satisfy the same requirement. That tradeoff
+is acceptable for a dev-only identity because it avoids keychain prompts,
+certificate trust repair, and machine-specific signing state. Production keeps
+its separate identifier, `so.epicenter.whispering`, and must never use this dev
+signing model.
 
 ## Granting and resetting
 
@@ -53,8 +63,8 @@ Then relaunch dev and grant Accessibility again.
 bun run dev:doctor
 ```
 
-prints the dev binary path, its signed identifier and authority, whether the
-signature is stable, and the reset command. Live trust, the current
-`DictationCapability`, and the rdev listener's health are owned by the running
-app's supervisor (`src/keyboard/mod.rs`) and show up in the app and the Tauri
-log.
+prints the dev binary path, its signed identifier, signature, designated
+requirement, whether the fixed requirement is present, and the reset command.
+Live trust, the current `DictationCapability`, and the rdev listener's health
+are owned by the running app's supervisor
+(`src/keyboard/mod.rs`) and show up in the app and the Tauri log.

--- a/apps/whispering/src-tauri/scripts/dev-codesign-runner.sh
+++ b/apps/whispering/src-tauri/scripts/dev-codesign-runner.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Tauri dev `build.runner` for macOS: build, codesign, then BECOME the app.
+# Tauri dev `build.runner` for macOS: build, codesign, then become the app.
 #
 # Why this exists
 # ---------------
@@ -15,18 +15,14 @@
 # cargo with a custom `build.runner` that it invokes as `<runner> run <args>`
 # and then treats as the long-lived app process (it kills this PID to restart
 # on file changes). So this runner does the one thing dev is missing: it builds,
-# re-signs the binary with a STABLE identity + identifier (constant designated
-# requirement across relinks, so the TCC grant sticks), then `exec`s the binary
-# so Tauri's monitored PID is the app itself.
+# overwrites the ad-hoc signature with a fixed identifier-only designated
+# requirement, then `exec`s the binary so Tauri's monitored PID is the app
+# itself.
 #
-# Any STABLE code-signing cert works: a DISTINCT identifier
-# (so.epicenter.whispering.dev, not the production so.epicenter.whispering) keeps
-# dev and production as separate TCC entries, so granting one never touches the
-# other. If the machine has no real cert, the runner mints a persistent
-# self-signed one (see provision_self_signed_identity) rather than falling back
-# to ad-hoc, whose cdhash identity changes every relink and breaks the grant.
-# Override the cert with WHISPERING_DEV_SIGNING_IDENTITY if you have a dedicated
-# one.
+# The fixed identifier (so.epicenter.whispering.dev, not the production
+# so.epicenter.whispering) keeps dev and production as separate TCC entries. The
+# explicit requirement keeps the dev TCC grant tied to the identifier instead of
+# the changing cdhash.
 #
 # This runner is wired in only on macOS (see scripts/launch-dev.ts); other
 # platforms run plain `tauri dev`.
@@ -79,95 +75,10 @@ while [ "$index" -lt "${#cargo_flags[@]}" ]; do
 done
 binary="$target_dir/${triple:+$triple/}$profile/whispering"
 
-# A self-signed code-signing cert minted once and reused forever. The common
-# name doubles as the codesign identity string and as the lookup key for "did we
-# already mint it". Distinct from the bundle identifier: this names the signer,
-# DEV_IDENTIFIER names the signed app.
-readonly SELF_SIGNED_CN="Whispering Dev Local Codesign"
-
-# Mint (or reuse) a persistent self-signed code-signing identity in the login
-# keychain and echo its name. A self-signed cert gives the binary a STABLE
-# designated requirement across relinks (unlike ad-hoc), so the TCC grant
-# sticks, with no Apple account and no manual setup. Idempotent: the first run
-# mints, every later run reuses.
-provision_self_signed_identity() {
-	if security find-certificate -c "$SELF_SIGNED_CN" >/dev/null 2>&1; then
-		printf '%s' "$SELF_SIGNED_CN"
-		return 0
-	fi
-
-	echo "dev-codesign-runner: no stable cert found; minting a self-signed one (\"$SELF_SIGNED_CN\")." >&2
-	echo "dev-codesign-runner: macOS will ask once to let codesign use the key. Click \"Always Allow\"." >&2
-
-	local workdir key crt p12 login_kc import_err
-	workdir="$(mktemp -d)"
-	key="$workdir/key.pem"
-	crt="$workdir/cert.pem"
-	p12="$workdir/cert.p12"
-	login_kc="$HOME/Library/Keychains/login.keychain-db"
-
-	# A 10-year self-signed cert carrying the codeSigning extended key usage:
-	# the one property codesign requires of an identity.
-	openssl req -x509 -newkey rsa:2048 -nodes \
-		-keyout "$key" -out "$crt" -days 3650 \
-		-subj "/CN=$SELF_SIGNED_CN" \
-		-addext "basicConstraints=critical,CA:FALSE" \
-		-addext "keyUsage=critical,digitalSignature" \
-		-addext "extendedKeyUsage=codeSigning" >/dev/null 2>&1
-
-	# Bundle to PKCS#12 with a NON-EMPTY passphrase and the legacy SHA1-3DES PBE:
-	# Apple's Security framework fails MAC verification on empty-password p12s and
-	# is happiest with the legacy algorithms, so an empty pass or modern PBE makes
-	# `security import` reject the bundle ("MAC verification failed"). The
-	# passphrase is a throwaway that never leaves this function.
-	openssl pkcs12 -export -out "$p12" -inkey "$key" -in "$crt" \
-		-passout pass:"$SELF_SIGNED_CN" \
-		-certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES -macalg sha1 >/dev/null 2>&1
-
-	# Import into the login keychain. -T names codesign on the key's access list
-	# and -A widens that to local tooling, so the first build surfaces a GUI
-	# "Always Allow" dialog (click it once) rather than a denial. These flags do
-	# NOT by themselves suppress the prompt on modern macOS; the one-time Always
-	# Allow is what persists it. For a fully headless flow (CI), grant zero-prompt
-	# access with the login password instead:
-	#   security set-key-partition-list -S apple-tool:,apple: -s \
-	#     -k "$LOGIN_PW" "$login_kc"
-	# or skip self-signing entirely and set WHISPERING_DEV_SIGNING_IDENTITY.
-	import_err="$(security import "$p12" -k "$login_kc" \
-		-P "$SELF_SIGNED_CN" -A -T /usr/bin/codesign 2>&1)"
-	if [ -n "$import_err" ] && ! security find-certificate -c "$SELF_SIGNED_CN" >/dev/null 2>&1; then
-		# Fail loudly with the real reason rather than handing back a name whose
-		# cert isn't in the keychain (which surfaces later as a baffling codesign
-		# "item could not be found"). The usual culprit is a locked keychain in a
-		# non-GUI session: run `bun run dev` from a real Terminal/iTerm window.
-		echo "dev-codesign-runner: could not import the signing cert: $import_err" >&2
-		echo "dev-codesign-runner: is the login keychain unlocked / is this a GUI session?" >&2
-		rm -rf "$workdir"
-		return 1
-	fi
-
-	rm -rf "$workdir"
-	printf '%s' "$SELF_SIGNED_CN"
-}
-
-# Pick the signing identity, in preference order:
-#   1. an explicit override (WHISPERING_DEV_SIGNING_IDENTITY)
-#   2. a real Apple cert already on the machine (Developer ID / Apple Development)
-#   3. a persistent self-signed cert this runner mints itself
-# Every tier yields a STABLE identity, so the TCC grant survives rebuilds; the
-# old ad-hoc fallback could not, which is why it is gone.
-identity="${WHISPERING_DEV_SIGNING_IDENTITY:-}"
-if [ -z "$identity" ]; then
-	identity="$(security find-identity -v -p codesigning \
-		| awk -F'"' '/Developer ID Application|Apple Development/ { print $2; exit }')"
-fi
-if [ -z "$identity" ]; then
-	identity="$(provision_self_signed_identity)" || exit 1
-fi
-
 codesign --force \
-	--sign "$identity" \
+	--sign - \
 	--identifier "$DEV_IDENTIFIER" \
+	--requirements "=designated => identifier \"$DEV_IDENTIFIER\"" \
 	--entitlements "$SRC_TAURI/entitlements.plist" \
 	"$binary"
 

--- a/apps/whispering/tests/dev-identity.test.ts
+++ b/apps/whispering/tests/dev-identity.test.ts
@@ -1,18 +1,24 @@
+/**
+ * Dev macOS Identity Tests
+ *
+ * Guards the macOS dev Accessibility identity against silent regression. The
+ * dev grant only survives rebuilds while the configs and runner agree on one
+ * identifier-only designated requirement, so these tests pin that contract.
+ *
+ * Key behaviors:
+ * - Dev and production keep distinct identifiers.
+ * - The dev runner signs ad-hoc with an explicit identifier-only requirement.
+ * - Certificate and keychain provisioning do not return.
+ */
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-/**
- * Guards the macOS dev Accessibility identity against silent regression.
- *
- * The dev grant only survives rebuilds while three things agree on one
- * identifier and dev stays distinct from production. If any of these drift, dev
- * Accessibility quietly breaks again, so assert them instead of trusting code
- * review to notice a one-character edit.
- */
 const SRC_TAURI = join(import.meta.dir, '..', 'src-tauri');
 const DEV_IDENTIFIER = 'so.epicenter.whispering.dev';
 
+const readApp = (name: string) =>
+	readFileSync(join(import.meta.dir, '..', name), 'utf8');
 const read = (name: string) => readFileSync(join(SRC_TAURI, name), 'utf8');
 const json = (name: string) => JSON.parse(read(name));
 
@@ -29,9 +35,41 @@ describe('dev macOS identity', () => {
 		expect(prod.productName).toBe('Whispering');
 	});
 
-	test('the codesign runner signs with the same dev identifier', () => {
+	test('the codesign runner signs ad-hoc with the same dev identifier', () => {
 		const runner = read('scripts/dev-codesign-runner.sh');
 		expect(runner).toContain(`DEV_IDENTIFIER="${DEV_IDENTIFIER}"`);
+		expect(runner).toContain('--sign -');
+	});
+
+	test('the codesign runner embeds an identifier-only designated requirement', () => {
+		const runner = read('scripts/dev-codesign-runner.sh');
+
+		expect(runner).toContain(
+			'--requirements "=designated => identifier \\"$DEV_IDENTIFIER\\""',
+		);
+	});
+
+	test('the codesign runner has no cert or keychain provisioning path', () => {
+		const runner = read('scripts/dev-codesign-runner.sh');
+
+		expect(runner).not.toContain('WHISPERING_DEV_SIGNING_IDENTITY');
+		expect(runner).not.toContain('openssl');
+		expect(runner).not.toContain('security import');
+		expect(runner).not.toContain('add-trusted-cert');
+		expect(runner).not.toContain('find-identity');
+	});
+
+	test('the dev doctor verifies the fixed ad-hoc requirement, not keychain state', () => {
+		const doctor = readApp('scripts/dev-doctor.ts');
+
+		expect(doctor).toContain('Signature=');
+		expect(doctor).toContain('TeamIdentifier=');
+		expect(doctor).toContain('designated => identifier');
+		expect(doctor).toContain('expected ad-hoc');
+		expect(doctor).not.toContain('WHISPERING_DEV_SIGNING_IDENTITY');
+		expect(doctor).not.toContain('security');
+		expect(doctor).not.toContain('keychain');
+		expect(doctor).not.toContain('self-signed');
 	});
 
 	test('the macOS dev config wires in the codesign runner', () => {


### PR DESCRIPTION
This deletes the local dev certificate path for Whispering. Dev signing no longer mints a self-signed cert, imports a p12, mutates keychain trust, or picks between signing identities; the Tauri dev runner builds the bare binary, signs it ad-hoc, embeds `designated => identifier "so.epicenter.whispering.dev"`, and then `exec`s it.

That is enough for macOS TCC to keep the Accessibility grant across relinks. We verified the missing behavior manually with a temporary test identifier: grant Accessibility once, rebuild so the `CDHash` changes, relaunch, and the global shortcut still works without re-granting.

The trade-off is explicit and dev-only: any local process could ad-hoc sign itself with `so.epicenter.whispering.dev` and satisfy the same requirement. That is acceptable for the local dev identity because production keeps `so.epicenter.whispering` and still uses the production signing path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785620252&installation_id=128463665&pr_number=2279&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2279&signature=8df2db54e7d91acc6fb58c67cb8dc4538cd52b9ccb230af9b7946ee79691c1ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->