### PR TITLE
refactor(workspace): align local storage readiness

### DIFF
--- a/.agents/skills/workspace-app-composition/SKILL.md
+++ b/.agents/skills/workspace-app-composition/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workspace-app-composition
-description: 'How a workspace-backed app under `apps/*` is composed: the isomorphic doc factory (`create<App>`), the environment factories (`open<App>Browser` / `open<App>Extension` / tauri) with the one boot call (`connect(toConnection(auth, nodeId))`, ADR-0088/ADR-0094), the `#platform/*` build-time platform DI for multi-platform (Tauri) apps, the workspace singleton, the sign-in migration wiring, daemon/script placement under per-project `workspaces/<app>/`, and the file layout itself. Use when creating a new app, naming or placing the iso/browser/extension factory, wiring `#platform/*` subpath imports for a Tauri seam, placing the workspace singleton, wiring the first-sign-in migration, registering daemon/script bindings, or gating first paint on IndexedDB hydration (load gate vs WorkspaceGate).'
+description: 'How a workspace-backed app under `apps/*` is composed: the isomorphic doc factory (`create<App>`), the environment factories (`open<App>Browser` / `open<App>Extension` / tauri) with the one boot call (`connect(toConnection(auth, nodeId))`, ADR-0088/ADR-0094), the `#platform/*` build-time platform DI for multi-platform (Tauri) apps, the workspace singleton, the sign-in migration wiring, daemon/script placement under per-project `workspaces/<app>/`, and the file layout itself. Use when creating a new app, naming or placing the iso/browser/extension factory, wiring `#platform/*` subpath imports for a Tauri seam, placing the workspace singleton, wiring the first-sign-in migration, registering daemon/script bindings, or gating first paint on local storage hydration (load gate vs WorkspaceGate).'
 metadata:
   author: epicenter
   version: '6.0'
@@ -235,8 +235,8 @@ where the workspace is built.
 - Correctness gates (404 / redirect / param) always go in `load`; only `load`
   can `error()` / `redirect()` (matter `vault/[id]`).
 - The promise must be resolve-only or the gate blocks paint forever
-  (`whenLoaded = idb.whenSynced`, kept resolve-only by the y-indexeddb
-  corrupt-load patch). Fix the promise, never add a timeout.
+  (`storage.whenLoaded` is kept resolve-only by the y-indexeddb corrupt-load
+  patch). Fix the promise, never add a timeout.
 
 The blank-shell (load) vs `<Loading>` (`WorkspaceGate`) difference follows from
 the boundary, not a separate choice. For the `load`-blocks-render rule ground

--- a/apps/skills/src/routes/+layout.ts
+++ b/apps/skills/src/routes/+layout.ts
@@ -4,11 +4,11 @@ import type { LayoutLoad } from './$types';
 export const ssr = false;
 
 /**
- * Gate the first paint on IndexedDB hydration. `SkillsList` reads an empty table
- * until `idb.whenLoaded` resolves, so without this the "No skills yet" empty
- * state flashes before the skills load from disk. SvelteKit blocks the route's
- * render until this load resolves; `whenReady` is a single promise
- * (`idb.whenLoaded`), so it resolves once and a reload never re-blocks.
+ * Gate the first paint on local storage hydration. `SkillsList` reads an empty
+ * table until storage loads, so without this the "No skills yet" empty state
+ * flashes before the skills load from disk. SvelteKit blocks the route's render
+ * until this load resolves; `whenReady` is a single promise, so it resolves once
+ * and a reload never re-blocks.
  */
 export const load: LayoutLoad = async () => {
 	await skills.whenReady;

--- a/apps/todos/src/routes/+layout.ts
+++ b/apps/todos/src/routes/+layout.ts
@@ -4,11 +4,11 @@ import type { LayoutLoad } from './$types';
 export const ssr = false;
 
 /**
- * Gate the first paint on local storage hydration. `todosState` reads an empty table
- * until `storage.whenLoaded` resolves, so without this the "All clear" empty state
- * flashes before the todos load from disk. SvelteKit blocks the route's render
- * until this load resolves; `whenReady` is a single promise (`storage.whenLoaded`),
- * so it resolves once and a reload never re-blocks.
+ * Gate the first paint on local storage hydration. `todosState` reads an empty
+ * table until `storage.whenLoaded` resolves, so without this the "All clear"
+ * empty state flashes before the todos load from disk. SvelteKit blocks the
+ * route's render until this load resolves; `whenReady` is a single promise, so
+ * it resolves once and a reload never re-blocks.
  */
 export const load: LayoutLoad = async () => {
 	await todos.whenReady;

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.ts
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.ts
@@ -2,12 +2,12 @@ import { whispering } from '#platform/whispering';
 import type { PageLoad } from './$types';
 
 /**
- * Gate the recordings paint on IndexedDB hydration. The table reads
+ * Gate the recordings paint on local storage hydration. The table reads
  * `fromTable(whispering.tables.recordings)`, which is empty until
- * `idb.whenLoaded` resolves, so without this gate the "No recordings yet" empty
- * state flashes before recordings load from disk. SvelteKit blocks the route's
- * render until this load resolves; `whenReady` is a single promise
- * (`idb.whenLoaded`), so it resolves once and a later navigation never re-blocks.
+ * `storage.whenLoaded` resolves, so without this gate the "No recordings yet"
+ * empty state flashes before recordings load from disk. SvelteKit blocks the
+ * route's render until this load resolves; `whenReady` is a single promise, so
+ * it resolves once and a later navigation never re-blocks.
  */
 export const load: PageLoad = async () => {
 	await whispering.whenReady;

--- a/apps/whispering/src/routes/(app)/(config)/transformations/+page.ts
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/+page.ts
@@ -2,12 +2,12 @@ import { whispering } from '#platform/whispering';
 import type { PageLoad } from './$types';
 
 /**
- * Gate the transformations paint on IndexedDB hydration. The table reads
+ * Gate the transformations paint on local storage hydration. The table reads
  * `fromTable(whispering.tables.transformations)`, which is empty until
- * `idb.whenLoaded` resolves, so without this gate the "No transformations yet"
+ * `storage.whenLoaded` resolves, so without this gate the "No transformations yet"
  * empty state flashes before transformations load from disk. SvelteKit blocks
- * the route's render until this load resolves; `whenReady` is a single promise
- * (`idb.whenLoaded`), so it resolves once and a later navigation never re-blocks.
+ * the route's render until this load resolves; `whenReady` is a single promise,
+ * so it resolves once and a later navigation never re-blocks.
  * Same gate as the sibling `recordings/+page.ts`.
  */
 export const load: PageLoad = async () => {

--- a/packages/app-shell/src/workspace-gate/workspace-gate.svelte
+++ b/packages/app-shell/src/workspace-gate/workspace-gate.svelte
@@ -17,7 +17,7 @@
 	</script>
 
 	<WorkspaceGate
-		pending={honeycrisp.idb.whenLoaded}
+		pending={honeycrisp.storage.whenLoaded}
 		onForgetDevice={() => honeycrisp.wipe()}
 		onSignOut={() => auth.signOut()}
 	>

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -65,8 +65,6 @@ bun add @epicenter/workspace @epicenter/field
 ```typescript
 import { field } from '@epicenter/field';
 import {
-	attachBroadcastChannel,
-	attachIndexedDb,
 	defineTable,
 	defineWorkspace,
 } from '@epicenter/workspace';
@@ -85,24 +83,14 @@ const blogWorkspace = defineWorkspace({
 });
 
 export function openBlog() {
-	const workspace = blogWorkspace.connect();
-	const idb = attachIndexedDb(workspace.ydoc);
-	// Cross-tab broadcast keyed by ydoc.guid. Skip this line for a Tauri
-	// or Electron app that only ever runs one window.
-	attachBroadcastChannel(workspace.ydoc);
-
-	return {
-		...workspace,
-		idb,
-		batch: (fn: () => void) => workspace.ydoc.transact(fn),
-	};
+	return blogWorkspace.connect(null);
 }
 
 // Singleton style: open once at module scope, use everywhere.
 export const blog = openBlog();
 
 async function quickStart() {
-	await blog.idb.whenLoaded;
+	await blog.storage.whenLoaded;
 
 	blog.tables.posts.set({
 		id: 'welcome',
@@ -123,13 +111,13 @@ void quickStart;
 That example uses the current public API end to end:
 
 - `defineTable(...)` with a real schema
-- a direct `openBlog()` builder function that calls `blogWorkspace.connect()`
+- a direct `openBlog()` builder function that calls `blogWorkspace.connect(null)`
 - `defineWorkspace(...)` for the shared contract and `open()` for the live root
 - direct property access via `blog.tables.posts`
 - `set`, `get`, `update`, `delete`, `scan`, and `observe`
 
-The quick start is local-first: it persists to IndexedDB and works offline.
-Sync is one more line in the builder: add `openCollaboration`. See [Sync](#sync).
+The quick start is local-first: it persists to browser storage and works
+offline. Sync is the credentialed arm of the same call. See [Sync](#sync).
 
 Singleton apps (one workspace per app) call a builder like `openBlog()` once at
 module scope. Browser child documents are declared on tables and opened through
@@ -296,11 +284,11 @@ function openBlog(connection: ConnectionConfig) {
 }
 ```
 
-Daemon and test paths can use `open()` to compose root-only infrastructure:
+Daemon and test paths can use `create()` to compose root-only infrastructure:
 
 ```typescript
 function openBlogDaemon() {
-	const workspace = blogWorkspace.connect();
+	const workspace = blogWorkspace.create();
 	const collaboration = openCollaboration(workspace.ydoc, {
 		url,
 		openWebSocket,
@@ -404,12 +392,12 @@ Yjs supports multiple providers simultaneously. A phone can connect to desktop, 
 
 1. Define tables and KV entries with `defineTable` and `defineKv`.
 2. Export a `defineWorkspace({ id, tables, kv, actions })` value beside the schema.
-3. For singleton apps: call `definition.connect()` once at module scope. For cloud
+3. For singleton apps: call `definition.connect(null)` once at module scope. For cloud
    browser apps: call `definition.connect(connection)`. For browser child documents:
    declare them with `table.docs(...)` and call `tables.<table>.docs.<field>.open(rowId)`.
    For one-shot Node operations: derive the same child-doc guid and read the room directly.
 4. Await the right readiness signal before reading persisted state. There are two shapes here, and the choice is load-bearing:
-   - **One subsystem to wait on.** Expose the subsystem (`idb`, `persistence`, ...) on the bundle root and let consumers reach through: `await bundle.idb.whenLoaded`. Do not alias `whenLoaded`/`whenReady` flat at the bundle root just to save a `.idb`; the alias lies about composition.
+   - **One subsystem to wait on.** Expose the subsystem (`storage`, `persistence`, ...) on the bundle root and let consumers reach through: `await bundle.storage.whenLoaded`. Do not alias `whenLoaded`/`whenReady` flat at the bundle root just to save `.storage`; the alias lies about composition.
    - **Two or more subsystems to compose into one barrier.** Then `whenReady` earns its place: `whenReady: Promise.all([persistence.whenLoaded, unlock.whenChecked, sync.whenConnected])`. Because the field is typed `Promise<unknown>`, `Promise.all([...])` is assignable directly. Consumers `await bundle.whenReady`. The CLI's `run` command, migrations, `@epicenter/filesystem` ops, the sqlite-index materializer, and `{#await}` gates in editors all consume this aggregate.
 
 5. Read and write through `bundle.tables`, `bundle.kv`, and `bundle.collaboration.peers`, and (for per-row content docs) whatever you exposed in the returned bundle.
@@ -1329,7 +1317,7 @@ Two composition shapes, one builder contract.
 │     kv: {},                                               │
 │     actions: ({ tables }) => defineActions({ ... }),      │
 │ });                                                       │
-│ export const workspace = appWorkspace.connect();             │
+│ export const workspace = appWorkspace.connect(null);         │
 └──────────────────────────────────────────────────────────┘
 ```
 
@@ -1374,14 +1362,14 @@ Yjs transactions do not roll back on throw. They batch notifications; they are n
 
 | API | What it means |
 | --- | --- |
-| `bundle.idb.whenLoaded` (or `bundle.sqlite.whenLoaded`) | Direct subsystem readiness; the default form |
+| `bundle.storage.whenLoaded` (or `bundle.sqlite.whenLoaded`) | Direct subsystem readiness; the default form |
 | `bundle.whenReady` | Optional aggregate: only when the bundle composes 2+ subsystem signals into `Promise.all([...])` |
-| `bundle.idb.clearLocal()` (or `bundle.sqlite.clearLocal()`) | Wipes persisted local state for that attachment |
+| `bundle.storage.clearLocal()` (or `bundle.sqlite.clearLocal()`) | Wipes persisted local state for that attachment |
 | `bundle[Symbol.dispose]()` | Singleton teardown: your builder calls `ydoc.destroy()` |
 | `handle[Symbol.dispose]()` | Cache handle: decrements refcount; last dispose arms `gcTime` |
 | `cache[Symbol.dispose]()` | Flushes every cached entry immediately |
 
-Disposal preserves data: it releases the handle. To wipe persisted local state, call `clearLocal()` on the persistence attachment (`bundle.idb` or `bundle.sqlite`) directly.
+Disposal preserves data: it releases the handle. To wipe persisted local state, call `clearLocal()` on the persistence attachment (`bundle.storage` or `bundle.sqlite`) directly.
 
 ### Cleanup lifecycle (cache)
 
@@ -1413,7 +1401,7 @@ Disposal preserves data: it releases the handle. To wipe persisted local state, 
 
 ```ts
 cache[Symbol.dispose]();
-await handle.idb.whenDisposed;
+await handle.storage.whenDisposed;
 ```
 
 ## Client vs Server
@@ -1467,11 +1455,11 @@ Everything below is a *convention*: the builder is free to expose more or less. 
 - `ydoc`
 - `tables`
 - `kv`
-- `idb` (or `sqlite`)
+- `storage` (or `sqlite`)
 - `collaboration` (from `openCollaboration`)
 - `actions`
 - `batch(fn)`
-- `whenReady` (only when composed from 2+ subsystem signals; otherwise consumers await `idb.whenLoaded` directly)
+- `whenReady` (only when composed from 2+ subsystem signals; otherwise consumers await `storage.whenLoaded` directly)
 - `[Symbol.dispose]()`
 
 ### Document content attachments

--- a/packages/workspace/src/document/README.md
+++ b/packages/workspace/src/document/README.md
@@ -6,7 +6,7 @@ A typed interface over Y.js for apps that need to evolve their data schema over 
 
 This is a wrapper around Y.js that handles schema versioning. Local-first apps can't run migration scripts, so data has to evolve gracefully. Old data coexists with new. The Workspace API bakes that into the design: define your schemas once with versions, write a migration function, and everything else is typed.
 
-The pattern: `defineWorkspace({ id, tables, kv, actions })` declares the shared isomorphic model. `definition.create()` builds the unconnected root doc for daemon composition. `definition.connect(connection)` creates the browser runtime with principal-scoped local storage, root sync, wipe, and table child-doc openers. `definition.connect(connection, compose)` lets a runtime add extras and expose its final action registry on the workspace bundle. `createWorkspace({ id, tables, kv })` and `satisfiesWorkspace(...)` remain lower-level primitives for internals, tests, and ports that have not moved to definitions yet.
+The pattern: `defineWorkspace({ id, tables, kv, actions })` declares the shared isomorphic model. `definition.create()` builds the unconnected root doc for daemon composition. `definition.connect(connection | null)` creates the runtime with local storage, optional sync, wipe, and table child-doc openers. `definition.connect(connection, compose)` or `definition.connect(connection, { persistence, compose })` lets a runtime add extras and expose its final action registry on the workspace bundle. `createWorkspace({ id, tables, kv })` and `satisfiesWorkspace(...)` remain lower-level primitives for internals, tests, and ports that have not moved to definitions yet.
 
 ```
 +----------------------------------------------------------------+
@@ -54,7 +54,7 @@ const blogWorkspace = defineWorkspace({
   kv: {},
 });
 
-using workspace = blogWorkspace.connect();
+using workspace = blogWorkspace.connect(null);
 workspace.tables.posts.set({ id: '1', title: 'Hello' });
 ```
 
@@ -85,10 +85,12 @@ function openBlog({
 }
 ```
 
-`connect(null)` derives bare local storage and BroadcastChannel keys from each
-doc guid. `connect(connection)` derives principal-scoped keys from `baseURL`,
-`principalId`, and each doc guid. `wipe()` deletes the databases for the active
-arm in one call: no explicit guid list to maintain.
+`connect(null)` derives bare browser storage and BroadcastChannel keys from each
+doc guid, unless the caller injects another local persistence environment with
+`connect(null, { persistence })`. `connect(connection)` derives principal-scoped
+keys from `baseURL`, `principalId`, and each doc guid. `wipe()` deletes the
+databases or local log files for the active arm in one call: no explicit guid
+list to maintain.
 
 Actions live on the workspace bundle. Collaboration is sync and presence only,
 so content documents (rich-text bodies, attachments) use the same collaboration

--- a/packages/workspace/src/document/workspace.test.ts
+++ b/packages/workspace/src/document/workspace.test.ts
@@ -15,7 +15,11 @@ import type { ConnectionConfig } from './connect-doc.js';
 import { defineKv } from './define-kv.js';
 import { defineTable } from './define-table.js';
 import { asNodeId } from './node-id.js';
-import { createWorkspace, defineWorkspace } from './workspace.js';
+import {
+	createWorkspace,
+	defineWorkspace,
+	type LocalPersistence,
+} from './workspace.js';
 
 Object.assign(globalThis, { indexedDB, IDBKeyRange });
 
@@ -236,6 +240,47 @@ describe('defineWorkspace', () => {
 			two[Symbol.dispose]();
 			workspace[Symbol.dispose]();
 		}
+	});
+
+	test('wipe waits for open child-doc storage before deleting local data', async () => {
+		let wipeCalled = false;
+		const childDisposed = Promise.withResolvers<void>();
+		const persistence: LocalPersistence = {
+			attach(ydoc) {
+				if (ydoc.guid === 'ws-wipe-child-storage') {
+					const rootDisposed = Promise.withResolvers<void>();
+					ydoc.once('destroy', () => rootDisposed.resolve());
+					return {
+						whenLoaded: Promise.resolve(),
+						whenDisposed: rootDisposed.promise,
+					};
+				}
+
+				return {
+					whenLoaded: Promise.resolve(),
+					whenDisposed: childDisposed.promise,
+				};
+			},
+			async wipe() {
+				wipeCalled = true;
+			},
+		};
+		const workspace = defineWorkspace({
+			id: 'ws-wipe-child-storage',
+			name: 'ws-wipe-child-storage',
+			tables: { notes: notesDefinition.docs({ body: attachPlainText }) },
+			kv: {},
+		}).connect(null, { persistence });
+
+		workspace.tables.notes.docs.body.open('note-1');
+		const wipe = workspace.wipe();
+
+		await Promise.resolve();
+		expect(wipeCalled).toBe(false);
+
+		childDisposed.resolve();
+		await wipe;
+		expect(wipeCalled).toBe(true);
 	});
 
 	test('docs touch stamps the row on local edits, not on synced ones', () => {

--- a/packages/workspace/src/document/workspace.ts
+++ b/packages/workspace/src/document/workspace.ts
@@ -281,7 +281,7 @@ function browserLocalPersistence(): LocalPersistence {
 	};
 }
 
-type ConnectOptions<
+export type ConnectOptions<
 	TTables extends TableDefinitions,
 	TKv extends KvDefinitions,
 	TActions extends ActionRegistry,

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -170,6 +170,7 @@ export {
 	type ConnectedTables,
 	type ConnectedWorkspace,
 	type ConnectedWorkspaceContext,
+	type ConnectOptions,
 	type CreateWorkspaceOptions,
 	createWorkspace,
 	type DefineWorkspaceOptions,


### PR DESCRIPTION
Workspace runtime readiness now speaks in terms of the neutral storage handle instead of the browser-specific idb name. The docs, app route gates, and workspace composition skill all point readers at storage.whenLoaded as the public bundle readiness signal, while low-level attachment examples can still talk about local idb variables where that is the real attachment.

The connect options type is exported alongside the rest of the workspace definition surface so callers using connect(null, { persistence }) can name the injected-persistence seam directly.

This also pins the destructive wipe ordering for child docs: wipe waits for any open child-doc storage handles to dispose before deleting the local guid family.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785629238&installation_id=128463665&pr_number=2282&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2282&signature=b69836ad2f0ebebc9c844522de2fc04e4d78b6b0bd52a06e0a0b8a361dc6d770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->