### PR TITLE
refactor(api-ui): align billing empty and error states

### DIFF
--- a/apps/api/ui/src/lib/components/ActivityFeed.svelte
+++ b/apps/api/ui/src/lib/components/ActivityFeed.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { providerLabel } from '@epicenter/constants/ai-providers';
+	import * as Empty from '@epicenter/ui/empty';
 	import { Skeleton } from '@epicenter/ui/skeleton';
 	import * as Table from '@epicenter/ui/table';
 	import { createQuery } from '@tanstack/svelte-query';
@@ -24,9 +25,17 @@
 		{/each}
 	</div>
 {:else if events.isError}
-	<p class="text-sm text-destructive">Failed to load activity.</p>
+	<Empty.Root class="py-8 border-0" role="alert">
+		<Empty.Header>
+			<Empty.Title class="text-destructive">Failed to load activity</Empty.Title>
+		</Empty.Header>
+	</Empty.Root>
 {:else if !events.data?.events.length}
-	<p class="text-sm text-muted-foreground py-8 text-center">No activity yet.</p>
+	<Empty.Root class="py-8 border-0">
+		<Empty.Header>
+			<Empty.Title>No activity yet</Empty.Title>
+		</Empty.Header>
+	</Empty.Root>
 {:else}
 	<Table.Root>
 		<Table.Header>

--- a/apps/api/ui/src/lib/components/TopModels.svelte
+++ b/apps/api/ui/src/lib/components/TopModels.svelte
@@ -47,7 +47,13 @@
 				{/each}
 			</div>
 		{:else if usage.isError}
-			<p class="text-sm text-destructive">Failed to load model data.</p>
+			<Empty.Root class="py-4 border-0" role="alert">
+				<Empty.Content>
+					<Empty.Title class="text-destructive"
+						>Failed to load model data</Empty.Title
+					>
+				</Empty.Content>
+			</Empty.Root>
 		{:else if sortedModels.length === 0}
 			<Empty.Root class="py-4 border-0">
 				<Empty.Content>

--- a/apps/api/ui/src/lib/components/UsageChart.svelte
+++ b/apps/api/ui/src/lib/components/UsageChart.svelte
@@ -114,9 +114,13 @@
 		{#if usage.isPending}
 			<Skeleton class="h-48 w-full" />
 		{:else if usage.isError}
-			<p class="text-sm text-destructive py-12 text-center">
-				Failed to load usage data.
-			</p>
+			<Empty.Root class="py-12 border-0" role="alert">
+				<Empty.Content>
+					<Empty.Title class="text-destructive"
+						>Failed to load usage data</Empty.Title
+					>
+				</Empty.Content>
+			</Empty.Root>
 		{:else if chartData.length === 0}
 			<Empty.Root class="py-8 border-0">
 				<Empty.Content>


### PR DESCRIPTION
This makes the billing dashboard's usage tables and charts use the same structured state primitives for empty and error branches.

The activity feed, top models table, and usage chart now render absent or failed data through `Empty.*` instead of one-off centered paragraphs. Loading and data rows are unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785629836&installation_id=128463665&pr_number=2283&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2283&signature=216628aca0aa7916fdfc02267c4a81711be955038856d64bb7a42a52ec9954fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->