### PR TITLE
docs(skills): clarify asymmetric wins promise refusals

### DIFF
--- a/.agents/skills/asymmetric-wins/SKILL.md
+++ b/.agents/skills/asymmetric-wins/SKILL.md
@@ -1,24 +1,43 @@
 ---
 name: asymmetric-wins
-description: "Find the small product refusal that collapses a large implementation graph: refuse 10-20 percent of functionality to delete 80-90 percent of complexity. Use when the user says \"asymmetric wins\", \"asymmetric win\", \"what can we refuse\", \"what collapses the most code\", or when a design adds a fast path, fallback parser, provider-specific SDK, second transport, or compatibility alias beside a canonical path. Pairs with one-sentence-test (detects the opportunity) and cohesive-clean-breaks (executes the break)."
+description: "Find the small promise to refuse when preserving it forces a large implementation family: trade a measured amount of fidelity, compatibility, modes, or reproducibility to delete disproportionate complexity. Use when the user says \"asymmetric wins\", \"asymmetric win\", \"what can we refuse\", \"what collapses the most code\", \"does this UI refactor need to be pixel perfect\", or when a design adds a fast path, fallback parser, provider-specific SDK, second transport, compatibility alias, exact reproduction requirement, or rare mode beside the canonical path. Pairs with one-sentence-test (detects the opportunity), refactoring (counts the code family), and cohesive-clean-breaks (executes the break)."
 ---
 
 # Asymmetric Wins
 
 An asymmetric win is a refusal that gives back more complexity than it costs in
-product capability. The usual shape: refuse 10-20 percent of functionality and
-collapse 80-90 percent of the implementation graph.
+product capability.
+
+The spine:
+
+```txt
+Preserve the product sentence.
+Refuse the small promise.
+Delete the code family.
+```
+
+The usual shape: trade a small amount of fidelity, compatibility, modes, or
+reproducibility to collapse a much larger implementation graph.
 
 This is not arithmetic and not a quota. Do not remove arbitrary features. The
 job is to find the one small promise that owns a disproportionate code family,
 then decide whether refusing that exact promise leaves the product sentence
 intact.
 
+Do not say "good enough" and ship drift. Name the product sentence first. Keep
+the workflow, safety, accessibility, and recognizable product feel. Refuse only
+the promise that was forcing a second system, and keep it when the evidence says
+the loss is load-bearing.
+
 ## Compose With
 
 - `one-sentence-test` detects the opportunity (the surface audit surfaces the
   convenience feature that forces a second product sentence). This skill owns
   the decision.
+- `refactoring` counts callers, fixtures, state branches, styling branches,
+  docs paths, and other code-family evidence before the refusal is executed.
+- `frontend-design` owns visual direction, accessibility, brand, and whether a
+  UI detail is load-bearing before pixel fidelity is refused.
 - `cohesive-clean-breaks` executes the resulting breaking change, wave ordering,
   and old-path deletion.
 - `greenfield-clean-breaks` and `radical-options` link here instead of
@@ -26,7 +45,7 @@ intact.
 
 ## When To Run
 
-Run this pass when a design adds:
+Run this pass when a design adds or preserves:
 
 ```txt
 a fast path beside the canonical path
@@ -36,6 +55,38 @@ a second transport for one environment's nicer UX
 a compatibility alias nobody explicitly asked for
 an option that only preserves an old mental model
 a partial reflection API that makes callers ask which surfaces are real
+pixel-perfect reproduction of an old UI as a refactor requirement
+exact snapshot, fixture, layout, animation, or responsive-state compatibility
+a hand-drawn HTML diagram or component tree that reproduces structure already
+  owned by a UI primitive
+a rare mode whose tests, docs, branches, and state outlive its value
+```
+
+## Domain Manifestations
+
+The same move shows up in different clothes:
+
+```txt
+UI refactor
+  Refuse exact pixel or markup reproduction only when the core workflow,
+  hierarchy, accessibility, important states, and product feel survive.
+
+Code refactor
+  Refuse legacy aliases, duplicate helpers, fallback parsers, and old call
+  shapes when callers can move to one canonical path.
+
+Tests and reproducibility
+  Refuse exact old snapshots, fixture quirks, or transitional behavior when the
+  product contract is clearer than the old artifact.
+
+Design artifacts
+  Refuse full HTML facsimiles and exhaustive component trees when a native
+  primitive, screenshot, compact sketch, or state table preserves the same
+  decision.
+
+Architecture
+  Refuse keeping both mental models alive. A half-old, half-new system is
+  usually the expensive promise.
 ```
 
 ## Procedure
@@ -43,18 +94,21 @@ a partial reflection API that makes callers ask which surfaces are real
 ```txt
 1. Name the product sentence that must remain true.
 2. List candidate refusal points: fast paths, old shapes, rare modes, provider
-   exceptions, compatibility aliases, fallback parsers, partial reflection.
+   exceptions, compatibility aliases, fallback parsers, exact reproduction,
+   partial reflection, hand-reproduced UI structure.
 3. For each candidate, list the code family it forces: methods, adapters,
-   unions, error variants, tests, docs branches, UI states, migrations.
+   unions, error variants, tests, docs branches, UI states, styling branches,
+   fixtures, screenshots, migrations, local markup, custom CSS, diagram upkeep.
 4. Pick the candidate with the largest code family, not the most visible name.
 5. Ask who loses what if that behavior is refused.
 6. If the loss is a small convenience and the deletion removes a second shape,
    refuse the behavior and write that refusal into the spec.
 ```
 
-The rule is deliberately pushy: if the product sentence survives and the code
-family disappears, default to refusal. Keep the feature only when the user loss
-is load-bearing.
+The rule is evidence-seeking, not dramatic: if the product sentence survives and
+the code family disappears, refusal is the default recommendation. Keep the
+feature when the user loss is load-bearing or when the "deletion" would only move
+complexity somewhere harder to see.
 
 ## Decision Template
 
@@ -76,6 +130,65 @@ User loss:
 Decision:
   Refuse it / keep it because ...
 ```
+
+## UI Refactor Template
+
+Use this when the promise is visual or interaction fidelity:
+
+```txt
+Product sentence:
+  ...
+
+Must preserve:
+  workflow, information hierarchy, accessibility, important states,
+  recognizable product feel, inspectable state, reviewable intent
+
+Can refuse:
+  exact spacing, old breakpoints, one-off hover states, incidental animation,
+  pixel-perfect empty/loading/error states, duplicate responsive layouts,
+  locally reproduced HTML when a shared primitive owns the same contract,
+  exhaustive component trees when a smaller artifact preserves the decision
+
+Code family it deletes:
+  ...
+
+Replacement artifact:
+  shared primitive / screenshot / compact sketch / state table / full tree
+
+Decision:
+  Refuse it / keep it because ...
+```
+
+Pixel, markup, and screenshot fidelity are load-bearing when the exact detail
+carries comprehension, accessibility, trust, brand, or a regression-sensitive
+state. Otherwise, exact reproduction is a promise like any other: keep it only
+when it earns the code family it forces.
+
+## UI Artifact Ladder
+
+Use the smallest artifact that preserves the design decision:
+
+```txt
+1. Shared primitive or existing component
+   Use when the UI library already owns the structure, spacing, states, and
+   accessibility contract.
+
+2. Screenshot or generated image
+   Use when visual appearance matters more than exact markup.
+
+3. Compact sketch or state table
+   Use when the decision is hierarchy, state, or flow.
+
+4. Partial tree
+   Use when parent-child structure is the point under review.
+
+5. Full HTML diagram
+   Use only when exact DOM shape is the product contract or the bug.
+```
+
+Do not make agents reproduce a full HTML tree to prove a design unless the tree
+is the thing that must stay stable. Prefer the natural primitive, then verify the
+states that matter.
 
 ## Worked Example: Social Sign-In
 

--- a/.agents/skills/collapse-pass/SKILL.md
+++ b/.agents/skills/collapse-pass/SKILL.md
@@ -27,6 +27,12 @@ Load on demand:
 
 When a library refuses your model, treat the refusal as information about the model, not as friction to route around. If a "simplification" requires reimplementing a library's public surface, stop and delete the model instead.
 
+When preserving a promise keeps a second system alive, run
+[asymmetric-wins](../asymmetric-wins/SKILL.md). A collapse pass may sacrifice a
+small amount of fidelity, compatibility, reproducibility, or rare-mode support
+when the product sentence survives and the deletion removes a disproportionate
+implementation family. Name the refused promise before editing.
+
 ## Per-iteration ritual
 
 For each candidate file or symbol family:

--- a/.agents/skills/frontend-design/SKILL.md
+++ b/.agents/skills/frontend-design/SKILL.md
@@ -33,6 +33,26 @@ Use this pattern when you need to:
 - Avoid generic, repetitive AI-style design choices.
 - Match implementation complexity to the chosen visual direction.
 
+## Refactor Fidelity
+
+When redesigning or refactoring an existing UI, treat pixel fidelity as a
+question to classify, not a default requirement. This skill owns visual
+direction, hierarchy, accessibility, important states, and recognizable product
+feel.
+
+If exact spacing, breakpoints, animations, hover states, empty states, DOM shape,
+full component trees, or snapshot fidelity force a large styling or state
+family, switch to [asymmetric-wins](../asymmetric-wins/SKILL.md) for the refusal
+decision. Return here for the visual judgment: fidelity is load-bearing when it
+affects comprehension, accessibility, trust, brand, or regression-sensitive
+state.
+
+Prefer local UI primitives when they preserve the same workflow, hierarchy,
+states, and accessibility contract. Do not reproduce a full HTML tree merely to
+make a design artifact feel precise; use a screenshot, compact sketch, state
+table, or partial tree unless exact DOM structure is the product contract or the
+bug.
+
 ## Design Thinking
 
 Before coding, understand the context and commit to a BOLD aesthetic direction:

--- a/.agents/skills/refactoring/SKILL.md
+++ b/.agents/skills/refactoring/SKILL.md
@@ -12,6 +12,13 @@ Systematic approach to auditing and improving code. Every change is evidence-bas
 
 > **Related Skills**: See `post-implementation-review` for the full second-read ritual after implementation. See `cohesive-clean-breaks` when the refactor changes public shape, ownership, naming, or lifecycle boundaries. See `control-flow` for linearizing conditionals and guard clauses. See `factory-function-composition` for the four-zone factory anatomy. See `method-shorthand-jsdoc` for when to use `this.method()` vs direct calls.
 
+Use [asymmetric-wins](../asymmetric-wins/SKILL.md) when a refactor is preserving
+a small promise that owns a large code family: legacy aliases, fallback parsers,
+exact old fixtures, pixel-perfect UI reproduction, duplicate call shapes, or a
+rare mode with its own tests and docs. Refactors do not need to preserve every
+old promise. They need to preserve the product sentence and the load-bearing
+contracts.
+
 ## When to Apply This Skill
 
 Use this methodology when you need to:


### PR DESCRIPTION
This sharpens the agent skill guidance around asymmetric wins so refusal decisions are grounded in the product sentence and the code family they delete.

The related collapse, refactoring, and frontend design skills now route fidelity-preserving refactors through the same decision frame: keep load-bearing behavior, but avoid preserving old shapes when they force a second system. The updated guidance also names UI artifact fidelity directly: prefer native primitives, screenshots, compact sketches, or state tables over full HTML/component-tree reproductions unless DOM shape is the contract or bug.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785629849&installation_id=128463665&pr_number=2284&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2284&signature=f192a21d2980e5e02e49c4ac65a6e4d82de1d8a1b86b9730a744b112ec352ef2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->