### PR TITLE
feat(super-chat): load trusted tool modules through the injected host API

### DIFF
--- a/apps/super-chat/AGENTS.md
+++ b/apps/super-chat/AGENTS.md
@@ -7,6 +7,7 @@ Design authority: [ADR-0080](../../docs/adr/0080-the-super-app-is-a-desktop-host
 ## Shape
 
 - `src/host.ts` composes the static install list: in-process Yjs apps (arm A) as durable local `connect(null, { persistence })` replicas over their action registries, boxed apps (arm B, Local Books) as a local stdio MCP subprocess via `src/stdio-mcp-catalog.ts`. Every source is namespaced (`todos__`, `localbooks__`) and merged with `composeToolCatalogs` into the one `ToolCatalog` the agent loop consumes.
+- `src/tool-loader.ts` is the one dynamic source (ADR-0097): at startup it scans `<dataDir>/tools/*.ts`, imports each file with Bun `import()`, and calls the default-exported factory with the injected `ToolHost` (host-owned `defineQuery`, `defineMutation`, `Type`, and scoped `workspaces`). Each file's tools compose under its file-name namespace; a malformed module or a namespace collision fails startup with the file named, and a missing directory just means no modules are installed.
 - The in-process apps use `bunLocalPersistence({ dir, nodeId })` under the host data directory. This is signed-out local durability only; sign-in and relay sync for the host are a later enhancement.
 - Chat history is intentionally ephemeral (`src/message-store.ts`) until the transcript-persistence decision is made; tool results can carry data ADR-0080's confidentiality rule keeps off hosted readable planes.
 

--- a/apps/super-chat/src/host.test.ts
+++ b/apps/super-chat/src/host.test.ts
@@ -13,6 +13,10 @@ import { createSuperChatHost, type SuperChatHostOptions } from './host.ts';
 const FIXTURE = new URL('../test-fixtures/mini-mcp-server.ts', import.meta.url)
 	.pathname;
 
+function fixtureDir(name: string): string {
+	return new URL(`../test-fixtures/${name}/`, import.meta.url).pathname;
+}
+
 /**
  * A scripted engine: each model call consumes the next chunk list. The last
  * script repeats, so a trailing text answer also serves any extra step.
@@ -143,6 +147,97 @@ describe('createSuperChatHost', () => {
 		expect(results).toHaveLength(1);
 		expect(results[0]!.isError).toBe(false);
 		expect(results[0]!.content).toContain('Acme | 4200.00');
+	});
+
+	test('startup-scanned tool modules add verbs through the injected host API', async () => {
+		await using host = await createTestHost({
+			engine: scriptedEngine([[]]),
+			toolsDir: fixtureDir('tools'),
+		});
+		const names = host.tools.definitions().map((d) => d.name);
+		// The built-in apps still compose beside the loaded modules.
+		expect(names).toContain('todos__todos_create');
+		// weather.ts (registry form): built entirely from injected helpers.
+		expect(names).toContain('weather__weather_get');
+		// insights.ts (escape hatch): a module-returned full ToolCatalog.
+		expect(names).toContain('insights__ping');
+
+		const signal = new AbortController().signal;
+		const weather = await host.tools.resolve(
+			{
+				toolCallId: 'call-weather',
+				toolName: 'weather__weather_get',
+				input: { city: 'Oslo' },
+			},
+			signal,
+		);
+		expect(weather.isError).toBe(false);
+		expect(weather.content).toBe('Sunny in Oslo');
+
+		// The scoped workspaces bag is the one cross-app entry point (ADR-0097).
+		const scopes = await host.tools.resolve(
+			{
+				toolCallId: 'call-scopes',
+				toolName: 'weather__workspaces_list',
+				input: {},
+			},
+			signal,
+		);
+		expect(scopes.content).toBe('honeycrisp,todos');
+
+		const pong = await host.tools.resolve(
+			{ toolCallId: 'call-ping', toolName: 'insights__ping', input: {} },
+			signal,
+		);
+		expect(pong.isError).toBe(false);
+		expect(pong.content).toBe('pong');
+	});
+
+	test('a chat turn drives a loaded module verb like any built-in', async () => {
+		const engine = scriptedEngine([
+			[
+				{
+					type: 'tool-call',
+					toolCallId: 'call-1',
+					toolName: 'weather__weather_get',
+					input: { city: 'Lima' },
+				},
+			],
+			[{ type: 'text-delta', delta: 'Sunny there.' }],
+		]);
+		await using host = await createTestHost({
+			engine,
+			toolsDir: fixtureDir('tools'),
+		});
+
+		host.conversation.send('weather in lima?');
+		await settle(host);
+
+		const { messages, error } = host.conversation.snapshot();
+		expect(error).toBeNull();
+		const results = messages.flatMap((m) => toolResults(m.parts));
+		expect(results).toHaveLength(1);
+		expect(results[0]!.isError).toBe(false);
+		expect(results[0]!.content).toBe('Sunny in Lima');
+	});
+
+	test('a malformed tool module fails host startup naming the file', async () => {
+		// The documented policy: fail the launch, never skip silently.
+		await expect(
+			createTestHost({
+				engine: scriptedEngine([[]]),
+				toolsDir: fixtureDir('tools-malformed'),
+			}),
+		).rejects.toThrow(/not-a-factory\.ts" must default-export a factory/);
+	});
+
+	test('a module colliding with a built-in namespace fails host startup', async () => {
+		await expect(
+			createTestHost({
+				engine: scriptedEngine([[]]),
+				toolsDir: fixtureDir('tools-collision'),
+			}),
+		).rejects.toThrow(/namespace "todos", which is already taken/);
 	});
 
 	test('a second host over the same data dir reads the first host todos through the catalog', async () => {

--- a/apps/super-chat/src/host.ts
+++ b/apps/super-chat/src/host.ts
@@ -5,9 +5,11 @@
  * join as local stdio MCP subprocesses (arm B, Local Books today). One agent
  * loop consumes the composed catalog and never learns where a verb lives.
  *
- * The install list is static and code-owned: this file IS the discovery
- * mechanism for the first slice (no registry, no scanned tool files; dynamic
- * loading waits for the tool module contract ADR named in ADR-0084).
+ * The built-in install list is static and code-owned. Beside it, one dynamic
+ * source: trusted TypeScript tool modules scanned at startup from the host's
+ * tools directory and called with the injected host API (ADR-0084 mechanism,
+ * ADR-0097 contract; see `tool-loader.ts`). No registry, no trust prompts,
+ * no hot reload; a malformed module fails startup with the file named.
  *
  * The in-process apps open through the ungated durable local preset:
  * `connect(null, { persistence })`. Sign-in is still an enhancement; the Bun
@@ -19,7 +21,12 @@ import { homedir, platform } from 'node:os';
 import { dirname, join } from 'node:path';
 import { honeycrispWorkspace } from '@epicenter/honeycrisp';
 import { todosWorkspace } from '@epicenter/todos';
-import { createNodeId, generateId } from '@epicenter/workspace';
+import {
+	createNodeId,
+	defineMutation,
+	defineQuery,
+	generateId,
+} from '@epicenter/workspace';
 import {
 	type AgentEngine,
 	type Approval,
@@ -31,11 +38,13 @@ import {
 	type ToolCatalog,
 } from '@epicenter/workspace/agent';
 import { bunLocalPersistence } from '@epicenter/workspace/node';
+import Type from 'typebox';
 import { createInMemoryMessageStore } from './message-store.ts';
 import {
 	createStdioMcpCatalog,
 	type StdioMcpCatalogOptions,
 } from './stdio-mcp-catalog.ts';
+import { loadToolModuleCatalogs } from './tool-loader.ts';
 
 export type {
 	ToolHost,
@@ -60,6 +69,12 @@ export type SuperChatHostOptions = {
 	localBooks?: StdioMcpCatalogOptions;
 	/** Host-owned data directory for installed app replicas and node identity. */
 	dataDir?: string;
+	/**
+	 * Directory scanned at startup for trusted `.ts` tool modules (ADR-0097).
+	 * Defaults to `<dataDir>/tools`. A missing directory means none are
+	 * installed; a malformed module fails startup with the file named.
+	 */
+	toolsDir?: string;
 };
 
 export type SuperChatHost = {
@@ -71,8 +86,8 @@ export type SuperChatHost = {
 };
 
 /**
- * Open the installed apps, compose their catalogs, and start the one chat
- * session over them. Async only when arm B spawns (the MCP handshake).
+ * Open the installed apps, load the trusted tool modules, compose their
+ * catalogs, and start the one chat session over them.
  */
 export async function createSuperChatHost(
 	options: SuperChatHostOptions,
@@ -94,6 +109,26 @@ export async function createSuperChatHost(
 		),
 		namespaceToolCatalog('todos', createLocalToolCatalog(todos.actions)),
 	];
+
+	// Trusted tool modules (ADR-0097): scanned once at startup, each factory
+	// called with the host-owned runtime helpers and the workspaces the host
+	// chooses to expose. Reserving `localbooks` even when arm B is not installed
+	// keeps a module from squatting on a namespace an install would later claim.
+	const toolModuleCatalogs = await loadToolModuleCatalogs({
+		dir: options.toolsDir ?? join(dataDir, 'tools'),
+		host: {
+			defineQuery,
+			defineMutation,
+			Type,
+			workspaces: { honeycrisp, todos },
+		},
+		reservedNamespaces: ['honeycrisp', 'todos', 'localbooks'],
+	}).catch((error) => {
+		honeycrisp[Symbol.dispose]();
+		todos[Symbol.dispose]();
+		throw error;
+	});
+	catalogs.push(...toolModuleCatalogs);
 
 	// Arm B: boxed apps join as stdio MCP subprocesses behind the same seam.
 	const localBooks = options.localBooks

--- a/apps/super-chat/src/tool-loader.ts
+++ b/apps/super-chat/src/tool-loader.ts
@@ -1,0 +1,147 @@
+/**
+ * Startup loading of trusted TypeScript tool modules: the ADR-0084 mechanism
+ * (Bun's native `import()` over vendored `.ts` files) carrying the ADR-0097
+ * contract (a default-exported factory that receives the host API). The loader
+ * scans one flat directory, calls each factory with the host-owned
+ * {@link ToolHost}, and projects each result into a namespaced
+ * {@link ToolCatalog} the host merges beside the built-in apps.
+ *
+ * Failure policy: a malformed module fails host startup instead of being
+ * skipped. Tool files are trusted, user-installed code; a launch failure that
+ * names the file is easier to notice and fix than a verb that silently never
+ * appears. A missing directory is not a failure: nothing is installed, and the
+ * host runs with the built-in apps only.
+ */
+
+import { type Dirent, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+	createLocalToolCatalog,
+	namespaceToolCatalog,
+	type ToolCatalog,
+} from '@epicenter/workspace/agent';
+import type { ToolHost, ToolModule, ToolModuleResult } from './tool-module.ts';
+
+export type LoadToolModulesOptions = {
+	/** The flat directory scanned for `*.ts` tool modules. */
+	dir: string;
+	/** The host API injected into every module factory (ADR-0097). */
+	host: ToolHost;
+	/**
+	 * Namespaces the static install list already owns. A module file whose name
+	 * matches one fails startup; under first-wins composition it would otherwise
+	 * silently shadow (or be shadowed by) a built-in app's verbs.
+	 */
+	reservedNamespaces: readonly string[];
+};
+
+/**
+ * Load every tool module in `dir` and return one namespaced catalog per file.
+ * The namespace is the file name without `.ts`: `weather.ts` contributes
+ * `weather__<tool>` verbs to the composed surface.
+ */
+export async function loadToolModuleCatalogs({
+	dir,
+	host,
+	reservedNamespaces,
+}: LoadToolModulesOptions): Promise<ToolCatalog[]> {
+	const taken = new Set(reservedNamespaces);
+	const catalogs: ToolCatalog[] = [];
+	for (const file of listToolFiles(dir)) {
+		const path = join(dir, file);
+		const namespace = file.slice(0, -'.ts'.length);
+		// `namespaceToolCatalog` requires a prefix free of the `__` separator.
+		if (
+			!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(namespace) ||
+			namespace.includes('__')
+		) {
+			throw new Error(
+				`Tool module "${path}" has an invalid namespace "${namespace}": use letters, digits, "-", or single "_" (never "__"). Rename the file.`,
+			);
+		}
+		if (taken.has(namespace)) {
+			throw new Error(
+				`Tool module "${path}" would claim the namespace "${namespace}", which is already taken. Rename the file.`,
+			);
+		}
+		taken.add(namespace);
+		catalogs.push(
+			namespaceToolCatalog(namespace, await loadToolModule(path, host)),
+		);
+	}
+	return catalogs;
+}
+
+/** The `.ts` files directly in `dir`, sorted for a deterministic load order. */
+function listToolFiles(dir: string): string[] {
+	let entries: Dirent[];
+	try {
+		entries = readdirSync(dir, { withFileTypes: true });
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+		throw error;
+	}
+	return entries
+		.filter(
+			(entry) =>
+				entry.isFile() &&
+				entry.name.endsWith('.ts') &&
+				!entry.name.endsWith('.d.ts'),
+		)
+		.map((entry) => entry.name)
+		.sort();
+}
+
+/** Import one module, run its factory, and project the result to a catalog. */
+async function loadToolModule(
+	path: string,
+	host: ToolHost,
+): Promise<ToolCatalog> {
+	const module: { default?: unknown } = await import(
+		pathToFileURL(path).href
+	).catch((cause) => {
+		throw new Error(`Tool module "${path}" failed to import.`, { cause });
+	});
+	if (typeof module.default !== 'function') {
+		throw new Error(
+			`Tool module "${path}" must default-export a factory function receiving the ToolHost (ADR-0097); its default export is ${typeof module.default}.`,
+		);
+	}
+	const factory = module.default as ToolModule;
+	let result: ToolModuleResult;
+	try {
+		result = await factory(host);
+	} catch (cause) {
+		throw new Error(`Tool module "${path}" threw while building its tools.`, {
+			cause,
+		});
+	}
+	if (isToolCatalog(result)) return result;
+	if (typeof result !== 'object' || result === null) {
+		throw new Error(
+			`Tool module "${path}" must return an action registry or a ToolCatalog; it returned ${result === null ? 'null' : typeof result}.`,
+		);
+	}
+	// The registry form: every value must be an action (the callable IS the
+	// handler, with `type` attached by the injected defineQuery/defineMutation).
+	for (const [key, action] of Object.entries(result)) {
+		if (
+			typeof action !== 'function' ||
+			(action.type !== 'query' && action.type !== 'mutation')
+		) {
+			throw new Error(
+				`Tool module "${path}" registry entry "${key}" is not an action; build entries with the injected defineQuery/defineMutation.`,
+			);
+		}
+	}
+	return createLocalToolCatalog(result);
+}
+
+/** The escape-hatch form: a full catalog is `{ definitions(), resolve() }`. */
+function isToolCatalog(result: ToolModuleResult): result is ToolCatalog {
+	return (
+		typeof (result as ToolCatalog).definitions === 'function' &&
+		typeof (result as ToolCatalog).resolve === 'function'
+	);
+}

--- a/apps/super-chat/src/tool-module.ts
+++ b/apps/super-chat/src/tool-module.ts
@@ -32,7 +32,10 @@ export type ToolHost<TWorkspaces extends ToolWorkspaces = ToolWorkspaces> = {
  */
 export type ToolModuleResult = ActionRegistry | ToolCatalog;
 
-/** Default export contract for `~/.epicenter/super-chat/tools/*.ts`. */
+/**
+ * Default export contract for trusted tool modules scanned at startup from the
+ * host's tools directory (`<dataDir>/tools/*.ts`; see `tool-loader.ts`).
+ */
 export type ToolModule<TWorkspaces extends ToolWorkspaces = ToolWorkspaces> = (
 	host: ToolHost<TWorkspaces>,
 ) => ToolModuleResult | Promise<ToolModuleResult>;

--- a/apps/super-chat/test-fixtures/tools-collision/todos.ts
+++ b/apps/super-chat/test-fixtures/tools-collision/todos.ts
@@ -1,0 +1,11 @@
+import type { ToolHost } from '@epicenter/super-chat';
+
+/** A valid factory whose file name collides with the built-in `todos` app. */
+export default function ({ defineQuery }: ToolHost) {
+	return {
+		shadow_probe: defineQuery({
+			description: 'Never composes; the namespace collision fails startup.',
+			handler: () => 'unreachable',
+		}),
+	};
+}

--- a/apps/super-chat/test-fixtures/tools-malformed/not-a-factory.ts
+++ b/apps/super-chat/test-fixtures/tools-malformed/not-a-factory.ts
@@ -1,0 +1,2 @@
+/** Malformed on purpose: the default export is not a factory function. */
+export default { nope: true };

--- a/apps/super-chat/test-fixtures/tools/insights.ts
+++ b/apps/super-chat/test-fixtures/tools/insights.ts
@@ -1,0 +1,14 @@
+import type { ToolHost, ToolModuleResult } from '@epicenter/super-chat';
+
+/**
+ * The escape-hatch form (ADR-0097): a module that returns a full ToolCatalog
+ * for a custom adapter, instead of the default action registry.
+ */
+export default function (_host: ToolHost): ToolModuleResult {
+	return {
+		definitions: () => [
+			{ name: 'ping', kind: 'query' as const, description: 'Answers pong.' },
+		],
+		resolve: async () => ({ content: 'pong', isError: false }),
+	};
+}

--- a/apps/super-chat/test-fixtures/tools/weather.ts
+++ b/apps/super-chat/test-fixtures/tools/weather.ts
@@ -1,0 +1,20 @@
+import type { ToolHost } from '@epicenter/super-chat';
+
+/**
+ * The registry form (ADR-0097): no runtime imports. `defineQuery` and `Type`
+ * arrive through the injected host, and the type-only import above erases at
+ * transpile time, so loading never resolves host packages.
+ */
+export default function ({ defineQuery, Type, workspaces }: ToolHost) {
+	return {
+		weather_get: defineQuery({
+			description: 'Current weather for a city.',
+			input: Type.Object({ city: Type.String() }),
+			handler: ({ city }) => `Sunny in ${city}`,
+		}),
+		workspaces_list: defineQuery({
+			description: 'The workspace handles the host exposed to this module.',
+			handler: () => Object.keys(workspaces).sort().join(','),
+		}),
+	};
+}


### PR DESCRIPTION
Super Chat can now load trusted local tool modules without letting those modules import host runtime helpers directly. A module defaults to a factory, receives the host-owned API, and returns either an action registry or a full catalog:

```ts
import type { ToolHost } from '@epicenter/super-chat';

export default function weather(host: ToolHost) {
  return {
    weather_get: host.defineQuery({
      input: host.Type.Object({ city: host.Type.String() }),
      handler: ({ city }) => `Sunny in ${city}`,
    }),
  };
}
```

The host scans `<dataDir>/tools/*.ts` at startup, imports each file with Bun, injects `defineQuery`, `defineMutation`, `Type`, and scoped workspaces, then composes the loaded tools beside the built-in Honeycrisp, Todos, and Local Books surfaces. Registry-shaped modules are projected through `createLocalToolCatalog`; catalog-shaped modules are accepted as an escape hatch.

Malformed modules fail startup with the file named instead of silently disappearing. Loaded catalogs are namespaced by file name, and collisions with built-in namespaces are refused, so a local module cannot shadow `todos__`, `honeycrisp__`, or `localbooks__` tools.

## Changelog
- Add startup-loaded trusted TypeScript tool modules to Super Chat

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785632927&installation_id=128463665&pr_number=2285&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2285&signature=63ec47b21b4f10413685b57ac92cebc9d5da761409e512e77a5908047318e969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->