### PR TITLE
feat(super-chat): replace the placeholder page with a single-file session SPA

### DIFF
--- a/apps/super-chat/package.json
+++ b/apps/super-chat/package.json
@@ -9,8 +9,9 @@
 	},
 	"scripts": {
 		"start": "bun run src/main.ts",
+		"build": "vite build",
 		"test": "bun test",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsc --noEmit && svelte-check --tsconfig ./tsconfig.json"
 	},
 	"dependencies": {
 		"@epicenter/client": "workspace:*",
@@ -24,8 +25,13 @@
 		"yjs": "catalog:"
 	},
 	"devDependencies": {
+		"@sveltejs/vite-plugin-svelte": "catalog:",
 		"@types/bun": "catalog:",
-		"typescript": "catalog:"
+		"svelte": "catalog:",
+		"svelte-check": "catalog:",
+		"typescript": "catalog:",
+		"vite": "catalog:",
+		"vite-plugin-singlefile": "catalog:"
 	},
 	"license": "AGPL-3.0-or-later"
 }

--- a/apps/super-chat/src/main.ts
+++ b/apps/super-chat/src/main.ts
@@ -50,7 +50,17 @@ const engine = createOpenAiAgentEngine({
 });
 
 const host = await createSuperChatHost({ engine });
-const { app, websocket } = createSuperChatServer({ host, token });
+
+const pageFile = Bun.file(new URL('../dist/index.html', import.meta.url));
+if (!(await pageFile.exists())) {
+	console.error(
+		'The built SPA is missing. Run `bun run --filter @epicenter/super-chat build` first.',
+	);
+	process.exit(1);
+}
+const page = await pageFile.text();
+
+const { app, websocket } = createSuperChatServer({ host, token, page });
 
 const server = Bun.serve({
 	// Loopback only, never a LAN-reachable interface; port 0 lets the OS pick.

--- a/apps/super-chat/src/server.test.ts
+++ b/apps/super-chat/src/server.test.ts
@@ -1,7 +1,29 @@
+/**
+ * Super Chat Server Tests
+ *
+ * Verifies the loopback shell around one host session (ADR-0084): the
+ * per-launch token gates every HTTP request and WebSocket upgrade, the SPA is
+ * one self-contained document served byte-for-byte at `/`, and the WebSocket
+ * drives the single shared chat session.
+ *
+ * Key behaviors:
+ * - Every route 401s without the token (bearer header or `?token=` query)
+ * - `/` returns exactly the page string the server was constructed with
+ * - The real vite build emits one document with no external asset references
+ * - The spawned `main.ts` sidecar announces a port, serves the built SPA, and
+ *   drives a tool-calling turn against an OpenAI-compatible endpoint
+ *
+ * See also:
+ * - `host.test.ts` for tool catalog composition and turn execution
+ * - `packages/client/src/openai-provider.test.ts` for the SSE frame shapes
+ *   the fake inference endpoint below reuses
+ */
+
 import { describe, expect, test } from 'bun:test';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { AgentEngine, EngineChunk } from '@epicenter/workspace/agent';
 import {
 	createSuperChatHost,
@@ -11,6 +33,11 @@ import {
 import { createSuperChatServer, type ServerEvent } from './server.ts';
 
 const TOKEN = 'per-launch-secret';
+
+/** A stand-in for the built SPA document; `/` must return it byte-for-byte. */
+const PAGE = '<!doctype html><html><body>Super Chat test page</body></html>';
+
+const superChatDir = fileURLToPath(new URL('..', import.meta.url));
 
 function scriptedEngine(scripts: EngineChunk[][]): AgentEngine {
 	let step = 0;
@@ -29,8 +56,12 @@ function createTestHost(options: Omit<SuperChatHostOptions, 'dataDir'>) {
 	return createSuperChatHost({ dataDir: testDataDir(), ...options });
 }
 
-async function serveHost(host: SuperChatHost) {
-	const { app, websocket } = createSuperChatServer({ host, token: TOKEN });
+async function serveHost(host: SuperChatHost, page: string = PAGE) {
+	const { app, websocket } = createSuperChatServer({
+		host,
+		token: TOKEN,
+		page,
+	});
 	const server = Bun.serve({
 		hostname: '127.0.0.1',
 		port: 0,
@@ -45,9 +76,9 @@ describe('createSuperChatServer', () => {
 		await using host = await createTestHost({
 			engine: scriptedEngine([[]]),
 		});
-		expect(() => createSuperChatServer({ host, token: '' })).toThrow(
-			/per-launch token/,
-		);
+		expect(() =>
+			createSuperChatServer({ host, token: '', page: PAGE }),
+		).toThrow(/per-launch token/);
 	});
 
 	test('rejects every request without the token, on any route', async () => {
@@ -73,10 +104,14 @@ describe('createSuperChatServer', () => {
 		});
 		const server = await serveHost(host);
 		try {
-			// The initial window URL carries the token once as a query parameter.
+			// The initial window URL carries the token once as a query parameter,
+			// and the response IS the page the server was constructed with.
 			const page = await fetch(`${server.url.origin}/?token=${TOKEN}`);
 			expect(page.status).toBe(200);
-			expect(await page.text()).toContain('Super Chat');
+			expect(await page.text()).toBe(PAGE);
+			// The tokened navigation must never land in a disk cache keyed by
+			// its full URL (ADR-0084: the token dies with the process).
+			expect(page.headers.get('cache-control')).toBe('no-store');
 
 			// Subsequent fetches carry it as a bearer header.
 			const tools = await fetch(`${server.url.origin}/api/tools`, {
@@ -205,4 +240,301 @@ describe('createSuperChatServer', () => {
 			await server.stop(true);
 		}
 	});
+});
+
+// ============================================================================
+// Built SPA Tests (the real vite build)
+// ============================================================================
+
+let builtPagePromise: Promise<string> | undefined;
+
+/**
+ * Run the real vite build once per test run and return dist/index.html.
+ * Memoized because both the built-SPA describe and the sidecar smoke need it,
+ * and bun test does not guarantee an ordering contract between describes.
+ */
+function buildSpaOnce(): Promise<string> {
+	builtPagePromise ??= (async () => {
+		const build = Bun.spawn(['bun', 'x', 'vite', 'build'], {
+			cwd: superChatDir,
+			stdout: 'pipe',
+			stderr: 'pipe',
+		});
+		const exitCode = await build.exited;
+		if (exitCode !== 0) {
+			const stderr = await new Response(build.stderr).text();
+			throw new Error(`vite build exited with ${exitCode}:\n${stderr}`);
+		}
+		return Bun.file(join(superChatDir, 'dist', 'index.html')).text();
+	})();
+	return builtPagePromise;
+}
+
+describe('the built SPA', () => {
+	test('the build emits one self-contained document and the server returns it byte-for-byte', async () => {
+		const page = await buildSpaOnce();
+
+		// One inline script, and it must be inline: a `src` attribute would be
+		// a second request the token gate 401s (ADR-0084: the page is ONE
+		// request; every other request carries the token explicitly).
+		const scriptTags = page.match(/<script\b[^>]*>/gi) ?? [];
+		expect(scriptTags.length).toBeGreaterThan(0);
+		for (const tag of scriptTags) {
+			expect(tag).not.toMatch(/\ssrc\s*=/i);
+		}
+		// No asset-bearing tag may reference an external file. Matching tag
+		// attributes (not raw substrings) keeps legitimate inline JS or CSS
+		// content from false-positives.
+		for (const [tag] of page.matchAll(
+			/<(?:img|iframe|source|audio|video|embed)\b[^>]*>/gi,
+		)) {
+			expect(tag).not.toMatch(/\ssrc\s*=/i);
+		}
+		expect(page).not.toMatch(/<link\b[^>]*\brel\s*=\s*["']?stylesheet/i);
+		expect(page).not.toMatch(/<link\b[^>]*\bhref\s*=/i);
+
+		await using host = await createTestHost({
+			engine: scriptedEngine([[]]),
+		});
+		const server = await serveHost(host, page);
+		try {
+			const response = await fetch(`${server.url.origin}/?token=${TOKEN}`);
+			expect(response.status).toBe(200);
+			expect(await response.text()).toBe(page);
+		} finally {
+			await server.stop(true);
+		}
+	}, 60_000);
+});
+
+// ============================================================================
+// Sidecar End-to-End Smoke (the real main.ts entrypoint)
+// ============================================================================
+
+/** Build an OpenAI SSE response: one `data:` frame per chunk, then `[DONE]`. */
+function openAiSse(chunks: object[]): Response {
+	const encoder = new TextEncoder();
+	const body = new ReadableStream<Uint8Array>({
+		start(controller) {
+			for (const chunk of chunks) {
+				controller.enqueue(
+					encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`),
+				);
+			}
+			controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+			controller.close();
+		},
+	});
+	return new Response(body, {
+		status: 200,
+		headers: { 'content-type': 'text/event-stream' },
+	});
+}
+
+/** First model call: a fragmented streamed tool call to `todos__todos_list`. */
+const TOOL_CALL_TURN = [
+	{
+		choices: [
+			{
+				delta: {
+					tool_calls: [
+						{
+							index: 0,
+							id: 'call_1',
+							type: 'function',
+							function: { name: 'todos__todos_list', arguments: '' },
+						},
+					],
+				},
+				finish_reason: null,
+			},
+		],
+	},
+	{
+		choices: [
+			{
+				delta: { tool_calls: [{ index: 0, function: { arguments: '{}' } }] },
+				finish_reason: null,
+			},
+		],
+	},
+	{ choices: [{ delta: {}, finish_reason: 'tool_calls' }] },
+];
+
+const FINAL_TEXT = 'Your todo list is empty.';
+
+/** Second model call: the final assistant sentence as text deltas. */
+const FINAL_TEXT_TURN = [
+	{
+		choices: [{ delta: { content: 'Your todo list' }, finish_reason: null }],
+	},
+	{ choices: [{ delta: { content: ' is empty.' }, finish_reason: null }] },
+	{ choices: [{ delta: {}, finish_reason: 'stop' }] },
+];
+
+/**
+ * Read the sidecar's stdout until the one-line `{"port": N}` announcement.
+ * Rejects with the buffered stdout (or the sidecar's stderr, if it exited)
+ * so a failed launch names its cause instead of timing out silently.
+ */
+async function readPortAnnouncement(
+	sidecar: {
+		stdout: ReadableStream<Uint8Array>;
+		stderr: ReadableStream<Uint8Array>;
+	},
+	timeoutMs: number,
+): Promise<number> {
+	const reader = sidecar.stdout.getReader();
+	const decoder = new TextDecoder();
+	let buffer = '';
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<never>((_, reject) => {
+		timer = setTimeout(() => {
+			reject(
+				new Error(
+					`no port announcement within ${timeoutMs}ms; stdout so far: ${JSON.stringify(buffer)}`,
+				),
+			);
+		}, timeoutMs);
+	});
+	try {
+		while (true) {
+			const { value, done } = await Promise.race([reader.read(), timeout]);
+			if (value) {
+				buffer += decoder.decode(value, { stream: true });
+				const newline = buffer.indexOf('\n');
+				if (newline !== -1) {
+					const line = buffer.slice(0, newline);
+					return (JSON.parse(line) as { port: number }).port;
+				}
+			}
+			if (done) {
+				const stderr = await new Response(sidecar.stderr).text();
+				throw new Error(
+					`the sidecar exited before announcing a port:\n${stderr}`,
+				);
+			}
+		}
+	} finally {
+		clearTimeout(timer);
+		reader.releaseLock();
+	}
+}
+
+describe('sidecar end-to-end smoke', () => {
+	test('the spawned entrypoint serves the built SPA and drives a tool-calling turn', async () => {
+		const page = await buildSpaOnce();
+
+		// The fake OpenAI-compatible backend: first request streams a
+		// `todos__todos_list` tool call, second streams the final sentence.
+		let inferenceRequests = 0;
+		const inference = Bun.serve({
+			hostname: '127.0.0.1',
+			port: 0,
+			fetch(request) {
+				const { pathname } = new URL(request.url);
+				if (request.method !== 'POST' || pathname !== '/v1/chat/completions') {
+					return new Response('Not found', { status: 404 });
+				}
+				inferenceRequests += 1;
+				return openAiSse(
+					inferenceRequests === 1 ? TOOL_CALL_TURN : FINAL_TEXT_TURN,
+				);
+			},
+		});
+
+		const sidecar = Bun.spawn(['bun', 'run', 'src/main.ts'], {
+			cwd: superChatDir,
+			env: {
+				...process.env,
+				// The engine POSTs `${baseURL}/chat/completions`, so the base
+				// carries the `/v1` prefix.
+				SUPER_CHAT_INFERENCE_URL: `${inference.url.origin}/v1`,
+				SUPER_CHAT_MODEL: 'fake-model',
+				// Keep the host's replicas out of the real user data directory.
+				SUPER_CHAT_DATA_DIR: testDataDir(),
+			},
+			stdin: 'pipe',
+			stdout: 'pipe',
+			stderr: 'pipe',
+		});
+		try {
+			// The per-launch token travels as the first stdin line, never argv.
+			sidecar.stdin.write(`${TOKEN}\n`);
+			await sidecar.stdin.flush();
+			const port = await readPortAnnouncement(sidecar, 30_000);
+			const origin = `http://127.0.0.1:${port}`;
+
+			// The one-request page: exactly the built document.
+			const served = await fetch(`${origin}/?token=${TOKEN}`);
+			expect(served.status).toBe(200);
+			expect(await served.text()).toBe(page);
+
+			// The API behind the bearer exposes the composed catalog.
+			const tools = await fetch(`${origin}/api/tools`, {
+				headers: { authorization: `Bearer ${TOKEN}` },
+			});
+			expect(tools.status).toBe(200);
+			const catalog = (await tools.json()) as {
+				tools: Array<{ name: string }>;
+			};
+			expect(catalog.tools.map((t) => t.name)).toContain('todos__todos_list');
+
+			// One WebSocket turn: send, then await the settled snapshot.
+			const ws = new WebSocket(`ws://127.0.0.1:${port}/ws?token=${TOKEN}`);
+			const settled = new Promise<ServerEvent>((resolve, reject) => {
+				const timer = setTimeout(
+					() => reject(new Error('the turn never settled')),
+					20_000,
+				);
+				ws.addEventListener('message', (event) => {
+					const parsed = JSON.parse(String(event.data)) as ServerEvent;
+					const last = parsed.snapshot.messages.at(-1);
+					if (
+						!parsed.snapshot.isGenerating &&
+						last?.role === 'assistant' &&
+						last.parts.some(
+							(part) => part.type === 'text' && part.text.includes(FINAL_TEXT),
+						)
+					) {
+						clearTimeout(timer);
+						resolve(parsed);
+					}
+				});
+				ws.addEventListener('error', () => {
+					clearTimeout(timer);
+					reject(new Error('socket error'));
+				});
+			});
+			ws.addEventListener('open', () => {
+				ws.send(JSON.stringify({ type: 'send', content: 'list my todos' }));
+			});
+			let final: ServerEvent;
+			try {
+				final = await settled;
+			} finally {
+				ws.close();
+			}
+
+			expect(final.snapshot.error).toBeNull();
+			const parts = final.snapshot.messages.flatMap((m) => m.parts);
+			expect(parts).toContainEqual(
+				expect.objectContaining({
+					type: 'tool-call',
+					toolName: 'todos__todos_list',
+				}),
+			);
+			expect(parts).toContainEqual(
+				expect.objectContaining({
+					type: 'tool-result',
+					toolName: 'todos__todos_list',
+					isError: false,
+				}),
+			);
+			expect(inferenceRequests).toBe(2);
+		} finally {
+			sidecar.kill();
+			await inference.stop(true);
+		}
+	}, 120_000);
 });

--- a/apps/super-chat/src/server.ts
+++ b/apps/super-chat/src/server.ts
@@ -36,6 +36,8 @@ export type SuperChatServerOptions = {
 	host: SuperChatHost;
 	/** The per-launch token; the process must refuse to serve without one. */
 	token: string;
+	/** The built SPA document; the caller owns reading it from disk. */
+	page: string;
 };
 
 /**
@@ -43,7 +45,11 @@ export type SuperChatServerOptions = {
  * Binding (loopback, port 0) is the entrypoint's job, so tests can serve the
  * same app on an ephemeral port.
  */
-export function createSuperChatServer({ host, token }: SuperChatServerOptions) {
+export function createSuperChatServer({
+	host,
+	token,
+	page,
+}: SuperChatServerOptions) {
 	if (token === '') {
 		throw new Error(
 			'Super Chat refuses to serve without a per-launch token (ADR-0084).',
@@ -65,9 +71,15 @@ export function createSuperChatServer({ host, token }: SuperChatServerOptions) {
 		await next();
 	});
 
-	// The SPA slot. The real static assets land with the SPA slice; until then
-	// the placeholder proves the serving shape (page and API from one origin).
-	app.get('/', (c) => c.html(PLACEHOLDER_PAGE));
+	// The SPA: one self-contained document (all JS and CSS inlined by the
+	// build), because a separate asset request could not carry the bearer.
+	// `no-store` keeps the `/?token=` navigation out of the webview's disk
+	// cache, whose entries are keyed by the full URL including the query; the
+	// token must never outlive the process (ADR-0084).
+	app.get('/', (c) => {
+		c.header('cache-control', 'no-store');
+		return c.html(page);
+	});
 
 	app.get('/api/tools', (c) => c.json(listTools(host.tools)));
 
@@ -150,16 +162,3 @@ function parseCommand(data: unknown): ClientCommand | undefined {
 	if (command.type === 'retry') return { type: 'retry' };
 	return undefined;
 }
-
-const PLACEHOLDER_PAGE = `<!doctype html>
-<html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<title>Super Chat</title>
-	</head>
-	<body>
-		<h1>Super Chat</h1>
-		<p>The shell is serving. The SPA lands in a later slice; until then, talk to /ws.</p>
-	</body>
-</html>
-`;

--- a/apps/super-chat/src/ui/App.svelte
+++ b/apps/super-chat/src/ui/App.svelte
@@ -1,0 +1,206 @@
+<script lang="ts">
+	import Composer from './Composer.svelte';
+	import Transcript from './Transcript.svelte';
+	import { createSession } from './session.svelte.ts';
+
+	const { token }: { token: string | null } = $props();
+
+	// The token never changes within a page load (boot strips it from the URL
+	// and passes it once), so capturing its initial value is the point.
+	// svelte-ignore state_referenced_locally
+	const session = token === null ? null : createSession({ token });
+
+	const connectionLabel = {
+		connecting: 'Connecting',
+		open: 'Connected',
+		closed: 'Disconnected',
+	} as const;
+</script>
+
+{#if session === null}
+	<main class="missing-token">
+		<h1>Super Chat</h1>
+		<p>
+			This page is missing its launch token. Relaunch Super Chat from the app;
+			opening this address by hand will not work.
+		</p>
+	</main>
+{:else}
+	<div class="shell">
+		<header>
+			<span class="title">Super Chat</span>
+			<span class="connection {session.connection}">
+				<span class="dot"></span>
+				{connectionLabel[session.connection]}
+			</span>
+			<details class="tools">
+				<summary>
+					{session.tools.length}
+					{session.tools.length === 1 ? 'tool' : 'tools'}
+				</summary>
+				<ul>
+					{#each session.tools as tool (tool.name)}
+						<li>
+							<code>{tool.name}</code>
+							{#if tool.title}<span class="tool-title">{tool.title}</span>{/if}
+							{#if tool.description}
+								<p class="tool-description">{tool.description}</p>
+							{/if}
+						</li>
+					{/each}
+				</ul>
+			</details>
+		</header>
+
+		<Transcript snapshot={session.snapshot} />
+
+		{#if session.snapshot.error}
+			<div class="error" role="alert">
+				<strong>
+					Turn failed{session.snapshot.error.code
+						? ` (${session.snapshot.error.code})`
+						: ''}:
+				</strong>
+				{session.snapshot.error.message}
+			</div>
+		{/if}
+
+		<Composer
+			isGenerating={session.snapshot.isGenerating}
+			isConnected={session.connection === 'open'}
+			canRetry={session.snapshot.error !== null &&
+				!session.snapshot.isGenerating}
+			onSend={(content) => session.send(content)}
+			onStop={() => session.stop()}
+			onRetry={() => session.retry()}
+		/>
+	</div>
+{/if}
+
+<style>
+	.shell {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+	}
+
+	header {
+		display: flex;
+		align-items: baseline;
+		gap: 12px;
+		padding: 8px 12px;
+		border-bottom: 1px solid #26282e;
+		flex: none;
+	}
+
+	.title {
+		font-weight: 600;
+		color: #eceef2;
+	}
+
+	.connection {
+		display: inline-flex;
+		align-items: center;
+		gap: 5px;
+		font-size: 12px;
+		color: #8b8f98;
+	}
+
+	.dot {
+		width: 7px;
+		height: 7px;
+		border-radius: 50%;
+		background: #8b8f98;
+	}
+
+	.connection.open .dot {
+		background: #4cc38a;
+	}
+
+	.connection.connecting .dot {
+		background: #d8b44a;
+	}
+
+	.connection.closed .dot {
+		background: #e5484d;
+	}
+
+	.tools {
+		margin-left: auto;
+		position: relative;
+		font-size: 12px;
+		color: #8b8f98;
+	}
+
+	.tools summary {
+		cursor: pointer;
+		user-select: none;
+	}
+
+	.tools ul {
+		position: absolute;
+		right: 0;
+		top: calc(100% + 4px);
+		z-index: 1;
+		margin: 0;
+		padding: 8px 10px;
+		list-style: none;
+		width: 320px;
+		max-height: 60vh;
+		overflow-y: auto;
+		background: #1a1c21;
+		border: 1px solid #2c2f36;
+		border-radius: 6px;
+	}
+
+	.tools li + li {
+		margin-top: 8px;
+		padding-top: 8px;
+		border-top: 1px solid #26282e;
+	}
+
+	.tools code {
+		font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+		font-size: 11.5px;
+		color: #c3c6cc;
+	}
+
+	.tool-title {
+		margin-left: 6px;
+		color: #8b8f98;
+	}
+
+	.tool-description {
+		margin: 2px 0 0;
+		color: #7a7e87;
+	}
+
+	.error {
+		flex: none;
+		margin: 0 12px 8px;
+		padding: 8px 10px;
+		border: 1px solid #5c2e31;
+		border-radius: 6px;
+		background: #2a1d1e;
+		color: #f2b8ba;
+	}
+
+	.error strong {
+		color: #f59396;
+	}
+
+	.missing-token {
+		max-width: 32rem;
+		margin: 20vh auto 0;
+		padding: 0 16px;
+	}
+
+	.missing-token h1 {
+		font-size: 16px;
+		color: #eceef2;
+	}
+
+	.missing-token p {
+		color: #a3a7af;
+	}
+</style>

--- a/apps/super-chat/src/ui/Composer.svelte
+++ b/apps/super-chat/src/ui/Composer.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+	const {
+		isGenerating,
+		isConnected,
+		canRetry,
+		onSend,
+		onStop,
+		onRetry,
+	}: {
+		isGenerating: boolean;
+		isConnected: boolean;
+		canRetry: boolean;
+		/** Returns whether the message went out; the draft is kept on failure. */
+		onSend: (content: string) => boolean;
+		onStop: () => void;
+		onRetry: () => void;
+	} = $props();
+
+	let draft = $state('');
+	const canSend = $derived(
+		isConnected && !isGenerating && draft.trim().length > 0,
+	);
+
+	function submit() {
+		if (!canSend) return;
+		if (!onSend(draft)) return;
+		draft = '';
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key !== 'Enter' || event.shiftKey) return;
+		event.preventDefault();
+		submit();
+	}
+</script>
+
+<div class="composer">
+	<textarea
+		bind:value={draft}
+		onkeydown={handleKeydown}
+		placeholder="Message Super Chat (Enter to send, Shift+Enter for a new line)"
+		rows="3"
+	></textarea>
+	<div class="actions">
+		{#if isGenerating}
+			<button type="button" class="stop" onclick={onStop}>Stop</button>
+		{/if}
+		{#if canRetry}
+			<button type="button" onclick={onRetry}>Retry</button>
+		{/if}
+		<button type="button" class="send" disabled={!canSend} onclick={submit}>
+			Send
+		</button>
+	</div>
+</div>
+
+<style>
+	.composer {
+		flex: none;
+		display: flex;
+		gap: 8px;
+		padding: 0 12px 12px;
+		align-items: flex-end;
+	}
+
+	textarea {
+		flex: 1;
+		resize: none;
+		padding: 7px 9px;
+		font: inherit;
+		color: inherit;
+		background: #1b1d22;
+		border: 1px solid #2c2f36;
+		border-radius: 6px;
+	}
+
+	textarea:focus {
+		outline: none;
+		border-color: #3d6fb4;
+	}
+
+	.actions {
+		display: flex;
+		gap: 6px;
+	}
+
+	button {
+		padding: 6px 12px;
+		font: inherit;
+		color: #d4d6db;
+		background: #24262c;
+		border: 1px solid #2c2f36;
+		border-radius: 6px;
+		cursor: pointer;
+	}
+
+	button:hover:not(:disabled) {
+		background: #2b2e35;
+	}
+
+	button:disabled {
+		opacity: 0.45;
+		cursor: default;
+	}
+
+	.send {
+		background: #2f5e9e;
+		border-color: #3d6fb4;
+		color: #eef3fa;
+	}
+
+	.send:hover:not(:disabled) {
+		background: #366cb5;
+	}
+
+	.stop {
+		border-color: #5c2e31;
+		color: #f2b8ba;
+	}
+</style>

--- a/apps/super-chat/src/ui/Transcript.svelte
+++ b/apps/super-chat/src/ui/Transcript.svelte
@@ -1,0 +1,179 @@
+<script lang="ts">
+	import type {
+		AgentMessage,
+		ConversationSnapshot,
+	} from '@epicenter/workspace/agent';
+
+	const { snapshot }: { snapshot: ConversationSnapshot } = $props();
+
+	const isEmpty = $derived(
+		snapshot.messages.length === 0 &&
+			snapshot.streaming === null &&
+			!snapshot.isThinking,
+	);
+
+	let container: HTMLElement | undefined = $state();
+
+	// Whether the user was near the bottom before this render; measured on
+	// every scroll (including our own programmatic one), read by the effect.
+	// Deliberately not $state: its changes should never rerun the effect.
+	let nearBottom = true;
+
+	function trackScroll() {
+		if (!container) return;
+		nearBottom =
+			container.scrollHeight - container.scrollTop - container.clientHeight <
+			80;
+	}
+
+	$effect(() => {
+		// Every server event replaces the snapshot wholesale, so reading it is
+		// the "new content arrived" signal.
+		snapshot;
+		if (container && nearBottom) container.scrollTop = container.scrollHeight;
+	});
+</script>
+
+{#snippet bubble(message: AgentMessage)}
+	<article class="bubble {message.role}">
+		{#each message.parts as part, index (index)}
+			{#if part.type === 'text'}
+				<div class="text">{part.text}</div>
+			{:else if part.type === 'tool-call'}
+				<div class="tool-call">&rarr; {part.toolName}</div>
+			{:else}
+				<details class="tool-result" class:is-error={part.isError}>
+					<summary>
+						&larr; {part.toolName}{part.isError ? ' (error)' : ''}
+					</summary>
+					<pre>{part.content}</pre>
+					{#if part.details !== undefined}
+						<pre>{JSON.stringify(part.details, null, 2)}</pre>
+					{/if}
+				</details>
+			{/if}
+		{/each}
+	</article>
+{/snippet}
+
+<div class="transcript" bind:this={container} onscroll={trackScroll}>
+	{#if isEmpty}
+		<p class="empty">No messages yet. Ask something to get started.</p>
+	{/if}
+	{#each snapshot.messages as message (message.id)}
+		{@render bubble(message)}
+	{/each}
+	{#if snapshot.streaming}
+		{@render bubble(snapshot.streaming)}
+	{/if}
+	{#if snapshot.isThinking}
+		<div class="thinking" aria-label="The assistant is thinking">
+			<span></span><span></span><span></span>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.transcript {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+		padding: 12px;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.empty {
+		margin: auto;
+		color: #6f737c;
+	}
+
+	.bubble {
+		max-width: 72ch;
+		padding: 7px 10px;
+		border-radius: 8px;
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	.bubble.user {
+		align-self: flex-end;
+		background: #23303f;
+		color: #dfe5ec;
+	}
+
+	.bubble.assistant {
+		align-self: flex-start;
+		background: #1b1d22;
+		border: 1px solid #26282e;
+	}
+
+	.text {
+		white-space: pre-wrap;
+		overflow-wrap: anywhere;
+	}
+
+	.tool-call,
+	.tool-result summary {
+		font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+		font-size: 12px;
+		color: #8fb4e8;
+	}
+
+	.tool-result summary {
+		cursor: pointer;
+		user-select: none;
+	}
+
+	.tool-result.is-error summary {
+		color: #f59396;
+	}
+
+	.tool-result pre {
+		margin: 4px 0 0;
+		padding: 6px 8px;
+		max-height: 240px;
+		overflow: auto;
+		font-size: 11.5px;
+		background: #131418;
+		border-radius: 5px;
+		white-space: pre-wrap;
+		overflow-wrap: anywhere;
+	}
+
+	.thinking {
+		align-self: flex-start;
+		display: flex;
+		gap: 4px;
+		padding: 10px 12px;
+	}
+
+	.thinking span {
+		width: 6px;
+		height: 6px;
+		border-radius: 50%;
+		background: #6f737c;
+		animation: pulse 1.2s ease-in-out infinite;
+	}
+
+	.thinking span:nth-child(2) {
+		animation-delay: 0.2s;
+	}
+
+	.thinking span:nth-child(3) {
+		animation-delay: 0.4s;
+	}
+
+	@keyframes pulse {
+		0%,
+		60%,
+		100% {
+			opacity: 0.35;
+		}
+		30% {
+			opacity: 1;
+		}
+	}
+</style>

--- a/apps/super-chat/src/ui/index.html
+++ b/apps/super-chat/src/ui/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<meta name="color-scheme" content="dark">
+		<title>Super Chat</title>
+		<style>
+			html,
+			body {
+				height: 100%;
+			}
+			body {
+				margin: 0;
+				background: #131418;
+				color: #d4d6db;
+				font-family:
+					-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+					Arial, sans-serif;
+				font-size: 13px;
+				line-height: 1.45;
+			}
+			#app {
+				height: 100%;
+			}
+			* {
+				box-sizing: border-box;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="module" src="./main.ts"></script>
+	</body>
+</html>

--- a/apps/super-chat/src/ui/main.ts
+++ b/apps/super-chat/src/ui/main.ts
@@ -1,0 +1,20 @@
+/**
+ * SPA boot: pull the per-launch token out of the query string, scrub it from
+ * the visible URL, and keep it only in memory. Never write it to
+ * localStorage, sessionStorage, or a cookie; storage outlives the launch and
+ * hands the token to anything else that ever runs on this origin.
+ */
+
+import { mount } from 'svelte';
+import App from './App.svelte';
+
+// An empty `?token=` is as useless as a missing one; both show the
+// missing-token screen instead of reconnecting into 401s forever.
+const token = new URLSearchParams(location.search).get('token') || null;
+history.replaceState(null, '', location.pathname);
+
+mount(App, {
+	// biome-ignore lint/style/noNonNullAssertion: index.html always ships the mount node.
+	target: document.getElementById('app')!,
+	props: { token },
+});

--- a/apps/super-chat/src/ui/session.svelte.ts
+++ b/apps/super-chat/src/ui/session.svelte.ts
@@ -1,0 +1,129 @@
+/**
+ * The browser side of the Super Chat session: one WebSocket to `/ws`, one
+ * startup fetch of `/api/tools`, and a `$state`-backed view the components
+ * read. The server snapshot is the only transcript state; every `snapshot`
+ * event replaces it wholesale, so the client never accumulates a second
+ * transcript that could drift.
+ *
+ * Server types are imported type-only so no server runtime code (Hono, Bun
+ * WebSocket glue) enters the browser bundle.
+ */
+
+import type { ConversationSnapshot } from '@epicenter/workspace/agent';
+import type { ClientCommand, ServerEvent } from '../server.ts';
+
+export type ToolSummary = {
+	name: string;
+	kind: string;
+	title?: string;
+	description?: string;
+};
+
+export type ConnectionStatus = 'connecting' | 'open' | 'closed';
+
+const RECONNECT_DELAY_MS = 1500;
+
+export function createSession({ token }: { token: string }) {
+	let snapshot = $state<ConversationSnapshot>({
+		messages: [],
+		streaming: null,
+		isThinking: false,
+		isGenerating: false,
+		error: null,
+	});
+	let connection = $state<ConnectionStatus>('connecting');
+	let tools = $state<ToolSummary[]>([]);
+
+	let socket: WebSocket | undefined;
+	let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+	let disposed = false;
+
+	async function fetchTools() {
+		try {
+			const response = await fetch('/api/tools', {
+				headers: { authorization: `Bearer ${token}` },
+			});
+			if (!response.ok) return;
+			const body = (await response.json()) as { tools: ToolSummary[] };
+			tools = body.tools;
+		} catch {
+			// The tool list is informational; the chat works without it.
+		}
+	}
+
+	function connect() {
+		if (disposed) return;
+		connection = 'connecting';
+		// The browser WebSocket constructor cannot set headers, so the token
+		// rides the query string (the server gate accepts either).
+		const url = new URL(
+			`/ws?token=${encodeURIComponent(token)}`,
+			location.href,
+		);
+		// Match the page's scheme: plain ws: against the loopback origin, wss:
+		// when a remote overlay proxy serves this page over https.
+		url.protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+		const ws = new WebSocket(url);
+		socket = ws;
+		ws.onopen = () => {
+			connection = 'open';
+		};
+		ws.onmessage = (event) => {
+			if (typeof event.data !== 'string') return;
+			let parsed: ServerEvent;
+			try {
+				parsed = JSON.parse(event.data);
+			} catch {
+				return;
+			}
+			if (parsed.type === 'snapshot') snapshot = parsed.snapshot;
+		};
+		ws.onclose = () => {
+			if (socket !== ws) return;
+			socket = undefined;
+			if (disposed) return;
+			connection = 'closed';
+			reconnectTimer = setTimeout(connect, RECONNECT_DELAY_MS);
+		};
+	}
+
+	/** Returns whether the command actually went out over an open socket. */
+	function sendCommand(command: ClientCommand): boolean {
+		if (socket?.readyState !== WebSocket.OPEN) return false;
+		socket.send(JSON.stringify(command));
+		return true;
+	}
+
+	void fetchTools();
+	connect();
+
+	return {
+		get snapshot() {
+			return snapshot;
+		},
+		get connection() {
+			return connection;
+		},
+		get tools() {
+			return tools;
+		},
+		/** Returns whether the message went out, so the composer keeps the draft on failure. */
+		send(content: string) {
+			return sendCommand({ type: 'send', content });
+		},
+		stop() {
+			sendCommand({ type: 'stop' });
+		},
+		retry() {
+			sendCommand({ type: 'retry' });
+		},
+		/** Stop reconnecting and close the socket for good. */
+		dispose() {
+			disposed = true;
+			clearTimeout(reconnectTimer);
+			socket?.close();
+		},
+	};
+}
+
+export type Session = ReturnType<typeof createSession>;

--- a/apps/super-chat/svelte.config.js
+++ b/apps/super-chat/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+	preprocess: vitePreprocess(),
+};

--- a/apps/super-chat/tsconfig.json
+++ b/apps/super-chat/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.base.json",
+	"extends": "../../tsconfig.dom.json",
 	"compilerOptions": {
 		"types": ["bun"],
 		"noUnusedLocals": true,

--- a/apps/super-chat/vite.config.ts
+++ b/apps/super-chat/vite.config.ts
@@ -1,0 +1,29 @@
+/**
+ * Build the SPA as one self-contained document. The token gate 401s any
+ * request without the bearer, and injected `<script src>` / `<link href>`
+ * tags cannot carry one, so every byte of JS and CSS must inline into
+ * dist/index.html.
+ */
+
+import { fileURLToPath } from 'node:url';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { defineConfig } from 'vite';
+import { viteSingleFile } from 'vite-plugin-singlefile';
+
+export default defineConfig({
+	// Absolute, so the build works regardless of the invoking cwd (a relative
+	// root resolves against process.cwd(), not this file).
+	root: fileURLToPath(new URL('./src/ui', import.meta.url)),
+	plugins: [
+		// The plugin resolves svelte.config.js against the Vite root (src/ui),
+		// so point it back at the package-root config explicitly.
+		svelte({
+			configFile: fileURLToPath(new URL('./svelte.config.js', import.meta.url)),
+		}),
+		viteSingleFile(),
+	],
+	build: {
+		outDir: fileURLToPath(new URL('./dist', import.meta.url)),
+		emptyOutDir: true,
+	},
+});

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",
@@ -376,8 +375,13 @@
         "yjs": "catalog:",
       },
       "devDependencies": {
+        "@sveltejs/vite-plugin-svelte": "catalog:",
         "@types/bun": "catalog:",
+        "svelte": "catalog:",
+        "svelte-check": "catalog:",
         "typescript": "catalog:",
+        "vite": "catalog:",
+        "vite-plugin-singlefile": "catalog:",
       },
     },
     "apps/tab-manager": {
@@ -1103,6 +1107,7 @@
     "typescript": "^5.9.3",
     "virtua": "^0.48.5",
     "vite": "^7.3.5",
+    "vite-plugin-singlefile": "^2.3.3",
     "wellcrafted": "^0.43.0",
     "wrangler": "^4.71.0",
     "y-indexeddb": "^9.0.12",
@@ -3944,6 +3949,8 @@
     "vite-plugin-devtools-json": ["vite-plugin-devtools-json@1.0.0", "", { "dependencies": { "uuid": "^11.1.0" }, "peerDependencies": { "vite": "^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-MobvwqX76Vqt/O4AbnNMNWoXWGrKUqZbphCUle/J2KXH82yKQiunOeKnz/nqEPosPsoWWPP9FtNuPBSYpiiwkw=="],
 
     "vite-plugin-node-polyfills": ["vite-plugin-node-polyfills@0.26.0", "", { "dependencies": { "@rollup/plugin-inject": "^5.0.5", "node-stdlib-browser": "^1.3.1" }, "peerDependencies": { "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-BAe5YzJf368XGev02hDvioidx4uVH8dqEJlG73bjQSxM26/AQnGcKFomq9n3vGq5yqpSHKN4h1XQNxx9l98mBg=="],
+
+    "vite-plugin-singlefile": ["vite-plugin-singlefile@2.3.3", "", { "dependencies": { "micromatch": "^4.0.8" }, "peerDependencies": { "rollup": "^4.59.0", "vite": "^5.4.21 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["rollup"] }, "sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg=="],
 
     "vite-plugin-static-copy": ["vite-plugin-static-copy@4.1.1", "", { "dependencies": { "chokidar": "^3.6.0", "p-map": "^7.0.4", "picocolors": "^1.1.1", "tinyglobby": "^0.2.17" }, "peerDependencies": { "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-GrlA8YklrAfSyxJ4M3fdQLOo9oNkp56IM9FYgX/WtEgeIFkPwhu4wzpufBCIuNKCa6Fn77FkRdYxkHqV0FwjAw=="],
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 			"@sveltejs/vite-plugin-svelte": "^6.2.1",
 			"svelte-check": "^4.3.4",
 			"vite": "^7.3.5",
+			"vite-plugin-singlefile": "^2.3.3",
 			"tailwindcss": "^4.1.17",
 			"clsx": "^2.1.1",
 			"tailwind-merge": "^3.4.0",


### PR DESCRIPTION
Super Chat's shell has been serving a placeholder paragraph while the real surface was the CLI session client. This replaces it with a usable chat SPA over the protocol the server already speaks: the first screen is the live session, with the transcript in the center, a composer at the bottom, and a header carrying connection status plus the live tool list from `/api/tools`.

**The build is one self-contained HTML file, and that is forced by the token gate, not taste.** ADR-0084 rejects every request without the per-launch token. An injected `<script src>` tag cannot carry a bearer header, and a cookie on `127.0.0.1` is port-unscoped, so it would hand the token to any other local process that binds a loopback port. Inlining every byte of JS and CSS into `dist/index.html` (plain Vite plus `vite-plugin-singlefile`, no SvelteKit; one screen needs no router) keeps "every request carries the token" literally true: the tokened navigation is the only page request that ever happens. That response also goes out with `Cache-Control: no-store`, so the `/?token=` URL never lands in a webview disk cache keyed by its query string.

**The browser owns zero transcript state.** `src/ui/session.svelte.ts` is the whole client: one bearer fetch of `/api/tools`, one WebSocket, and a `$state`-backed view that replaces the snapshot wholesale on every server event.

```ts
const session = createSession({ token });
session.snapshot;   // the server's ConversationSnapshot, replaced on every event
session.connection; // 'connecting' | 'open' | 'closed', with a 1.5s reconnect loop
session.send(text); // returns whether it went out; the composer keeps the draft on failure
```

The token is read once from `?token=`, scrubbed from the visible URL with `history.replaceState`, and lives only in the `createSession` closure; it never touches storage.

**The server stays free of file IO.** `createSuperChatServer` now takes the built document as a required string, and the entrypoint owns reading it:

```ts
// Before: the placeholder was a constant inside server.ts
createSuperChatServer({ host, token });
// After: the caller provides the page; main.ts reads dist/index.html
createSuperChatServer({ host, token, page });
```

`main.ts` exits with a pointer to `bun run --filter @epicenter/super-chat build` when `dist/index.html` is missing.

Tests extend the existing protocol suite: the page route is asserted byte-for-byte with `no-store`, a real `vite build` runs in-test and its output is proven self-contained (no external `src`/`href` references) and served through the gate, and a sidecar end-to-end smoke spawns the real `main.ts` against a fake OpenAI endpoint and drives a full tool-calling turn (`todos__todos_list`) over the WebSocket, asserting the tool call, the tool result, and the final assistant text.

Two named trade-offs. The package's tsconfig now extends `tsconfig.dom.json`, so the sidecar files see DOM globals; the browser-to-server seam is still policed by type-only imports in the UI, but the reverse direction is convention, not compiler. And there is no `vite dev` story: the dev loop is `build` then `start`, because a second unauthenticated dev origin would sit outside the token gate.

Out of scope, deliberately: transcript persistence, settings, model config, Tauri sidecar wiring, marketplace or tool installation UI, and markdown rendering.

## Changelog

- Super Chat now serves a real chat interface: live transcript with tool calls and results, stop and retry, connection status, and the installed tool list.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785642908&installation_id=128463665&pr_number=2288&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2288&signature=82127a59cce15f46044d1f8d4b2c21daf0e896f3f4192aad789f669f9c289a1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->