### PR TITLE
chore: sweep keyring boundary stragglers after the keychain merge

### DIFF
--- a/apps/whispering/src/lib/platform/auth.tauri.ts
+++ b/apps/whispering/src/lib/platform/auth.tauri.ts
@@ -15,6 +15,8 @@ import type { PlatformAuth } from './types';
 
 const log = createLogger('whispering/platform/auth');
 
+// Allowlisted in `KEYRING_ACCOUNTS` (src-tauri/src/keyring_storage.rs); Rust
+// rejects any account name not on that list.
 const KEYRING_ACCOUNT = 'auth-grant';
 
 /**

--- a/apps/whispering/src/lib/tauri/commands.ts
+++ b/apps/whispering/src/lib/tauri/commands.ts
@@ -111,7 +111,6 @@ export type {
 	Engine,
 	Key,
 	KeyBinding,
-	KeyringError,
 	LocalModelState,
 	ModelEntry,
 	ModelFileDownload,

--- a/specs/20260701T150000-api-keyring-and-vault-wiring.md
+++ b/specs/20260701T150000-api-keyring-and-vault-wiring.md
@@ -67,7 +67,7 @@ Sign in on any device; the client fetches `GET /api/keyring` with its bearer; th
 | Vault doc identity | 1 evidence | User-global guid constant, owner-scoped persistence | ADR-0074 invariants 2 and 3. Constant lives in `packages/constants` beside the other cross-app identifiers. |
 | Per-doc key derivation | 1 evidence | `deriveWorkspaceKey(keyBytes, guid)` per keyring version into a `WorkspaceKeyring` map | Exactly what `activateEncryption` consumes (`keys.ts:41`, `y-keyvalue-lww-encrypted.ts`). The vault guid is the workspaceId label. |
 | Offline keyring cache | 2 coherence | Cache the fetched keyring on device: OS keychain on desktop, `localStorage` on web | Invariant 5 has no `locked` state; an offline boot with a synced vault replica MUST still decrypt, so the keyring must survive offline. Web cache is the same risk class as the grant beside it; desktop keychain is the "bootstrap root" role the keychain commit anticipated. |
-| Secret migration on sign-in | 2 coherence | Write-through device values into the vault, then delete local | Invariant 4 forbids a two-place read. Migration is copy-then-remove, mirroring the keychain grant migration pattern (`auth.tauri.ts`): local copy cleared only after a confirmed vault write. |
+| Secret migration on sign-in | 2 coherence | Write-through device values into the vault, then delete local | Invariant 4 forbids a two-place read. Migration is copy-then-remove: local copy cleared only after a confirmed vault write. |
 | Zero-knowledge / passphrase | Banked | Refused | ADR-0074 forecloses it as default; deferred premium seam. Do not reopen. |
 
 ## Architecture
@@ -238,4 +238,4 @@ export function mountSessionApp<E extends Env = Env>(
 - `packages/server/src/routes/session.ts` — the mount pattern to mirror.
 - `packages/server/src/server-bindings.ts` — where `ENCRYPTION_SECRETS?` joins.
 - `apps/whispering/src/lib/state/secrets.svelte.ts` — the facade whose JSDoc already narrates this exact wave.
-- `apps/whispering/src/lib/platform/auth.tauri.ts` — keychain command surface the desktop keyring cache reuses; the copy-confirm-delete migration pattern.
+- `apps/whispering/src/lib/platform/auth.tauri.ts` — the existing consumer of the keyring commands; the desktop keyring cache mirrors its `tauriOnly.keyring` usage.


### PR DESCRIPTION
#2286 locked the desktop grant to the keychain seam; this is the follow-up sweep over the files it touched. The generated `KeyringError` re-export in the command boundary had zero importers (the `tauriOnly.keyring` wrapper converts the IPC error into its own `defineErrors` variants, so the generated type never leaves the boundary) and its name collided with the app-level `KeyringError`; it is gone. The `auth-grant` account constant now carries a pointer at the Rust `KEYRING_ACCOUNTS` allowlist, so a TS-side rename cannot silently turn into runtime "unknown keyring account" rejections.

The keyring spec also cited the copy-confirm-delete grant migration as a live pattern; #2286 deleted that migration, so the citations are gone and the copy-then-remove rule stands on its own.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785643020&installation_id=128463665&pr_number=2289&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2289&signature=b9ad058644407dff3bddbd4afc4ed184f263fbd958b1ad2466df23ec4b0402bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->