### PR TITLE
refactor(auth): trim internal factory exports

### DIFF
--- a/packages/auth/src/contract.test.ts
+++ b/packages/auth/src/contract.test.ts
@@ -22,8 +22,8 @@ import { Ok, type Result } from 'wellcrafted/result';
 // they are the credential-shaped cell and grant, internal to auth core.
 // Import them from their source module.
 import type { OAuthTokenGrant, PersistedAuth } from './auth-types.js';
+import { createOAuthAppAuth } from './create-oauth-app-auth.js';
 import type { AuthClient, PersistedAuthStorage } from './index.js';
-import { createOAuthAppAuth } from './index.js';
 import type { OAuthLaunchResult } from './oauth-launchers/contract.js';
 
 const now = 1_000_000;

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -16,10 +16,6 @@ export {
 	Principal,
 } from './auth-types.js';
 export {
-	type CreateOAuthAppAuthConfig,
-	createOAuthAppAuth,
-} from './create-oauth-app-auth.js';
-export {
 	type Instance,
 	InstanceUrlError,
 	normalizeInstanceUrl,
@@ -39,10 +35,6 @@ export {
 	generateInstanceToken,
 	MIN_INSTANCE_TOKEN_CHARS,
 } from './instance-token.js';
-export {
-	type CreateInstanceTokenAuthConfig,
-	createInstanceTokenAuth,
-} from './instance-token-auth.js';
 export {
 	createWebStoragePersistedAuthStorage,
 	loadPersistedAuthStorage,


### PR DESCRIPTION
@epicenter/auth should expose the app-level auth client and shared contract types, not the two credential-strategy factories that createAppAuthClient already owns. This removes the OAuth and instance-token factory exports from the root barrel, while keeping their source modules available for internal auth composition and tests.

The contract test now imports createOAuthAppAuth from its source module, matching the rest of auth core's internal callers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785644718&installation_id=128463665&pr_number=2291&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2291&signature=69a2fcdba7d7f505835f8f14f7f90bd868f3ef3863971eac4901bf19d1df5287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->