### PR TITLE
feat(super-chat): canonicalize session protocol

### DIFF
--- a/apps/super-chat/package.json
+++ b/apps/super-chat/package.json
@@ -15,6 +15,7 @@
 	},
 	"dependencies": {
 		"@epicenter/client": "workspace:*",
+		"@epicenter/constants": "workspace:*",
 		"@epicenter/honeycrisp": "workspace:*",
 		"@epicenter/todos": "workspace:*",
 		"@epicenter/workspace": "workspace:*",

--- a/apps/super-chat/src/server.test.ts
+++ b/apps/super-chat/src/server.test.ts
@@ -129,6 +129,14 @@ describe('createSuperChatServer', () => {
 			};
 			expect(body.tools.map((t) => t.name)).toContain('todos__todos_create');
 			expect(body.snapshot.messages).toEqual([]);
+
+			const oldTools = await fetch(`${server.url.origin}/api/tools`, {
+				headers: { authorization: `Bearer ${TOKEN}` },
+			});
+			expect(oldTools.status).toBe(404);
+
+			const oldWs = await fetch(`${server.url.origin}/ws?token=${TOKEN}`);
+			expect(oldWs.status).toBe(404);
 		} finally {
 			await server.stop(true);
 		}

--- a/apps/super-chat/src/server.test.ts
+++ b/apps/super-chat/src/server.test.ts
@@ -87,7 +87,12 @@ describe('createSuperChatServer', () => {
 		});
 		const server = await serveHost(host);
 		try {
-			for (const path of ['/', '/api/tools', '/ws', '/nope']) {
+			for (const path of [
+				'/',
+				'/api/session',
+				'/api/session/stream',
+				'/nope',
+			]) {
 				const bare = await fetch(server.url.origin + path);
 				expect(bare.status).toBe(401);
 				const wrong = await fetch(`${server.url.origin}${path}?token=wrong`);
@@ -114,14 +119,16 @@ describe('createSuperChatServer', () => {
 			expect(page.headers.get('cache-control')).toBe('no-store');
 
 			// Subsequent fetches carry it as a bearer header.
-			const tools = await fetch(`${server.url.origin}/api/tools`, {
+			const session = await fetch(`${server.url.origin}/api/session`, {
 				headers: { authorization: `Bearer ${TOKEN}` },
 			});
-			expect(tools.status).toBe(200);
-			const body = (await tools.json()) as {
+			expect(session.status).toBe(200);
+			const body = (await session.json()) as {
 				tools: Array<{ name: string; kind: string }>;
+				snapshot: { messages: unknown[] };
 			};
 			expect(body.tools.map((t) => t.name)).toContain('todos__todos_create');
+			expect(body.snapshot.messages).toEqual([]);
 		} finally {
 			await server.stop(true);
 		}
@@ -135,7 +142,7 @@ describe('createSuperChatServer', () => {
 		});
 		const server = await serveHost(host);
 		try {
-			const url = `${server.url.origin.replace('http', 'ws')}/ws?token=${TOKEN}`;
+			const url = `${server.url.origin.replace('http', 'ws')}/api/session/stream?token=${TOKEN}`;
 			const ws = new WebSocket(url);
 			const answered = new Promise<ServerEvent>((resolve, reject) => {
 				ws.addEventListener('message', (event) => {
@@ -177,7 +184,7 @@ describe('createSuperChatServer', () => {
 		});
 		const server = await serveHost(host);
 		try {
-			const url = `${server.url.origin.replace('http', 'ws')}/ws?token=${TOKEN}`;
+			const url = `${server.url.origin.replace('http', 'ws')}/api/session/stream?token=${TOKEN}`;
 			const watcher = new WebSocket(url);
 			const driver = new WebSocket(url);
 			const settledAt = (ws: WebSocket) =>
@@ -229,7 +236,9 @@ describe('createSuperChatServer', () => {
 		});
 		const server = await serveHost(host);
 		try {
-			const ws = new WebSocket(`${server.url.origin.replace('http', 'ws')}/ws`);
+			const ws = new WebSocket(
+				`${server.url.origin.replace('http', 'ws')}/api/session/stream`,
+			);
 			const outcome = await new Promise<'open' | 'refused'>((resolve) => {
 				ws.addEventListener('open', () => resolve('open'));
 				ws.addEventListener('error', () => resolve('refused'));
@@ -470,18 +479,22 @@ describe('sidecar end-to-end smoke', () => {
 			expect(served.status).toBe(200);
 			expect(await served.text()).toBe(page);
 
-			// The API behind the bearer exposes the composed catalog.
-			const tools = await fetch(`${origin}/api/tools`, {
+			// The API behind the bearer exposes the composed catalog and snapshot.
+			const session = await fetch(`${origin}/api/session`, {
 				headers: { authorization: `Bearer ${TOKEN}` },
 			});
-			expect(tools.status).toBe(200);
-			const catalog = (await tools.json()) as {
+			expect(session.status).toBe(200);
+			const catalog = (await session.json()) as {
 				tools: Array<{ name: string }>;
+				snapshot: { messages: unknown[] };
 			};
 			expect(catalog.tools.map((t) => t.name)).toContain('todos__todos_list');
+			expect(catalog.snapshot.messages).toEqual([]);
 
 			// One WebSocket turn: send, then await the settled snapshot.
-			const ws = new WebSocket(`ws://127.0.0.1:${port}/ws?token=${TOKEN}`);
+			const ws = new WebSocket(
+				`ws://127.0.0.1:${port}/api/session/stream?token=${TOKEN}`,
+			);
 			const settled = new Promise<ServerEvent>((resolve, reject) => {
 				const timer = setTimeout(
 					() => reject(new Error('the turn never settled')),

--- a/apps/super-chat/src/server.ts
+++ b/apps/super-chat/src/server.ts
@@ -32,6 +32,16 @@ export type ClientCommand =
 /** What the server pushes: the full render state, on every loop change. */
 export type ServerEvent = { type: 'snapshot'; snapshot: ConversationSnapshot };
 
+export type SessionResponse = {
+	tools: Array<{
+		name: string;
+		kind: string;
+		title?: string;
+		description?: string;
+	}>;
+	snapshot: ConversationSnapshot;
+};
+
 export type SuperChatServerOptions = {
 	host: SuperChatHost;
 	/** The per-launch token; the process must refuse to serve without one. */
@@ -81,10 +91,15 @@ export function createSuperChatServer({
 		return c.html(page);
 	});
 
-	app.get('/api/tools', (c) => c.json(listTools(host.tools)));
+	app.get('/api/session', (c) =>
+		c.json({
+			tools: listTools(host.tools),
+			snapshot: host.conversation.snapshot(),
+		} satisfies SessionResponse),
+	);
 
 	app.get(
-		'/ws',
+		'/api/session/stream',
 		upgradeWebSocket(() => {
 			let unsubscribe: (() => void) | undefined;
 			const push = (ws: { send(data: string): void }) => {
@@ -134,15 +149,13 @@ function tokensMatch(candidate: string, expected: string): boolean {
 	return timingSafeEqual(a, b);
 }
 
-function listTools(tools: ToolCatalog) {
-	return {
-		tools: tools.definitions().map(({ name, kind, title, description }) => ({
-			name,
-			kind,
-			...(title !== undefined && { title }),
-			...(description !== undefined && { description }),
-		})),
-	};
+function listTools(tools: ToolCatalog): SessionResponse['tools'] {
+	return tools.definitions().map(({ name, kind, title, description }) => ({
+		name,
+		kind,
+		...(title !== undefined && { title }),
+		...(description !== undefined && { description }),
+	}));
 }
 
 function parseCommand(data: unknown): ClientCommand | undefined {

--- a/apps/super-chat/src/server.ts
+++ b/apps/super-chat/src/server.ts
@@ -15,6 +15,7 @@
  */
 
 import { createHash, timingSafeEqual } from 'node:crypto';
+import { API_ROUTES } from '@epicenter/constants/api-routes';
 import type {
 	ConversationSnapshot,
 	ToolCatalog,
@@ -91,7 +92,7 @@ export function createSuperChatServer({
 		return c.html(page);
 	});
 
-	app.get('/api/session', (c) =>
+	app.get(API_ROUTES.session.pattern, (c) =>
 		c.json({
 			tools: listTools(host.tools),
 			snapshot: host.conversation.snapshot(),
@@ -99,7 +100,7 @@ export function createSuperChatServer({
 	);
 
 	app.get(
-		'/api/session/stream',
+		API_ROUTES.session.stream.pattern,
 		upgradeWebSocket(() => {
 			let unsubscribe: (() => void) | undefined;
 			const push = (ws: { send(data: string): void }) => {

--- a/apps/super-chat/src/session-client.ts
+++ b/apps/super-chat/src/session-client.ts
@@ -1,7 +1,7 @@
 /**
- * A stand-in for "the phone": a CLI client of the shell's `/ws` session
- * endpoint. Connects, prints the live transcript as it streams, and sends
- * whatever you type as a new turn.
+ * A stand-in for "the phone": a CLI client of the shell's
+ * `/api/session/stream` session endpoint. Connects, prints the live transcript
+ * as it streams, and sends whatever you type as a new turn.
  *
  * This is the ADR-0080 remote-session proof carried forward from the Slice 1
  * prototype's `remote-client.ts`: every connected socket shares the SAME host
@@ -26,7 +26,7 @@ if (!origin || !token) {
 	process.exit(1);
 }
 
-const url = `${origin.replace(/\/$/, '')}/ws?token=${encodeURIComponent(token)}`;
+const url = `${origin.replace(/\/$/, '')}/api/session/stream?token=${encodeURIComponent(token)}`;
 console.log(`Connecting to ${origin} ...`);
 
 const socket = new WebSocket(url);

--- a/apps/super-chat/src/ui/session.svelte.ts
+++ b/apps/super-chat/src/ui/session.svelte.ts
@@ -1,23 +1,16 @@
 /**
- * The browser side of the Super Chat session: one WebSocket to `/ws`, one
- * startup fetch of `/api/tools`, and a `$state`-backed view the components
- * read. The server snapshot is the only transcript state; every `snapshot`
- * event replaces it wholesale, so the client never accumulates a second
- * transcript that could drift.
+ * The browser side of the Super Chat session: one startup fetch of
+ * `/api/session`, one WebSocket to `/api/session/stream`, and a `$state`-backed
+ * view the components read. The server snapshot is the only transcript state;
+ * every initial payload and `snapshot` event replaces it wholesale, so the
+ * client never accumulates a second transcript that could drift.
  *
  * Server types are imported type-only so no server runtime code (Hono, Bun
  * WebSocket glue) enters the browser bundle.
  */
 
 import type { ConversationSnapshot } from '@epicenter/workspace/agent';
-import type { ClientCommand, ServerEvent } from '../server.ts';
-
-export type ToolSummary = {
-	name: string;
-	kind: string;
-	title?: string;
-	description?: string;
-};
+import type { ClientCommand, ServerEvent, SessionResponse } from '../server.ts';
 
 export type ConnectionStatus = 'connecting' | 'open' | 'closed';
 
@@ -32,22 +25,28 @@ export function createSession({ token }: { token: string }) {
 		error: null,
 	});
 	let connection = $state<ConnectionStatus>('connecting');
-	let tools = $state<ToolSummary[]>([]);
+	let tools = $state<SessionResponse['tools']>([]);
 
 	let socket: WebSocket | undefined;
 	let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
 	let disposed = false;
 
-	async function fetchTools() {
+	async function hydrate() {
 		try {
-			const response = await fetch('/api/tools', {
+			const response = await fetch('/api/session', {
 				headers: { authorization: `Bearer ${token}` },
 			});
-			if (!response.ok) return;
-			const body = (await response.json()) as { tools: ToolSummary[] };
+			if (!response.ok) {
+				connection = 'closed';
+				return false;
+			}
+			const body = (await response.json()) as SessionResponse;
 			tools = body.tools;
+			snapshot = body.snapshot;
+			return true;
 		} catch {
-			// The tool list is informational; the chat works without it.
+			connection = 'closed';
+			return false;
 		}
 	}
 
@@ -57,7 +56,7 @@ export function createSession({ token }: { token: string }) {
 		// The browser WebSocket constructor cannot set headers, so the token
 		// rides the query string (the server gate accepts either).
 		const url = new URL(
-			`/ws?token=${encodeURIComponent(token)}`,
+			`/api/session/stream?token=${encodeURIComponent(token)}`,
 			location.href,
 		);
 		// Match the page's scheme: plain ws: against the loopback origin, wss:
@@ -94,8 +93,9 @@ export function createSession({ token }: { token: string }) {
 		return true;
 	}
 
-	void fetchTools();
-	connect();
+	void hydrate().then((ready) => {
+		if (ready) connect();
+	});
 
 	return {
 		get snapshot() {

--- a/apps/super-chat/src/ui/session.svelte.ts
+++ b/apps/super-chat/src/ui/session.svelte.ts
@@ -9,6 +9,7 @@
  * WebSocket glue) enters the browser bundle.
  */
 
+import { API_ROUTES } from '@epicenter/constants/api-routes';
 import type { ConversationSnapshot } from '@epicenter/workspace/agent';
 import type { ClientCommand, ServerEvent, SessionResponse } from '../server.ts';
 
@@ -33,7 +34,7 @@ export function createSession({ token }: { token: string }) {
 
 	async function hydrate() {
 		try {
-			const response = await fetch('/api/session', {
+			const response = await fetch(API_ROUTES.session.url(location.origin), {
 				headers: { authorization: `Bearer ${token}` },
 			});
 			if (!response.ok) {
@@ -55,10 +56,8 @@ export function createSession({ token }: { token: string }) {
 		connection = 'connecting';
 		// The browser WebSocket constructor cannot set headers, so the token
 		// rides the query string (the server gate accepts either).
-		const url = new URL(
-			`/api/session/stream?token=${encodeURIComponent(token)}`,
-			location.href,
-		);
+		const url = new URL(API_ROUTES.session.stream.url(location.origin));
+		url.searchParams.set('token', token);
 		// Match the page's scheme: plain ws: against the loopback origin, wss:
 		// when a remote overlay proxy serves this page over https.
 		url.protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/bun.lock
+++ b/bun.lock
@@ -366,6 +366,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@epicenter/client": "workspace:*",
+        "@epicenter/constants": "workspace:*",
         "@epicenter/honeycrisp": "workspace:*",
         "@epicenter/todos": "workspace:*",
         "@epicenter/workspace": "workspace:*",

--- a/packages/constants/src/api-routes.ts
+++ b/packages/constants/src/api-routes.ts
@@ -43,6 +43,10 @@ export const API_ROUTES = {
 	session: {
 		pattern: '/api/session',
 		url: (baseURL: string) => `${stripTrailing(baseURL)}/api/session`,
+		stream: {
+			pattern: '/api/session/stream',
+			url: (baseURL: string) => `${stripTrailing(baseURL)}/api/session/stream`,
+		},
 	},
 	/**
 	 * Content-addressed blob store. POST mints an upload ticket (presigned R2


### PR DESCRIPTION
Super Chat now has one bootstrap endpoint and one stream endpoint for the browser session. The page still comes from `GET /`, but the old split between `/api/tools` and `/ws` is gone.

```txt
GET /api/session
  -> { tools, snapshot }

WS /api/session/stream
  <- { type: "snapshot", snapshot }
  -> { type: "send" | "stop" | "retry", ... }
```

The browser hydrates tools and the initial transcript snapshot from `/api/session`, then adopts every WebSocket snapshot wholesale. The manual `session-client.ts` proof uses the same stream endpoint, so the remote-session path matches the browser protocol.

Old route aliases are intentionally not preserved. With a valid token, both `/api/tools` and `/ws` now return 404 so future changes do not accidentally recreate the compatibility surface.

## Changelog

- Super Chat session bootstrap now lives at `GET /api/session`.
- Super Chat streaming commands and snapshots now use `WS /api/session/stream`.
- Removed compatibility for the old `/api/tools` and `/ws` routes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785648830&installation_id=128463665&pr_number=2293&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2293&signature=9449b5395e113aa45d64b4284213a076b1c56d67d3eba1ce60887dd5382cf297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->