### PR TITLE
fix(billing): harden STT Autumn metering

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -38,7 +38,7 @@
 		"@epicenter/workspace": "workspace:*",
 		"@hono/standard-validator": "catalog:",
 		"arktype": "catalog:",
-		"autumn-js": "^1.0.7",
+		"autumn-js": "^1.2.34",
 		"better-auth": "catalog:",
 		"drizzle-orm": "catalog:",
 		"hono": "catalog:",

--- a/apps/api/worker/billing/service.ts
+++ b/apps/api/worker/billing/service.ts
@@ -185,6 +185,14 @@ export function createBillingService(
 	 * properties). Called after the gateway answered 200, off the after-response
 	 * queue. A small overspend is possible: the one call that tips a near-empty
 	 * wallet negative. The pre-call `checkAiCredits` gate keeps it to that call.
+	 *
+	 * Enqueued with `async: true`: Autumn records the event and returns 202 with
+	 * no `balances` in the body. SDK response validation still runs, but with no
+	 * balance map there is nothing for it to reject, so this post-success path
+	 * cannot throw on the null-balance drift the `autumn-js` bump also fixes.
+	 * Fire-and-forget matches the settle-after contract: the user's transcription
+	 * already succeeded, and a metering enqueue failure is logged at the adapter,
+	 * never surfaced to the client.
 	 */
 	async function trackAiTranscription(input: {
 		seconds: number;
@@ -202,6 +210,7 @@ export function createBillingService(
 				customerId: identity.principalId,
 				featureId: FEATURE_IDS.aiUsage,
 				value: credits,
+				async: true,
 				properties: {
 					model: input.model,
 					provider: input.provider,

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "@epicenter/workspace": "workspace:*",
         "@hono/standard-validator": "catalog:",
         "arktype": "catalog:",
-        "autumn-js": "^1.0.7",
+        "autumn-js": "^1.2.34",
         "better-auth": "catalog:",
         "drizzle-orm": "catalog:",
         "hono": "catalog:",
@@ -2136,7 +2136,7 @@
 
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
-    "autumn-js": ["autumn-js@1.2.5", "", { "dependencies": { "query-string": "^9.2.2", "rou3": "^0.6.1", "zod": "^4.0.0" }, "peerDependencies": { "better-auth": "^1.3.17", "better-call": "^1.0.12", "express": "^5.2.1", "hono": "^4.0.0", "next": "^14.0.0 || ^15.0.0", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["better-auth", "better-call", "express", "hono", "next", "react"] }, "sha512-hgAW7lls4cGv/wK804Fhvf67+qF0cqebvkQfXw2//UcSDZkha1CGsUeRLNCTSQ9VjmPf+Wi0vDWzBmPJS9s/pw=="],
+    "autumn-js": ["autumn-js@1.2.34", "", { "dependencies": { "query-string": "^9.2.2", "rou3": "^0.6.1", "zod": "^4.0.0" }, "peerDependencies": { "better-auth": "^1.6.0", "better-call": "^1.0.12", "express": "^5.2.1", "hono": "^4.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["better-auth", "better-call", "express", "hono", "next", "react"] }, "sha512-8MyMfceA37OvIrzUZRfwZDLnMW2Sk6sgJt0hx6v/G2quZTXju6BdLEoMRN674aBv0ICeXtie2EKGa0wXw7hKlg=="],
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 

--- a/docs/adr/0100-ai-credits-are-product-units-and-the-charge-shape-follows-when-cost-is-known.md
+++ b/docs/adr/0100-ai-credits-are-product-units-and-the-charge-shape-follows-when-cost-is-known.md
@@ -1,0 +1,33 @@
+# 0100. AI credits are product-priced units, and the charge shape follows whether cost is known before the call
+
+- **Status:** Accepted
+- **Date:** 2026-07-02
+- **Relates:** [ADR-0054](0054-an-inference-backend-is-the-metered-gateway-or-a-custom-server.md) (the metered hosted gateway these credits price; house-key-only, no BYOK bypass), [ADR-0053](0053-the-epicenter-bearer-is-an-audience-scoped-credential.md) (the audience-scoped bearer that authorizes metering)
+
+## Context
+
+The hosted gateway meters every AI call ([ADR-0054](0054-an-inference-backend-is-the-metered-gateway-or-a-custom-server.md)), but "meter" was never pinned to a unit. Two failure modes bracket the design. Request-unit billing (one credit per call regardless of work, the model GitHub Copilot is retreating from) prices a two-second clip the same as a thirty-minute recording. Raw provider pass-through (bill the user Autumn's cents-per-token) makes spend unpredictable and leaks provider pricing into the product. Between them sits the real constraint: some AI costs are known before the call (a chat model has a fixed per-call credit price) and some are not (a transcription's cost is its audio duration, known only after the provider returns). A billing shape that ignores that split either over-charges cheap calls or cannot fail closed on expensive ones.
+
+## Decision
+
+An Epicenter AI credit is a predictable product unit, not a request count and not a provider cost. How a call charges is dictated by whether its cost is known before the provider runs.
+
+- **Cost known before the call (chat): reserve the exact amount.** The model's catalog credit price is taken as an Autumn lock before the provider call, then confirmed on success or released on failure. The gate is exact: a wallet that cannot cover this model's price fails closed before any provider spend.
+- **Cost unknown before the call (STT): gate on a non-empty wallet, then meter by duration.** Transcription is priced per transcribed minute (rounded up, floor of one credit). Before the provider call, a cheap check refuses an empty wallet (or a provider outage that hides the balance). After a 200, the real per-minute charge is tracked off the after-response queue from the duration the gateway returns.
+- **Pre-provider billing fails closed; post-success metering never fails the user's response.** If entitlement cannot be verified before spend, the call is rejected (`failOpen: false`). Once the provider has answered the user, settling the charge is best-effort telemetry: its failure is swallowed, never surfaced as an error to a browser that already holds its result.
+
+STT is deliberately not a fixed per-call reservation. Its cost profile is unlike chat's, and forcing it into chat's reserve-exact shape is rejected below.
+
+## Consequences
+
+- **Two honest billing shapes, not one symmetric one.** Chat and STT charge through different code paths (`reserveAiChat` with a lock versus `checkAiCredits` plus `trackAiTranscription`) because their cost profiles differ. This is deliberate asymmetry; a later reader should not "unify" them.
+- **STT's pre-gate is structurally weaker than chat's, and that is inherent.** Because duration is unknown up front, the STT gate can only prove "some credits exist," not "enough for this call." Overspend is possible on the one call that tips a near-empty wallet negative, bounded by in-flight concurrency. A reservation lock would tighten it and is deferred; it is not a defect to remove by abandoning duration pricing.
+- **The metering path depends on Autumn parsing balance responses that legitimately contain nulls.** A metered feature that only feeds a credit system (`ai_usage` into `ai_credits`) reports `ai_usage: null` in `track` and `check` responses. `autumn-js` must be at a version whose response schema treats those map values as nullable (1.2.33 or later; the repo pins `^1.2.34`). Below that, a successful 200 charge throws a client-side `ResponseValidationError` after the fact. Customer-read responses omit null-balance features, so only the `track` and `check` path needs the nullable schema.
+- **Post-success metering can move to Autumn async usage events later.** Because settling is already best-effort and tolerant of eventual consistency, the STT charge can migrate from synchronous `track()` (200 with a balance body) to Autumn's async usage-event ingestion (202, no balance body), removing the response-validation surface entirely. That is a metering-path semantics change, taken as its own follow-up, not justified as a bug fix (the nullable schema already removes the failure).
+- **Provider pricing stays out of the product.** Users see credits, never tokens or cents. The credit-to-provider-cost margin is a catalog concern (`ai-model-pricing.ts`), invisible at the billing boundary.
+
+## Considered alternatives
+
+- **Fixed per-call STT reservation** (one credit reserved and confirmed per transcription, mirroring chat's lock). Rejected: it makes "fail closed before spend" clean but prices a thirty-minute recording identically to a two-second clip, which is the request-unit problem this ADR exists to avoid. Accurate product units beat a tidy symmetric gate.
+- **Raw provider pass-through** (bill Autumn's per-token or per-minute provider cost directly). Rejected: unpredictable user-facing spend, and provider pricing leaking into the product; credits exist precisely to decouple the two.
+- **One unified metered call shape for chat and STT.** Rejected: chat cost is known pre-call and STT cost is not, so a single shape must either over-charge cheap calls or drop the pre-spend gate. The split is the honest model.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -167,5 +167,6 @@ Each option and the one reason it lost. Terse. This is not the spec.
 | [0097](0097-super-chat-tool-modules-receive-a-host-api.md) | Super Chat tool modules receive a host API | Accepted |
 | [0098](0098-local-mail-state-round-trips-through-gmail.md) | Every Local Mail concept a human acts on round-trips through Gmail API state | Accepted |
 | [0099](0099-replace-transformations-with-a-dictionary-polish-and-a-portable-recipe-library.md) | Replace Transformations with a Dictionary, an always-on Polish, and a portable Recipe library | Accepted |
+| [0100](0100-ai-credits-are-product-units-and-the-charge-shape-follows-when-cost-is-known.md) | AI credits are product-priced units; the charge shape follows whether cost is known before the call | Accepted |
 
 When you add an ADR, add its row here.


### PR DESCRIPTION
Hosted STT was succeeding and Autumn was deducting the credit, but the older `autumn-js` client rejected Autumn's valid `balances.ai_usage: null` response while parsing the post-success tracking response. This bumps the SDK to the version with nullable balance parsing and moves post-success STT metering to Autumn async usage events so a successful transcription no longer depends on a returned balance body.

The branch also records ADR-0100: Epicenter AI credits are product-priced units. Chat reserves exact model-priced credits because cost is known before the provider call; STT gates on a usable wallet, then charges by duration after success because its cost is known only after transcription completes.

## Changelog

- Fix hosted STT billing telemetry so successful transcriptions no longer emit Autumn response-validation noise after the 200 response.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785651040&installation_id=128463665&pr_number=2296&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2296&signature=68d24e49efdded8199cdbff01e281fc2f3c653636e6ec76838cf8989c390caca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->