### PR TITLE
feat(whispering): surface Polish privacy boundary

### DIFF
--- a/apps/whispering/README.md
+++ b/apps/whispering/README.md
@@ -521,22 +521,33 @@ Change the recording shortcut to whatever feels natural:
 
 ## How is my data stored?
 
-Whispering stores as much data as possible locally on your device, including recordings and text transcriptions. This approach ensures maximum privacy and data security. Here's an overview of how data is handled:
+Whispering stores as much data as possible locally on your device, including recordings and text transcriptions. The privacy boundary depends on two separate choices: where audio is transcribed, and where Polish sends transcript text. Here's an overview of how data is handled:
 
 1. **Local Storage**: Voice recordings and transcriptions are stored in IndexedDB, which is used as blob storage and a place to store all of your data like text and transcriptions.
 
-2. **Transcription Service**: The only data sent elsewhere is your recording to an external transcription service. If you choose one. You have the following options:
+2. **Transcription Service**: If you choose a cloud or self-hosted transcription service, your recording is sent to that service. If you choose a local transcription engine, audio stays on your device. You have the following options:
    - External services like OpenAI, Groq, or ElevenLabs (with your own API keys)
-   - A local transcription service such as Speaches, which keeps everything on-device
+   - Self-hosted transcription through Speaches
+   - Local transcription engines like Whisper C++, Parakeet, or Moonshine, which keep audio on-device
 
-3. **Transformation Service (Optional)**: Whispering includes configurable transformation settings that allow you to pipe transcription output into custom transformation flows. These flows can leverage:
-   - External Large Language Models (LLMs) like OpenAI's GPT-4, Anthropic's Claude, Google's Gemini, or Groq's Llama models
-   - Hosted LLMs within your custom workflows for advanced text processing
-   - Simple find-and-replace operations for basic text modifications
+3. **Polish and Recipes**: Polish is the meaning-preserving cleanup pass that can run after transcription. Recipes are manual text transformations. Both use the selected completion provider when they need AI.
+   - Cloud completion providers send transcript text to services like OpenAI, Anthropic, Google, Groq, or OpenRouter.
+   - Custom completion can point at a local OpenAI-compatible server, such as Ollama or LM Studio. With a local server and no API key, Polish transcript text stays on your device.
 
-   When using AI-powered transformations, your transcribed text is sent to your chosen LLM provider using your own API key. All transformation configurations, including prompts and step sequences, are stored locally in your settings.
+   Local transcription does not automatically make Polish local. Audio can stay on-device while transcript text is still sent to a cloud completion provider. The Dictation settings page shows the current boundary.
 
-You can change both the transcription and transformation services in the settings to ensure maximum local functionality and privacy.
+You can change both the transcription and completion providers in settings to control which parts of the pipeline stay local.
+
+### Local Polish with Ollama or LM Studio
+
+Local Polish already works through the Custom completion provider. Run an OpenAI-compatible local server yourself, choose **Custom (OpenAI-compatible)** as the completion provider, paste the server URL, leave the API key empty unless your server requires one, and type the model name you want to use.
+
+Common local URLs:
+
+- Ollama: `http://localhost:11434/v1`
+- LM Studio: `http://localhost:1234/v1`
+
+Whispering does not start or discover local completion servers. It only sends Polish and Recipe requests to the endpoint you configure.
 
 ## Frequently Asked Questions
 
@@ -552,7 +563,7 @@ Svelte 5 + Tauri. The app is tiny (~22MB), starts instantly, and uses minimal re
 
 ### Can I use it offline?
 
-Yes, use the Speaches provider for local transcription. No internet, no API keys, completely private.
+Yes, use a local transcription engine such as Whisper C++, Parakeet, or Moonshine. No internet, no API keys, completely private.
 
 ### How much does it actually cost?
 

--- a/apps/whispering/src/lib/components/settings/ProviderConfigFields.svelte
+++ b/apps/whispering/src/lib/components/settings/ProviderConfigFields.svelte
@@ -193,7 +193,7 @@
 				placeholder: 'e.g. http://localhost:11434/v1',
 				configKey: 'providers.custom.endpoint',
 				description: [
-					'URL for OpenAI-compatible endpoints (Ollama, LM Studio, llama.cpp, etc.). Every Polish and Recipe run that uses the Custom provider calls this endpoint.',
+					'URL for OpenAI-compatible endpoints. For local Polish, run Ollama or LM Studio yourself and paste its URL here. Every Polish and Recipe run that uses the Custom provider calls this endpoint.',
 				],
 			},
 			{

--- a/apps/whispering/src/lib/operations/completion-target.test.ts
+++ b/apps/whispering/src/lib/operations/completion-target.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Completion Target Tests
+ *
+ * Verifies the pure completion targeting rules that decide whether Polish can
+ * run and what privacy boundary the UI reports.
+ *
+ * Key behaviors:
+ * - Custom endpoint without a key is a usable local completion target
+ * - Cloud providers need a key before Polish can run
+ * - Locality follows the resolved host (loopback), not the provider id or key
+ * - Destination copy separates local audio from local transcript text
+ */
+import { describe, expect, test } from 'bun:test';
+import type { InferenceProviderId } from '../constants/inference';
+import {
+	type CompletionState,
+	describePolishDestination,
+	type InferenceConfigKey,
+	resolveCompletionStateFromConfig,
+} from './completion-target';
+
+function config(values: Partial<Record<InferenceConfigKey, string>>) {
+	return (key: InferenceConfigKey) => values[key] ?? '';
+}
+
+function state(
+	provider: InferenceProviderId,
+	values: Partial<Record<InferenceConfigKey, string>>,
+): CompletionState {
+	return resolveCompletionStateFromConfig({
+		provider,
+		getDeviceConfig: config(values),
+	});
+}
+
+describe('resolveCompletionState', () => {
+	test('endpoint override beats the provider default', () => {
+		expect(
+			state('OpenAI', {
+				'providers.openai.endpoint': ' https://proxy.example/v1 ',
+				'providers.openai.apiKey': ' sk-test ',
+			}),
+		).toEqual({
+			target: { baseUrl: 'https://proxy.example/v1', apiKey: 'sk-test' },
+			canRun: true,
+			textStaysOnDevice: false,
+		});
+	});
+
+	test('Custom without an endpoint has no completion target and cannot run', () => {
+		expect(state('Custom', {})).toEqual({
+			target: null,
+			canRun: false,
+			textStaysOnDevice: false,
+		});
+	});
+
+	test('keyless Custom loopback endpoint can serve local Polish', () => {
+		expect(
+			state('Custom', {
+				'providers.custom.endpoint': 'http://localhost:11434/v1',
+			}),
+		).toEqual({
+			target: { baseUrl: 'http://localhost:11434/v1', apiKey: undefined },
+			canRun: true,
+			textStaysOnDevice: true,
+		});
+	});
+
+	test('cloud provider without a key cannot serve Polish', () => {
+		expect(state('Google', {})).toEqual({
+			target: {
+				baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+				apiKey: undefined,
+			},
+			canRun: false,
+			textStaysOnDevice: false,
+		});
+	});
+
+	test('cloud provider endpoint override to localhost with no key runs and stays on device', () => {
+		expect(
+			state('OpenAI', {
+				'providers.openai.endpoint': 'http://localhost:1234/v1',
+			}),
+		).toEqual({
+			target: { baseUrl: 'http://localhost:1234/v1', apiKey: undefined },
+			canRun: true,
+			textStaysOnDevice: true,
+		});
+	});
+
+	test('loopback endpoint with a key still stays on device', () => {
+		expect(
+			state('Custom', {
+				'providers.custom.endpoint': 'http://127.0.0.1:11434/v1',
+				'providers.custom.apiKey': 'local-key',
+			}),
+		).toEqual({
+			target: { baseUrl: 'http://127.0.0.1:11434/v1', apiKey: 'local-key' },
+			canRun: true,
+			textStaysOnDevice: true,
+		});
+	});
+});
+
+describe('describePolishDestination', () => {
+	test('local transcription and keyless Custom keeps audio and text on device', () => {
+		expect(
+			describePolishDestination('parakeet', 'Custom', {
+				target: { baseUrl: 'http://localhost:11434/v1', apiKey: undefined },
+				canRun: true,
+				textStaysOnDevice: true,
+			}),
+		).toBe('Audio and transcript text both stay on this device.');
+	});
+
+	test('local transcription and cloud Polish names the text provider', () => {
+		expect(
+			describePolishDestination('parakeet', 'Google', {
+				target: {
+					baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+					apiKey: 'key',
+				},
+				canRun: true,
+				textStaysOnDevice: false,
+			}),
+		).toBe(
+			'Audio is transcribed on-device, but Polish sends transcript text to Google.',
+		);
+	});
+
+	test('cloud transcription and keyless Custom splits audio from local text', () => {
+		expect(
+			describePolishDestination('OpenAI', 'Custom', {
+				target: { baseUrl: 'http://localhost:11434/v1', apiKey: undefined },
+				canRun: true,
+				textStaysOnDevice: true,
+			}),
+		).toBe(
+			'Audio is sent to OpenAI, then Polish keeps transcript text on this device.',
+		);
+	});
+
+	test('local transcription and OpenAI pointed at localhost keeps text on device', () => {
+		expect(
+			describePolishDestination('parakeet', 'OpenAI', {
+				target: { baseUrl: 'http://localhost:1234/v1', apiKey: undefined },
+				canRun: true,
+				textStaysOnDevice: true,
+			}),
+		).toBe('Audio and transcript text both stay on this device.');
+	});
+
+	test('cloud transcription and cloud Polish names both providers', () => {
+		expect(
+			describePolishDestination('OpenAI', 'Google', {
+				target: {
+					baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+					apiKey: 'key',
+				},
+				canRun: true,
+				textStaysOnDevice: false,
+			}),
+		).toBe(
+			'Audio is sent to OpenAI, and Polish sends transcript text to Google.',
+		);
+	});
+
+	test('cloud provider default without a key ships raw instead of claiming Polish sends text', () => {
+		expect(
+			describePolishDestination('parakeet', 'Google', {
+				target: {
+					baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+					apiKey: undefined,
+				},
+				canRun: false,
+				textStaysOnDevice: false,
+			}),
+		).toBe(
+			'Audio stays on this device. Polish is not ready, so transcripts ship raw.',
+		);
+	});
+
+	test('keyless Custom remote endpoint does not claim transcript text stays on device', () => {
+		expect(
+			describePolishDestination('parakeet', 'Custom', {
+				target: { baseUrl: 'https://completion.example/v1', apiKey: undefined },
+				canRun: true,
+				textStaysOnDevice: false,
+			}),
+		).toBe(
+			'Audio is transcribed on-device, but Polish sends transcript text to Custom (OpenAI-compatible).',
+		);
+	});
+});

--- a/apps/whispering/src/lib/operations/completion-target.ts
+++ b/apps/whispering/src/lib/operations/completion-target.ts
@@ -1,0 +1,114 @@
+import { INFERENCE, type InferenceProviderId } from '../constants/inference';
+import {
+	PROVIDERS,
+	type TranscriptionServiceId,
+} from '../services/transcription/providers';
+
+export type CompletionTarget = {
+	baseUrl: string;
+	apiKey: string | undefined;
+};
+
+/**
+ * The single resolved completion fact set: what to call, whether Polish can run,
+ * and whether transcript text leaves the machine. All three are derived together
+ * from one config read so they can never disagree (a null target with `canRun`,
+ * or copy that claims a different locality than the target it was resolved from).
+ * The Polish gate reads `canRun`, the call path reads `target`, and the privacy
+ * copy reads the whole state.
+ */
+export type CompletionState = {
+	/**
+	 * The OpenAI-compatible connection to hand `complete()`. Null only when there
+	 * is no base URL to talk to (Custom with no endpoint configured), the one
+	 * genuinely un-runnable state.
+	 */
+	target: CompletionTarget | null;
+	/**
+	 * Whether the selected provider can serve a request now. A configured key is
+	 * capability; so is a configured endpoint override with no key, the keyless
+	 * local case (Custom pointed at Ollama or LM Studio). A canonical cloud
+	 * provider with no key would 401, so it is not capable.
+	 */
+	canRun: boolean;
+	/**
+	 * Whether transcript text never leaves this machine: true when the resolved
+	 * base URL host is loopback, regardless of provider id or API key. This is a
+	 * property of the resolved host, not the provider label, so an OpenAI or Groq
+	 * base URL pointed at localhost is correctly reported as on-device.
+	 */
+	textStaysOnDevice: boolean;
+};
+
+export type InferenceConfigKey =
+	| (typeof INFERENCE)[InferenceProviderId]['apiKeyConfigKey']
+	| NonNullable<(typeof INFERENCE)[InferenceProviderId]['endpointConfigKey']>;
+
+type DeviceConfigReader = (key: InferenceConfigKey) => string;
+
+export function resolveCompletionStateFromConfig({
+	provider,
+	getDeviceConfig,
+}: {
+	provider: InferenceProviderId;
+	getDeviceConfig: DeviceConfigReader;
+}): CompletionState {
+	const { apiKeyConfigKey, endpointConfigKey, defaultBaseUrl } =
+		INFERENCE[provider];
+	const override = endpointConfigKey
+		? getDeviceConfig(endpointConfigKey).trim()
+		: '';
+	const baseUrl = override || defaultBaseUrl;
+	if (!baseUrl) return { target: null, canRun: false, textStaysOnDevice: false };
+	const apiKey = getDeviceConfig(apiKeyConfigKey).trim() || undefined;
+	return {
+		target: { baseUrl, apiKey },
+		canRun: apiKey !== undefined || override.length > 0,
+		textStaysOnDevice: isLoopbackBaseUrl(baseUrl),
+	};
+}
+
+function isLoopbackBaseUrl(baseUrl: string): boolean {
+	try {
+		const hostname = new URL(baseUrl).hostname;
+		return (
+			hostname === 'localhost' ||
+			hostname === '127.0.0.1' ||
+			hostname === '[::1]'
+		);
+	} catch {
+		return false;
+	}
+}
+
+export function describePolishDestination(
+	transcriptionService: TranscriptionServiceId,
+	completionProvider: InferenceProviderId,
+	state: CompletionState,
+): string {
+	const transcriptionProvider = PROVIDERS[transcriptionService];
+	const completionLabel = INFERENCE[completionProvider].label;
+
+	if (!state.target || !state.canRun) {
+		if (transcriptionProvider.location === 'local') {
+			return 'Audio stays on this device. Polish is not ready, so transcripts ship raw.';
+		}
+		return `Audio is sent to ${transcriptionProvider.label}. Polish is not ready, so transcripts ship raw.`;
+	}
+
+	const { textStaysOnDevice } = state;
+
+	if (transcriptionProvider.location === 'local' && textStaysOnDevice) {
+		return 'Audio and transcript text both stay on this device.';
+	}
+
+	if (transcriptionProvider.location === 'local') {
+		return `Audio is transcribed on-device, but Polish sends transcript text to ${completionLabel}.`;
+	}
+
+	if (textStaysOnDevice) {
+		return `Audio is sent to ${transcriptionProvider.label}, then Polish keeps transcript text on this device.`;
+	}
+
+	return `Audio is sent to ${transcriptionProvider.label}, and Polish sends transcript text to ${completionLabel}.`;
+}

--- a/apps/whispering/src/lib/operations/completion-target.ts
+++ b/apps/whispering/src/lib/operations/completion-target.ts
@@ -59,7 +59,8 @@ export function resolveCompletionStateFromConfig({
 		? getDeviceConfig(endpointConfigKey).trim()
 		: '';
 	const baseUrl = override || defaultBaseUrl;
-	if (!baseUrl) return { target: null, canRun: false, textStaysOnDevice: false };
+	if (!baseUrl)
+		return { target: null, canRun: false, textStaysOnDevice: false };
 	const apiKey = getDeviceConfig(apiKeyConfigKey).trim() || undefined;
 	return {
 		target: { baseUrl, apiKey },

--- a/apps/whispering/src/lib/operations/completion.ts
+++ b/apps/whispering/src/lib/operations/completion.ts
@@ -1,33 +1,26 @@
 import { CompleteError, complete, resolveConnection } from '@epicenter/client';
 import type { Result } from 'wellcrafted/result';
 import { customFetch } from '#platform/http';
-import { INFERENCE } from '$lib/constants/inference';
+import {
+	type CompletionState,
+	resolveCompletionStateFromConfig,
+} from '$lib/operations/completion-target';
 import { deviceConfig } from '$lib/state/device-config.svelte';
 import { settings } from '$lib/state/settings.svelte';
 
 /**
- * Resolve the single global completion target: the OpenAI-compatible base URL
- * (an endpoint override in deviceConfig beats the provider's canonical default)
- * and the optional Bearer key, both read at use (ADR 0012) from the global
- * `completion.*` setting and deviceConfig. Null when there is no base URL to talk
- * to (Custom with no endpoint configured), the one genuinely un-runnable state.
+ * Resolve the single global completion state: what to call (`target`), whether
+ * Polish can run (`canRun`), and whether transcript text stays on this device
+ * (`textStaysOnDevice`). All three are derived together from the global
+ * `completion.*` setting and deviceConfig, read at use (ADR 0012) so nothing goes
+ * stale. `target` is null when there is no base URL to talk to (Custom with no
+ * endpoint configured), the one genuinely un-runnable state.
  */
-function resolveCompletionTarget(): {
-	baseUrl: string;
-	apiKey: string | undefined;
-} | null {
-	const provider = settings.get('completion.provider');
-	const { apiKeyConfigKey, endpointConfigKey, defaultBaseUrl } =
-		INFERENCE[provider];
-	const override = endpointConfigKey
-		? deviceConfig.get(endpointConfigKey).trim()
-		: '';
-	const baseUrl = override || defaultBaseUrl;
-	if (!baseUrl) return null;
-	return {
-		baseUrl,
-		apiKey: deviceConfig.get(apiKeyConfigKey).trim() || undefined,
-	};
+export function resolveCompletionState(): CompletionState {
+	return resolveCompletionStateFromConfig({
+		provider: settings.get('completion.provider'),
+		getDeviceConfig: deviceConfig.get,
+	});
 }
 
 /**
@@ -51,7 +44,7 @@ export function completeWithGlobalDefault({
 	userPrompt: string;
 	signal?: AbortSignal;
 }): Promise<Result<string, CompleteError>> {
-	const target = resolveCompletionTarget();
+	const { target } = resolveCompletionState();
 	if (!target) {
 		const provider = settings.get('completion.provider');
 		return Promise.resolve(
@@ -73,25 +66,5 @@ export function completeWithGlobalDefault({
 			userPrompt,
 			signal,
 		},
-	);
-}
-
-/**
- * Whether the selected completion provider can serve a request right now: the
- * Polish gate ("on by default only when it will actually work") reads this so the
- * AI pass is skipped silently on a fresh, unconfigured install instead of failing
- * a request. A configured key is capability; so is a configured endpoint override
- * with no key, the keyless local case (Custom pointed at Ollama or LM Studio,
- * where a cloud key is neither needed nor wanted). A canonical cloud provider with
- * no key would 401, so it is not capable. Read at use, like the completion call.
- */
-export function hasCompletionCapability(): boolean {
-	const target = resolveCompletionTarget();
-	if (!target) return false;
-	if (target.apiKey) return true;
-	const { endpointConfigKey } = INFERENCE[settings.get('completion.provider')];
-	return (
-		endpointConfigKey !== null &&
-		deviceConfig.get(endpointConfigKey).trim().length > 0
 	);
 }

--- a/apps/whispering/src/lib/operations/run-polish.ts
+++ b/apps/whispering/src/lib/operations/run-polish.ts
@@ -7,8 +7,9 @@ import { isErr, Ok, type Result } from 'wellcrafted/result';
 import { buildPolishSystemPrompt } from '$lib/operations/build-system-prompt';
 import {
 	completeWithGlobalDefault,
-	hasCompletionCapability,
+	resolveCompletionState,
 } from '$lib/operations/completion';
+import { describePolishDestination } from '$lib/operations/completion-target';
 import { settings } from '$lib/state/settings.svelte';
 
 export const RunPolishError = defineErrors({
@@ -43,7 +44,22 @@ export type PolishStatus = 'off' | 'on' | 'needs-key';
 
 export function polishStatus(): PolishStatus {
 	if (!settings.get('polish.enabled')) return 'off';
-	return hasCompletionCapability() ? 'on' : 'needs-key';
+	return resolveCompletionState().canRun ? 'on' : 'needs-key';
+}
+
+/**
+ * The privacy boundary the UI shows for the current Polish configuration: where
+ * audio is transcribed and where Polish sends transcript text. Assembled once
+ * here, beside {@link polishStatus}, so the Polish controls only render the
+ * derived sentence instead of each reconstructing it from settings and the
+ * resolved completion target. Read at use per ADR 0012.
+ */
+export function polishDestination(): string {
+	return describePolishDestination(
+		settings.get('transcription.service'),
+		settings.get('completion.provider'),
+		resolveCompletionState(),
+	);
 }
 
 /**

--- a/apps/whispering/src/routes/(app)/(config)/settings/dictation/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/dictation/+page.svelte
@@ -10,7 +10,7 @@
 	import PlusIcon from '@lucide/svelte/icons/plus';
 	import XIcon from '@lucide/svelte/icons/x';
 	import { SettingSwitch } from '$lib/components/settings';
-	import { polishStatus } from '$lib/operations/run-polish';
+	import { polishDestination, polishStatus } from '$lib/operations/run-polish';
 	import { settings } from '$lib/state/settings.svelte';
 
 	const dictionary = $derived(settings.get('dictionary'));
@@ -19,6 +19,7 @@
 	// the provider is missing so the control never silently reads "on" while the
 	// pipeline ships raw.
 	const polish = $derived(polishStatus());
+	const destination = $derived(polishDestination());
 
 	let newTerm = $state('');
 
@@ -52,7 +53,7 @@
 			<Field.Legend variant="label">Polish</Field.Legend>
 			<Field.Description>
 				An always-on AI pass that fixes grammar and punctuation while keeping
-				your wording. It runs only when an AI key is configured.
+				your wording.
 			</Field.Description>
 			<Field.Group>
 				<SettingSwitch
@@ -60,6 +61,9 @@
 					label="Polish transcripts with AI"
 					description="Turn off for speed mode: the raw transcript ships instantly, with no AI call."
 				/>
+				{#if settings.get('polish.enabled')}
+					<p class="text-muted-foreground text-sm">{destination}</p>
+				{/if}
 
 				{#if polish === 'needs-key'}
 					<div
@@ -67,8 +71,9 @@
 					>
 						<KeyRoundIcon class="mt-0.5 size-4 shrink-0 text-amber-500" />
 						<p>
-							Polish is on but has no AI key, so transcripts still ship raw. <Link
-								href="/settings/api-keys">Add a completion key</Link
+							Polish is on, but the completion provider is not ready, so
+							transcripts still ship raw. <Link href="/settings/api-keys"
+								>Check completion settings</Link
 							> to start cleaning them up.
 						</p>
 					</div>

--- a/apps/whispering/src/routes/(app)/_components/PolishPipelineControl.svelte
+++ b/apps/whispering/src/routes/(app)/_components/PolishPipelineControl.svelte
@@ -6,7 +6,8 @@
 	import KeyRoundIcon from '@lucide/svelte/icons/key-round';
 	import SparklesIcon from '@lucide/svelte/icons/sparkles';
 	import { SettingSwitch } from '$lib/components/settings';
-	import { polishStatus } from '$lib/operations/run-polish';
+	import { polishDestination, polishStatus } from '$lib/operations/run-polish';
+	import { settings } from '$lib/state/settings.svelte';
 
 	// The post-transcription stage of the capture pipeline, surfaced beside the
 	// model selector so the delivered output's mode (raw vs polished) is legible
@@ -18,6 +19,7 @@
 	let open = $state(false);
 
 	const status = $derived(polishStatus());
+	const destination = $derived(polishDestination());
 
 	const meta = $derived(
 		{
@@ -37,7 +39,8 @@
 			},
 			'needs-key': {
 				label: 'Polish',
-				tooltip: 'Polish is on but needs an AI key. Transcripts ship raw',
+				tooltip:
+					'Polish is on, but the completion provider is not ready. Transcripts ship raw',
 				Icon: KeyRoundIcon,
 				triggerClass: 'text-amber-600 dark:text-amber-500',
 				iconClass: 'text-amber-500',
@@ -70,6 +73,9 @@
 				label="Polish transcripts with AI"
 				description="An always-on AI pass that fixes grammar and punctuation while keeping your wording. Turn off for speed mode: instant raw transcript, no AI call."
 			/>
+			{#if settings.get('polish.enabled')}
+				<p class="text-muted-foreground text-sm">{destination}</p>
+			{/if}
 
 			{#if status === 'needs-key'}
 				<div
@@ -77,8 +83,8 @@
 				>
 					<KeyRoundIcon class="mt-0.5 size-4 shrink-0 text-amber-500" />
 					<p>
-						No AI key, so transcripts still ship raw. <Link
-							href="/settings/api-keys">Add a completion key</Link
+						The completion provider is not ready, so transcripts still ship raw. <Link
+							href="/settings/api-keys">Check completion settings</Link
 						> to start polishing.
 					</p>
 				</div>


### PR DESCRIPTION
Whispering now makes the Polish privacy boundary explicit. Local transcription and local Polish are separate choices: audio can stay on-device while transcript text is still sent to the selected completion provider.

This adds a shared Polish destination reader used by both the Dictation settings page and the home Polish control. Completion resolution now produces one state for the target, readiness, and whether transcript text stays on-device, so privacy copy follows the same facts the runtime uses. A loopback completion endpoint is treated as on-device based on the resolved URL, not the provider label.

Custom completion guidance and the README now explain the local Polish path through OpenAI-compatible servers such as Ollama or LM Studio, without adding new providers, server discovery, model discovery, or managed local runtime support.

## Changelog

- Add privacy messaging that shows where Polish sends transcript text
- Document local Polish setup with Custom OpenAI-compatible endpoints