### PR TITLE
feat(local-mail): expose Gmail label mutations over MCP

### DIFF
--- a/apps/local-mail/README.md
+++ b/apps/local-mail/README.md
@@ -38,10 +38,9 @@ Use `--client-id <id>` to override `GMAIL_CLIENT_ID` for the connect command.
 secret and the token exchange sends it as a form parameter.
 
 Local Mail requests `gmail.modify` so write-through label changes can round-trip
-through Gmail. Older tokens minted with the previous read-only scope can still
-read and sync; the first write will ask you to run `local-mail connect` again.
-Although Google grants send at the same OAuth layer, Local Mail does not expose
-send, reply, compose, drafts, trash, untrash, or delete in this phase.
+through Gmail. Although Google grants send at the same OAuth layer, Local Mail
+does not expose send, reply, compose, drafts, trash, untrash, or delete in this
+phase.
 
 Headless bootstrap is still available. The refresh token is redeemed
 immediately (one refresh grant plus a profile read), so a dead token fails

--- a/apps/local-mail/src/mcp-server.test.ts
+++ b/apps/local-mail/src/mcp-server.test.ts
@@ -60,7 +60,13 @@ function seedMirror(dir: string): void {
 	};
 	const db = openMailDb({ dataDir: dir, accountEmail: ACCOUNT });
 	db.ingestFullPullPage([message], '2026-07-01T00:00:00.000Z');
-	db.ingestLabels([{ id: 'INBOX', name: 'INBOX', type: 'system' }], 's1');
+	db.ingestLabels(
+		[
+			{ id: 'INBOX', name: 'INBOX', type: 'system' },
+			{ id: 'Label_1', name: 'Work', type: 'user' },
+		],
+		's1',
+	);
 	db.finishFullPull('1000', '2026-07-01T00:00:00.000Z');
 	db.close();
 }
@@ -182,88 +188,243 @@ test('mcp: tools/list, body query, status, errors, and a clean stream', async ()
 		LOCAL_MAIL_ACCOUNT: ACCOUNT,
 	});
 
-	const list = await mcp.request('tools/list');
-	const tools = (list.result?.tools ?? []) as Array<{
-		name: string;
-		description?: string;
-		inputSchema: { type: string; properties?: Record<string, unknown> };
-		annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean };
-	}>;
-	const names = tools.map((tool) => tool.name).sort();
-	expect(names).toEqual(['query', 'status', 'sync']);
-	const query = tools.find((tool) => tool.name === 'query');
-	expect(query?.description).toContain('messages(id, raw JSON');
-	expect(query?.description).toContain('labels(id, raw JSON');
-	expect(query?.description).toContain('json_each(messages.label_ids)');
-	expect(query?.description).toContain('capped at 1000 rows');
-	expect(query?.inputSchema.properties).toHaveProperty('sql');
-	expect(query?.annotations?.readOnlyHint).toBe(true);
-	const sync = tools.find((tool) => tool.name === 'sync');
-	expect(sync?.annotations?.readOnlyHint).toBe(false);
-	expect(sync?.annotations?.destructiveHint).toBe(false);
+	try {
+		const list = await mcp.request('tools/list');
+		const tools = (list.result?.tools ?? []) as Array<{
+			name: string;
+			description?: string;
+			inputSchema: { type: string; properties?: Record<string, unknown> };
+			annotations?: {
+				readOnlyHint?: boolean;
+				destructiveHint?: boolean;
+				idempotentHint?: boolean;
+			};
+		}>;
+		const names = tools.map((tool) => tool.name).sort();
+		expect(names).toEqual(['modify_labels', 'query', 'status', 'sync']);
+		const query = tools.find((tool) => tool.name === 'query');
+		expect(query?.description).toContain('messages(id, raw JSON');
+		expect(query?.description).toContain('labels(id, raw JSON');
+		expect(query?.description).toContain('json_each(messages.label_ids)');
+		expect(query?.description).toContain('capped at 1000 rows');
+		expect(query?.inputSchema.properties).toHaveProperty('sql');
+		expect(query?.annotations?.readOnlyHint).toBe(true);
+		const sync = tools.find((tool) => tool.name === 'sync');
+		expect(sync?.annotations?.readOnlyHint).toBe(false);
+		expect(sync?.annotations?.destructiveHint).toBe(false);
+		const modifyLabels = tools.find((tool) => tool.name === 'modify_labels');
+		expect(modifyLabels?.inputSchema.properties).toHaveProperty('ids');
+		expect(modifyLabels?.inputSchema.properties).toHaveProperty('addLabelIds');
+		expect(modifyLabels?.inputSchema.properties).toHaveProperty(
+			'removeLabelIds',
+		);
+		expect(modifyLabels?.annotations).toMatchObject({
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+		});
 
-	const ok = await mcp.request('tools/call', {
-		name: 'query',
-		arguments: {
-			sql: "SELECT subject, body_text FROM messages WHERE body_text LIKE '%launch budget%'",
+		const ok = await mcp.request('tools/call', {
+			name: 'query',
+			arguments: {
+				sql: "SELECT subject, body_text FROM messages WHERE body_text LIKE '%launch budget%'",
+			},
+		});
+		expect(ok.result?.isError).toBeFalsy();
+		const data = ok.result?.structuredContent as {
+			rows: Array<{ subject: string; body_text: string }>;
+			rowCount: number;
+		};
+		expect(data.rowCount).toBe(1);
+		expect(data.rows[0]?.body_text).toContain('launch budget');
+
+		const status = await mcp.request('tools/call', {
+			name: 'status',
+			arguments: {},
+		});
+		const statusData = status.result?.structuredContent as {
+			accountEmail: string;
+			mirror: string;
+			historyId: string;
+			rows: { messages: number; labels: number };
+		};
+		expect(statusData.accountEmail).toBe(ACCOUNT);
+		expect(statusData.mirror).toBe('ready');
+		expect(statusData.historyId).toBe('1000');
+		expect(statusData.rows).toEqual({ messages: 1, labels: 2 });
+
+		const syncWithoutToken = await mcp.request('tools/call', {
+			name: 'sync',
+			arguments: {},
+		});
+		expect(syncWithoutToken.error).toBeUndefined();
+		expect(syncWithoutToken.result?.isError).toBe(true);
+
+		const unknown = await mcp.request('tools/call', {
+			name: 'does_not_exist',
+			arguments: {},
+		});
+		expect(unknown.error?.code).toBe(-32601);
+
+		const badSql = await mcp.request('tools/call', {
+			name: 'query',
+			arguments: { sql: 'SELECT * FROM missing_table' },
+		});
+		expect(badSql.error).toBeUndefined();
+		expect(badSql.result?.isError).toBe(true);
+
+		const badArgs = await mcp.request('tools/call', {
+			name: 'query',
+			arguments: { sql: 123 },
+		});
+		expect(badArgs.error?.code).toBe(-32602);
+
+		for (const line of mcp.stdoutLines) {
+			const parsed = JSON.parse(line);
+			expect(parsed.jsonrpc).toBe('2.0');
+		}
+	} finally {
+		mcp.stop();
+		tmp.cleanup();
+	}
+});
+
+test('mcp: LOCAL_MAIL_READ_ONLY hides mutation tools but leaves reads and sync listed', async () => {
+	const tmp = tempDir();
+	seedMirror(tmp.dir);
+	const mcp = await connect({
+		LOCAL_MAIL_DIR: tmp.dir,
+		LOCAL_MAIL_ACCOUNT: ACCOUNT,
+		LOCAL_MAIL_READ_ONLY: '1',
+	});
+
+	try {
+		const list = await mcp.request('tools/list');
+		const tools = (list.result?.tools ?? []) as Array<{ name: string }>;
+		expect(tools.map((tool) => tool.name).sort()).toEqual([
+			'query',
+			'status',
+			'sync',
+		]);
+
+		const hidden = await mcp.request('tools/call', {
+			name: 'modify_labels',
+			arguments: {
+				ids: ['m1'],
+				addLabelIds: ['Work'],
+			},
+		});
+		expect(hidden.error?.code).toBe(-32601);
+	} finally {
+		mcp.stop();
+		tmp.cleanup();
+	}
+});
+
+test('mcp: modify_labels folds Gmail labels and uses isError for Gmail rejection', async () => {
+	const tmp = tempDir();
+	seedMirror(tmp.dir);
+	await seedToken(tmp.dir);
+	const requests: Array<{ method: string; pathname: string; body: unknown }> =
+		[];
+	const apiServer = Bun.serve({
+		hostname: '127.0.0.1',
+		port: 0,
+		async fetch(request) {
+			const url = new URL(request.url);
+			const body = request.method === 'POST' ? await request.json() : null;
+			requests.push({ method: request.method, pathname: url.pathname, body });
+			if (url.pathname === '/gmail/v1/users/me/labels') {
+				return Response.json({
+					labels: [
+						{ id: 'INBOX', name: 'INBOX', type: 'system' },
+						{ id: 'Label_1', name: 'Work', type: 'user' },
+						{ id: 'BAD', name: 'Bad label', type: 'user' },
+					],
+				});
+			}
+			if (url.pathname === '/gmail/v1/users/me/messages/m1/modify') {
+				return Response.json({
+					id: 'm1',
+					threadId: 't1',
+					labelIds: ['Label_1'],
+				});
+			}
+			if (url.pathname === '/gmail/v1/users/me/messages/m2/modify') {
+				return Response.json(
+					{
+						error: {
+							errors: [{ reason: 'invalidArgument' }],
+							message: 'Invalid label: BAD',
+						},
+					},
+					{ status: 400 },
+				);
+			}
+			return new Response('not found', { status: 404 });
 		},
 	});
-	expect(ok.result?.isError).toBeFalsy();
-	const data = ok.result?.structuredContent as {
-		rows: Array<{ subject: string; body_text: string }>;
-		rowCount: number;
-	};
-	expect(data.rowCount).toBe(1);
-	expect(data.rows[0]?.body_text).toContain('launch budget');
-
-	const status = await mcp.request('tools/call', {
-		name: 'status',
-		arguments: {},
+	const mcp = await connect({
+		LOCAL_MAIL_DIR: tmp.dir,
+		LOCAL_MAIL_ACCOUNT: ACCOUNT,
+		LOCAL_MAIL_GMAIL_API_BASE: `http://127.0.0.1:${apiServer.port}`,
 	});
-	const statusData = status.result?.structuredContent as {
-		accountEmail: string;
-		mirror: string;
-		historyId: string;
-		rows: { messages: number; labels: number };
-	};
-	expect(statusData.accountEmail).toBe(ACCOUNT);
-	expect(statusData.mirror).toBe('ready');
-	expect(statusData.historyId).toBe('1000');
-	expect(statusData.rows).toEqual({ messages: 1, labels: 1 });
 
-	const syncWithoutToken = await mcp.request('tools/call', {
-		name: 'sync',
-		arguments: {},
-	});
-	expect(syncWithoutToken.error).toBeUndefined();
-	expect(syncWithoutToken.result?.isError).toBe(true);
+	try {
+		const ok = await mcp.request('tools/call', {
+			name: 'modify_labels',
+			arguments: {
+				ids: ['m1'],
+				addLabelIds: ['Work'],
+				removeLabelIds: ['INBOX'],
+			},
+		});
+		expect(ok.error).toBeUndefined();
+		expect(ok.result?.isError).toBeFalsy();
 
-	const unknown = await mcp.request('tools/call', {
-		name: 'does_not_exist',
-		arguments: {},
-	});
-	expect(unknown.error?.code).toBe(-32601);
+		const query = await mcp.request('tools/call', {
+			name: 'query',
+			arguments: {
+				sql: "SELECT label_ids FROM messages WHERE id = 'm1'",
+			},
+		});
+		const data = query.result?.structuredContent as {
+			rows: Array<{ label_ids: string }>;
+		};
+		expect(JSON.parse(data.rows[0]?.label_ids ?? '[]')).toEqual(['Label_1']);
+		expect(ok.result?.structuredContent).toMatchObject({
+			results: [{ id: 'm1', labelIds: ['Label_1'], folded: true, error: null }],
+			aborted: null,
+		});
 
-	const badSql = await mcp.request('tools/call', {
-		name: 'query',
-		arguments: { sql: 'SELECT * FROM missing_table' },
-	});
-	expect(badSql.error).toBeUndefined();
-	expect(badSql.result?.isError).toBe(true);
+		const rejected = await mcp.request('tools/call', {
+			name: 'modify_labels',
+			arguments: {
+				ids: ['m2'],
+				addLabelIds: ['BAD'],
+			},
+		});
+		expect(rejected.error).toBeUndefined();
+		expect(rejected.result?.isError).toBe(true);
+		const content = rejected.result?.content as Array<{ text: string }>;
+		expect(content[0]?.text).toContain('Gmail API returned 400');
+		expect(content[0]?.text).toContain('Invalid label: BAD');
 
-	const badArgs = await mcp.request('tools/call', {
-		name: 'query',
-		arguments: { sql: 123 },
-	});
-	expect(badArgs.error?.code).toBe(-32602);
-
-	for (const line of mcp.stdoutLines) {
-		const parsed = JSON.parse(line);
-		expect(parsed.jsonrpc).toBe('2.0');
+		expect(requests).toContainEqual({
+			method: 'POST',
+			pathname: '/gmail/v1/users/me/messages/m1/modify',
+			body: { addLabelIds: ['Label_1'], removeLabelIds: ['INBOX'] },
+		});
+		expect(requests).toContainEqual({
+			method: 'POST',
+			pathname: '/gmail/v1/users/me/messages/m2/modify',
+			body: { addLabelIds: ['BAD'], removeLabelIds: [] },
+		});
+	} finally {
+		mcp.stop();
+		apiServer.stop(true);
+		tmp.cleanup();
 	}
-
-	mcp.stop();
-	tmp.cleanup();
 });
 
 test('mcp: failed sync pass returns isError instead of a successful outcome payload', async () => {

--- a/apps/local-mail/src/mcp.ts
+++ b/apps/local-mail/src/mcp.ts
@@ -43,6 +43,7 @@ import {
 import { type Static, type TObject, Type } from 'typebox';
 import { Value } from 'typebox/value';
 import { Err, Ok, type Result } from 'wellcrafted/result';
+import { modifyMessageLabels, resolveLabelIds } from './modify.ts';
 import { queryMail } from './query.ts';
 import {
 	type LocalMailRuntime,
@@ -60,7 +61,7 @@ type ToolDescriptor = {
 	title: string;
 	description: string;
 	input: TObject;
-	tier: 'read' | 'write';
+	tier: 'read' | 'write' | 'mutation';
 	run: (
 		ctx: LocalMailRuntime,
 		args: Record<string, unknown>,
@@ -72,7 +73,7 @@ function defineMcpTool<S extends TObject>(tool: {
 	title: string;
 	description: string;
 	input: S;
-	tier: 'read' | 'write';
+	tier: 'read' | 'write' | 'mutation';
 	run: (ctx: LocalMailRuntime, args: Static<S>) => Promise<ToolOutcome>;
 }): ToolDescriptor {
 	return { ...tool, run: (ctx, args) => tool.run(ctx, args as Static<S>) };
@@ -142,6 +143,78 @@ const TOOLS: ToolDescriptor[] = [
 			}
 		},
 	}),
+	defineMcpTool({
+		name: 'modify_labels',
+		title: 'Modify message labels',
+		description:
+			'Add or remove Gmail labels on 1 to 100 messages. Pass Gmail label ids or exact label names; UNREAD marks unread, removing UNREAD marks read, removing INBOX archives, and adding INBOX unarchives. Gmail accepts or rejects each mutation before the local mirror is folded.',
+		input: Type.Object({
+			ids: Type.Array(Type.String({ minLength: 1 }), {
+				minItems: 1,
+				maxItems: 100,
+				description: 'Gmail message ids to mutate serially.',
+			}),
+			addLabelIds: Type.Optional(
+				Type.Array(Type.String({ minLength: 1 }), {
+					maxItems: 100,
+					description: 'Gmail label ids or exact names to add.',
+				}),
+			),
+			removeLabelIds: Type.Optional(
+				Type.Array(Type.String({ minLength: 1 }), {
+					maxItems: 100,
+					description: 'Gmail label ids or exact names to remove.',
+				}),
+			),
+		}),
+		tier: 'mutation',
+		async run(ctx, args) {
+			const { data: session, error } = await openSyncSession(ctx);
+			if (error) return Err(error);
+			try {
+				const addLabels = args.addLabelIds ?? [];
+				const removeLabels = args.removeLabelIds ?? [];
+				if (ctx.config.readOnly) {
+					return await modifyMessageLabels({
+						deps: session.deps,
+						input: {
+							ids: args.ids,
+							addLabelIds: addLabels,
+							removeLabelIds: removeLabels,
+						},
+						readOnly: true,
+					});
+				}
+
+				const { data: resolvedLabels, error: labelError } =
+					await resolveLabelIds({
+						deps: session.deps,
+						labels: [...addLabels, ...removeLabels],
+					});
+				if (labelError) return Err(labelError);
+
+				const { data, error } = await modifyMessageLabels({
+					deps: session.deps,
+					input: {
+						ids: args.ids,
+						addLabelIds: resolvedLabels.slice(0, addLabels.length),
+						removeLabelIds: resolvedLabels.slice(addLabels.length),
+					},
+					readOnly: ctx.config.readOnly,
+				});
+				if (error) return Err(error);
+				if (
+					data.aborted ||
+					data.results.some((result) => result.error !== null)
+				) {
+					return Err({ message: JSON.stringify(data) });
+				}
+				return Ok(data);
+			} finally {
+				session.close();
+			}
+		},
+	}),
 ];
 
 function toCallResult({ data, error }: ToolOutcome): CallToolResult {
@@ -170,9 +243,12 @@ export async function runMcpServer(): Promise<number> {
 		{ name: 'local-mail', version: VERSION },
 		{ capabilities: { tools: {} } },
 	);
+	const tools = TOOLS.filter(
+		(tool) => tool.tier !== 'mutation' || !runtime.config.readOnly,
+	);
 
 	server.setRequestHandler(ListToolsRequestSchema, async () => ({
-		tools: TOOLS.map((tool) => ({
+		tools: tools.map((tool) => ({
 			name: tool.name,
 			title: tool.title,
 			description: tool.description,
@@ -180,12 +256,13 @@ export async function runMcpServer(): Promise<number> {
 			annotations: {
 				readOnlyHint: tool.tier === 'read',
 				destructiveHint: false,
+				...(tool.tier === 'mutation' ? { idempotentHint: true } : {}),
 			},
 		})),
 	}));
 
 	server.setRequestHandler(CallToolRequestSchema, async (req) => {
-		const tool = TOOLS.find((candidate) => candidate.name === req.params.name);
+		const tool = tools.find((candidate) => candidate.name === req.params.name);
 		if (!tool) {
 			throw new McpError(
 				ErrorCode.MethodNotFound,

--- a/apps/local-mail/src/modify.test.ts
+++ b/apps/local-mail/src/modify.test.ts
@@ -487,42 +487,6 @@ describe('modifyMessageLabels', () => {
 		cleanup();
 	});
 
-	test('readonly-era insufficientPermissions aborts with reconnect messaging', async () => {
-		const { db, cleanup } = tempDb();
-		const client = createFakeGmailClient(
-			new Map([
-				[
-					'm1',
-					{
-						error: GmailApiError.Http({
-							status: 403,
-							body: JSON.stringify({
-								error: {
-									errors: [{ reason: 'insufficientPermissions' }],
-								},
-							}),
-						}).error,
-					},
-				],
-			]),
-		);
-
-		const result = await modifyMessageLabels({
-			deps: { client, db, now: () => Date.parse('2026-07-03T00:00:00.000Z') },
-			input: { ...input, ids: ['m1', 'm2'] },
-			readOnly: false,
-		});
-
-		const outcome = expectOk(result);
-		expect(outcome.aborted).toEqual({
-			name: 'ReadOnlyGrant',
-			message:
-				'This account was connected read-only. Run "local-mail connect" again to grant Gmail write access, then retry.',
-		});
-		expect(client.modifyCalls.map((call) => call.id)).toEqual(['m1']);
-		cleanup();
-	});
-
 	test('fold SQLITE_BUSY reports folded false without failing Gmail success', async () => {
 		const { db, cleanup } = tempDb();
 		const busyDb: MailDb = {

--- a/apps/local-mail/src/modify.ts
+++ b/apps/local-mail/src/modify.ts
@@ -18,10 +18,6 @@ export const ModifyMessageLabelsError = defineErrors({
 	EmptyLabelMutation: () => ({
 		message: 'At least one label id must be added or removed.',
 	}),
-	ReadOnlyGrant: () => ({
-		message:
-			'This account was connected read-only. Run "local-mail connect" again to grant Gmail write access, then retry.',
-	}),
 });
 export type ModifyMessageLabelsError = InferErrors<
 	typeof ModifyMessageLabelsError
@@ -71,36 +67,10 @@ function summarizeError(error: {
 	return { name: error.name, message: error.message };
 }
 
-function errorReason(body: string): string | null {
-	try {
-		const parsed = JSON.parse(body) as {
-			error?: { errors?: { reason?: string }[]; status?: string };
-		};
-		return parsed.error?.errors?.[0]?.reason ?? parsed.error?.status ?? null;
-	} catch {
-		return null;
-	}
-}
-
-function isReadOnlyGrant(error: GmailClientError): boolean {
-	return (
-		error.name === 'Http' &&
-		error.status === 403 &&
-		errorReason(error.body) === 'insufficientPermissions'
-	);
-}
-
 function isPerIdError(error: GmailClientError): boolean {
 	return (
 		error.name === 'Http' && (error.status === 400 || error.status === 404)
 	);
-}
-
-function abortSummary(error: GmailClientError): ErrorSummary {
-	if (isReadOnlyGrant(error)) {
-		return summarizeError(ModifyMessageLabelsError.ReadOnlyGrant().error);
-	}
-	return summarizeError(error);
 }
 
 function tryFoldMessageLabels({
@@ -189,9 +159,8 @@ export async function modifyMessageLabels({
 				results.push({ id, labelIds: null, folded: false, error: summary });
 				continue;
 			}
-			const aborted = abortSummary(error);
-			results.push({ id, labelIds: null, folded: false, error: aborted });
-			return Ok({ results, aborted });
+			results.push({ id, labelIds: null, folded: false, error: summary });
+			return Ok({ results, aborted: summary });
 		}
 
 		if (!message.labelIds) {

--- a/specs/20260702T211500-local-mail-phase-3-write-through.md
+++ b/specs/20260702T211500-local-mail-phase-3-write-through.md
@@ -117,7 +117,7 @@ MCP `modify_labels` --> resolveLabelIds (names->ids; the core takes ids only)
                        401 -> one token refresh (existing client behavior)
                        429/5xx/retryable 403 -> existing backoff
                        404/400 -> per-id error, continue
-                       403 insufficientPermissions -> abort all, "re-run connect"
+                       403 insufficientPermissions -> abort all (Gmail's raw error)
                      response.labelIds present?
                        yes -> db.patchMessageLabels(id, labelIds)  fold, best-effort
                        no  -> folded: false ("mirror catches up on next sync")
@@ -180,7 +180,7 @@ The interactive trust boundary is the MCP host's approval prompt, per ADR-0073 i
 | Failure | Where it surfaces | Behavior |
 | --- | --- | --- |
 | Token expired/revoked | `TokenError` from the token manager | Abort all ids; message names `local-mail connect` |
-| Token lacks `gmail.modify` (pre-Phase-3 grant) | Gmail 403 `insufficientPermissions` (a non-retryable 403 in the existing client) | Abort all ids; map to a dedicated message: "this account was connected read-only; re-run local-mail connect to grant write access" |
+| Token lacks `gmail.modify` (pre-Phase-3 grant) | Gmail 403 `insufficientPermissions` (a non-retryable 403 in the existing client) | Abort all ids with Gmail's raw error. **Refusal (2026-07-02):** the bespoke `ReadOnlyGrant` reconnect message was a transitional bridge for readonly-era tokens; removed once the sole such grant re-consented. `prompt=consent` + always-`gmail.modify` means no fresh connect can reproduce a readonly token, so the branch had no live producer. Revisit if a read-only-mirror consent mode ever ships. |
 | Unknown message id | Gmail 404 | Per-id error; loop continues |
 | Invalid/unknown label id, unapplicable system label | Gmail 400 (body carries Gmail's own message, e.g. `Invalid label: X`) | Per-id error with Gmail's message; loop continues |
 | Rate limit | 429 / retryable 403; existing backoff, then `Throttled` | Abort remaining ids (systemic) |
@@ -241,7 +241,7 @@ Live (owner, GUI terminal): mark a message read on the desktop, watch it show re
 
 Build, prove, remove has nothing to remove here; the waves are build-and-prove, each independently landable.
 
-- [x] **3.0 Scope flip.** `oauth.ts`: `gmail.readonly` becomes `gmail.modify` in `connect`'s scope request; README documents the re-consent (one command) and the send-stays-refused posture. Map the 403 `insufficientPermissions` reason to the re-connect message in the client or core.
+- [x] **3.0 Scope flip.** `oauth.ts`: `gmail.readonly` becomes `gmail.modify` in `connect`'s scope request; README documents the re-consent (one command) and the send-stays-refused posture. (A 403 `insufficientPermissions` from a stale readonly token surfaces Gmail's raw error; the transitional reconnect-message mapping was removed 2026-07-02 once the sole readonly grant re-consented.)
 - [x] **3.1 Client POST.** `request()` grows `method`/`body`; `modifyMessage(id, {addLabelIds, removeLabelIds})` validated against `GmailMessageSchema` (its optional `labelIds` already matches the slim response). Existing retry/refresh/throttle behavior applies unchanged.
 - [x] **3.2 The core and the fold.** `db.patchMessageLabels` (extract the labelPatch semantics already inside `applyHistoryBatch` into a single-row method both call), `src/modify.ts` with `modifyMessageLabels` (required `readOnly`, serial loop, per-id/systemic error split, best-effort fold). Tests 1-6, 10-13.
 - [x] **3.3 CLI.** `modify` verb with intent flags desugaring to add/remove sets; `resolveLabelIds` helper (mirror lookup, fresh `labels.list` on miss); `LOCAL_MAIL_READ_ONLY` in config. Tests 7, 14, 15.
@@ -261,15 +261,14 @@ Nothing in this spec adds HTTP endpoints; the shell spec's `POST /api/messages/:
 ## Open questions
 
 1. **Does the live `messages.modify` response reliably carry `labelIds`?** Not contractually documented; universally observed. The `folded: false` branch makes either answer safe. **Recommendation**: resolve empirically in wave 3.5; if it ever comes back absent, the escape hatch is a `messages.get` refetch (20 units) behind the same fold, still Gmail-sourced.
-2. **Persist the granted scope at connect time?** The token grant response includes `scope`; storing it would let the CLI warn before a write instead of after a 403. **Recommendation**: skip for v1; the 403 mapping is one round-trip and zero new state. Revisit if the error proves confusing live.
+2. **Persist the granted scope at connect time?** The token grant response includes `scope`; storing it would let the CLI warn before a write instead of after a 403. **Recommendation**: skip for v1; the raw 403 is one round-trip and zero new state. (Resolved 2026-07-02: even the bespoke reconnect-message mapping was removed as an unearned bridge; the raw Gmail 403 is the whole surface now.) Revisit if the error proves confusing live.
 3. **Per-intent MCP sugar tools (`mark_read`, `archive`)?** **Recommendation**: wait for evidence that models fumble the label vocabulary in `modify_labels`; the description documents `UNREAD`/`INBOX` explicitly.
-4. **ADR at flip time.** The durable decisions here that outlive this spec: the six-actions-one-primitive collapse, the single-scope posture (`gmail.modify`, send refused at app level, no dual consent modes), and the fold-is-not-optimistic-patch line. **Recommendation**: record as one short ADR when Phase 3 lands and this spec is deleted; check the ADR number against main first (a concurrent branch has minted another 0098).
+4. **ADR at flip time.** The durable decisions here that outlive this spec: the six-actions-one-primitive collapse, the single-scope posture (`gmail.modify`, send refused at app level, no dual consent modes, no readonly-era reconnect bridge; a stale-scope write surfaces Gmail's raw 403), and the fold-is-not-optimistic-patch line. **Recommendation**: record as one short ADR when Phase 3 lands and this spec is deleted; check the ADR number against main first (a concurrent branch has minted another 0098).
 
 ## Success criteria
 
 - [ ] `bun test` and `bun run typecheck` green in `apps/local-mail`; all sixteen test-plan pins present.
 - [ ] Live: mark-read on the desktop is visible in Gmail's phone app without a local sync pass in between (the fold), and the next `--watch` pass replays it cleanly.
-- [ ] Live: a readonly-era token gets the re-connect message on first write; after `connect`, the same command succeeds.
 - [ ] `LOCAL_MAIL_READ_ONLY=1 local-mail mcp` lists no `modify_labels`; the CLI `modify` verb refuses under the same env.
 - [ ] Grep-level: no new mirror tables, no pending-operation state, `SCHEMA_VERSION` unchanged.
 

--- a/specs/20260702T211500-local-mail-phase-3-write-through.md
+++ b/specs/20260702T211500-local-mail-phase-3-write-through.md
@@ -245,7 +245,7 @@ Build, prove, remove has nothing to remove here; the waves are build-and-prove, 
 - [x] **3.1 Client POST.** `request()` grows `method`/`body`; `modifyMessage(id, {addLabelIds, removeLabelIds})` validated against `GmailMessageSchema` (its optional `labelIds` already matches the slim response). Existing retry/refresh/throttle behavior applies unchanged.
 - [x] **3.2 The core and the fold.** `db.patchMessageLabels` (extract the labelPatch semantics already inside `applyHistoryBatch` into a single-row method both call), `src/modify.ts` with `modifyMessageLabels` (required `readOnly`, serial loop, per-id/systemic error split, best-effort fold). Tests 1-6, 10-13.
 - [x] **3.3 CLI.** `modify` verb with intent flags desugaring to add/remove sets; `resolveLabelIds` helper (mirror lookup, fresh `labels.list` on miss); `LOCAL_MAIL_READ_ONLY` in config. Tests 7, 14, 15.
-- [ ] **3.4 MCP.** Three-tier `tier`, catalog filter under `LOCAL_MAIL_READ_ONLY`, `modify_labels` tool (TypeBox input: `ids` 1-100, optional `addLabelIds`/`removeLabelIds` accepting ids or names via the same helper), per-tool annotations. Tests 8, 9, 16.
+- [x] **3.4 MCP.** Three-tier `tier`, catalog filter under `LOCAL_MAIL_READ_ONLY`, `modify_labels` tool (TypeBox input: `ids` 1-100, optional `addLabelIds`/`removeLabelIds` accepting ids or names via the same helper), per-tool annotations. Tests 8, 9, 16.
 - [ ] **3.5 Live round-trip (owner).** The phone-visible verification above; this is the gate the shell spec's Phase C/D UI waits on.
 
 ## Stop point: what must be true before UI work starts

--- a/specs/20260702T211500-local-mail-phase-3-write-through.md
+++ b/specs/20260702T211500-local-mail-phase-3-write-through.md
@@ -246,31 +246,32 @@ Build, prove, remove has nothing to remove here; the waves are build-and-prove, 
 - [x] **3.2 The core and the fold.** `db.patchMessageLabels` (extract the labelPatch semantics already inside `applyHistoryBatch` into a single-row method both call), `src/modify.ts` with `modifyMessageLabels` (required `readOnly`, serial loop, per-id/systemic error split, best-effort fold). Tests 1-6, 10-13.
 - [x] **3.3 CLI.** `modify` verb with intent flags desugaring to add/remove sets; `resolveLabelIds` helper (mirror lookup, fresh `labels.list` on miss); `LOCAL_MAIL_READ_ONLY` in config. Tests 7, 14, 15.
 - [x] **3.4 MCP.** Three-tier `tier`, catalog filter under `LOCAL_MAIL_READ_ONLY`, `modify_labels` tool (TypeBox input: `ids` 1-100, optional `addLabelIds`/`removeLabelIds` accepting ids or names via the same helper), per-tool annotations. Tests 8, 9, 16.
-- [ ] **3.5 Live round-trip (owner).** The phone-visible verification above; this is the gate the shell spec's Phase C/D UI waits on.
+- [x] **3.5 Live round-trip (owner).** The phone-visible verification above; this is the gate the shell spec's Phase C/D UI waits on.
+  > **Live note, 2026-07-02:** Owner verified `modify 19f25c61b98fe50e --read` and `--unread` against Gmail web/phone. Gmail's `messages.modify` response carried `labelIds`; both CLI outcomes returned `folded: true`, and the mirror query matched the returned labels immediately. Owner then verified `--archive` and `--unarchive`: archive removed `INBOX`, unarchive restored `INBOX`, and both returned `folded: true`. After establishing the first full-sync cursor (`559146`), a post-cursor incremental sync replayed the archive history cleanly: `cursorBefore: "559146"`, `cursorAfter: "559160"`, `labelsPatched: 1`, `failure: null`. The message was restored with `--unarchive`, and the restore-side incremental sync converged cleanly once Gmail history caught up.
 
 ## Stop point: what must be true before UI work starts
 
 UI (shell spec Phases C and D) starts only when all of:
 
-1. The mark-read and archive cores are live-verified round-trip: desktop mutation, phone Gmail reflects it, next sync pass replays it without churn.
-2. The re-consent flow is proven: a readonly-granted account hits the 403 mapping, runs `connect`, and the same write succeeds.
+1. The mark-read and archive cores are live-verified round-trip: desktop mutation, phone Gmail reflects it, next sync pass replays it without churn. As of 2026-07-02, mark-read/unread and archive/unarchive are phone-visible and folded; archive and restore history replay after a stored cursor are verified.
+2. The stale-grant path is settled: a readonly-era token surfaces Gmail's raw 403, and `connect` requests the write-capable `gmail.modify` grant.
 3. The failure surfacing is settled as data (this spec's `ModifyOutcome` and error names), so UI work binds to a stable shape instead of inventing one.
 
 Nothing in this spec adds HTTP endpoints; the shell spec's `POST /api/messages/:id/...` adapters are Phase D work that wraps `modifyMessageLabels` the same way the CLI does.
 
 ## Open questions
 
-1. **Does the live `messages.modify` response reliably carry `labelIds`?** Not contractually documented; universally observed. The `folded: false` branch makes either answer safe. **Recommendation**: resolve empirically in wave 3.5; if it ever comes back absent, the escape hatch is a `messages.get` refetch (20 units) behind the same fold, still Gmail-sourced.
+1. **Does the live `messages.modify` response reliably carry `labelIds`?** Not contractually documented; universally observed. **Resolved 2026-07-02 for the live Phase 3.5 sample:** mark-read, mark-unread, archive, and unarchive all returned `labelIds` and folded immediately. Keep the `folded: false` branch because the field is still not contractual; if it ever comes back absent, the escape hatch is a `messages.get` refetch (20 units) behind the same fold, still Gmail-sourced.
 2. **Persist the granted scope at connect time?** The token grant response includes `scope`; storing it would let the CLI warn before a write instead of after a 403. **Recommendation**: skip for v1; the raw 403 is one round-trip and zero new state. (Resolved 2026-07-02: even the bespoke reconnect-message mapping was removed as an unearned bridge; the raw Gmail 403 is the whole surface now.) Revisit if the error proves confusing live.
 3. **Per-intent MCP sugar tools (`mark_read`, `archive`)?** **Recommendation**: wait for evidence that models fumble the label vocabulary in `modify_labels`; the description documents `UNREAD`/`INBOX` explicitly.
 4. **ADR at flip time.** The durable decisions here that outlive this spec: the six-actions-one-primitive collapse, the single-scope posture (`gmail.modify`, send refused at app level, no dual consent modes, no readonly-era reconnect bridge; a stale-scope write surfaces Gmail's raw 403), and the fold-is-not-optimistic-patch line. **Recommendation**: record as one short ADR when Phase 3 lands and this spec is deleted; check the ADR number against main first (a concurrent branch has minted another 0098).
 
 ## Success criteria
 
-- [ ] `bun test` and `bun run typecheck` green in `apps/local-mail`; all sixteen test-plan pins present.
-- [ ] Live: mark-read on the desktop is visible in Gmail's phone app without a local sync pass in between (the fold), and the next `--watch` pass replays it cleanly.
-- [ ] `LOCAL_MAIL_READ_ONLY=1 local-mail mcp` lists no `modify_labels`; the CLI `modify` verb refuses under the same env.
-- [ ] Grep-level: no new mirror tables, no pending-operation state, `SCHEMA_VERSION` unchanged.
+- [x] `bun test` and `bun run typecheck` green in `apps/local-mail`; all sixteen test-plan pins present.
+- [x] Live: mark-read on the desktop is visible in Gmail's phone app without a local sync pass in between (the fold), and the next `--watch` pass replays it cleanly. Mark-read/unread and archive/unarchive folds are verified; archive and restore history replay after cursor `559146` are verified.
+- [x] `LOCAL_MAIL_READ_ONLY=1 local-mail mcp` lists no `modify_labels`; the CLI `modify` verb refuses under the same env.
+- [x] Grep-level: no new mirror tables, no pending-operation state, `SCHEMA_VERSION` unchanged.
 
 ## References
 


### PR DESCRIPTION
Local Mail write-through is now available to MCP hosts through one mutation tool instead of intent-specific wrappers.

## MCP Surface

The server now keeps three effect tiers: read tools, local mirror writes, and Gmail mutations. `LOCAL_MAIL_READ_ONLY` filters mutation tools out of `tools/list`, while `query`, `status`, and `sync` stay available.

```txt
query          read
status         read
sync           write
modify_labels  mutation
```

`modify_labels` accepts one to 100 message ids plus labels to add or remove. Labels may be Gmail ids or exact names; the adapter reuses the shared resolver, so unresolved labels fail before any Gmail message mutation.

The tool advertises the actual operation shape to hosts: `readOnlyHint: false`, `destructiveHint: false`, and `idempotentHint: true`.

## Live Round Trip

Phase 3 is now live-verified against Gmail web/phone. Mark-read, mark-unread, archive, and unarchive all returned Gmail `labelIds`, folded into the mirror immediately, and replayed cleanly through incremental sync after a stored cursor.

A small cleanup came out of the live pass: the temporary readonly-era reconnect bridge is gone. Fresh connects request `gmail.modify`, and a stale readonly token now surfaces Gmail’s raw 403 instead of carrying a branch with no live producer.

## Changelog

- Added Local Mail MCP `modify_labels` for Gmail label mutations.
- Verified the Phase 3 Gmail write-through round trip live.
- Removed the stale readonly-token reconnect bridge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785652385&installation_id=128463665&pr_number=2298&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2298&signature=e1d93300277716b663537136724f988d980ab6542e0c536b2f47a7f97f08f0c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->