### PR TITLE
fix(super-chat): route session client through API_ROUTES

### DIFF
--- a/apps/super-chat/src/session-client.ts
+++ b/apps/super-chat/src/session-client.ts
@@ -16,6 +16,7 @@
  */
 
 import type { AgentMessage } from '@epicenter/workspace/agent';
+import { API_ROUTES } from '@epicenter/constants/api-routes';
 import type { ServerEvent } from './server.ts';
 
 const [, , origin, token] = process.argv;
@@ -26,7 +27,7 @@ if (!origin || !token) {
 	process.exit(1);
 }
 
-const url = `${origin.replace(/\/$/, '')}/api/session/stream?token=${encodeURIComponent(token)}`;
+const url = `${API_ROUTES.session.stream.url(origin)}?token=${encodeURIComponent(token)}`;
 console.log(`Connecting to ${origin} ...`);
 
 const socket = new WebSocket(url);

--- a/apps/super-chat/src/session-client.ts
+++ b/apps/super-chat/src/session-client.ts
@@ -15,8 +15,8 @@
  * Run: bun run apps/super-chat/src/session-client.ts ws://127.0.0.1:<port> <token>
  */
 
-import type { AgentMessage } from '@epicenter/workspace/agent';
 import { API_ROUTES } from '@epicenter/constants/api-routes';
+import type { AgentMessage } from '@epicenter/workspace/agent';
 import type { ServerEvent } from './server.ts';
 
 const [, , origin, token] = process.argv;


### PR DESCRIPTION
The session CLI proof still hardcoded the canonical stream route after the rest of Super Chat moved production route strings behind `API_ROUTES`.

This routes the CLI client through `API_ROUTES.session.stream.url(origin)` like the server and browser session client, so future route changes have one source of truth.