### PR TITLE
refactor(local-mail): consolidate pre-UI write surfaces

### DIFF
--- a/apps/local-mail/README.md
+++ b/apps/local-mail/README.md
@@ -74,6 +74,25 @@ Query the mirror:
 bun run src/bin.ts query "SELECT subject, sender FROM messages ORDER BY internal_date DESC LIMIT 10"
 ```
 
+Triage messages. Each verb is a Gmail label change that the mirror folds in
+after Gmail accepts it. Output is human-readable; add `--json` for the typed
+`ModifyMessageLabelsOutcome` that MCP and a future HTTP adapter share.
+
+```sh
+bun run src/bin.ts archive <id...>
+bun run src/bin.ts unarchive <id...>
+bun run src/bin.ts mark-read <id...>
+bun run src/bin.ts mark-unread <id...>
+bun run src/bin.ts label <id...> --add Work --remove Promotions
+```
+
+`archive`, `mark-read`, and friends are the triage vocabulary; `label` is the
+transparent primitive they desugar to (`archive` is `label --remove INBOX`).
+Any per-id rejection or a systemic abort exits nonzero, so
+`mark-read <id> && next` never proceeds on a mailbox that did not change.
+`LOCAL_MAIL_READ_ONLY` refuses every write while leaving `query`/`status`/`sync`
+available.
+
 Serve tools to an MCP host:
 
 ```sh
@@ -88,6 +107,11 @@ Tools:
 - `query`: read-only SQL over the mirror, capped at 1000 returned rows.
 - `status`: account, cursor, and row counts.
 - `sync`: one local mirror refresh pass. This writes only the local cache.
+- `modify_labels`: add or remove Gmail labels on 1 to 100 messages by id or
+  exact name (`addLabels`/`removeLabels`), then fold Gmail's response. Per-id
+  rejections ride inside the structured result; only a systemic abort sets
+  `isError`. Unlisted under `LOCAL_MAIL_READ_ONLY`. The CLI triage verbs above
+  are the human-facing form of this one tool.
 
 ## Config
 
@@ -114,8 +138,9 @@ stdio subprocess for the agent-facing protocol surface.
 
 ## Not built yet
 
-- CLI, MCP, HTTP, and UI surfaces for Gmail write-through actions such as
-  archive, mark-read, and label edits.
+- HTTP and UI surfaces for the write-through actions. When they land, the UI
+  calls one `POST /api/messages/modify` adapter over the same core the CLI and
+  MCP use, not per-intent routes.
 - Send, reply, compose, drafts, trash, untrash, and permanent delete.
 - FTS5. `LIKE` over `body_text` is enough for the current mirror size.
 - Push/Pub/Sub.

--- a/apps/local-mail/src/cli.test.ts
+++ b/apps/local-mail/src/cli.test.ts
@@ -13,8 +13,9 @@ import { expect, test } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { parseArgs, runCli } from './cli.ts';
+import { modifyExitCode, parseArgs, runCli } from './cli.ts';
 import { loadConfig } from './config.ts';
+import type { ModifyMessageLabelsOutcome } from './modify.ts';
 import { createFileTokenStore } from './token-store.ts';
 import type { TokenSet } from './tokens.ts';
 
@@ -50,25 +51,57 @@ test('--watch followed by another flag stays flag-only', () => {
 	expect(args.watchIntervalMs).toBeUndefined();
 });
 
-test('modify parses intent flags and repeatable label changes', () => {
+test('triage verbs collect ids as positionals', () => {
+	const args = parseArgs(['mark-read', 'm1', 'm2']);
+	expect(args.command).toBe('mark-read');
+	expect(args.positionals).toEqual(['m1', 'm2']);
+	expect(args.addLabels).toEqual([]);
+	expect(args.removeLabels).toEqual([]);
+});
+
+test('label parses repeatable label changes and --json', () => {
 	const args = parseArgs([
-		'modify',
+		'label',
 		'm1',
 		'm2',
-		'--read',
-		'--archive',
 		'--add',
 		'Work',
 		'--add=Label_2',
 		'--remove',
 		'Travel',
+		'--json',
 	]);
-	expect(args.command).toBe('modify');
+	expect(args.command).toBe('label');
 	expect(args.positionals).toEqual(['m1', 'm2']);
-	expect(args.read).toBe(true);
-	expect(args.archive).toBe(true);
 	expect(args.addLabels).toEqual(['Work', 'Label_2']);
 	expect(args.removeLabels).toEqual(['Travel']);
+	expect(args.json).toBe(true);
+});
+
+test('modifyExitCode is nonzero on any per-id failure or systemic abort', () => {
+	const clean: ModifyMessageLabelsOutcome = {
+		results: [{ id: 'm1', labelIds: ['INBOX'], folded: true, error: null }],
+		aborted: null,
+	};
+	const perId: ModifyMessageLabelsOutcome = {
+		results: [
+			{ id: 'm1', labelIds: ['INBOX'], folded: true, error: null },
+			{
+				id: 'm2',
+				labelIds: null,
+				folded: false,
+				error: { name: 'Http', message: 'not found' },
+			},
+		],
+		aborted: null,
+	};
+	const aborted: ModifyMessageLabelsOutcome = {
+		results: [{ id: 'm1', labelIds: ['INBOX'], folded: true, error: null }],
+		aborted: { name: 'Throttled', message: 'slow down' },
+	};
+	expect(modifyExitCode(clean)).toBe(0);
+	expect(modifyExitCode(perId)).toBe(1);
+	expect(modifyExitCode(aborted)).toBe(1);
 });
 
 test('LOCAL_MAIL_READ_ONLY enables read-only config mode', () => {
@@ -82,7 +115,7 @@ test('LOCAL_MAIL_READ_ONLY enables read-only config mode', () => {
 	}
 });
 
-test('modify honors LOCAL_MAIL_READ_ONLY before resolving labels', async () => {
+test('label honors LOCAL_MAIL_READ_ONLY before resolving labels', async () => {
 	const dir = mkdtempSync(join(tmpdir(), 'local-mail-cli-readonly-test-'));
 	const token: TokenSet = {
 		accountEmail: 'you@example.com',
@@ -107,7 +140,7 @@ test('modify honors LOCAL_MAIL_READ_ONLY before resolving labels', async () => {
 		errors.push(String(message));
 	};
 	try {
-		expect(await runCli(['modify', 'm1', '--add', 'Missing Label'])).toBe(1);
+		expect(await runCli(['label', 'm1', '--add', 'Missing Label'])).toBe(1);
 		expect(errors.join('\n')).toContain('Refusing to write: read-only mode');
 		expect(errors.join('\n')).not.toContain('Unknown Gmail label');
 	} finally {
@@ -125,7 +158,7 @@ test('modify honors LOCAL_MAIL_READ_ONLY before resolving labels', async () => {
 	}
 });
 
-test('status resolves the sole stored account and prints JSON', async () => {
+test('status --json resolves the sole stored account and prints JSON', async () => {
 	const dir = mkdtempSync(join(tmpdir(), 'local-mail-cli-test-'));
 	const token: TokenSet = {
 		accountEmail: 'you@example.com',
@@ -148,7 +181,7 @@ test('status resolves the sole stored account and prints JSON', async () => {
 		logs.push(String(message));
 	};
 	try {
-		expect(await runCli(['status'])).toBe(0);
+		expect(await runCli(['status', '--json'])).toBe(0);
 		expect(JSON.parse(logs[0] ?? '{}').accountEmail).toBe('you@example.com');
 	} finally {
 		console.log = originalLog;

--- a/apps/local-mail/src/cli.ts
+++ b/apps/local-mail/src/cli.ts
@@ -1,10 +1,12 @@
 import { loadConfig } from './config.ts';
-import type { MailDb } from './db.ts';
-import { resolveAndModifyMessageLabels } from './modify.ts';
+import {
+	type ModifyMessageLabelsOutcome,
+	resolveAndModifyMessageLabels,
+} from './modify.ts';
 import { redeemRefreshToken, runAuthorizationFlow } from './oauth.ts';
 import { queryMail } from './query.ts';
 import { openLocalMailRuntime, openSyncSession } from './runtime.ts';
-import { readMailStatus } from './status.ts';
+import { type MailStatus, readMailStatus } from './status.ts';
 import { runSyncLoop, type SyncOutcome, syncMailbox } from './sync.ts';
 import { createFileTokenStore } from './token-store.ts';
 import { VERSION } from './version.ts';
@@ -18,10 +20,7 @@ export type ParsedArgs = {
 	clientId?: string;
 	addLabels: string[];
 	removeLabels: string[];
-	read: boolean;
-	unread: boolean;
-	archive: boolean;
-	unarchive: boolean;
+	json: boolean;
 	help: boolean;
 	version: boolean;
 };
@@ -33,10 +32,11 @@ const HELP = `local-mail: keep a private local copy of Gmail for local tools and
 Usage:
   local-mail connect [--client-id <id>]
   local-mail seed-token <refreshToken>
-  local-mail sync [--full] [--watch [intervalMs]]
-  local-mail status
+  local-mail sync [--full] [--watch [intervalMs]] [--json]
+  local-mail status [--json]
   local-mail query "<sql>"
-  local-mail modify <id...> [--read|--unread|--archive|--unarchive] [--add <label>...] [--remove <label>...]
+  local-mail archive|unarchive|mark-read|mark-unread <id...> [--json]
+  local-mail label <id...> [--add <label>...] [--remove <label>...] [--json]
   local-mail mcp
 
 Commands:
@@ -46,20 +46,22 @@ Commands:
                the Gmail profile.
   sync         Refresh the local mirror. Use --watch to keep polling.
   status       Show connection state, cursor, and row counts.
-  query        Run a read-only SQL query over the local mirror.
-  modify       Apply Gmail label changes, then fold Gmail's response into the mirror.
-  mcp          Serve query/status/sync tools to an agent over stdio.
+  query        Run a read-only SQL query over the local mirror (JSON output).
+  archive      Archive messages by removing INBOX, then fold Gmail's response.
+  unarchive    Move messages back to the inbox by adding INBOX.
+  mark-read    Mark messages read by removing UNREAD.
+  mark-unread  Mark messages unread by adding UNREAD.
+  label        Add or remove Gmail labels by exact name or id.
+  mcp          Serve query/status/sync/modify_labels tools over stdio.
 
 Options:
   --client-id <id>      Override GMAIL_CLIENT_ID for connect.
   --full                Force a full pull on the first sync pass.
   --watch [intervalMs]  Keep syncing on a loop. Default: 30000.
-  --read                Mark messages read by removing UNREAD.
-  --unread              Mark messages unread by adding UNREAD.
-  --archive             Archive messages by removing INBOX.
-  --unarchive           Move messages to the inbox by adding INBOX.
   --add <label>         Add a Gmail label by exact name or id. Repeatable.
   --remove <label>      Remove a Gmail label by exact name or id. Repeatable.
+  --json                Print typed JSON instead of human text. query is
+                        always JSON, so --json is a no-op there.
   -h, --help            Show this help.
   -v, --version         Show version.
 
@@ -70,6 +72,25 @@ Environment:
   LOCAL_MAIL_TOKEN_FILE                   Override the credentials file path.
   LOCAL_MAIL_READ_ONLY                    Disable Gmail mutations.
 `;
+
+/**
+ * The four triage verbs desugar to a fixed Gmail label change. `label` is the
+ * transparent primitive: it takes the same add/remove sets these verbs hide.
+ * One core (`resolveAndModifyMessageLabels`) runs all five.
+ */
+const TRIAGE_VERBS: Record<
+	'archive' | 'unarchive' | 'mark-read' | 'mark-unread',
+	{ addLabels: string[]; removeLabels: string[]; done: string }
+> = {
+	archive: { addLabels: [], removeLabels: ['INBOX'], done: 'archived' },
+	unarchive: { addLabels: ['INBOX'], removeLabels: [], done: 'moved to inbox' },
+	'mark-read': { addLabels: [], removeLabels: ['UNREAD'], done: 'marked read' },
+	'mark-unread': {
+		addLabels: ['UNREAD'],
+		removeLabels: [],
+		done: 'marked unread',
+	},
+};
 
 function parseWatchInterval(input: string): number {
 	const value = Number(input.trim());
@@ -89,10 +110,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
 		watch: false,
 		addLabels: [],
 		removeLabels: [],
-		read: false,
-		unread: false,
-		archive: false,
-		unarchive: false,
+		json: false,
 		help: false,
 		version: false,
 	};
@@ -136,23 +154,14 @@ export function parseArgs(argv: string[]): ParsedArgs {
 				}
 				break;
 			}
-			case '--read':
-				args.read = true;
-				break;
-			case '--unread':
-				args.unread = true;
-				break;
-			case '--archive':
-				args.archive = true;
-				break;
-			case '--unarchive':
-				args.unarchive = true;
-				break;
 			case '--add':
 				args.addLabels.push(takeValue());
 				break;
 			case '--remove':
 				args.removeLabels.push(takeValue());
+				break;
+			case '--json':
+				args.json = true;
 				break;
 			case '-h':
 			case '--help':
@@ -218,17 +227,17 @@ async function runSeedToken(args: ParsedArgs): Promise<number> {
 	return 0;
 }
 
-function printOutcome(db: MailDb, outcome: SyncOutcome): void {
-	console.log(JSON.stringify(outcome, null, 2));
-	if (outcome.failure) return;
-
-	const { messages } = db.counts();
-	console.log(`\n${messages} live messages mirrored. Most recent:`);
-	for (const row of db.recentMessages(5)) {
-		console.log(
-			`  ${row.sender ?? '(unknown)'}: ${row.subject ?? '(no subject)'}`,
-		);
+function renderSyncOutcome(outcome: SyncOutcome): string {
+	if (outcome.failure) {
+		return `Sync failed (${outcome.failure.name}): ${outcome.failure.message}. The cursor did not advance.`;
 	}
+	const mode = outcome.mode === 'FULL' ? 'Full sync' : 'Incremental sync';
+	const labelWord = outcome.labelsPatched === 1 ? 'label' : 'labels';
+	const cursor =
+		outcome.cursorBefore === outcome.cursorAfter
+			? `cursor ${outcome.cursorAfter ?? 'none'}`
+			: `cursor ${outcome.cursorBefore ?? 'none'} to ${outcome.cursorAfter ?? 'none'}`;
+	return `${mode}: ${outcome.messagesUpserted} upserted, ${outcome.messagesDeleted} deleted, ${outcome.labelsPatched} ${labelWord} patched, ${cursor}.`;
 }
 
 async function runSync(args: ParsedArgs): Promise<number> {
@@ -243,11 +252,13 @@ async function runSync(args: ParsedArgs): Promise<number> {
 		console.error(runtimeError.message);
 		return 1;
 	}
+	// Progress goes to stderr so stdout carries only the outcome, keeping
+	// --json (and the human summary line) a clean single-value stream.
 	const { data: session, error: sessionError } = await openSyncSession(
 		runtime,
 		{
-			gmailLog: (m) => console.log(`[gmail] ${m}`),
-			syncLog: (m) => console.log(`[sync] ${m}`),
+			gmailLog: (m) => console.error(`[gmail] ${m}`),
+			syncLog: (m) => console.error(`[sync] ${m}`),
 		},
 	);
 	if (sessionError) {
@@ -257,14 +268,15 @@ async function runSync(args: ParsedArgs): Promise<number> {
 
 	if (!args.watch) {
 		const outcome = await syncMailbox(session.deps, { forceFull: args.full });
-		printOutcome(session.deps.db, outcome);
-		const failed = outcome.failure !== null;
+		console.log(
+			args.json ? JSON.stringify(outcome, null, 2) : renderSyncOutcome(outcome),
+		);
 		session.close();
-		return failed ? 1 : 0;
+		return outcome.failure ? 1 : 0;
 	}
 
 	const intervalMs = args.watchIntervalMs ?? DEFAULT_WATCH_INTERVAL_MS;
-	console.log(`Watching every ${intervalMs}ms. Ctrl-C to stop.`);
+	console.error(`Watching every ${intervalMs}ms. Ctrl-C to stop.`);
 	const controller = new AbortController();
 	process.on('SIGINT', () => controller.abort());
 	// The exit code reflects the LAST pass, so a supervisor restarting on
@@ -276,28 +288,62 @@ async function runSync(args: ParsedArgs): Promise<number> {
 		signal: controller.signal,
 		onPass: (outcome, pass) => {
 			lastPassFailed = outcome.failure !== null;
-			console.log(`\n=== pass ${pass} ===`);
-			printOutcome(session.deps.db, outcome);
+			if (args.json) {
+				console.log(JSON.stringify(outcome));
+			} else {
+				console.log(`=== pass ${pass} ===`);
+				console.log(renderSyncOutcome(outcome));
+			}
 		},
 	});
 	session.close();
 	return lastPassFailed ? 1 : 0;
 }
 
-async function runModify(args: ParsedArgs): Promise<number> {
-	if (args.positionals.length === 0) {
-		console.error(
-			'Usage: local-mail modify <id...> [--read|--unread|--archive|--unarchive] [--add <label>...] [--remove <label>...]',
+/**
+ * 0 only when Gmail accepted every id. Any per-id rejection or a systemic
+ * abort exits 1 so `local-mail mark-read <id> && next` never proceeds on a
+ * mailbox that did not change.
+ */
+export function modifyExitCode(outcome: ModifyMessageLabelsOutcome): number {
+	const anyFailed = outcome.results.some((result) => result.error !== null);
+	return outcome.aborted !== null || anyFailed ? 1 : 0;
+}
+
+function renderModifyOutcome(
+	outcome: ModifyMessageLabelsOutcome,
+	done: string,
+): string {
+	const lines = outcome.results.map((result) => {
+		if (result.error) return `✗ ${result.id}  ${result.error.message}`;
+		const tail = result.folded
+			? ''
+			: ' (local mirror will catch up on next sync)';
+		return `✓ ${result.id}  ${done}${tail}`;
+	});
+	const ok = outcome.results.filter((result) => result.error === null).length;
+	const failed = outcome.results.length - ok;
+	lines.push(`${ok} succeeded, ${failed} failed`);
+	if (outcome.aborted) {
+		lines.push(
+			`Aborted after ${outcome.results.length}: ${outcome.aborted.message}`,
 		);
+	}
+	return lines.join('\n');
+}
+
+async function runLabelMutation(
+	args: ParsedArgs,
+	verb: { addLabels: string[]; removeLabels: string[]; done: string },
+): Promise<number> {
+	if (args.positionals.length === 0) {
+		const extra =
+			args.command === 'label'
+				? ' [--add <label>...] [--remove <label>...]'
+				: '';
+		console.error(`Usage: local-mail ${args.command} <id...>${extra} [--json]`);
 		return 1;
 	}
-
-	const addLabels = [...args.addLabels];
-	const removeLabels = [...args.removeLabels];
-	if (args.unread) addLabels.push('UNREAD');
-	if (args.unarchive) addLabels.push('INBOX');
-	if (args.read) removeLabels.push('UNREAD');
-	if (args.archive) removeLabels.push('INBOX');
 
 	const { data: runtime, error: runtimeError } = await openLocalMailRuntime();
 	if (runtimeError) {
@@ -314,16 +360,20 @@ async function runModify(args: ParsedArgs): Promise<number> {
 		const { data, error } = await resolveAndModifyMessageLabels({
 			deps: session.deps,
 			ids: args.positionals,
-			addLabels,
-			removeLabels,
+			addLabels: verb.addLabels,
+			removeLabels: verb.removeLabels,
 			readOnly: runtime.config.readOnly,
 		});
 		if (error) {
 			console.error(error.message);
 			return 1;
 		}
-		console.log(JSON.stringify(data, null, 2));
-		return data.aborted ? 1 : 0;
+		console.log(
+			args.json
+				? JSON.stringify(data, null, 2)
+				: renderModifyOutcome(data, verb.done),
+		);
+		return modifyExitCode(data);
 	} finally {
 		session.close();
 	}
@@ -349,19 +399,50 @@ async function runQuery(args: ParsedArgs): Promise<number> {
 		console.error(error.message);
 		return 1;
 	}
+	// query is JSON-first by design: an arbitrary SELECT over raw/body_text is
+	// not column-shaped, and the rows pipe straight to jq. --json is a no-op.
 	console.log(JSON.stringify(data.rows, null, 2));
 	const note = data.truncated ? ' (capped; more rows matched)' : '';
 	console.error(`${data.rowCount} row${data.rowCount === 1 ? '' : 's'}${note}`);
 	return 0;
 }
 
-async function runStatus(): Promise<number> {
+function renderStatus(status: MailStatus): string {
+	const accessToken = status.accessToken
+		? status.accessToken.valid
+			? `valid (expires ${status.accessToken.expiresAt})`
+			: `expired (${status.accessToken.expiresAt})`
+		: 'none';
+	const rows: [string, string][] = [
+		['account', status.accountEmail],
+		['data dir', status.dataDir],
+		['token file', status.tokenFile],
+		['connected', status.connected ? 'yes' : 'no'],
+		['access token', accessToken],
+		['mirror', status.mirror],
+		['schema version', status.schemaVersion ?? 'none'],
+		['history cursor', status.historyId ?? 'none'],
+		['last full pull', status.lastFullPullAt ?? 'never'],
+		['last synced', status.lastSyncedAt ?? 'never'],
+		['messages', String(status.rows.messages)],
+		['labels', String(status.rows.labels)],
+	];
+	const width = Math.max(...rows.map(([key]) => key.length));
+	return rows
+		.map(([key, value]) => `${key.padEnd(width)}  ${value}`)
+		.join('\n');
+}
+
+async function runStatus(args: ParsedArgs): Promise<number> {
 	const { data: runtime, error } = await openLocalMailRuntime();
 	if (error) {
 		console.error(error.message);
 		return 1;
 	}
-	console.log(JSON.stringify(await readMailStatus(runtime), null, 2));
+	const status = await readMailStatus(runtime);
+	console.log(
+		args.json ? JSON.stringify(status, null, 2) : renderStatus(status),
+	);
 	return 0;
 }
 
@@ -385,11 +466,20 @@ export async function runCli(argv: string[]): Promise<number> {
 		case 'sync':
 			return runSync(args);
 		case 'status':
-			return runStatus();
+			return runStatus(args);
 		case 'query':
 			return runQuery(args);
-		case 'modify':
-			return runModify(args);
+		case 'archive':
+		case 'unarchive':
+		case 'mark-read':
+		case 'mark-unread':
+			return runLabelMutation(args, TRIAGE_VERBS[args.command]);
+		case 'label':
+			return runLabelMutation(args, {
+				addLabels: args.addLabels,
+				removeLabels: args.removeLabels,
+				done: 'labels updated',
+			});
 		case 'mcp': {
 			const { runMcpServer } = await import('./mcp.ts');
 			return runMcpServer();

--- a/apps/local-mail/src/cli.ts
+++ b/apps/local-mail/src/cli.ts
@@ -1,6 +1,6 @@
 import { loadConfig } from './config.ts';
 import type { MailDb } from './db.ts';
-import { modifyMessageLabels, resolveLabelIds } from './modify.ts';
+import { resolveAndModifyMessageLabels } from './modify.ts';
 import { redeemRefreshToken, runAuthorizationFlow } from './oauth.ts';
 import { queryMail } from './query.ts';
 import { openLocalMailRuntime, openSyncSession } from './runtime.ts';
@@ -311,47 +311,17 @@ async function runModify(args: ParsedArgs): Promise<number> {
 	}
 
 	try {
-		if (runtime.config.readOnly) {
-			const { error } = await modifyMessageLabels({
-				deps: session.deps,
-				input: {
-					ids: args.positionals,
-					addLabelIds: addLabels,
-					removeLabelIds: removeLabels,
-				},
-				readOnly: true,
-			});
-			if (error) {
-				console.error(error.message);
-				return 1;
-			}
-			return 0;
-		}
-
-		const labels = [...addLabels, ...removeLabels];
-		const { data: resolvedLabels, error: labelError } = await resolveLabelIds({
+		const { data, error } = await resolveAndModifyMessageLabels({
 			deps: session.deps,
-			labels,
-		});
-		if (labelError) {
-			console.error(labelError.message);
-			return 1;
-		}
-
-		const { data, error } = await modifyMessageLabels({
-			deps: session.deps,
-			input: {
-				ids: args.positionals,
-				addLabelIds: resolvedLabels.slice(0, addLabels.length),
-				removeLabelIds: resolvedLabels.slice(addLabels.length),
-			},
+			ids: args.positionals,
+			addLabels,
+			removeLabels,
 			readOnly: runtime.config.readOnly,
 		});
 		if (error) {
 			console.error(error.message);
 			return 1;
 		}
-
 		console.log(JSON.stringify(data, null, 2));
 		return data.aborted ? 1 : 0;
 	} finally {

--- a/apps/local-mail/src/mcp-server.test.ts
+++ b/apps/local-mail/src/mcp-server.test.ts
@@ -214,10 +214,8 @@ test('mcp: tools/list, body query, status, errors, and a clean stream', async ()
 		expect(sync?.annotations?.destructiveHint).toBe(false);
 		const modifyLabels = tools.find((tool) => tool.name === 'modify_labels');
 		expect(modifyLabels?.inputSchema.properties).toHaveProperty('ids');
-		expect(modifyLabels?.inputSchema.properties).toHaveProperty('addLabelIds');
-		expect(modifyLabels?.inputSchema.properties).toHaveProperty(
-			'removeLabelIds',
-		);
+		expect(modifyLabels?.inputSchema.properties).toHaveProperty('addLabels');
+		expect(modifyLabels?.inputSchema.properties).toHaveProperty('removeLabels');
 		expect(modifyLabels?.annotations).toMatchObject({
 			readOnlyHint: false,
 			destructiveHint: false,
@@ -311,7 +309,7 @@ test('mcp: LOCAL_MAIL_READ_ONLY hides mutation tools but leaves reads and sync l
 			name: 'modify_labels',
 			arguments: {
 				ids: ['m1'],
-				addLabelIds: ['Work'],
+				addLabels: ['Work'],
 			},
 		});
 		expect(hidden.error?.code).toBe(-32601);
@@ -321,7 +319,7 @@ test('mcp: LOCAL_MAIL_READ_ONLY hides mutation tools but leaves reads and sync l
 	}
 });
 
-test('mcp: modify_labels folds Gmail labels and uses isError for Gmail rejection', async () => {
+test('mcp: modify_labels folds Gmail labels and keeps per-id rejections structured', async () => {
 	const tmp = tempDir();
 	seedMirror(tmp.dir);
 	await seedToken(tmp.dir);
@@ -375,8 +373,8 @@ test('mcp: modify_labels folds Gmail labels and uses isError for Gmail rejection
 			name: 'modify_labels',
 			arguments: {
 				ids: ['m1'],
-				addLabelIds: ['Work'],
-				removeLabelIds: ['INBOX'],
+				addLabels: ['Work'],
+				removeLabels: ['INBOX'],
 			},
 		});
 		expect(ok.error).toBeUndefined();
@@ -397,18 +395,32 @@ test('mcp: modify_labels folds Gmail labels and uses isError for Gmail rejection
 			aborted: null,
 		});
 
+		// A per-id Gmail rejection is not the error channel: it rides inside the
+		// structured results so the model can retry that id and keep the others.
 		const rejected = await mcp.request('tools/call', {
 			name: 'modify_labels',
 			arguments: {
 				ids: ['m2'],
-				addLabelIds: ['BAD'],
+				addLabels: ['BAD'],
 			},
 		});
 		expect(rejected.error).toBeUndefined();
-		expect(rejected.result?.isError).toBe(true);
-		const content = rejected.result?.content as Array<{ text: string }>;
-		expect(content[0]?.text).toContain('Gmail API returned 400');
-		expect(content[0]?.text).toContain('Invalid label: BAD');
+		expect(rejected.result?.isError).toBeFalsy();
+		const rejectedData = rejected.result?.structuredContent as {
+			results: Array<{
+				id: string;
+				error: { name: string; message: string } | null;
+			}>;
+			aborted: unknown;
+		};
+		expect(rejectedData.aborted).toBeNull();
+		expect(rejectedData.results[0]?.id).toBe('m2');
+		expect(rejectedData.results[0]?.error?.message).toContain(
+			'Gmail API returned 400',
+		);
+		expect(rejectedData.results[0]?.error?.message).toContain(
+			'Invalid label: BAD',
+		);
 
 		expect(requests).toContainEqual({
 			method: 'POST',

--- a/apps/local-mail/src/mcp.ts
+++ b/apps/local-mail/src/mcp.ts
@@ -54,7 +54,13 @@ import { readMailStatus } from './status.ts';
 import { syncMailbox } from './sync.ts';
 import { VERSION } from './version.ts';
 
-type ToolOutcome = Result<unknown, { message: string }>;
+/**
+ * A tool that ran to completion but failed can still carry its structured
+ * outcome: `modify_labels` sets `structured` on a systemic abort so the model
+ * reads the per-id results even while `isError` flags the abort.
+ */
+type ToolFailure = { message: string; structured?: unknown };
+type ToolOutcome = Result<unknown, ToolFailure>;
 
 type ToolDescriptor = {
 	name: string;
@@ -154,13 +160,13 @@ const TOOLS: ToolDescriptor[] = [
 				maxItems: 100,
 				description: 'Gmail message ids to mutate serially.',
 			}),
-			addLabelIds: Type.Optional(
+			addLabels: Type.Optional(
 				Type.Array(Type.String({ minLength: 1 }), {
 					maxItems: 100,
 					description: 'Gmail label ids or exact names to add.',
 				}),
 			),
-			removeLabelIds: Type.Optional(
+			removeLabels: Type.Optional(
 				Type.Array(Type.String({ minLength: 1 }), {
 					maxItems: 100,
 					description: 'Gmail label ids or exact names to remove.',
@@ -176,16 +182,22 @@ const TOOLS: ToolDescriptor[] = [
 					await resolveAndModifyMessageLabels({
 						deps: session.deps,
 						ids: args.ids,
-						addLabels: args.addLabelIds ?? [],
-						removeLabels: args.removeLabelIds ?? [],
+						addLabels: args.addLabels ?? [],
+						removeLabels: args.removeLabels ?? [],
 						readOnly: ctx.config.readOnly,
 					});
-				if (modifyError) return Err(modifyError);
-				if (
-					data.aborted ||
-					data.results.some((result) => result.error !== null)
-				) {
-					return Err({ message: JSON.stringify(data) });
+				// A whole-request refusal (read-only, empty sets, unknown label)
+				// never ran, so it is a plain error with no structured payload.
+				if (modifyError) return Err({ message: modifyError.message });
+				// A systemic abort (token, throttle, network) ran partway: flag
+				// isError but keep the per-id results so the model sees what
+				// succeeded. Per-id Gmail rejections are NOT an error channel;
+				// they ride inside the structured results for per-id self-repair.
+				if (data.aborted) {
+					return Err({
+						message: `Modify aborted after ${data.results.length} of ${args.ids.length} id(s): ${data.aborted.message}`,
+						structured: data,
+					});
 				}
 				return Ok(data);
 			} finally {
@@ -197,7 +209,14 @@ const TOOLS: ToolDescriptor[] = [
 
 function toCallResult({ data, error }: ToolOutcome): CallToolResult {
 	if (error) {
-		return { content: [{ type: 'text', text: error.message }], isError: true };
+		const result: CallToolResult = {
+			content: [{ type: 'text', text: error.message }],
+			isError: true,
+		};
+		if (error.structured !== undefined) {
+			result.structuredContent = error.structured as Record<string, unknown>;
+		}
+		return result;
 	}
 	return {
 		content: [{ type: 'text', text: JSON.stringify(data) }],

--- a/apps/local-mail/src/mcp.ts
+++ b/apps/local-mail/src/mcp.ts
@@ -43,7 +43,7 @@ import {
 import { type Static, type TObject, Type } from 'typebox';
 import { Value } from 'typebox/value';
 import { Err, Ok, type Result } from 'wellcrafted/result';
-import { modifyMessageLabels, resolveLabelIds } from './modify.ts';
+import { resolveAndModifyMessageLabels } from './modify.ts';
 import { queryMail } from './query.ts';
 import {
 	type LocalMailRuntime,
@@ -172,37 +172,15 @@ const TOOLS: ToolDescriptor[] = [
 			const { data: session, error } = await openSyncSession(ctx);
 			if (error) return Err(error);
 			try {
-				const addLabels = args.addLabelIds ?? [];
-				const removeLabels = args.removeLabelIds ?? [];
-				if (ctx.config.readOnly) {
-					return await modifyMessageLabels({
+				const { data, error: modifyError } =
+					await resolveAndModifyMessageLabels({
 						deps: session.deps,
-						input: {
-							ids: args.ids,
-							addLabelIds: addLabels,
-							removeLabelIds: removeLabels,
-						},
-						readOnly: true,
-					});
-				}
-
-				const { data: resolvedLabels, error: labelError } =
-					await resolveLabelIds({
-						deps: session.deps,
-						labels: [...addLabels, ...removeLabels],
-					});
-				if (labelError) return Err(labelError);
-
-				const { data, error } = await modifyMessageLabels({
-					deps: session.deps,
-					input: {
 						ids: args.ids,
-						addLabelIds: resolvedLabels.slice(0, addLabels.length),
-						removeLabelIds: resolvedLabels.slice(addLabels.length),
-					},
-					readOnly: ctx.config.readOnly,
-				});
-				if (error) return Err(error);
+						addLabels: args.addLabelIds ?? [],
+						removeLabels: args.removeLabelIds ?? [],
+						readOnly: ctx.config.readOnly,
+					});
+				if (modifyError) return Err(modifyError);
 				if (
 					data.aborted ||
 					data.results.some((result) => result.error !== null)

--- a/apps/local-mail/src/modify.test.ts
+++ b/apps/local-mail/src/modify.test.ts
@@ -22,6 +22,7 @@ import { GmailApiError, type GmailClient } from './gmail-client.ts';
 import {
 	type ModifyMessageLabelsInput,
 	modifyMessageLabels,
+	resolveAndModifyMessageLabels,
 	resolveLabelIds,
 } from './modify.ts';
 import type { GmailLabel, GmailMessage, HistoryPage } from './schema.ts';
@@ -540,6 +541,66 @@ describe('modifyMessageLabels', () => {
 		});
 		expect(client.modifyCalls.map((call) => call.id)).toEqual(['m1']);
 		expect(messageRaw(db, 'm1')).toBeNull();
+		cleanup();
+	});
+
+	test('resolveAndModifyMessageLabels refuses read-only before any network', async () => {
+		const { db, cleanup } = tempDb();
+		const client = createFakeGmailClient(
+			new Map([['m1', { data: message('m1', { labelIds: ['INBOX'] }) }]]),
+			[{ id: 'Label_work', name: 'Work', type: 'user' }],
+		);
+
+		const result = await resolveAndModifyMessageLabels({
+			deps: { client, db, now: () => Date.parse('2026-07-03T00:00:00.000Z') },
+			ids: ['m1'],
+			addLabels: ['Work'],
+			removeLabels: [],
+			readOnly: true,
+		});
+
+		expect(result.error?.name).toBe('ReadOnly');
+		expect(client.listLabelsCalls).toBe(0);
+		expect(client.modifyCalls).toHaveLength(0);
+		cleanup();
+	});
+
+	test('resolveAndModifyMessageLabels resolves a label name then folds Gmail bytes', async () => {
+		const { db, cleanup } = tempDb();
+		db.ingestFullPullPage([message('m1')], 's1');
+		db.ingestLabels([{ id: 'Label_work', name: 'Work', type: 'user' }], 's1');
+		const client = createFakeGmailClient(
+			new Map([
+				['m1', { data: message('m1', { labelIds: ['INBOX', 'Label_work'] }) }],
+			]),
+			[{ id: 'Label_work', name: 'Work', type: 'user' }],
+		);
+
+		const result = await resolveAndModifyMessageLabels({
+			deps: { client, db, now: () => Date.parse('2026-07-03T00:00:00.000Z') },
+			ids: ['m1'],
+			addLabels: ['Work'],
+			removeLabels: [],
+			readOnly: false,
+		});
+
+		const outcome = expectOk(result);
+		expect(outcome.results[0]).toEqual({
+			id: 'm1',
+			labelIds: ['INBOX', 'Label_work'],
+			folded: true,
+			error: null,
+		});
+		// The core sees the resolved id, never the name.
+		expect(client.modifyCalls[0]).toEqual({
+			id: 'm1',
+			addLabelIds: ['Label_work'],
+			removeLabelIds: [],
+		});
+		expect(JSON.parse(messageRaw(db, 'm1') ?? '{}').labelIds).toEqual([
+			'INBOX',
+			'Label_work',
+		]);
 		cleanup();
 	});
 });

--- a/apps/local-mail/src/modify.ts
+++ b/apps/local-mail/src/modify.ts
@@ -48,7 +48,7 @@ export type ModifyMessageLabelsOutcome = {
 	aborted: ErrorSummary | null;
 };
 
-type ModifyMessageLabelsDeps = {
+type ModifyDeps = {
 	client: GmailClient;
 	db: MailDb;
 	now: () => number;
@@ -59,13 +59,6 @@ export type ModifyMessageLabelsInput = {
 	addLabelIds: string[];
 	removeLabelIds: string[];
 };
-
-function summarizeError(error: {
-	name: string;
-	message: string;
-}): ErrorSummary {
-	return { name: error.name, message: error.message };
-}
 
 function isPerIdError(error: GmailClientError): boolean {
 	return (
@@ -91,17 +84,11 @@ function tryFoldMessageLabels({
 	}
 }
 
-type ResolveLabelIdsDeps = {
-	client: GmailClient;
-	db: MailDb;
-	now: () => number;
-};
-
 export async function resolveLabelIds({
 	deps,
 	labels,
 }: {
-	deps: ResolveLabelIdsDeps;
+	deps: ModifyDeps;
 	labels: string[];
 }): Promise<Result<string[], ResolveLabelIdsError | GmailClientError>> {
 	const resolved: string[] = [];
@@ -128,7 +115,7 @@ export async function modifyMessageLabels({
 	input,
 	readOnly,
 }: {
-	deps: ModifyMessageLabelsDeps;
+	deps: ModifyDeps;
 	input: ModifyMessageLabelsInput;
 	/**
 	 * Required so every adapter decides explicitly whether Gmail writes are
@@ -154,12 +141,14 @@ export async function modifyMessageLabels({
 			removeLabelIds: input.removeLabelIds,
 		});
 		if (error) {
-			const summary = summarizeError(error);
-			if (isPerIdError(error)) {
-				results.push({ id, labelIds: null, folded: false, error: summary });
-				continue;
-			}
+			const summary: ErrorSummary = {
+				name: error.name,
+				message: error.message,
+			};
 			results.push({ id, labelIds: null, folded: false, error: summary });
+			// A 400/404 is about this id alone; a token, throttle, or network
+			// error is systemic, so stop attempting the rest.
+			if (isPerIdError(error)) continue;
 			return Ok({ results, aborted: summary });
 		}
 
@@ -185,4 +174,53 @@ export async function modifyMessageLabels({
 	}
 
 	return Ok({ results, aborted: null });
+}
+
+/**
+ * The adapter path both the CLI `modify` verb and the MCP `modify_labels` tool
+ * take: resolve label names to Gmail ids, then run the core. The core refuses
+ * read-only mode before touching the network, so name resolution (which can
+ * hit `labels.list`) is skipped entirely in that mode.
+ */
+export async function resolveAndModifyMessageLabels({
+	deps,
+	ids,
+	addLabels,
+	removeLabels,
+	readOnly,
+}: {
+	deps: ModifyDeps;
+	ids: string[];
+	addLabels: string[];
+	removeLabels: string[];
+	readOnly: boolean;
+}): Promise<
+	Result<
+		ModifyMessageLabelsOutcome,
+		ModifyMessageLabelsError | ResolveLabelIdsError | GmailClientError
+	>
+> {
+	if (readOnly) {
+		return modifyMessageLabels({
+			deps,
+			input: { ids, addLabelIds: addLabels, removeLabelIds: removeLabels },
+			readOnly: true,
+		});
+	}
+
+	const { data: resolved, error } = await resolveLabelIds({
+		deps,
+		labels: [...addLabels, ...removeLabels],
+	});
+	if (error) return { data: null, error };
+
+	return modifyMessageLabels({
+		deps,
+		input: {
+			ids,
+			addLabelIds: resolved.slice(0, addLabels.length),
+			removeLabelIds: resolved.slice(addLabels.length),
+		},
+		readOnly: false,
+	});
 }

--- a/specs/20260701T141500-local-mail-up-bun-served-shell.md
+++ b/specs/20260701T141500-local-mail-up-bun-served-shell.md
@@ -105,7 +105,10 @@ local-mail up
   |       GET  /api/threads          list (from messages GROUP BY thread_id)
   |       GET  /api/threads/:id      messages in thread (raw JSON projected)
   |       POST /api/sync             request one poll pass ("refresh now")
-  |       (Phase D lands: POST /api/messages/:id/read|archive -> write-through cores)
+  |       (Phase D lands: POST /api/messages/modify {ids, addLabels, removeLabels}
+  |             -> resolveAndModifyMessageLabels; NOT per-intent routes. The UI's
+  |             archive/mark-read buttons desugar to add/remove client-side, so
+  |             CLI, MCP, and HTTP share one ModifyMessageLabelsOutcome contract)
   |-- syncGate: a single in-process promise chain; runSyncLoop and POST /api/sync
   |             both enqueue onto it, so at most one syncMailbox pass runs at a
   |             time. POST /api/sync coalesces onto the in-flight pass.
@@ -225,7 +228,7 @@ Known unknown to resolve early in Phase C: fragment-token handling timing versus
 
 Depends on engine Phase 3 write-through (`gmail.modify` re-consent is one command once `connect` exists).
 
-- [ ] **D.1** Mark-read and archive from the UI, minimum, through the same write-through cores the CLI/MCP mutation verbs use; label edits follow.
+- [ ] **D.1** Mark-read and archive from the UI, minimum, through one `POST /api/messages/modify` adapter over `resolveAndModifyMessageLabels` (the same core the CLI verbs and the MCP `modify_labels` tool use). The route takes `{ ids, addLabels, removeLabels }` and returns `ModifyMessageLabelsOutcome`; the UI desugars the button intents to add/remove sets client-side. One route, not per-intent routes, so per-id failures stay structured data the UI can render ("3 archived, 1 failed"). Label edits follow on the same route.
 
 ### Distribution wave (former Phase A; not a v1 gate)
 

--- a/specs/20260702T211500-local-mail-phase-3-write-through.md
+++ b/specs/20260702T211500-local-mail-phase-3-write-through.md
@@ -98,17 +98,18 @@ Google now serves these under `developers.google.com/workspace/gmail/...`; old U
 | Label input | 3 taste | The core takes Gmail label ids only. Adapters (CLI, MCP) resolve names to ids through one shared helper: exact-name lookup in the mirrored `labels` table, one fresh `labels.list` on miss, error if still missing | The user default. Ids stay the only identity; names are an adapter courtesy. No local label identity is ever invented. |
 | Return shape | 2 coherence | An operation summary per id: `{ id, labelIds (Gmail's post-state or null), folded }` plus per-id errors; never the raw Gmail response, never a mirror row | Mirrors `RecategorizeResult`. The raw response is an unstable wire shape; a mirror row would imply the mirror is the authority the caller should read. |
 | Local precondition checks | 2 coherence | Only two: non-empty add/remove sets, and name resolution. No system-label blocklist | "Gmail accepts or rejects the mutation" is the model; a local `DRAFT`/`SENT` blocklist would drift and duplicate Gmail's authority. |
-| MCP surface | 2 coherence | One `modify_labels` mutation tool; no per-intent tools | Same collapse as the core. The tool description documents the `UNREAD`/`INBOX` vocabulary. Per-intent sugar tools can come later if models fumble it. |
+| MCP surface | 2 coherence | One `modify_labels` mutation tool; no per-intent tools. Input fields are `addLabels`/`removeLabels` (they accept ids or exact names). A per-id Gmail rejection rides inside the structured `results`; only a systemic abort (token/throttle/network) sets `isError` (and still carries the structured outcome) | Same collapse as the core. The tool description documents the `UNREAD`/`INBOX` vocabulary. Per-id errors are data a model self-corrects per id, not a transport failure. Per-intent sugar tools can come later if models fumble the vocabulary. |
 | Trust boundary | 1 evidence | Copy local-books exactly: three-tier `'read' | 'write' | 'mutation'`, `LOCAL_MAIL_READ_ONLY` unlists mutation tools AND is enforced in the core (required argument), host approval prompt is the interactive boundary | ADR-0073 invariant 1; local-books `mcp.ts:239` (catalog filter) and `recategorize.ts` (core gate). A server-side auth gate adds nothing: anything that can spawn `local-mail mcp` runs as the user and can already read the 0600 credentials file. |
 | Annotations | 1 evidence | `readOnlyHint: false`, `destructiveHint: false`, `idempotentHint: true` on `modify_labels` | MCP spec: "destructive" means irreversible; every Phase 3 op is a reversible, idempotent label flip (add-present/remove-absent are observed no-ops). Deliberate divergence from local-books' per-tier `destructiveHint` mapping: its one mutation moves money. Annotate per-tool truth. Trash/send, when they arrive, get `destructiveHint: true`. |
-| CLI verb | 3 taste | One `modify` verb: `local-mail modify <id...> [--read|--unread|--archive|--unarchive] [--add <label>...] [--remove <label>...]`; intent flags desugar to add/remove sets | One verb = one surface to test and document. Six top-level verbs are ergonomic sugar an implementer may add later without design impact. |
+| CLI verb | 3 taste | Product verbs, not one primitive-with-flags: `archive`, `unarchive`, `mark-read`, `mark-unread` (each desugars to a fixed add/remove set) plus `label <id...> [--add <name\|id>...] [--remove <name\|id>...]` as the transparent primitive. All five run the one core through `resolveAndModifyMessageLabels`. Human output by default, `--json` for the typed `ModifyMessageLabelsOutcome`; any per-id failure or systemic abort exits nonzero | The CLI is human-first (agents have MCP), so it should teach the product vocabulary a person thinks in ("archive"), not the Gmail label mechanic ("remove INBOX"). `label` keeps the mechanic reachable and is where composition lives. One core, five thin surfaces: no new Gmail behavior, only argument mapping. Superseded the earlier single-`modify`-verb decision before any UI bound to it. |
 
 ## Architecture
 
 ```txt
-CLI `modify` ----\
-MCP `modify_labels` --> resolveLabelIds (names->ids; the core takes ids only)
-                          |
+CLI archive|unarchive|mark-read|mark-unread|label --\
+MCP `modify_labels` -------------------------------> resolveAndModifyMessageLabels
+                          |                            (adapter: resolveLabelIds names->ids,
+                          |                             then the core; the core takes ids only)
                           v
                  modifyMessageLabels(core)          src/modify.ts (new)
                    readOnly? -> refuse, zero network
@@ -257,7 +258,7 @@ UI (shell spec Phases C and D) starts only when all of:
 2. The stale-grant path is settled: a readonly-era token surfaces Gmail's raw 403, and `connect` requests the write-capable `gmail.modify` grant.
 3. The failure surfacing is settled as data (this spec's `ModifyOutcome` and error names), so UI work binds to a stable shape instead of inventing one.
 
-Nothing in this spec adds HTTP endpoints; the shell spec's `POST /api/messages/:id/...` adapters are Phase D work that wraps `modifyMessageLabels` the same way the CLI does.
+Nothing in this spec adds HTTP endpoints. When the shell spec's Phase D lands, the UI calls one `POST /api/messages/modify` adapter (body: `{ ids, addLabels, removeLabels }`, returning `ModifyMessageLabelsOutcome`) over `resolveAndModifyMessageLabels`, the same core the CLI and MCP use. Not per-intent routes: the UI's archive/mark-read buttons desugar to add/remove sets client-side, exactly as the CLI verbs do, so one result contract is shared across CLI, MCP, and HTTP.
 
 ## Open questions
 


### PR DESCRIPTION
This consolidates Local Mail's Phase 3 write-through surfaces before the UI binds to them.

The CLI is now human-shaped: `archive`, `unarchive`, `mark-read`, `mark-unread`, and `label` replace the generic `modify` command with no compatibility alias. Human-readable output is the default for triage/status/sync, while `--json` preserves the typed machine contracts. `query` stays JSON-first as the deliberate exception.

MCP stays intentionally small: one `modify_labels` tool, no per-intent sugar. Its adapter-facing fields are now `addLabels` / `removeLabels` because they accept Gmail ids or exact names, and per-id failures remain structured data instead of being collapsed into a stringified transport error.

The planned UI boundary is now one modify adapter route:

```txt
POST /api/messages/modify
{ ids, addLabels, removeLabels } -> ModifyMessageLabelsOutcome
```

That keeps CLI, MCP, and future HTTP on the same result contract while preserving the one core primitive: Gmail writes go through `modifyMessageLabels`, and SQLite only folds Gmail-returned bytes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785655541&installation_id=128463665&pr_number=2301&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2301&signature=0f81a07352793cc39157ff69555a8d28174371578ebbfdff42bca32d02dfe3c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->