### PR TITLE
docs(billing): align STT overspend comments

### DIFF
--- a/apps/api/worker/billing/policies.ts
+++ b/apps/api/worker/billing/policies.ts
@@ -113,10 +113,11 @@ const HOSTED_STT_PROVIDER = 'openai';
  * per-minute charge is tracked off the after-response queue from the `duration`
  * the gateway returns. No reservation lock, because the cost is unknown until the
  * call returns; the charge settles after the call, so concurrent requests can each
- * pass the gate before any usage posts, and steady-state overspend is bounded by
- * in-flight concurrency rather than a single call. A reservation lock would tighten
- * that and is deferred. House-key-only (ADR-0054): every call is metered, no BYOK
- * bypass.
+ * pass the gate before any usage posts. Overspend is bounded by both the largest
+ * single call (a long recording can over-tip a near-empty wallet on its own) and
+ * the number of in-flight calls; the deferred remedy is an input duration ceiling,
+ * not a reservation lock (see ADR-0100). House-key-only (ADR-0054): every call is
+ * metered, no BYOK bypass.
  */
 export const chargeOpenAiTranscriptionCredits = createMiddleware<CloudEnv>(
 	async (c, next) => {

--- a/apps/api/worker/billing/service.ts
+++ b/apps/api/worker/billing/service.ts
@@ -183,8 +183,10 @@ export function createBillingService(
 	 * the usage event with `model` and `provider` so the dashboard groups STT
 	 * spend alongside chat (`listUsage` / `listEvents` already group by those
 	 * properties). Called after the gateway answered 200, off the after-response
-	 * queue. A small overspend is possible: the one call that tips a near-empty
-	 * wallet negative. The pre-call `checkAiCredits` gate keeps it to that call.
+	 * queue. The pre-call `checkAiCredits` gate only proves the wallet is non-empty,
+	 * so a bounded overspend is possible: a single long recording can settle a charge
+	 * larger than the balance, and concurrent calls can each pass the gate before any
+	 * usage posts (see ADR-0100).
 	 *
 	 * Enqueued with `async: true`: Autumn records the event and returns 202 with
 	 * no `balances` in the body. SDK response validation still runs, but with no


### PR DESCRIPTION
ADR-0100 now frames STT overspend as bounded by both the largest single recording and in-flight concurrency, with an input duration ceiling as the possible future remedy.

This aligns the nearby runtime comments with that settled policy. The billing behavior is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785657177&installation_id=128463665&pr_number=2303&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2303&signature=7d7968a0b70bd635e35055c1a7dbe6736333a1c89b428892a0ebcaf9367be568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->