### PR TITLE
refactor(matter): hold the dragged board card in state, not the drag payload

### DIFF
--- a/apps/matter/src/lib/components/BoardView.svelte
+++ b/apps/matter/src/lib/components/BoardView.svelte
@@ -6,13 +6,12 @@
 	import type { TableView } from '$lib/table.svelte';
 	import type { TableQuery } from '$lib/table-query.svelte';
 	import {
+		type BoardCard,
 		boardColumnsFor,
 		boardDropEditFor,
 		canWriteBoardColumn,
 	} from './board';
 	import FieldValue from './FieldValue.svelte';
-
-	const BOARD_CARD_MIME = 'application/x-epicenter-matter-board-card';
 
 	let {
 		table,
@@ -44,6 +43,11 @@
 		columns.reduce((count, column) => count + column.cards.length, 0),
 	);
 
+	// The card being dragged, held in state rather than serialized through the drag
+	// payload: it is a card this board just rendered, so its identity never leaves the
+	// process and `drop` acts on a trusted card, not an arbitrary browser payload.
+	let draggedCard = $state<BoardCard>();
+
 	function canDropOn(columnValue: string | null): boolean {
 		return (
 			groupByField !== undefined &&
@@ -51,13 +55,8 @@
 		);
 	}
 
-	// The card MIME scopes drops to board cards; the `text/plain` copy is a fallback for
-	// drag harnesses that only round-trip the standard type (the Playwright e2e). Reading an
-	// arbitrary payload is safe because `boardDropEditFor` refuses any name that is not a card
-	// currently in `columns`, so the fallback cannot write to an off-board file.
-	function dragStart(event: DragEvent, fileName: string): void {
-		event.dataTransfer?.setData(BOARD_CARD_MIME, fileName);
-		event.dataTransfer?.setData('text/plain', fileName);
+	function dragStart(event: DragEvent, card: BoardCard): void {
+		draggedCard = card;
 		if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move';
 	}
 
@@ -68,11 +67,10 @@
 	}
 
 	function drop(event: DragEvent, columnValue: string | null): void {
-		const fileName =
-			event.dataTransfer?.getData(BOARD_CARD_MIME) ||
-			event.dataTransfer?.getData('text/plain');
-		if (!fileName || groupByField === undefined) return;
-		const edit = boardDropEditFor({ columns, fileName, groupByField, columnValue });
+		const card = draggedCard;
+		draggedCard = undefined;
+		if (!card || groupByField === undefined) return;
+		const edit = boardDropEditFor({ card, groupByField, columnValue });
 		if (!edit) return;
 		event.preventDefault();
 		void table.saveField(edit.fileName, edit.key, edit.value);
@@ -145,7 +143,7 @@
 										role="listitem"
 										draggable={true}
 										data-board-card={card.row.fileName}
-										ondragstart={(event) => dragStart(event, card.row.fileName)}
+										ondragstart={(event) => dragStart(event, card)}
 										class="cursor-grab rounded-md border bg-card p-3 shadow-sm active:cursor-grabbing"
 									>
 										<h3

--- a/apps/matter/src/lib/components/board.test.ts
+++ b/apps/matter/src/lib/components/board.test.ts
@@ -11,8 +11,8 @@
  * - Declared card fields render by name and omit non-card fields.
  * - Missing group values land in the trailing Unassigned column.
  * - Drop writes validate bucket values and clear Unassigned with undefined.
- * - Drop writes refuse payloads that name no card on the board and skip no-op
- *   same-column drops.
+ * - Drop writes skip no-op same-column drops. (The board only ever hands a drop a
+ *   card it rendered, so "the card is on this board" is structural, not checked.)
  */
 
 import { expect, test } from 'bun:test';
@@ -24,6 +24,7 @@ import {
 	validateContract,
 } from '@epicenter/matter-core';
 import {
+	type BoardCard,
 	boardColumnsFor,
 	boardDropEditFor,
 	canWriteBoardColumn,
@@ -174,15 +175,22 @@ test('boardColumnsFor defaults to up to three non-group fields when card is omit
 	]);
 });
 
-/** The board as rendered, holding `alpha.md` in the `todo` bucket, as a drop reads it. */
-function todoBoard(model: Contract) {
-	return boardColumnsFor({
+/** The `alpha.md` card as the board rendered it in the `todo` bucket, exactly as a
+ *  drop receives it: the dragged card is held in component state, so `boardDropEditFor`
+ *  gets a real rendered card, never a raw payload it has to re-resolve. */
+function todoCard(model: Contract): BoardCard {
+	const columns = boardColumnsFor({
 		conformance: classifyRows(model.fields, [
 			row('alpha.md', { title: 'Alpha', status: 'todo' }),
 		]),
 		fields: model.fields,
 		projection: board,
 	});
+	const card = columns
+		.flatMap((column) => column.cards)
+		.find((candidate) => candidate.row.fileName === 'alpha.md');
+	if (!card) throw new Error('missing alpha.md card');
+	return card;
 }
 
 test('boardDropEditFor writes valid bucket values through the group field', () => {
@@ -190,8 +198,7 @@ test('boardDropEditFor writes valid bucket values through the group field', () =
 
 	expect(
 		boardDropEditFor({
-			columns: todoBoard(model),
-			fileName: 'alpha.md',
+			card: todoCard(model),
 			groupByField: field(model, 'status'),
 			columnValue: 'done',
 		}),
@@ -205,8 +212,7 @@ test('boardDropEditFor writes valid bucket values through the group field', () =
 test('boardDropEditFor clears the group field for the unassigned bucket', () => {
 	const model = contract();
 	const edit = boardDropEditFor({
-		columns: todoBoard(model),
-		fileName: 'alpha.md',
+		card: todoCard(model),
 		groupByField: field(model, 'status'),
 		columnValue: null,
 	});
@@ -223,36 +229,9 @@ test('boardDropEditFor refuses buckets that fail the group field check', () => {
 	expect(canWriteBoardColumn(status, 'blocked')).toBe(false);
 	expect(
 		boardDropEditFor({
-			columns: todoBoard(model),
-			fileName: 'alpha.md',
+			card: todoCard(model),
 			groupByField: status,
 			columnValue: 'blocked',
-		}),
-	).toBeNull();
-});
-
-test('boardDropEditFor refuses a payload that names no card on the board', () => {
-	const model = contract();
-	const status = field(model, 'status');
-	const columns = todoBoard(model);
-
-	// A stray drag payload (an off-board file name, or plain text picked up by the
-	// text/plain fallback) must not write, or a drop could create a file the board
-	// never rendered.
-	expect(
-		boardDropEditFor({
-			columns,
-			fileName: 'ghost.md',
-			groupByField: status,
-			columnValue: 'done',
-		}),
-	).toBeNull();
-	expect(
-		boardDropEditFor({
-			columns,
-			fileName: 'some dragged sentence',
-			groupByField: status,
-			columnValue: 'done',
 		}),
 	).toBeNull();
 });
@@ -264,8 +243,7 @@ test('boardDropEditFor skips a drop onto the column the card already sits in', (
 	// no-op: no redundant same-value write.
 	expect(
 		boardDropEditFor({
-			columns: todoBoard(model),
-			fileName: 'alpha.md',
+			card: todoCard(model),
 			groupByField: field(model, 'status'),
 			columnValue: 'todo',
 		}),

--- a/apps/matter/src/lib/components/board.ts
+++ b/apps/matter/src/lib/components/board.ts
@@ -97,14 +97,12 @@ export function boardColumnsFor({
 
 /**
  * Decide the write a card drop should make, or `null` when the drop should do
- * nothing. `columns` is the board as currently rendered, so the decision is made
- * against real cards, not the raw drag payload:
+ * nothing. `card` is a card the board actually rendered, handed straight from the
+ * drag it started: the dragged card's identity is held in component state, never
+ * serialized through the drag payload and re-looked-up, so "the drop only writes a
+ * card on this board" is structural (only a rendered card can start a drag), not a
+ * refusal against an arbitrary browser payload.
  *
- * - A `fileName` that names no card on this board is refused. A drag payload can be
- *   anything the browser hands us (a plain-text selection, an off-board element via
- *   the `text/plain` fallback), so a name is only allowed to write once it matches a
- *   card actually on the board. Without this, an arbitrary payload could write to (and
- *   create) a stray file in the vault folder.
  * - A drop onto the column the card already sits in is a no-op, so a card released
  *   where it started never issues a redundant same-value write (and watcher echo).
  * - Unassigned clears the field (`value: undefined`, the nullish contract: delete the
@@ -112,20 +110,15 @@ export function boardColumnsFor({
  *   column) is refused.
  */
 export function boardDropEditFor({
-	columns,
-	fileName,
+	card,
 	groupByField,
 	columnValue,
 }: {
-	columns: readonly BoardColumn[];
-	fileName: string;
+	card: BoardCard;
 	groupByField: ContractField;
 	columnValue: string | null;
 }): BoardDropEdit | null {
-	const card = columns
-		.flatMap((column) => column.cards)
-		.find((candidate) => candidate.row.fileName === fileName);
-	if (!card) return null;
+	const fileName = card.row.fileName;
 	// Match the bucketing in `groupRowsByField`: a nullish cell is Unassigned, and a
 	// present value keys by its string form, so the no-op check compares like with like.
 	const current = card.row.frontmatter[groupByField.name];


### PR DESCRIPTION
A board move is a same-document drag of a card the board just rendered, so the card's identity never needs to leave the process. This holds the dragged card in Svelte state and passes it straight to the drop decision, instead of serializing a filename through `dataTransfer` and re-looking it up on drop.

**Before** — identity round-tripped through the drag payload, so the drop handler received an untrusted string and had to validate it:

```ts
// dragstart
event.dataTransfer.setData(BOARD_CARD_MIME, fileName);
event.dataTransfer.setData('text/plain', fileName); // fallback so Playwright round-trips
// drop
const fileName = getData(BOARD_CARD_MIME) || getData('text/plain');
const edit = boardDropEditFor({ columns, fileName, groupByField, columnValue });
// boardDropEditFor then scans `columns` to refuse any name that is not a card on the board
```

**After** — the card is captured at dragstart and handed directly to the decision:

```ts
let draggedCard = $state<BoardCard>();
function dragStart(event, card) { draggedCard = card; /* effectAllowed = 'move' */ }
// drop
const edit = boardDropEditFor({ card: draggedCard, groupByField, columnValue });
```

This deletes the custom card MIME type, the `text/plain` fallback (kept only so Playwright's `dragTo` round-tripped a payload), the payload security comment, `boardDropEditFor`'s `columns` argument and its off-board lookup, and the unit test that proved off-board names were refused. The invariant "a drop only writes a card on this board" is now **structural**: only a rendered card can start a drag, so there is no untrusted payload to defend against.

Native HTML5 drag-and-drop stays the mechanism; only the identity transport changed. This came out of an exploration of whether the board DnD layer should move to `@dnd-kit/svelte`, `svelte-dnd-action`, or Svelte attachments. The conclusion was that native is the right fit: the drag gesture is the board's product behavior so it can't be refused, no built-in Svelte primitive covers DnD, attachments would only relocate the same listeners, and the libraries' headline features (keyboard, touch, sorting) are either covered by the grid's accessible fallback or out of scope. The one future trigger that would earn a sortable library is persisted manual card ordering within a column, which does not exist yet.

**Behavior note:** the card's group value is now read from the grab-time snapshot rather than re-resolved on drop. These are identical in every normal drag; they can only diverge if an external process rewrites the same card's group field mid-drag, and both models then resolve idempotently (a redundant same-value write that the per-file serialized write and watcher echo absorb). The old re-resolution was incidental to the deleted payload lookup, not a deliberate freshness guarantee; anchoring the origin at grab is the faithful model of a drag gesture.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785658710&installation_id=128463665&pr_number=2305&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2305&signature=c1a08b3fcb0cc183ec3e1cfdfafcdb9320cc318020f7d16c7b0f33d377e6ce60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->