### PR TITLE
feat(local-mail): serve a triage UI over `local-mail up`

### DIFF
--- a/apps/local-mail/README.md
+++ b/apps/local-mail/README.md
@@ -93,6 +93,30 @@ Any per-id rejection or a systemic abort exits nonzero, so
 `LOCAL_MAIL_READ_ONLY` refuses every write while leaving `query`/`status`/`sync`
 available.
 
+Serve the triage UI and its API from one loopback process:
+
+```sh
+bun run src/bin.ts up
+```
+
+`up` runs the sync loop and serves the triage SPA (`ui/`) plus a same-origin
+`/api` on `127.0.0.1`, then prints `http://127.0.0.1:PORT/#token=...` and opens
+it. The tab is the app. Security is the up-shell spec's: a single-use bootstrap
+token rides in the URL fragment and is exchanged once at `POST /api/session`
+for a per-launch session bearer (kept in sessionStorage); every request is
+Host-checked first; the write route is the one `POST /api/messages/modify`
+(`{ ids, addLabels, removeLabels }` -> `ModifyMessageLabelsOutcome`) over the
+same core the CLI verbs and MCP tool use, so archive/read/label all desugar to
+add/remove sets client-side. `LOCAL_MAIL_READ_ONLY` disables writes end to end;
+`LOCAL_MAIL_NO_OPEN=1` prints the URL without launching a browser.
+
+Develop the UI against a running `up`:
+
+```sh
+LOCAL_MAIL_DEV=1 LOCAL_MAIL_TOKEN=devtoken LOCAL_MAIL_PORT=4177 bun run src/bin.ts up
+LOCAL_MAIL_TOKEN=devtoken bun run --cwd ui dev   # same token: Vite proxies /api to up, injecting this bearer
+```
+
 Serve tools to an MCP host:
 
 ```sh
@@ -122,6 +146,10 @@ Tools:
 - `LOCAL_MAIL_TOKEN_FILE`: token file override.
 - `LOCAL_MAIL_GMAIL_API_BASE`: test plumbing only; points the Gmail client at
   a mock server in the MCP subprocess test.
+- `LOCAL_MAIL_PORT`: pin the `up` server port (default: ephemeral).
+- `LOCAL_MAIL_DEV` / `LOCAL_MAIL_TOKEN`: dev-mode `up`; the Vite proxy injects
+  the fixed bearer. `bearerAuth` is never disabled in any mode.
+- `LOCAL_MAIL_NO_OPEN`: `up` prints the launch URL without opening a browser.
 
 ## Testing
 
@@ -138,10 +166,13 @@ stdio subprocess for the agent-facing protocol surface.
 
 ## Not built yet
 
-- HTTP and UI surfaces for the write-through actions. When they land, the UI
-  calls one `POST /api/messages/modify` adapter over the same core the CLI and
-  MCP use, not per-intent routes.
+- HTML mail-body rendering. The detail pane shows the pre-extracted plain-text
+  body; rich HTML rendering (the sanitizer + sandboxed srcdoc + CSP + show-images
+  proxy) is deferred, which is why the SPA has no mail-body iframe yet.
+- Compile-embed distribution (`bun build --compile`) and the Tauri wrapper. `up`
+  serves `ui/dist` from disk; the route table is the seam the distribution wave
+  swaps for embedded assets later.
 - Send, reply, compose, drafts, trash, untrash, and permanent delete.
+- Thread-level modify and `messages.batchModify`. Triage is message-level.
 - FTS5. `LIKE` over `body_text` is enough for the current mirror size.
-- Push/Pub/Sub.
-- The `up` local server and UI.
+- Push/Pub/Sub and any LAN or remote exposure (the server binds `127.0.0.1`).

--- a/apps/local-mail/src/cli.ts
+++ b/apps/local-mail/src/cli.ts
@@ -37,6 +37,7 @@ Usage:
   local-mail query "<sql>"
   local-mail archive|unarchive|mark-read|mark-unread <id...> [--json]
   local-mail label <id...> [--add <label>...] [--remove <label>...] [--json]
+  local-mail up
   local-mail mcp
 
 Commands:
@@ -480,6 +481,10 @@ export async function runCli(argv: string[]): Promise<number> {
 				removeLabels: args.removeLabels,
 				done: 'labels updated',
 			});
+		case 'up': {
+			const { runUp } = await import('./up.ts');
+			return runUp();
+		}
 		case 'mcp': {
 			const { runMcpServer } = await import('./mcp.ts');
 			return runMcpServer();

--- a/apps/local-mail/src/db.ts
+++ b/apps/local-mail/src/db.ts
@@ -75,7 +75,9 @@ function parseLabelIds(json: string | null): string[] {
 	if (!json) return [];
 	try {
 		const parsed = JSON.parse(json);
-		return Array.isArray(parsed) ? parsed.filter((v) => typeof v === 'string') : [];
+		return Array.isArray(parsed)
+			? parsed.filter((v) => typeof v === 'string')
+			: [];
 	} catch {
 		return [];
 	}
@@ -433,9 +435,7 @@ export function openMailDb({ dataDir, accountEmail }: MailDbLocation) {
 				params.$labelId = labelId;
 			}
 			if (search) {
-				where.push(
-					`(subject LIKE $q OR sender LIKE $q OR body_text LIKE $q)`,
-				);
+				where.push(`(subject LIKE $q OR sender LIKE $q OR body_text LIKE $q)`);
 				params.$q = `%${search}%`;
 			}
 			const clause = where.length ? `WHERE ${where.join(' AND ')}` : '';
@@ -518,10 +518,9 @@ export function openMailDb({ dataDir, accountEmail }: MailDbLocation) {
 		/** Every mirrored label, for the filter rail and the add/remove menu. */
 		listLabels(): LabelSummary[] {
 			return db
-				.query<
-					{ id: string; name: string | null; type: string | null },
-					[]
-				>(`SELECT id, name, type FROM labels ORDER BY type, name`)
+				.query<{ id: string; name: string | null; type: string | null }, []>(
+					`SELECT id, name, type FROM labels ORDER BY type, name`,
+				)
 				.all();
 		},
 

--- a/apps/local-mail/src/db.ts
+++ b/apps/local-mail/src/db.ts
@@ -40,6 +40,47 @@ export type RealmState = {
 	lastSyncedAt: string | null;
 };
 
+/**
+ * One row of the triage list, projected for the HTTP read surface. `labelIds`
+ * is the parsed array (the `label_ids` column stores Gmail's JSON string); the
+ * UI derives unread/inbox/label chips from it, so no state is invented here.
+ */
+export type MessageSummary = {
+	id: string;
+	threadId: string | null;
+	subject: string | null;
+	sender: string | null;
+	snippet: string | null;
+	internalDate: number | null;
+	labelIds: string[];
+};
+
+/** A single message opened in the detail pane: a summary plus its extracted
+ * plain-text body and the `To` header. Bodies are stored pre-extracted as
+ * text (`db.ts`'s `bodyText`), so the read surface never ships raw HTML. */
+export type MessageDetail = MessageSummary & {
+	to: string | null;
+	date: string | null;
+	bodyText: string | null;
+};
+
+/** A mirrored Gmail label, for the label-filter rail and the add/remove menu. */
+export type LabelSummary = {
+	id: string;
+	name: string | null;
+	type: string | null;
+};
+
+function parseLabelIds(json: string | null): string[] {
+	if (!json) return [];
+	try {
+		const parsed = JSON.parse(json);
+		return Array.isArray(parsed) ? parsed.filter((v) => typeof v === 'string') : [];
+	} catch {
+		return [];
+	}
+}
+
 export type MailDb = ReturnType<typeof openMailDb>;
 
 type GmailMessagePart = {
@@ -360,6 +401,128 @@ export function openMailDb({ dataDir, accountEmail }: MailDbLocation) {
 			limit: number,
 		): { subject: string | null; sender: string | null }[] {
 			return recentMessagesStmt.all(limit);
+		},
+
+		/**
+		 * The triage list read model. Newest first; an optional `labelId` filters
+		 * to messages carrying that Gmail label, and an optional `search` matches
+		 * subject/sender/body. Both are pushed into SQL so the process never
+		 * materializes the whole mirror. Compiled per call (dynamic WHERE), which
+		 * is fine at mirror scale and mirrors the `query` verb's discipline.
+		 */
+		listMessages({
+			labelId,
+			search,
+			limit,
+			offset,
+		}: {
+			labelId?: string;
+			search?: string;
+			limit: number;
+			offset: number;
+		}): MessageSummary[] {
+			const where: string[] = [];
+			const params: Record<string, string | number> = {
+				$limit: limit,
+				$offset: offset,
+			};
+			if (labelId) {
+				where.push(
+					`EXISTS (SELECT 1 FROM json_each(messages.label_ids) WHERE value = $labelId)`,
+				);
+				params.$labelId = labelId;
+			}
+			if (search) {
+				where.push(
+					`(subject LIKE $q OR sender LIKE $q OR body_text LIKE $q)`,
+				);
+				params.$q = `%${search}%`;
+			}
+			const clause = where.length ? `WHERE ${where.join(' AND ')}` : '';
+			const rows = db
+				.query<
+					{
+						id: string;
+						thread_id: string | null;
+						subject: string | null;
+						sender: string | null;
+						snippet: string | null;
+						internal_date: number | null;
+						label_ids: string | null;
+					},
+					Record<string, string | number>
+				>(
+					`SELECT id, thread_id, subject, sender, snippet, internal_date, label_ids
+					 FROM messages ${clause}
+					 ORDER BY internal_date DESC
+					 LIMIT $limit OFFSET $offset`,
+				)
+				.all(params);
+			return rows.map((row) => ({
+				id: row.id,
+				threadId: row.thread_id,
+				subject: row.subject,
+				sender: row.sender,
+				snippet: row.snippet,
+				internalDate: row.internal_date,
+				labelIds: parseLabelIds(row.label_ids),
+			}));
+		},
+
+		/** One message with its extracted body, for the detail pane. */
+		getMessageDetail(id: string): MessageDetail | null {
+			const row = db
+				.query<
+					{
+						id: string;
+						thread_id: string | null;
+						subject: string | null;
+						sender: string | null;
+						snippet: string | null;
+						internal_date: number | null;
+						label_ids: string | null;
+						body_text: string | null;
+						raw: string;
+					},
+					[string]
+				>(
+					`SELECT id, thread_id, subject, sender, snippet, internal_date,
+					        label_ids, body_text, raw
+					 FROM messages WHERE id = ?`,
+				)
+				.get(id);
+			if (!row) return null;
+			let to: string | null = null;
+			let date: string | null = null;
+			try {
+				const message = JSON.parse(row.raw) as GmailMessage;
+				to = headerValue(message, 'To');
+				date = headerValue(message, 'Date');
+			} catch {
+				// Fall back to nulls; the summary fields already carry the essentials.
+			}
+			return {
+				id: row.id,
+				threadId: row.thread_id,
+				subject: row.subject,
+				sender: row.sender,
+				snippet: row.snippet,
+				internalDate: row.internal_date,
+				labelIds: parseLabelIds(row.label_ids),
+				to,
+				date,
+				bodyText: row.body_text,
+			};
+		},
+
+		/** Every mirrored label, for the filter rail and the add/remove menu. */
+		listLabels(): LabelSummary[] {
+			return db
+				.query<
+					{ id: string; name: string | null; type: string | null },
+					[]
+				>(`SELECT id, name, type FROM labels ORDER BY type, name`)
+				.all();
 		},
 
 		/**

--- a/apps/local-mail/src/read-models.test.ts
+++ b/apps/local-mail/src/read-models.test.ts
@@ -18,7 +18,13 @@ import type { GmailLabel, GmailMessage } from './schema.ts';
 function openTmp(): { db: MailDb; cleanup: () => void } {
 	const dir = mkdtempSync(join(tmpdir(), 'local-mail-read-'));
 	const db = openMailDb({ dataDir: dir, accountEmail: 'you@example.com' });
-	return { db, cleanup: () => { db.close(); rmSync(dir, { recursive: true, force: true }); } };
+	return {
+		db,
+		cleanup: () => {
+			db.close();
+			rmSync(dir, { recursive: true, force: true });
+		},
+	};
 }
 
 const b64url = (s: string) => Buffer.from(s, 'utf8').toString('base64url');
@@ -61,11 +67,18 @@ function seed(db: MailDb) {
 						{ name: 'Date', value: 'Tue, 1 Jul 2026 08:00:00 -0700' },
 					],
 					parts: [
-						{ mimeType: 'text/plain', body: { data: b64url('Please pay the invoice.') } },
+						{
+							mimeType: 'text/plain',
+							body: { data: b64url('Please pay the invoice.') },
+						},
 					],
 				},
 			}),
-			message({ id: 'middle', internalDate: '2000', labelIds: ['CATEGORY_PROMOTIONS'] }),
+			message({
+				id: 'middle',
+				internalDate: '2000',
+				labelIds: ['CATEGORY_PROMOTIONS'],
+			}),
 			message({ id: 'oldest', internalDate: '1000', labelIds: ['INBOX'] }),
 		],
 		new Date().toISOString(),
@@ -97,7 +110,11 @@ describe('listMessages', () => {
 		const { db, cleanup } = openTmp();
 		try {
 			seed(db);
-			const inbox = db.listMessages({ labelId: 'INBOX', limit: 100, offset: 0 });
+			const inbox = db.listMessages({
+				labelId: 'INBOX',
+				limit: 100,
+				offset: 0,
+			});
 			expect(inbox.map((r) => r.id)).toEqual(['newest', 'oldest']);
 			const promos = db.listMessages({
 				labelId: 'CATEGORY_PROMOTIONS',
@@ -115,10 +132,14 @@ describe('listMessages', () => {
 		try {
 			seed(db);
 			expect(
-				db.listMessages({ search: 'invoice', limit: 100, offset: 0 }).map((r) => r.id),
+				db
+					.listMessages({ search: 'invoice', limit: 100, offset: 0 })
+					.map((r) => r.id),
 			).toEqual(['newest']);
 			expect(
-				db.listMessages({ search: 'billing@acme', limit: 100, offset: 0 }).map((r) => r.id),
+				db
+					.listMessages({ search: 'billing@acme', limit: 100, offset: 0 })
+					.map((r) => r.id),
 			).toEqual(['newest']);
 			expect(
 				db.listMessages({ search: 'nomatchxyz', limit: 100, offset: 0 }),
@@ -132,8 +153,12 @@ describe('listMessages', () => {
 		const { db, cleanup } = openTmp();
 		try {
 			seed(db);
-			expect(db.listMessages({ limit: 1, offset: 0 }).map((r) => r.id)).toEqual(['newest']);
-			expect(db.listMessages({ limit: 1, offset: 1 }).map((r) => r.id)).toEqual(['middle']);
+			expect(db.listMessages({ limit: 1, offset: 0 }).map((r) => r.id)).toEqual(
+				['newest'],
+			);
+			expect(db.listMessages({ limit: 1, offset: 1 }).map((r) => r.id)).toEqual(
+				['middle'],
+			);
 		} finally {
 			cleanup();
 		}

--- a/apps/local-mail/src/read-models.test.ts
+++ b/apps/local-mail/src/read-models.test.ts
@@ -1,0 +1,186 @@
+/**
+ * The HTTP read surface's projections (db.ts's `listMessages`,
+ * `getMessageDetail`, `listLabels`). These are the read models `local-mail up`
+ * serves to the triage SPA; the point of the tests is that they project Gmail's
+ * own mirrored bytes (label ids, epoch dates, headers, extracted body) without
+ * inventing state: label filtering is a `json_each` over the stored `labelIds`,
+ * search is a plain `LIKE`, and the detail pulls `To`/`Date` from the raw blob.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { Buffer } from 'node:buffer';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { type MailDb, openMailDb } from './db.ts';
+import type { GmailLabel, GmailMessage } from './schema.ts';
+
+function openTmp(): { db: MailDb; cleanup: () => void } {
+	const dir = mkdtempSync(join(tmpdir(), 'local-mail-read-'));
+	const db = openMailDb({ dataDir: dir, accountEmail: 'you@example.com' });
+	return { db, cleanup: () => { db.close(); rmSync(dir, { recursive: true, force: true }); } };
+}
+
+const b64url = (s: string) => Buffer.from(s, 'utf8').toString('base64url');
+
+function message(over: Partial<GmailMessage> & { id: string }): GmailMessage {
+	return {
+		threadId: `thread-${over.id}`,
+		labelIds: ['INBOX', 'UNREAD'],
+		snippet: 'a snippet',
+		internalDate: '1700000000000',
+		payload: {
+			headers: [
+				{ name: 'Subject', value: 'Default subject' },
+				{ name: 'From', value: 'Sender <sender@example.com>' },
+				{ name: 'To', value: 'you@example.com' },
+				{ name: 'Date', value: 'Mon, 2 Jul 2026 19:19:00 -0700' },
+			],
+			parts: [{ mimeType: 'text/plain', body: { data: b64url('Hello body') } }],
+		},
+		...over,
+	};
+}
+
+function label(id: string, name: string, type: string): GmailLabel {
+	return { id, name, type };
+}
+
+function seed(db: MailDb) {
+	db.ingestFullPullPage(
+		[
+			message({
+				id: 'newest',
+				internalDate: '3000',
+				labelIds: ['INBOX', 'UNREAD', 'Label_7'],
+				payload: {
+					headers: [
+						{ name: 'Subject', value: 'Invoice for June' },
+						{ name: 'From', value: 'Billing <billing@acme.com>' },
+						{ name: 'To', value: 'you@example.com' },
+						{ name: 'Date', value: 'Tue, 1 Jul 2026 08:00:00 -0700' },
+					],
+					parts: [
+						{ mimeType: 'text/plain', body: { data: b64url('Please pay the invoice.') } },
+					],
+				},
+			}),
+			message({ id: 'middle', internalDate: '2000', labelIds: ['CATEGORY_PROMOTIONS'] }),
+			message({ id: 'oldest', internalDate: '1000', labelIds: ['INBOX'] }),
+		],
+		new Date().toISOString(),
+	);
+	db.ingestLabels(
+		[
+			label('INBOX', 'INBOX', 'system'),
+			label('Label_7', 'Altered Trajectories', 'user'),
+			label('CATEGORY_PROMOTIONS', 'CATEGORY_PROMOTIONS', 'system'),
+		],
+		new Date().toISOString(),
+	);
+}
+
+describe('listMessages', () => {
+	test('returns rows newest first with parsed labelIds', () => {
+		const { db, cleanup } = openTmp();
+		try {
+			seed(db);
+			const rows = db.listMessages({ limit: 100, offset: 0 });
+			expect(rows.map((r) => r.id)).toEqual(['newest', 'middle', 'oldest']);
+			expect(rows[0]?.labelIds).toEqual(['INBOX', 'UNREAD', 'Label_7']);
+		} finally {
+			cleanup();
+		}
+	});
+
+	test('label filter matches only messages carrying that label', () => {
+		const { db, cleanup } = openTmp();
+		try {
+			seed(db);
+			const inbox = db.listMessages({ labelId: 'INBOX', limit: 100, offset: 0 });
+			expect(inbox.map((r) => r.id)).toEqual(['newest', 'oldest']);
+			const promos = db.listMessages({
+				labelId: 'CATEGORY_PROMOTIONS',
+				limit: 100,
+				offset: 0,
+			});
+			expect(promos.map((r) => r.id)).toEqual(['middle']);
+		} finally {
+			cleanup();
+		}
+	});
+
+	test('search matches subject, sender, or body', () => {
+		const { db, cleanup } = openTmp();
+		try {
+			seed(db);
+			expect(
+				db.listMessages({ search: 'invoice', limit: 100, offset: 0 }).map((r) => r.id),
+			).toEqual(['newest']);
+			expect(
+				db.listMessages({ search: 'billing@acme', limit: 100, offset: 0 }).map((r) => r.id),
+			).toEqual(['newest']);
+			expect(
+				db.listMessages({ search: 'nomatchxyz', limit: 100, offset: 0 }),
+			).toEqual([]);
+		} finally {
+			cleanup();
+		}
+	});
+
+	test('limit and offset paginate', () => {
+		const { db, cleanup } = openTmp();
+		try {
+			seed(db);
+			expect(db.listMessages({ limit: 1, offset: 0 }).map((r) => r.id)).toEqual(['newest']);
+			expect(db.listMessages({ limit: 1, offset: 1 }).map((r) => r.id)).toEqual(['middle']);
+		} finally {
+			cleanup();
+		}
+	});
+});
+
+describe('getMessageDetail', () => {
+	test('projects To/Date headers and the extracted body', () => {
+		const { db, cleanup } = openTmp();
+		try {
+			seed(db);
+			const detail = db.getMessageDetail('newest');
+			expect(detail?.subject).toBe('Invoice for June');
+			expect(detail?.to).toBe('you@example.com');
+			expect(detail?.date).toBe('Tue, 1 Jul 2026 08:00:00 -0700');
+			expect(detail?.bodyText).toBe('Please pay the invoice.');
+			expect(detail?.labelIds).toEqual(['INBOX', 'UNREAD', 'Label_7']);
+		} finally {
+			cleanup();
+		}
+	});
+
+	test('returns null for an unmirrored id', () => {
+		const { db, cleanup } = openTmp();
+		try {
+			seed(db);
+			expect(db.getMessageDetail('ghost')).toBeNull();
+		} finally {
+			cleanup();
+		}
+	});
+});
+
+describe('listLabels', () => {
+	test('returns every mirrored label with id, name, and type', () => {
+		const { db, cleanup } = openTmp();
+		try {
+			seed(db);
+			const labels = db.listLabels();
+			expect(labels).toHaveLength(3);
+			expect(labels.find((l) => l.id === 'Label_7')).toEqual({
+				id: 'Label_7',
+				name: 'Altered Trajectories',
+				type: 'user',
+			});
+		} finally {
+			cleanup();
+		}
+	});
+});

--- a/apps/local-mail/src/up.ts
+++ b/apps/local-mail/src/up.ts
@@ -94,7 +94,10 @@ function createSyncGate() {
 }
 
 /** Serve the built SPA from disk, falling back to index.html for deep links. */
-async function serveStatic(uiDist: string, pathname: string): Promise<Response> {
+async function serveStatic(
+	uiDist: string,
+	pathname: string,
+): Promise<Response> {
 	const rel = pathname === '/' ? '/index.html' : pathname;
 	// Reject path traversal before touching the filesystem. `join` collapses
 	// `..`, so match on a real separator boundary: a bare `startsWith(uiDist)`
@@ -105,12 +108,17 @@ async function serveStatic(uiDist: string, pathname: string): Promise<Response> 
 	}
 	const file = Bun.file(target);
 	if (await file.exists()) {
-		return new Response(file, { headers: { 'referrer-policy': 'no-referrer' } });
+		return new Response(file, {
+			headers: { 'referrer-policy': 'no-referrer' },
+		});
 	}
 	const index = Bun.file(join(uiDist, 'index.html'));
 	if (await index.exists()) {
 		return new Response(index, {
-			headers: { 'content-type': 'text/html', 'referrer-policy': 'no-referrer' },
+			headers: {
+				'content-type': 'text/html',
+				'referrer-policy': 'no-referrer',
+			},
 		});
 	}
 	return new Response('Not found', { status: 404 });
@@ -122,7 +130,9 @@ export async function runUp(): Promise<number> {
 	// the fetch/handleApi closures below, where only a truthiness guard on the
 	// const survives.
 	if (runtimeError || !runtime) {
-		console.error(runtimeError?.message ?? 'Failed to open local-mail runtime.');
+		console.error(
+			runtimeError?.message ?? 'Failed to open local-mail runtime.',
+		);
 		return 1;
 	}
 
@@ -135,10 +145,13 @@ export async function runUp(): Promise<number> {
 		return 1;
 	}
 
-	const { data: session, error: sessionError } = await openSyncSession(runtime, {
-		gmailLog: (m) => console.error(`[gmail] ${m}`),
-		syncLog: (m) => console.error(`[sync] ${m}`),
-	});
+	const { data: session, error: sessionError } = await openSyncSession(
+		runtime,
+		{
+			gmailLog: (m) => console.error(`[gmail] ${m}`),
+			syncLog: (m) => console.error(`[sync] ${m}`),
+		},
+	);
 	if (sessionError || !session) {
 		lock.release();
 		console.error(sessionError?.message ?? 'Failed to open sync session.');
@@ -231,10 +244,7 @@ export async function runUp(): Promise<number> {
 		}
 
 		if (pathname === '/api/messages' && req.method === 'GET') {
-			const limit = Math.min(
-				Number(url.searchParams.get('limit')) || 100,
-				200,
-			);
+			const limit = Math.min(Number(url.searchParams.get('limit')) || 100, 200);
 			const offset = Math.max(Number(url.searchParams.get('offset')) || 0, 0);
 			const labelId = url.searchParams.get('label') ?? undefined;
 			const search = url.searchParams.get('q')?.trim() || undefined;
@@ -245,7 +255,9 @@ export async function runUp(): Promise<number> {
 
 		const detailMatch = pathname.match(/^\/api\/messages\/([^/]+)$/);
 		if (detailMatch && req.method === 'GET') {
-			const detail = db.getMessageDetail(decodeURIComponent(detailMatch[1] as string));
+			const detail = db.getMessageDetail(
+				decodeURIComponent(detailMatch[1] as string),
+			);
 			if (!detail) return json({ error: 'Message not found.' }, 404);
 			return json(detail);
 		}
@@ -264,7 +276,10 @@ export async function runUp(): Promise<number> {
 				removeLabels?: string[];
 			} | null;
 			if (!body || !Array.isArray(body.ids)) {
-				return json({ error: 'Body must be { ids, addLabels, removeLabels }.' }, 400);
+				return json(
+					{ error: 'Body must be { ids, addLabels, removeLabels }.' },
+					400,
+				);
 			}
 			const { data, error } = await resolveAndModifyMessageLabels({
 				deps: sess.deps,

--- a/apps/local-mail/src/up.ts
+++ b/apps/local-mail/src/up.ts
@@ -1,0 +1,342 @@
+import { Database } from 'bun:sqlite';
+import { randomBytes } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { join, sep } from 'node:path';
+import { resolveAndModifyMessageLabels } from './modify.ts';
+import { openLocalMailRuntime, openSyncSession } from './runtime.ts';
+import { readMailStatus } from './status.ts';
+import { syncMailbox } from './sync.ts';
+
+/**
+ * `local-mail up`: one Bun process that serves the triage SPA and its `/api`
+ * over `127.0.0.1`, while the same process keeps the mirror fresh through the
+ * sync loop. The security model is the up-shell spec's, condensed:
+ *
+ * - A single-use bootstrap token rides in the URL fragment (never the query
+ *   string, so it never lands in a request line or access log). The SPA reads
+ *   it, strips it, and exchanges it at `POST /api/session` for a per-launch
+ *   session bearer it keeps in sessionStorage. Every other `/api` call carries
+ *   that bearer.
+ * - Every request is Host-checked first (the DNS-rebinding kill switch): a
+ *   request whose Host is not exactly `127.0.0.1:<port>` is rejected before
+ *   routing.
+ * - Dev mode (`LOCAL_MAIL_DEV=1`) never disables auth. The Vite proxy injects
+ *   a fixed `LOCAL_MAIL_TOKEN` bearer and rewrites Host, so the same checks run
+ *   against a developer's real mailbox.
+ *
+ * Writes go through the exact Phase 3 core the CLI and MCP use
+ * (`resolveAndModifyMessageLabels`); no per-intent routes exist.
+ */
+
+const DEV = process.env.LOCAL_MAIL_DEV === '1';
+const SYNC_INTERVAL_MS = 30_000;
+/** Bound online guessing by another local user against the exchange endpoint. */
+const MAX_FAILED_EXCHANGES = 25;
+
+/** 256 bits of CSPRNG, base64url: well past the spec's 128-bit floor. */
+function mintToken(): string {
+	return randomBytes(32).toString('base64url');
+}
+
+type LockHandle = { db: Database; release(): void };
+
+/**
+ * A dedicated `lock.db` held with `BEGIN EXCLUSIVE` for the process lifetime,
+ * so a second `up` for the same account is refused instantly. `flock` has no
+ * Bun API and an `O_EXCL` lockfile is stale-on-crash; the fcntl lock a live
+ * SQLite transaction holds is released by the kernel on `kill -9`.
+ */
+function acquireAccountLock(dir: string): LockHandle | null {
+	const db = new Database(join(dir, 'lock.db'), { create: true });
+	db.run('PRAGMA busy_timeout = 0;');
+	try {
+		db.run('BEGIN EXCLUSIVE;');
+	} catch {
+		db.close();
+		return null;
+	}
+	return {
+		db,
+		release() {
+			try {
+				db.run('ROLLBACK;');
+			} catch {
+				// The process is exiting; the kernel drops the lock regardless.
+			}
+			db.close();
+		},
+	};
+}
+
+function json(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: {
+			'content-type': 'application/json',
+			'referrer-policy': 'no-referrer',
+		},
+	});
+}
+
+/**
+ * One in-process promise chain: the background loop and a "refresh now" request
+ * both enqueue here, so at most one sync pass touches the mirror at a time. No
+ * coalescing (a refresh may ride a pass that started before the click); the
+ * spec accepts that for v1.
+ */
+function createSyncGate() {
+	let tail: Promise<unknown> = Promise.resolve();
+	return function run<T>(fn: () => Promise<T>): Promise<T> {
+		const result = tail.then(fn, fn);
+		tail = result.catch(() => {});
+		return result;
+	};
+}
+
+/** Serve the built SPA from disk, falling back to index.html for deep links. */
+async function serveStatic(uiDist: string, pathname: string): Promise<Response> {
+	const rel = pathname === '/' ? '/index.html' : pathname;
+	// Reject path traversal before touching the filesystem. `join` collapses
+	// `..`, so match on a real separator boundary: a bare `startsWith(uiDist)`
+	// would also accept a sibling like `<uiDist>-evil`.
+	const target = join(uiDist, rel);
+	if (target !== uiDist && !target.startsWith(uiDist + sep)) {
+		return new Response('Forbidden', { status: 403 });
+	}
+	const file = Bun.file(target);
+	if (await file.exists()) {
+		return new Response(file, { headers: { 'referrer-policy': 'no-referrer' } });
+	}
+	const index = Bun.file(join(uiDist, 'index.html'));
+	if (await index.exists()) {
+		return new Response(index, {
+			headers: { 'content-type': 'text/html', 'referrer-policy': 'no-referrer' },
+		});
+	}
+	return new Response('Not found', { status: 404 });
+}
+
+export async function runUp(): Promise<number> {
+	const { data: runtime, error: runtimeError } = await openLocalMailRuntime();
+	// Narrow on `runtime` itself, not just the error: the value is captured in
+	// the fetch/handleApi closures below, where only a truthiness guard on the
+	// const survives.
+	if (runtimeError || !runtime) {
+		console.error(runtimeError?.message ?? 'Failed to open local-mail runtime.');
+		return 1;
+	}
+
+	const accountDir = join(runtime.config.dataDir, runtime.accountEmail);
+	const lock = acquireAccountLock(accountDir);
+	if (!lock) {
+		console.error(
+			`local-mail up is already running for ${runtime.accountEmail}. Stop it first, or open the URL it printed.`,
+		);
+		return 1;
+	}
+
+	const { data: session, error: sessionError } = await openSyncSession(runtime, {
+		gmailLog: (m) => console.error(`[gmail] ${m}`),
+		syncLog: (m) => console.error(`[sync] ${m}`),
+	});
+	if (sessionError || !session) {
+		lock.release();
+		console.error(sessionError?.message ?? 'Failed to open sync session.');
+		return 1;
+	}
+
+	// Re-bind the non-null values: TS drops the post-guard narrowing of the
+	// destructured `runtime`/`session` bindings inside the fetch/loop/SIGINT
+	// closures below, so capture them here where the narrowing holds.
+	const rt = runtime;
+	const sess = session;
+	const { db } = sess.deps;
+	const readOnly = rt.config.readOnly;
+
+	// The valid-bearer set. Dev pre-seeds the fixed proxy token; prod fills it
+	// only through the bootstrap exchange.
+	const sessionBearers = new Set<string>();
+	let bootstrapToken: string | null = null;
+	if (DEV) {
+		const devToken = process.env.LOCAL_MAIL_TOKEN;
+		if (!devToken) {
+			lock.release();
+			sess.close();
+			console.error(
+				'LOCAL_MAIL_DEV=1 requires LOCAL_MAIL_TOKEN so the Vite proxy can authenticate.',
+			);
+			return 1;
+		}
+		sessionBearers.add(devToken);
+	} else {
+		bootstrapToken = mintToken();
+	}
+	let failedExchanges = 0;
+
+	const uiDist = join(import.meta.dir, '..', 'ui', 'dist');
+	const gate = createSyncGate();
+	const controller = new AbortController();
+
+	function bearerOf(req: Request): string | null {
+		const header = req.headers.get('authorization');
+		if (!header?.startsWith('Bearer ')) return null;
+		return header.slice('Bearer '.length);
+	}
+
+	async function handleApi(req: Request, url: URL): Promise<Response> {
+		const { pathname } = url;
+
+		// The one unauthenticated mutation: exchange the bootstrap for a bearer.
+		if (pathname === '/api/session' && req.method === 'POST') {
+			if (bootstrapToken === null) {
+				return json({ error: 'No bootstrap token is outstanding.' }, 401);
+			}
+			if (failedExchanges >= MAX_FAILED_EXCHANGES) {
+				return json({ error: 'Too many exchange attempts.' }, 429);
+			}
+			const body = (await req.json().catch(() => null)) as {
+				token?: string;
+			} | null;
+			if (!body?.token || body.token !== bootstrapToken) {
+				failedExchanges += 1;
+				return json({ error: 'Invalid bootstrap token.' }, 401);
+			}
+			const bearer = mintToken();
+			sessionBearers.add(bearer);
+			bootstrapToken = null; // single use: invalidate at exchange
+			return json({ token: bearer });
+		}
+
+		const bearer = bearerOf(req);
+		if (!bearer || !sessionBearers.has(bearer)) {
+			return json({ error: 'Unauthorized. Restart local-mail up.' }, 401);
+		}
+
+		if (pathname === '/api/status' && req.method === 'GET') {
+			const status = await readMailStatus(rt);
+			return json({
+				accountEmail: status.accountEmail,
+				connected: status.connected,
+				mirror: status.mirror,
+				historyId: status.historyId,
+				lastSyncedAt: status.lastSyncedAt,
+				lastFullPullAt: status.lastFullPullAt,
+				rows: status.rows,
+				readOnly,
+			});
+		}
+
+		if (pathname === '/api/labels' && req.method === 'GET') {
+			return json({ labels: db.listLabels() });
+		}
+
+		if (pathname === '/api/messages' && req.method === 'GET') {
+			const limit = Math.min(
+				Number(url.searchParams.get('limit')) || 100,
+				200,
+			);
+			const offset = Math.max(Number(url.searchParams.get('offset')) || 0, 0);
+			const labelId = url.searchParams.get('label') ?? undefined;
+			const search = url.searchParams.get('q')?.trim() || undefined;
+			return json({
+				messages: db.listMessages({ labelId, search, limit, offset }),
+			});
+		}
+
+		const detailMatch = pathname.match(/^\/api\/messages\/([^/]+)$/);
+		if (detailMatch && req.method === 'GET') {
+			const detail = db.getMessageDetail(decodeURIComponent(detailMatch[1] as string));
+			if (!detail) return json({ error: 'Message not found.' }, 404);
+			return json(detail);
+		}
+
+		if (pathname === '/api/sync' && req.method === 'POST') {
+			const outcome = await gate(() =>
+				syncMailbox(sess.deps, { forceFull: false }),
+			);
+			return json(outcome);
+		}
+
+		if (pathname === '/api/messages/modify' && req.method === 'POST') {
+			const body = (await req.json().catch(() => null)) as {
+				ids?: string[];
+				addLabels?: string[];
+				removeLabels?: string[];
+			} | null;
+			if (!body || !Array.isArray(body.ids)) {
+				return json({ error: 'Body must be { ids, addLabels, removeLabels }.' }, 400);
+			}
+			const { data, error } = await resolveAndModifyMessageLabels({
+				deps: sess.deps,
+				ids: body.ids,
+				addLabels: body.addLabels ?? [],
+				removeLabels: body.removeLabels ?? [],
+				readOnly,
+			});
+			if (error) return json({ error: error.message }, 400);
+			return json(data);
+		}
+
+		return json({ error: 'Not found.' }, 404);
+	}
+
+	const server = Bun.serve({
+		hostname: '127.0.0.1',
+		port: Number(process.env.LOCAL_MAIL_PORT) || 0,
+		async fetch(req) {
+			const url = new URL(req.url);
+
+			// Host check first: the DNS-rebinding kill switch. Every request must
+			// name this exact loopback origin (the Vite proxy rewrites Host to
+			// match via changeOrigin, so dev passes too).
+			const expectedHost = `127.0.0.1:${server.port}`;
+			if (req.headers.get('host') !== expectedHost) {
+				return new Response('Forbidden', { status: 403 });
+			}
+
+			if (url.pathname.startsWith('/api/')) return handleApi(req, url);
+			return serveStatic(uiDist, url.pathname);
+		},
+	});
+
+	// The background sync loop, serialized through the same gate as POST /api/sync.
+	(async () => {
+		while (!controller.signal.aborted) {
+			await gate(() => syncMailbox(sess.deps, { forceFull: false })).catch(
+				(cause) => console.error(`[sync] loop pass failed: ${cause}`),
+			);
+			if (controller.signal.aborted) break;
+			await Bun.sleep(SYNC_INTERVAL_MS);
+		}
+	})();
+
+	const origin = `http://127.0.0.1:${server.port}`;
+	if (DEV) {
+		console.error(`local-mail up (dev API) listening on ${origin}`);
+		console.error('Run the SPA with: bun run --cwd apps/local-mail/ui dev');
+	} else {
+		const launchUrl = `${origin}/#token=${bootstrapToken}`;
+		console.log(launchUrl);
+		if (!existsSync(uiDist)) {
+			console.error(
+				`Note: ${uiDist} does not exist yet. Build the SPA with "bun run --cwd apps/local-mail/ui build".`,
+			);
+		}
+		// `LOCAL_MAIL_NO_OPEN=1` prints the URL without launching a browser: for
+		// headless hosts, CI, and "copy the URL into the browser I want" workflows.
+		if (process.env.LOCAL_MAIL_NO_OPEN !== '1') {
+			Bun.spawn(['open', launchUrl]).exited.catch(() => {});
+		}
+	}
+
+	await new Promise<void>((resolve) => {
+		process.on('SIGINT', () => {
+			controller.abort();
+			server.stop();
+			sess.close();
+			lock.release();
+			resolve();
+		});
+	});
+	return 0;
+}

--- a/apps/local-mail/tsconfig.json
+++ b/apps/local-mail/tsconfig.json
@@ -4,5 +4,6 @@
 		"types": ["bun"],
 		"noUnusedLocals": true,
 		"noUnusedParameters": true
-	}
+	},
+	"exclude": ["ui"]
 }

--- a/apps/local-mail/ui/.gitignore
+++ b/apps/local-mail/ui/.gitignore
@@ -1,0 +1,20 @@
+node_modules
+
+# Output
+/.svelte-kit
+/dist
+/build
+/package
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Env
+.env
+.env.*
+!.env.example
+
+# Vite
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*

--- a/apps/local-mail/ui/package.json
+++ b/apps/local-mail/ui/package.json
@@ -1,0 +1,34 @@
+{
+	"name": "@epicenter/local-mail-ui",
+	"description": "Local Mail triage SPA, served same-origin by `local-mail up`",
+	"private": true,
+	"version": "0.0.1",
+	"type": "module",
+	"scripts": {
+		"dev": "vite dev",
+		"build": "vite build",
+		"preview": "vite preview",
+		"prepare": "svelte-kit sync || echo ''",
+		"typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
+	},
+	"devDependencies": {
+		"@epicenter/ui": "workspace:*",
+		"@lucide/svelte": "catalog:",
+		"@sveltejs/adapter-static": "catalog:",
+		"@sveltejs/kit": "catalog:",
+		"@sveltejs/vite-plugin-svelte": "catalog:",
+		"@tailwindcss/vite": "catalog:",
+		"@types/bun": "catalog:",
+		"mode-watcher": "catalog:",
+		"svelte": "catalog:",
+		"svelte-check": "catalog:",
+		"svelte-sonner": "catalog:",
+		"tailwindcss": "catalog:",
+		"typescript": "catalog:",
+		"vite": "catalog:"
+	},
+	"dependencies": {
+		"@tanstack/svelte-query": "catalog:"
+	},
+	"license": "AGPL-3.0-or-later"
+}

--- a/apps/local-mail/ui/src/app.css
+++ b/apps/local-mail/ui/src/app.css
@@ -1,0 +1,1 @@
+@import "@epicenter/ui/app.css";

--- a/apps/local-mail/ui/src/app.d.ts
+++ b/apps/local-mail/ui/src/app.d.ts
@@ -1,0 +1,6 @@
+// See https://svelte.dev/docs/kit/types#app.d.ts
+declare global {
+	namespace App {}
+}
+
+export {};

--- a/apps/local-mail/ui/src/app.html
+++ b/apps/local-mail/ui/src/app.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en" class="style-vega">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<title>Local Mail</title>
+		<script>
+			const mode = localStorage.getItem('mode-watcher-mode') ?? 'dark';
+			const isLight =
+				mode === 'light' ||
+				(mode === 'system' &&
+					matchMedia('(prefers-color-scheme: light)').matches);
+			document.documentElement.classList.toggle('dark', !isLight);
+			document.documentElement.style.colorScheme = isLight ? 'light' : 'dark';
+			localStorage.setItem('mode-watcher-mode', mode);
+		</script>
+		%sveltekit.head%
+	</head>
+	<body data-sveltekit-preload-data="hover">
+		<div style="display: contents">%sveltekit.body%</div>
+	</body>
+</html>

--- a/apps/local-mail/ui/src/lib/api.ts
+++ b/apps/local-mail/ui/src/lib/api.ts
@@ -1,0 +1,105 @@
+import type {
+	MailboxStatus,
+	MailLabel,
+	MessageDetail,
+	MessageSummary,
+	ModifyMessageLabelsOutcome,
+	SyncOutcome,
+} from './types';
+
+// The same-origin `/api` client. The bearer lives in sessionStorage: it
+// survives F5 within the tab, dies with the tab, and is unreadable by any
+// sandboxed mail-body frame. In production the SPA earns the bearer once by
+// exchanging the single-use bootstrap token carried in the URL fragment; in dev
+// the Vite proxy injects a fixed bearer, so no exchange runs and no credential
+// touches the browser.
+
+const BEARER_KEY = 'local-mail:session-bearer';
+
+function readBearer(): string | null {
+	if (typeof sessionStorage === 'undefined') return null;
+	return sessionStorage.getItem(BEARER_KEY);
+}
+
+/**
+ * Read the bootstrap token from `location.hash`, strip it immediately so it
+ * never lingers in history, and exchange it for the per-launch session bearer.
+ * No fragment (dev, or a reload after the exchange) is not an error: dev is
+ * proxy-authenticated and a reload already has the stored bearer.
+ */
+async function bootstrap(): Promise<void> {
+	if (typeof window === 'undefined' || readBearer()) return;
+	const match = window.location.hash.match(/token=([^&]+)/);
+	if (!match) return;
+	const bootstrapToken = decodeURIComponent(match[1] as string);
+	window.history.replaceState(
+		null,
+		'',
+		window.location.pathname + window.location.search,
+	);
+	const res = await fetch('/api/session', {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify({ token: bootstrapToken }),
+	});
+	if (!res.ok) return;
+	const body = (await res.json()) as { token?: string };
+	if (body.token) sessionStorage.setItem(BEARER_KEY, body.token);
+}
+
+let sessionReady: Promise<void> | null = null;
+function ensureSession(): Promise<void> {
+	sessionReady ??= bootstrap();
+	return sessionReady;
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+	await ensureSession();
+	const headers = new Headers(init?.headers);
+	headers.set('content-type', 'application/json');
+	const bearer = readBearer();
+	if (bearer) headers.set('authorization', `Bearer ${bearer}`);
+	const res = await fetch(path, { ...init, headers });
+	if (!res.ok) {
+		const body = (await res.json().catch(() => null)) as {
+			error?: string;
+		} | null;
+		throw new Error(body?.error ?? `Request failed (${res.status}).`);
+	}
+	return res.json() as Promise<T>;
+}
+
+export type MessageQuery = {
+	label?: string;
+	search?: string;
+	limit?: number;
+	offset?: number;
+};
+
+export const api = {
+	status: () => request<MailboxStatus>('/api/status'),
+	labels: () => request<{ labels: MailLabel[] }>('/api/labels'),
+	messages: (query: MessageQuery = {}) => {
+		const params = new URLSearchParams();
+		if (query.label) params.set('label', query.label);
+		if (query.search) params.set('q', query.search);
+		if (query.limit) params.set('limit', String(query.limit));
+		if (query.offset) params.set('offset', String(query.offset));
+		const qs = params.toString();
+		return request<{ messages: MessageSummary[] }>(
+			`/api/messages${qs ? `?${qs}` : ''}`,
+		);
+	},
+	message: (id: string) =>
+		request<MessageDetail>(`/api/messages/${encodeURIComponent(id)}`),
+	sync: () => request<SyncOutcome>('/api/sync', { method: 'POST' }),
+	modify: (input: {
+		ids: string[];
+		addLabels?: string[];
+		removeLabels?: string[];
+	}) =>
+		request<ModifyMessageLabelsOutcome>('/api/messages/modify', {
+			method: 'POST',
+			body: JSON.stringify(input),
+		}),
+};

--- a/apps/local-mail/ui/src/lib/components/LabelRail.svelte
+++ b/apps/local-mail/ui/src/lib/components/LabelRail.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+	import { Input } from '@epicenter/ui/input';
+	import { cn } from '@epicenter/ui/utils';
+	import InboxIcon from '@lucide/svelte/icons/inbox';
+	import MailIcon from '@lucide/svelte/icons/mail';
+	import MailsIcon from '@lucide/svelte/icons/mails';
+	import SearchIcon from '@lucide/svelte/icons/search';
+	import StarIcon from '@lucide/svelte/icons/star';
+	import TagIcon from '@lucide/svelte/icons/tag';
+	import type { Component } from 'svelte';
+	import { labelDisplayName } from '$lib/format';
+	import type { MailLabel } from '$lib/types';
+
+	let {
+		labels,
+		selectedLabel,
+		search,
+		onSelect,
+		onSearch,
+	}: {
+		labels: MailLabel[];
+		selectedLabel: string | null;
+		search: string;
+		onSelect: (id: string | null) => void;
+		onSearch: (value: string) => void;
+	} = $props();
+
+	type Quick = { id: string | null; label: string; icon: Component };
+	const quick: Quick[] = [
+		{ id: null, label: 'All mail', icon: MailsIcon },
+		{ id: 'INBOX', label: 'Inbox', icon: InboxIcon },
+		{ id: 'UNREAD', label: 'Unread', icon: MailIcon },
+		{ id: 'STARRED', label: 'Starred', icon: StarIcon },
+	];
+
+	const categories = $derived(
+		labels.filter((l) => l.id.startsWith('CATEGORY_')),
+	);
+	const userLabels = $derived(labels.filter((l) => l.type === 'user'));
+</script>
+
+<nav class="flex w-56 shrink-0 flex-col border-r border-border bg-background">
+	<div class="border-b border-border p-2">
+		<div class="relative">
+			<SearchIcon
+				class="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground"
+			/>
+			<Input
+				value={search}
+				oninput={(e) => onSearch(e.currentTarget.value)}
+				placeholder="Search mirror"
+				class="h-8 pl-7 text-xs"
+			/>
+		</div>
+	</div>
+
+	<div class="flex-1 min-h-0 overflow-y-auto p-2">
+		<ul class="space-y-0.5">
+			{#each quick as item (item.label)}
+				{@const Icon = item.icon}
+				<li>
+					<button
+						class={cn(
+							'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors',
+							selectedLabel === item.id
+								? 'bg-accent font-medium text-accent-foreground'
+								: 'text-foreground/80 hover:bg-accent/50',
+						)}
+						onclick={() => onSelect(item.id)}
+					>
+						<Icon class="size-4 shrink-0 text-muted-foreground" />
+						<span class="truncate">{item.label}</span>
+					</button>
+				</li>
+			{/each}
+		</ul>
+
+		{#if categories.length}
+			<p class="px-2 pb-1 pt-4 text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground">
+				Categories
+			</p>
+			<ul class="space-y-0.5">
+				{#each categories as label (label.id)}
+					<li>
+						<button
+							class={cn(
+								'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors',
+								selectedLabel === label.id
+									? 'bg-accent font-medium text-accent-foreground'
+									: 'text-foreground/80 hover:bg-accent/50',
+							)}
+							onclick={() => onSelect(label.id)}
+						>
+							<TagIcon class="size-4 shrink-0 text-muted-foreground" />
+							<span class="truncate">{labelDisplayName(label.id, label.name)}</span>
+						</button>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+
+		{#if userLabels.length}
+			<p class="px-2 pb-1 pt-4 text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground">
+				Labels
+			</p>
+			<ul class="space-y-0.5">
+				{#each userLabels as label (label.id)}
+					<li>
+						<button
+							class={cn(
+								'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors',
+								selectedLabel === label.id
+									? 'bg-accent font-medium text-accent-foreground'
+									: 'text-foreground/80 hover:bg-accent/50',
+							)}
+							onclick={() => onSelect(label.id)}
+						>
+							<TagIcon class="size-4 shrink-0 text-muted-foreground" />
+							<span class="truncate">{labelDisplayName(label.id, label.name)}</span>
+						</button>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</div>
+</nav>

--- a/apps/local-mail/ui/src/lib/components/MessageDetail.svelte
+++ b/apps/local-mail/ui/src/lib/components/MessageDetail.svelte
@@ -1,0 +1,275 @@
+<script lang="ts">
+	import { Badge } from '@epicenter/ui/badge';
+	import { Button } from '@epicenter/ui/button';
+	import * as DropdownMenu from '@epicenter/ui/dropdown-menu';
+	import * as Empty from '@epicenter/ui/empty';
+	import { Loading } from '@epicenter/ui/loading';
+	import { Separator } from '@epicenter/ui/separator';
+	import ArchiveIcon from '@lucide/svelte/icons/archive';
+	import ArchiveRestoreIcon from '@lucide/svelte/icons/archive-restore';
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import MailOpenIcon from '@lucide/svelte/icons/mail-open';
+	import MailIcon from '@lucide/svelte/icons/mail';
+	import MousePointerClickIcon from '@lucide/svelte/icons/mouse-pointer-click';
+	import StarIcon from '@lucide/svelte/icons/star';
+	import TagIcon from '@lucide/svelte/icons/tag';
+	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
+	import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query';
+	import { toast } from 'svelte-sonner';
+	import { api } from '$lib/api';
+	import { fullDate, labelDisplayName } from '$lib/format';
+	import type { MailLabel, ModifyMessageLabelsOutcome } from '$lib/types';
+
+	let {
+		id,
+		readOnly,
+		labels,
+	}: {
+		id: string | null;
+		readOnly: boolean;
+		labels: MailLabel[];
+	} = $props();
+
+	const queryClient = useQueryClient();
+	const message = createQuery(() => ({
+		queryKey: ['message', id ?? ''],
+		queryFn: () => api.message(id as string),
+		enabled: id !== null,
+	}));
+
+	let lastVerb = $state<string | null>(null);
+	let lastOutcome = $state<ModifyMessageLabelsOutcome | null>(null);
+
+	const modify = createMutation(() => ({
+		mutationFn: (input: { addLabels?: string[]; removeLabels?: string[] }) =>
+			api.modify({ ids: id ? [id] : [], ...input }),
+		onSuccess: (outcome) => {
+			lastOutcome = outcome;
+			const failed = outcome.results.filter((r) => r.error).length;
+			const ok = outcome.results.length - failed;
+			if (outcome.aborted) {
+				toast.error(`Aborted: ${outcome.aborted.message}`);
+			} else if (failed) {
+				toast.error(`${lastVerb}: ${ok} ok, ${failed} failed`, {
+					description: outcome.results.find((r) => r.error)?.error?.message,
+				});
+			} else {
+				const pending = outcome.results.some((r) => !r.folded);
+				toast.success(lastVerb ?? 'Done', {
+					description: pending
+						? 'Gmail accepted it; the mirror catches up on the next sync.'
+						: undefined,
+				});
+			}
+			queryClient.invalidateQueries({ queryKey: ['messages'] });
+			queryClient.invalidateQueries({ queryKey: ['status'] });
+			if (id) queryClient.invalidateQueries({ queryKey: ['message', id] });
+		},
+		onError: (error: Error) => toast.error(error.message),
+	}));
+
+	function run(
+		verb: string,
+		input: { addLabels?: string[]; removeLabels?: string[] },
+	) {
+		if (!id || readOnly) return;
+		lastVerb = verb;
+		modify.mutate(input);
+	}
+
+	const detail = $derived(message.data);
+	const inInbox = $derived(detail?.labelIds.includes('INBOX') ?? false);
+	const unread = $derived(detail?.labelIds.includes('UNREAD') ?? false);
+	const starred = $derived(detail?.labelIds.includes('STARRED') ?? false);
+	const busy = $derived(modify.isPending);
+
+	// Labels a person applies (user labels + Gmail categories), for the menu.
+	const applicableLabels = $derived(
+		labels.filter((l) => l.type === 'user' || l.id.startsWith('CATEGORY_')),
+	);
+	function toggleLabel(labelId: string, present: boolean) {
+		const name = labelDisplayName(labelId);
+		if (present) run(`Removed ${name}`, { removeLabels: [labelId] });
+		else run(`Added ${name}`, { addLabels: [labelId] });
+	}
+
+	// Reset the inline outcome strip when a different message opens.
+	$effect(() => {
+		id;
+		lastOutcome = null;
+		lastVerb = null;
+	});
+</script>
+
+{#snippet actionButton(
+	label: string,
+	icon: typeof ArchiveIcon,
+	onClick: () => void,
+)}
+	{@const Icon = icon}
+	<Button
+		size="sm"
+		variant="outline"
+		onclick={onClick}
+		disabled={busy || readOnly}
+		tooltip={readOnly ? 'Read-only mode (LOCAL_MAIL_READ_ONLY)' : label}
+	>
+		<Icon class="size-3.5" />
+		<span>{label}</span>
+	</Button>
+{/snippet}
+
+<section class="flex min-w-0 flex-1 flex-col bg-background">
+	{#if !id}
+		<Empty.Root class="flex-1 border-0">
+			<Empty.Media variant="icon">
+				<MousePointerClickIcon class="size-5" />
+			</Empty.Media>
+			<Empty.Title>Select a message</Empty.Title>
+			<Empty.Description>Pick a message to triage it.</Empty.Description>
+		</Empty.Root>
+	{:else if message.isPending}
+		<Loading class="flex-1" label="Loading message" />
+	{:else if message.error}
+		<Empty.Root class="flex-1 border-0">
+			<Empty.Media variant="icon">
+				<TriangleAlertIcon class="size-5 text-destructive" />
+			</Empty.Media>
+			<Empty.Title>Could not load this message</Empty.Title>
+			<Empty.Description>{message.error.message}</Empty.Description>
+		</Empty.Root>
+	{:else if detail}
+		<!-- Header -->
+		<div class="shrink-0 border-b border-border px-5 py-4">
+			<h1 class="text-lg font-semibold leading-snug">
+				{detail.subject || '(no subject)'}
+			</h1>
+			<dl class="mt-2 space-y-0.5 text-sm text-muted-foreground">
+				<div class="flex gap-2">
+					<dt class="w-10 shrink-0 text-right text-xs uppercase tracking-wide">from</dt>
+					<dd class="min-w-0 truncate text-foreground/90">{detail.sender ?? '(unknown)'}</dd>
+				</div>
+				{#if detail.to}
+					<div class="flex gap-2">
+						<dt class="w-10 shrink-0 text-right text-xs uppercase tracking-wide">to</dt>
+						<dd class="min-w-0 truncate">{detail.to}</dd>
+					</div>
+				{/if}
+				<div class="flex gap-2">
+					<dt class="w-10 shrink-0 text-right text-xs uppercase tracking-wide">date</dt>
+					<dd class="tabular-nums">{fullDate(detail.internalDate, detail.date)}</dd>
+				</div>
+			</dl>
+			{#if detail.labelIds.length}
+				<div class="mt-2.5 flex flex-wrap gap-1">
+					{#each detail.labelIds as labelId (labelId)}
+						<Badge variant="secondary" class="h-5 rounded px-1.5 text-[0.65rem] font-normal">
+							{labelDisplayName(labelId, labels.find((l) => l.id === labelId)?.name)}
+						</Badge>
+					{/each}
+				</div>
+			{/if}
+		</div>
+
+		<!-- Action toolbar -->
+		<div class="flex shrink-0 flex-wrap items-center gap-1.5 border-b border-border px-5 py-2.5">
+			{#if inInbox}
+				{@render actionButton('Archive', ArchiveIcon, () =>
+					run('Archived', { removeLabels: ['INBOX'] }),
+				)}
+			{:else}
+				{@render actionButton('Move to inbox', ArchiveRestoreIcon, () =>
+					run('Moved to inbox', { addLabels: ['INBOX'] }),
+				)}
+			{/if}
+			{#if unread}
+				{@render actionButton('Mark read', MailOpenIcon, () =>
+					run('Marked read', { removeLabels: ['UNREAD'] }),
+				)}
+			{:else}
+				{@render actionButton('Mark unread', MailIcon, () =>
+					run('Marked unread', { addLabels: ['UNREAD'] }),
+				)}
+			{/if}
+			{@render actionButton(
+				starred ? 'Unstar' : 'Star',
+				StarIcon,
+				() =>
+					starred
+						? run('Unstarred', { removeLabels: ['STARRED'] })
+						: run('Starred', { addLabels: ['STARRED'] }),
+			)}
+
+			<DropdownMenu.Root>
+				<DropdownMenu.Trigger disabled={busy || readOnly}>
+					{#snippet child({ props })}
+						<Button
+							{...props}
+							size="sm"
+							variant="outline"
+							disabled={busy || readOnly}
+							tooltip={readOnly
+								? 'Read-only mode (LOCAL_MAIL_READ_ONLY)'
+								: 'Add or remove existing Gmail labels'}
+						>
+							<TagIcon class="size-3.5" />
+							<span>Labels</span>
+						</Button>
+					{/snippet}
+				</DropdownMenu.Trigger>
+				<DropdownMenu.Content class="max-h-72 w-52 overflow-y-auto" align="start">
+					<DropdownMenu.Label>Gmail labels</DropdownMenu.Label>
+					<DropdownMenu.Separator />
+					{#each applicableLabels as label (label.id)}
+						{@const present = detail.labelIds.includes(label.id)}
+						<DropdownMenu.CheckboxItem
+							checked={present}
+							closeOnSelect={false}
+							onCheckedChange={() => toggleLabel(label.id, present)}
+						>
+							{labelDisplayName(label.id, label.name)}
+						</DropdownMenu.CheckboxItem>
+					{/each}
+				</DropdownMenu.Content>
+			</DropdownMenu.Root>
+		</div>
+
+		<!-- Last-action outcome strip -->
+		{#if lastOutcome}
+			{@const result = lastOutcome.results[0]}
+			<div
+				class="flex shrink-0 items-center gap-2 border-b px-5 py-1.5 text-xs
+				{lastOutcome.aborted || result?.error
+					? 'border-destructive/30 bg-destructive/10 text-destructive'
+					: result && !result.folded
+						? 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400'
+						: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'}"
+			>
+				{#if lastOutcome.aborted}
+					<TriangleAlertIcon class="size-3.5" />
+					<span>Aborted: {lastOutcome.aborted.message}</span>
+				{:else if result?.error}
+					<TriangleAlertIcon class="size-3.5" />
+					<span>{lastVerb} failed: {result.error.message}</span>
+				{:else if result && !result.folded}
+					<CheckIcon class="size-3.5" />
+					<span>{lastVerb}. Gmail accepted it; the mirror catches up on the next sync (folded: false).</span>
+				{:else}
+					<CheckIcon class="size-3.5" />
+					<span>{lastVerb}. Mirror updated from Gmail's response.</span>
+				{/if}
+			</div>
+		{/if}
+
+		<!-- Body: the pre-extracted plain text; raw HTML is never rendered. -->
+		<div class="flex-1 min-h-0 overflow-y-auto px-5 py-4">
+			{#if detail.bodyText}
+				<pre class="whitespace-pre-wrap break-words font-sans text-sm leading-relaxed text-foreground/90">{detail.bodyText}</pre>
+			{:else}
+				<p class="text-sm italic text-muted-foreground">
+					No text body extracted for this message.
+				</p>
+			{/if}
+		</div>
+	{/if}
+</section>

--- a/apps/local-mail/ui/src/lib/components/MessageList.svelte
+++ b/apps/local-mail/ui/src/lib/components/MessageList.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+	import { Badge } from '@epicenter/ui/badge';
+	import * as Empty from '@epicenter/ui/empty';
+	import { Skeleton } from '@epicenter/ui/skeleton';
+	import { cn } from '@epicenter/ui/utils';
+	import InboxIcon from '@lucide/svelte/icons/inbox';
+	import SearchXIcon from '@lucide/svelte/icons/search-x';
+	import StarIcon from '@lucide/svelte/icons/star';
+	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
+	import {
+		chipLabelIds,
+		decodeSnippet,
+		labelDisplayName,
+		senderName,
+		shortDate,
+	} from '$lib/format';
+	import type { MailLabel, MessageSummary } from '$lib/types';
+
+	let {
+		messages,
+		labels,
+		selectedId,
+		loading,
+		error,
+		isFiltered,
+		onSelect,
+	}: {
+		messages: MessageSummary[];
+		labels: MailLabel[];
+		selectedId: string | null;
+		loading: boolean;
+		error: string | null;
+		isFiltered: boolean;
+		onSelect: (id: string) => void;
+	} = $props();
+
+	const nameOf = $derived(
+		new Map(labels.map((l) => [l.id, labelDisplayName(l.id, l.name)])),
+	);
+</script>
+
+<div class="flex min-w-0 flex-1 flex-col border-r border-border">
+	{#if error}
+		<Empty.Root class="flex-1 border-0">
+			<Empty.Media variant="icon">
+				<TriangleAlertIcon class="size-5 text-destructive" />
+			</Empty.Media>
+			<Empty.Title>Could not load messages</Empty.Title>
+			<Empty.Description>{error}</Empty.Description>
+		</Empty.Root>
+	{:else if loading}
+		<ul class="divide-y divide-border">
+			{#each Array.from({ length: 8 }) as _, i (i)}
+				<li class="space-y-2 px-3 py-2.5">
+					<div class="flex justify-between gap-2">
+						<Skeleton class="h-3 w-32" />
+						<Skeleton class="h-3 w-10" />
+					</div>
+					<Skeleton class="h-3 w-full" />
+				</li>
+			{/each}
+		</ul>
+	{:else if messages.length === 0}
+		<Empty.Root class="flex-1 border-0">
+			<Empty.Media variant="icon">
+				{#if isFiltered}
+					<SearchXIcon class="size-5" />
+				{:else}
+					<InboxIcon class="size-5" />
+				{/if}
+			</Empty.Media>
+			<Empty.Title>
+				{isFiltered ? 'No messages match' : 'No messages mirrored'}
+			</Empty.Title>
+			<Empty.Description>
+				{isFiltered
+					? 'Try a different label or search term.'
+					: 'Run local-mail sync --full to populate the mirror.'}
+			</Empty.Description>
+		</Empty.Root>
+	{:else}
+		<ul class="flex-1 min-h-0 divide-y divide-border overflow-y-auto">
+			{#each messages as message (message.id)}
+				{@const unread = message.labelIds.includes('UNREAD')}
+				{@const starred = message.labelIds.includes('STARRED')}
+				{@const chips = chipLabelIds(message.labelIds)}
+				<li>
+					<button
+						class={cn(
+							'flex w-full items-start gap-2.5 px-3 py-2.5 text-left transition-colors',
+							selectedId === message.id
+								? 'bg-accent'
+								: 'hover:bg-accent/40',
+						)}
+						onclick={() => onSelect(message.id)}
+					>
+						<span
+							class={cn(
+								'mt-1.5 size-2 shrink-0 rounded-full',
+								unread ? 'bg-sky-500' : 'bg-transparent',
+							)}
+							title={unread ? 'Unread' : 'Read'}
+						></span>
+						<span class="min-w-0 flex-1">
+							<span class="flex items-center gap-2">
+								<span
+									class={cn(
+										'flex-1 truncate text-sm',
+										unread
+											? 'font-semibold text-foreground'
+											: 'text-foreground/70',
+									)}
+								>
+									{senderName(message.sender)}
+								</span>
+								{#if starred}
+									<StarIcon
+										class="size-3.5 shrink-0 fill-amber-400 text-amber-400"
+									/>
+								{/if}
+								<span class="shrink-0 font-mono text-[0.7rem] text-muted-foreground tabular-nums">
+									{shortDate(message.internalDate)}
+								</span>
+							</span>
+							<span class="mt-0.5 block truncate text-sm">
+								<span class={unread ? 'font-medium text-foreground' : 'text-foreground/80'}>
+									{message.subject || '(no subject)'}
+								</span>
+								{#if message.snippet}
+									<span class="text-muted-foreground">
+										&nbsp;· {decodeSnippet(message.snippet)}
+									</span>
+								{/if}
+							</span>
+							{#if chips.length}
+								<span class="mt-1 flex flex-wrap gap-1">
+									{#each chips as id (id)}
+										<Badge
+											variant="outline"
+											class="h-4 rounded px-1 text-[0.6rem] font-normal text-muted-foreground"
+										>
+											{nameOf.get(id) ?? labelDisplayName(id)}
+										</Badge>
+									{/each}
+								</span>
+							{/if}
+						</span>
+					</button>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</div>

--- a/apps/local-mail/ui/src/lib/components/StatusBar.svelte
+++ b/apps/local-mail/ui/src/lib/components/StatusBar.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+	import { Button } from '@epicenter/ui/button';
+	import { Spinner } from '@epicenter/ui/spinner';
+	import AlertTriangleIcon from '@lucide/svelte/icons/triangle-alert';
+	import LockIcon from '@lucide/svelte/icons/lock';
+	import RefreshCwIcon from '@lucide/svelte/icons/refresh-cw';
+	import { relativeTime } from '$lib/format';
+	import type { MailboxStatus } from '$lib/types';
+
+	let {
+		status,
+		syncing,
+		syncError,
+		onRefresh,
+	}: {
+		status: MailboxStatus | undefined;
+		syncing: boolean;
+		syncError: string | null;
+		onRefresh: () => void;
+	} = $props();
+
+	const mirror = $derived(status?.mirror ?? 'empty');
+	const mirrorTone = $derived(
+		mirror === 'ready'
+			? 'bg-emerald-500'
+			: mirror === 'building'
+				? 'bg-amber-500'
+				: 'bg-muted-foreground',
+	);
+	const numberFmt = new Intl.NumberFormat();
+</script>
+
+<header
+	class="flex h-12 shrink-0 items-center justify-between gap-4 border-b border-border bg-background px-4"
+>
+	<div class="flex items-center gap-3 min-w-0">
+		<span class="text-sm font-semibold tracking-tight">Local Mail</span>
+		{#if status}
+			<span class="truncate font-mono text-xs text-muted-foreground">
+				{status.accountEmail}
+			</span>
+		{/if}
+	</div>
+
+	<div class="flex items-center gap-3 text-xs text-muted-foreground">
+		{#if status}
+			<span class="flex items-center gap-1.5" title="Mirror state">
+				<span class="size-2 rounded-full {mirrorTone}"></span>
+				<span class="capitalize">{mirror}</span>
+			</span>
+			<span class="tabular-nums">
+				{numberFmt.format(status.rows.messages)} msgs · {status.rows.labels} labels
+			</span>
+			<span class="tabular-nums" title={status.lastSyncedAt ?? 'never synced'}>
+				synced {relativeTime(status.lastSyncedAt)}
+			</span>
+			{#if status.readOnly}
+				<span
+					class="flex items-center gap-1 rounded border border-border px-1.5 py-0.5 font-medium text-amber-500"
+					title="LOCAL_MAIL_READ_ONLY is set: Gmail writes are disabled"
+				>
+					<LockIcon class="size-3" /> read-only
+				</span>
+			{/if}
+		{/if}
+		{#if syncError}
+			<span
+				class="flex items-center gap-1 text-destructive"
+				title={syncError}
+			>
+				<AlertTriangleIcon class="size-3.5" /> sync failed
+			</span>
+		{/if}
+		<Button
+			size="sm"
+			variant="outline"
+			onclick={onRefresh}
+			disabled={syncing}
+			tooltip="Poll Gmail now (POST /api/sync)"
+		>
+			{#if syncing}
+				<Spinner class="size-3.5" />
+			{:else}
+				<RefreshCwIcon class="size-3.5" />
+			{/if}
+			<span>Refresh</span>
+		</Button>
+	</div>
+</header>

--- a/apps/local-mail/ui/src/lib/format.ts
+++ b/apps/local-mail/ui/src/lib/format.ts
@@ -1,0 +1,115 @@
+// Presentation helpers for the triage surface. None of this invents mail state;
+// it only makes Gmail's own bytes (label ids, epoch dates, RFC 5322 senders)
+// scannable for a human.
+
+const FRIENDLY_LABELS: Record<string, string> = {
+	INBOX: 'Inbox',
+	UNREAD: 'Unread',
+	STARRED: 'Starred',
+	IMPORTANT: 'Important',
+	SENT: 'Sent',
+	DRAFT: 'Draft',
+	SPAM: 'Spam',
+	TRASH: 'Trash',
+	CHAT: 'Chat',
+	CATEGORY_PERSONAL: 'Personal',
+	CATEGORY_SOCIAL: 'Social',
+	CATEGORY_PROMOTIONS: 'Promotions',
+	CATEGORY_UPDATES: 'Updates',
+	CATEGORY_FORUMS: 'Forums',
+};
+
+/** Turn a Gmail label id (and its mirrored name) into a human chip label. */
+export function labelDisplayName(id: string, name?: string | null): string {
+	return FRIENDLY_LABELS[id] ?? name ?? id;
+}
+
+/** Labels that are triage machinery or shown another way, not row chips. */
+const HIDDEN_ROW_LABELS = new Set([
+	'UNREAD',
+	'INBOX',
+	'SENT',
+	'DRAFT',
+	'STARRED',
+]);
+
+export function chipLabelIds(labelIds: string[]): string[] {
+	return labelIds.filter((id) => !HIDDEN_ROW_LABELS.has(id));
+}
+
+/** Strip the address, keep the display name: "Jane Doe <j@x.com>" -> "Jane Doe". */
+export function senderName(sender: string | null): string {
+	if (!sender) return '(unknown sender)';
+	const match = sender.match(/^\s*"?([^"<]+?)"?\s*<[^>]+>\s*$/);
+	if (match) return match[1] as string;
+	return sender.replace(/[<>]/g, '').trim() || sender;
+}
+
+const ENTITIES: Record<string, string> = {
+	'&amp;': '&',
+	'&lt;': '<',
+	'&gt;': '>',
+	'&quot;': '"',
+	'&#39;': "'",
+	'&nbsp;': ' ',
+};
+
+/** Gmail snippets arrive with HTML entities; decode the common ones for display. */
+export function decodeSnippet(snippet: string | null): string {
+	if (!snippet) return '';
+	return snippet
+		.replace(/&(amp|lt|gt|quot|#39|nbsp);/g, (m) => ENTITIES[m] ?? m)
+		.replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)))
+		.replace(/[‌ ]/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+/** Compact list timestamp: time-of-day today, month/day this year, else short date. */
+export function shortDate(epochMs: number | null): string {
+	if (!epochMs) return '';
+	const date = new Date(epochMs);
+	const now = new Date();
+	const sameDay = date.toDateString() === now.toDateString();
+	if (sameDay) {
+		return new Intl.DateTimeFormat(undefined, {
+			hour: 'numeric',
+			minute: '2-digit',
+		}).format(date);
+	}
+	if (date.getFullYear() === now.getFullYear()) {
+		return new Intl.DateTimeFormat(undefined, {
+			month: 'short',
+			day: 'numeric',
+		}).format(date);
+	}
+	return new Intl.DateTimeFormat(undefined, {
+		year: '2-digit',
+		month: 'numeric',
+		day: 'numeric',
+	}).format(date);
+}
+
+/** Full timestamp for the detail header. */
+export function fullDate(epochMs: number | null, fallback: string | null): string {
+	if (!epochMs) return fallback ?? '';
+	return new Intl.DateTimeFormat(undefined, {
+		dateStyle: 'medium',
+		timeStyle: 'short',
+	}).format(new Date(epochMs));
+}
+
+/** "2m ago" style relative time for the sync status. */
+export function relativeTime(iso: string | null): string {
+	if (!iso) return 'never';
+	const then = new Date(iso).getTime();
+	if (Number.isNaN(then)) return 'never';
+	const seconds = Math.round((Date.now() - then) / 1000);
+	if (seconds < 10) return 'just now';
+	if (seconds < 60) return `${seconds}s ago`;
+	const minutes = Math.round(seconds / 60);
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.round(minutes / 60);
+	if (hours < 24) return `${hours}h ago`;
+	return `${Math.round(hours / 24)}d ago`;
+}

--- a/apps/local-mail/ui/src/lib/format.ts
+++ b/apps/local-mail/ui/src/lib/format.ts
@@ -91,7 +91,10 @@ export function shortDate(epochMs: number | null): string {
 }
 
 /** Full timestamp for the detail header. */
-export function fullDate(epochMs: number | null, fallback: string | null): string {
+export function fullDate(
+	epochMs: number | null,
+	fallback: string | null,
+): string {
 	if (!epochMs) return fallback ?? '';
 	return new Intl.DateTimeFormat(undefined, {
 		dateStyle: 'medium',

--- a/apps/local-mail/ui/src/lib/types.ts
+++ b/apps/local-mail/ui/src/lib/types.ts
@@ -1,0 +1,65 @@
+// The `/api` wire shapes, mirrored from `apps/local-mail/src` (db.ts read models
+// and modify.ts). Kept as a small hand-copy rather than a cross-package import
+// so the SPA builds standalone; the contract is stable (Phase 3 froze
+// `ModifyMessageLabelsOutcome`, up-shell spec froze the routes).
+
+export type MailboxStatus = {
+	accountEmail: string;
+	connected: boolean;
+	mirror: 'empty' | 'building' | 'ready';
+	historyId: string | null;
+	lastSyncedAt: string | null;
+	lastFullPullAt: string | null;
+	rows: { messages: number; labels: number };
+	readOnly: boolean;
+};
+
+export type MailLabel = {
+	id: string;
+	name: string | null;
+	type: string | null;
+};
+
+export type MessageSummary = {
+	id: string;
+	threadId: string | null;
+	subject: string | null;
+	sender: string | null;
+	snippet: string | null;
+	internalDate: number | null;
+	labelIds: string[];
+};
+
+export type MessageDetail = MessageSummary & {
+	to: string | null;
+	date: string | null;
+	bodyText: string | null;
+};
+
+/** Per-id result of one `messages.modify`. `folded: false` means Gmail accepted
+ * the change but the mirror row was not patched from the response, so it catches
+ * up on the next sync. */
+export type ModifyMessageLabelsResult = {
+	id: string;
+	labelIds: string[] | null;
+	folded: boolean;
+	error: { name: string; message: string } | null;
+};
+
+/** The one contract shared by CLI, MCP, and this HTTP route. A systemic abort
+ * (token, throttle, network) sets `aborted` and stops the remaining ids. */
+export type ModifyMessageLabelsOutcome = {
+	results: ModifyMessageLabelsResult[];
+	aborted: { name: string; message: string } | null;
+};
+
+export type SyncOutcome = {
+	mode: 'FULL' | 'INCREMENTAL';
+	reason: string;
+	cursorBefore: string | null;
+	cursorAfter: string | null;
+	messagesUpserted: number;
+	messagesDeleted: number;
+	labelsPatched: number;
+	failure: { name: string; message: string } | null;
+};

--- a/apps/local-mail/ui/src/routes/+layout.svelte
+++ b/apps/local-mail/ui/src/routes/+layout.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import { Toaster } from '@epicenter/ui/sonner';
+	import * as Tooltip from '@epicenter/ui/tooltip';
+	import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
+	import { ModeWatcher } from 'mode-watcher';
+	import '../app.css';
+
+	let { children } = $props();
+
+	// The mirror is a local SQLite read: refetch is cheap and staleness matters
+	// (a background sync pass or a label fold changes rows), so keep staleTime
+	// short and refetch on focus.
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: { staleTime: 5_000, retry: 1 },
+		},
+	});
+</script>
+
+<svelte:head><title>Local Mail</title></svelte:head>
+
+<QueryClientProvider client={queryClient}>
+	<Tooltip.Provider delayDuration={300}>
+		<div class="h-dvh bg-background text-foreground">
+			{@render children()}
+		</div>
+	</Tooltip.Provider>
+</QueryClientProvider>
+
+<Toaster offset={16} closeButton />
+<ModeWatcher defaultMode="dark" track={false} />

--- a/apps/local-mail/ui/src/routes/+layout.ts
+++ b/apps/local-mail/ui/src/routes/+layout.ts
@@ -1,0 +1,5 @@
+// The triage UI is a client-only SPA served from disk by `local-mail up`
+// (adapter-static + fallback). No SSR, no prerender: the browser owns routing
+// and every byte of state comes from `/api` behind the per-launch bearer.
+export const ssr = false;
+export const prerender = false;

--- a/apps/local-mail/ui/src/routes/+page.svelte
+++ b/apps/local-mail/ui/src/routes/+page.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+	import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query';
+	import { toast } from 'svelte-sonner';
+	import LabelRail from '$lib/components/LabelRail.svelte';
+	import MessageDetail from '$lib/components/MessageDetail.svelte';
+	import MessageList from '$lib/components/MessageList.svelte';
+	import StatusBar from '$lib/components/StatusBar.svelte';
+	import { api } from '$lib/api';
+
+	// Default to the inbox: this is a triage surface, and the inbox is the queue.
+	let selectedLabel = $state<string | null>('INBOX');
+	let search = $state('');
+	let selectedId = $state<string | null>(null);
+
+	const queryClient = useQueryClient();
+	const status = createQuery(() => ({
+		queryKey: ['status'],
+		queryFn: () => api.status(),
+	}));
+	const labels = createQuery(() => ({
+		queryKey: ['labels'],
+		queryFn: () => api.labels(),
+	}));
+	const messages = createQuery(() => {
+		const query = {
+			label: selectedLabel ?? undefined,
+			search: search.trim() || undefined,
+			limit: 100,
+		};
+		return { queryKey: ['messages', query], queryFn: () => api.messages(query) };
+	});
+
+	const sync = createMutation(() => ({
+		mutationFn: () => api.sync(),
+		onSuccess: (outcome) => {
+			if (outcome.failure) {
+				toast.error(`Sync failed: ${outcome.failure.message}`);
+			} else {
+				toast.success(
+					`Synced: ${outcome.messagesUpserted} upserted, ${outcome.messagesDeleted} deleted, ${outcome.labelsPatched} labels patched`,
+				);
+			}
+			queryClient.invalidateQueries({ queryKey: ['messages'] });
+			queryClient.invalidateQueries({ queryKey: ['status'] });
+			queryClient.invalidateQueries({ queryKey: ['labels'] });
+		},
+		onError: (error: Error) => toast.error(error.message),
+	}));
+
+	const labelList = $derived(labels.data?.labels ?? []);
+	const messageList = $derived(messages.data?.messages ?? []);
+	const isFiltered = $derived(search.trim().length > 0 || selectedLabel !== null);
+	const syncError = $derived(
+		sync.error?.message ?? sync.data?.failure?.message ?? null,
+	);
+
+	// Keep the selection valid: default to the first row, and re-resolve when a
+	// filter change drops the current selection out of the list.
+	$effect(() => {
+		if (messageList.length === 0) {
+			selectedId = null;
+			return;
+		}
+		if (!selectedId || !messageList.some((m) => m.id === selectedId)) {
+			selectedId = messageList[0]?.id ?? null;
+		}
+	});
+</script>
+
+<div class="flex h-full flex-col">
+	<StatusBar
+		status={status.data}
+		syncing={sync.isPending}
+		{syncError}
+		onRefresh={() => sync.mutate()}
+	/>
+
+	<div class="flex min-h-0 flex-1">
+		<LabelRail
+			labels={labelList}
+			{selectedLabel}
+			{search}
+			onSelect={(id) => (selectedLabel = id)}
+			onSearch={(value) => (search = value)}
+		/>
+
+		<MessageList
+			messages={messageList}
+			labels={labelList}
+			{selectedId}
+			loading={messages.isPending}
+			error={messages.error?.message ?? null}
+			{isFiltered}
+			onSelect={(id) => (selectedId = id)}
+		/>
+
+		{#key selectedId}
+			<MessageDetail
+				id={selectedId}
+				readOnly={status.data?.readOnly ?? false}
+				labels={labelList}
+			/>
+		{/key}
+	</div>
+</div>

--- a/apps/local-mail/ui/svelte.config.js
+++ b/apps/local-mail/ui/svelte.config.js
@@ -1,0 +1,19 @@
+import staticAdapter from '@sveltejs/adapter-static';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	kit: {
+		// The SPA is served at the loopback origin root by `local-mail up`, which
+		// reads bytes from `ui/dist`. `fallback` makes every deep link resolve to
+		// the same shell (client-only routing).
+		adapter: staticAdapter({
+			pages: 'dist',
+			assets: 'dist',
+			fallback: 'index.html',
+		}),
+	},
+	preprocess: vitePreprocess(),
+};
+
+export default config;

--- a/apps/local-mail/ui/tsconfig.json
+++ b/apps/local-mail/ui/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": ["../../../tsconfig.base.json", "./.svelte-kit/tsconfig.json"],
+	"compilerOptions": {
+		"checkJs": true,
+		"types": ["bun"]
+	}
+}

--- a/apps/local-mail/ui/vite.config.ts
+++ b/apps/local-mail/ui/vite.config.ts
@@ -1,0 +1,42 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+import tailwindcss from '@tailwindcss/vite';
+import { defineConfig } from 'vite';
+
+// The SPA is same-origin with the API. In production `local-mail up` serves
+// both the built SPA and `/api` from one loopback origin. In dev, Vite serves
+// the SPA and proxies `/api` to the running `up` process; the proxy injects the
+// dev bearer (`LOCAL_MAIL_TOKEN`) server-side and rewrites Host via
+// `changeOrigin`, so the up server's Host check and bearer check both pass
+// without any credential ever reaching the browser (up-shell spec, Dev mode).
+const SPA_DEV_PORT = 5177;
+
+export default defineConfig(({ command }) => {
+	const UP_PORT = Number(process.env.LOCAL_MAIL_PORT) || 4177;
+	// The proxy must send the exact bearer `up` accepts. No default: a silent
+	// fallback that disagrees with `up` is the "Unauthorized" footgun. Both
+	// processes read the same LOCAL_MAIL_TOKEN, so require it for the dev server.
+	const DEV_TOKEN = process.env.LOCAL_MAIL_TOKEN;
+	if (command === 'serve' && !DEV_TOKEN) {
+		throw new Error(
+			'LOCAL_MAIL_TOKEN is required for the dev server so its /api proxy sends the same bearer as `local-mail up`. Start both with the same token, e.g. LOCAL_MAIL_TOKEN=devtoken.',
+		);
+	}
+	return {
+		plugins: [sveltekit(), tailwindcss()],
+		server: {
+			port: SPA_DEV_PORT,
+			strictPort: true,
+			proxy: {
+				'/api': {
+					target: `http://127.0.0.1:${UP_PORT}`,
+					changeOrigin: true,
+					configure: (proxy) => {
+						proxy.on('proxyReq', (proxyReq) => {
+							proxyReq.setHeader('authorization', `Bearer ${DEV_TOKEN}`);
+						});
+					},
+				},
+			},
+		},
+	};
+});

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",
@@ -185,6 +184,29 @@
       "devDependencies": {
         "@types/bun": "catalog:",
         "typescript": "catalog:",
+      },
+    },
+    "apps/local-mail/ui": {
+      "name": "@epicenter/local-mail-ui",
+      "version": "0.0.1",
+      "dependencies": {
+        "@tanstack/svelte-query": "catalog:",
+      },
+      "devDependencies": {
+        "@epicenter/ui": "workspace:*",
+        "@lucide/svelte": "catalog:",
+        "@sveltejs/adapter-static": "catalog:",
+        "@sveltejs/kit": "catalog:",
+        "@sveltejs/vite-plugin-svelte": "catalog:",
+        "@tailwindcss/vite": "catalog:",
+        "@types/bun": "catalog:",
+        "mode-watcher": "catalog:",
+        "svelte": "catalog:",
+        "svelte-check": "catalog:",
+        "svelte-sonner": "catalog:",
+        "tailwindcss": "catalog:",
+        "typescript": "catalog:",
+        "vite": "catalog:",
       },
     },
     "apps/matter": {
@@ -1369,6 +1391,8 @@
     "@epicenter/local-books": ["@epicenter/local-books@workspace:apps/local-books"],
 
     "@epicenter/local-mail": ["@epicenter/local-mail@workspace:apps/local-mail"],
+
+    "@epicenter/local-mail-ui": ["@epicenter/local-mail-ui@workspace:apps/local-mail/ui"],
 
     "@epicenter/matter": ["@epicenter/matter@workspace:apps/matter"],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"packages": [
 			"apps/*",
 			"apps/api/ui",
+			"apps/local-mail/ui",
 			"packages/*",
 			"examples/*"
 		],


### PR DESCRIPTION
`local-mail` has been headless: a CLI and a stdio MCP server over a private
Gmail mirror. This adds the first human surface without standing up a hosted
service. One Bun process, `local-mail up`, keeps the mirror fresh and serves a
triage SPA plus a same-origin `/api` on `127.0.0.1`:

```sh
local-mail up
# prints http://127.0.0.1:<port>/#token=... and opens the tab
```

The tab is the app: a label rail, a message list, and a detail pane. Triage
actions (archive, mark read, star, add or remove a label) all desugar
client-side to one write route, `POST /api/messages/modify { ids, addLabels,
removeLabels }`, which runs the same write-through core the CLI verbs and the
MCP tool already use. There are no per-intent routes and no thread modify, batch
modify, send, compose, or trash.

Security is loopback-local by construction. A single-use bootstrap token rides
in the URL fragment (never the query string, so it never reaches a request line
or an access log) and is exchanged once at `POST /api/session` for a per-launch
bearer kept in `sessionStorage`. Every request is Host-checked first as a
DNS-rebinding kill switch. `LOCAL_MAIL_READ_ONLY=1` refuses writes end to end,
and the UI disables every mutating control when it is set.

Body rendering is plain text: the detail pane shows the pre-extracted
`text/plain` body, so no HTML sanitizer, sandboxed frame, or image proxy is part
of this change.

For UI development, `up` runs the API and Vite serves the SPA, proxying `/api`
and injecting a shared dev bearer. Both processes read the same
`LOCAL_MAIL_TOKEN`, which is required rather than silently defaulted so the two
can never disagree:

```sh
LOCAL_MAIL_DEV=1 LOCAL_MAIL_TOKEN=devtoken LOCAL_MAIL_PORT=4177 local-mail up
LOCAL_MAIL_TOKEN=devtoken bun run --cwd ui dev
```

## Changelog

- `local-mail up` serves a local Gmail triage UI: browse, search, and label
  messages from a loopback web app backed by the local mirror. Writes go through
  Gmail; `LOCAL_MAIL_READ_ONLY=1` makes it read-only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785660245&installation_id=128463665&pr_number=2308&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2308&signature=32f38146c4096ed66df1bcb4fc25d44e36cf240317181443294de907ac413c2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->