### PR TITLE
fix(local-mail): correct empty-mirror empty-state and collapse triage UI feedback

### DIFF
--- a/apps/local-mail/src/up.ts
+++ b/apps/local-mail/src/up.ts
@@ -158,13 +158,11 @@ export async function runUp(): Promise<number> {
 		return 1;
 	}
 
-	// Re-bind the non-null values: TS drops the post-guard narrowing of the
-	// destructured `runtime`/`session` bindings inside the fetch/loop/SIGINT
-	// closures below, so capture them here where the narrowing holds.
-	const rt = runtime;
-	const sess = session;
-	const { db } = sess.deps;
-	const readOnly = rt.config.readOnly;
+	// `runtime`/`session` are `const`, so their post-guard non-null narrowing
+	// flows into the closures below (`handleApi` is an arrow, not a hoisted
+	// declaration, so it inherits the narrowing rather than the widened type).
+	const { db } = session.deps;
+	const readOnly = runtime.config.readOnly;
 
 	// The valid-bearer set. Dev pre-seeds the fixed proxy token; prod fills it
 	// only through the bootstrap exchange.
@@ -174,7 +172,7 @@ export async function runUp(): Promise<number> {
 		const devToken = process.env.LOCAL_MAIL_TOKEN;
 		if (!devToken) {
 			lock.release();
-			sess.close();
+			session.close();
 			console.error(
 				'LOCAL_MAIL_DEV=1 requires LOCAL_MAIL_TOKEN so the Vite proxy can authenticate.',
 			);
@@ -196,7 +194,7 @@ export async function runUp(): Promise<number> {
 		return header.slice('Bearer '.length);
 	}
 
-	async function handleApi(req: Request, url: URL): Promise<Response> {
+	const handleApi = async (req: Request, url: URL): Promise<Response> => {
 		const { pathname } = url;
 
 		// The one unauthenticated mutation: exchange the bootstrap for a bearer.
@@ -226,7 +224,7 @@ export async function runUp(): Promise<number> {
 		}
 
 		if (pathname === '/api/status' && req.method === 'GET') {
-			const status = await readMailStatus(rt);
+			const status = await readMailStatus(runtime);
 			return json({
 				accountEmail: status.accountEmail,
 				connected: status.connected,
@@ -264,7 +262,7 @@ export async function runUp(): Promise<number> {
 
 		if (pathname === '/api/sync' && req.method === 'POST') {
 			const outcome = await gate(() =>
-				syncMailbox(sess.deps, { forceFull: false }),
+				syncMailbox(session.deps, { forceFull: false }),
 			);
 			return json(outcome);
 		}
@@ -282,7 +280,7 @@ export async function runUp(): Promise<number> {
 				);
 			}
 			const { data, error } = await resolveAndModifyMessageLabels({
-				deps: sess.deps,
+				deps: session.deps,
 				ids: body.ids,
 				addLabels: body.addLabels ?? [],
 				removeLabels: body.removeLabels ?? [],
@@ -293,7 +291,7 @@ export async function runUp(): Promise<number> {
 		}
 
 		return json({ error: 'Not found.' }, 404);
-	}
+	};
 
 	const server = Bun.serve({
 		hostname: '127.0.0.1',
@@ -317,7 +315,7 @@ export async function runUp(): Promise<number> {
 	// The background sync loop, serialized through the same gate as POST /api/sync.
 	(async () => {
 		while (!controller.signal.aborted) {
-			await gate(() => syncMailbox(sess.deps, { forceFull: false })).catch(
+			await gate(() => syncMailbox(session.deps, { forceFull: false })).catch(
 				(cause) => console.error(`[sync] loop pass failed: ${cause}`),
 			);
 			if (controller.signal.aborted) break;
@@ -348,7 +346,7 @@ export async function runUp(): Promise<number> {
 		process.on('SIGINT', () => {
 			controller.abort();
 			server.stop();
-			sess.close();
+			session.close();
 			lock.release();
 			resolve();
 		});

--- a/apps/local-mail/ui/src/lib/components/MessageDetail.svelte
+++ b/apps/local-mail/ui/src/lib/components/MessageDetail.svelte
@@ -18,7 +18,7 @@
 	import { toast } from 'svelte-sonner';
 	import { api } from '$lib/api';
 	import { fullDate, labelDisplayName } from '$lib/format';
-	import type { MailLabel, ModifyMessageLabelsOutcome } from '$lib/types';
+	import type { MailLabel } from '$lib/types';
 
 	let {
 		id,
@@ -38,13 +38,11 @@
 	}));
 
 	let lastVerb = $state<string | null>(null);
-	let lastOutcome = $state<ModifyMessageLabelsOutcome | null>(null);
 
 	const modify = createMutation(() => ({
 		mutationFn: (input: { addLabels?: string[]; removeLabels?: string[] }) =>
 			api.modify({ ids: id ? [id] : [], ...input }),
 		onSuccess: (outcome) => {
-			lastOutcome = outcome;
 			const failed = outcome.results.filter((r) => r.error).length;
 			const ok = outcome.results.length - failed;
 			if (outcome.aborted) {
@@ -92,13 +90,6 @@
 		if (present) run(`Removed ${name}`, { removeLabels: [labelId] });
 		else run(`Added ${name}`, { addLabels: [labelId] });
 	}
-
-	// Reset the inline outcome strip when a different message opens.
-	$effect(() => {
-		id;
-		lastOutcome = null;
-		lastVerb = null;
-	});
 </script>
 
 {#snippet actionButton(
@@ -235,19 +226,19 @@
 		</div>
 
 		<!-- Last-action outcome strip -->
-		{#if lastOutcome}
-			{@const result = lastOutcome.results[0]}
+		{#if modify.data}
+			{@const result = modify.data.results[0]}
 			<div
 				class="flex shrink-0 items-center gap-2 border-b px-5 py-1.5 text-xs
-				{lastOutcome.aborted || result?.error
+				{modify.data.aborted || result?.error
 					? 'border-destructive/30 bg-destructive/10 text-destructive'
 					: result && !result.folded
 						? 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400'
 						: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'}"
 			>
-				{#if lastOutcome.aborted}
+				{#if modify.data.aborted}
 					<TriangleAlertIcon class="size-3.5" />
-					<span>Aborted: {lastOutcome.aborted.message}</span>
+					<span>Aborted: {modify.data.aborted.message}</span>
 				{:else if result?.error}
 					<TriangleAlertIcon class="size-3.5" />
 					<span>{lastVerb} failed: {result.error.message}</span>

--- a/apps/local-mail/ui/src/lib/components/MessageDetail.svelte
+++ b/apps/local-mail/ui/src/lib/components/MessageDetail.svelte
@@ -4,10 +4,8 @@
 	import * as DropdownMenu from '@epicenter/ui/dropdown-menu';
 	import * as Empty from '@epicenter/ui/empty';
 	import { Loading } from '@epicenter/ui/loading';
-	import { Separator } from '@epicenter/ui/separator';
 	import ArchiveIcon from '@lucide/svelte/icons/archive';
 	import ArchiveRestoreIcon from '@lucide/svelte/icons/archive-restore';
-	import CheckIcon from '@lucide/svelte/icons/check';
 	import MailOpenIcon from '@lucide/svelte/icons/mail-open';
 	import MailIcon from '@lucide/svelte/icons/mail';
 	import MousePointerClickIcon from '@lucide/svelte/icons/mouse-pointer-click';
@@ -224,33 +222,6 @@
 				</DropdownMenu.Content>
 			</DropdownMenu.Root>
 		</div>
-
-		<!-- Last-action outcome strip -->
-		{#if modify.data}
-			{@const result = modify.data.results[0]}
-			<div
-				class="flex shrink-0 items-center gap-2 border-b px-5 py-1.5 text-xs
-				{modify.data.aborted || result?.error
-					? 'border-destructive/30 bg-destructive/10 text-destructive'
-					: result && !result.folded
-						? 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400'
-						: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'}"
-			>
-				{#if modify.data.aborted}
-					<TriangleAlertIcon class="size-3.5" />
-					<span>Aborted: {modify.data.aborted.message}</span>
-				{:else if result?.error}
-					<TriangleAlertIcon class="size-3.5" />
-					<span>{lastVerb} failed: {result.error.message}</span>
-				{:else if result && !result.folded}
-					<CheckIcon class="size-3.5" />
-					<span>{lastVerb}. Gmail accepted it; the mirror catches up on the next sync (folded: false).</span>
-				{:else}
-					<CheckIcon class="size-3.5" />
-					<span>{lastVerb}. Mirror updated from Gmail's response.</span>
-				{/if}
-			</div>
-		{/if}
 
 		<!-- Body: the pre-extracted plain text; raw HTML is never rendered. -->
 		<div class="flex-1 min-h-0 overflow-y-auto px-5 py-4">

--- a/apps/local-mail/ui/src/lib/components/MessageList.svelte
+++ b/apps/local-mail/ui/src/lib/components/MessageList.svelte
@@ -22,7 +22,7 @@
 		selectedId,
 		loading,
 		error,
-		isFiltered,
+		mirrorEmpty,
 		onSelect,
 	}: {
 		messages: MessageSummary[];
@@ -30,7 +30,7 @@
 		selectedId: string | null;
 		loading: boolean;
 		error: string | null;
-		isFiltered: boolean;
+		mirrorEmpty: boolean;
 		onSelect: (id: string) => void;
 	} = $props();
 
@@ -63,19 +63,19 @@
 	{:else if messages.length === 0}
 		<Empty.Root class="flex-1 border-0">
 			<Empty.Media variant="icon">
-				{#if isFiltered}
-					<SearchXIcon class="size-5" />
-				{:else}
+				{#if mirrorEmpty}
 					<InboxIcon class="size-5" />
+				{:else}
+					<SearchXIcon class="size-5" />
 				{/if}
 			</Empty.Media>
 			<Empty.Title>
-				{isFiltered ? 'No messages match' : 'No messages mirrored'}
+				{mirrorEmpty ? 'No messages mirrored' : 'No messages match'}
 			</Empty.Title>
 			<Empty.Description>
-				{isFiltered
-					? 'Try a different label or search term.'
-					: 'Run local-mail sync --full to populate the mirror.'}
+				{mirrorEmpty
+					? 'Run local-mail sync --full to populate the mirror.'
+					: 'Try a different label or search term.'}
 			</Empty.Description>
 		</Empty.Root>
 	{:else}

--- a/apps/local-mail/ui/src/routes/+page.svelte
+++ b/apps/local-mail/ui/src/routes/+page.svelte
@@ -49,7 +49,10 @@
 
 	const labelList = $derived(labels.data?.labels ?? []);
 	const messageList = $derived(messages.data?.messages ?? []);
-	const isFiltered = $derived(search.trim().length > 0 || selectedLabel !== null);
+	// True when the mirror holds no messages at all (nothing synced yet), as
+	// opposed to this label/search view simply matching none. Drives which empty
+	// state the list shows: "run sync" vs "no match".
+	const mirrorEmpty = $derived((status.data?.rows.messages ?? 0) === 0);
 	const syncError = $derived(
 		sync.error?.message ?? sync.data?.failure?.message ?? null,
 	);
@@ -90,7 +93,7 @@
 			{selectedId}
 			loading={messages.isPending}
 			error={messages.error?.message ?? null}
-			{isFiltered}
+			{mirrorEmpty}
 			onSelect={(id) => (selectedId = id)}
 		/>
 


### PR DESCRIPTION
The triage list showed the wrong empty state on a freshly-synced mailbox. `isFiltered` was derived from `selectedLabel !== null`, but the list defaults to `INBOX`, so it was almost always true: an empty mirror rendered "No messages match / try a different label" instead of "No messages mirrored / run `sync --full`". The list now keys its empty state off the real signal, `status.rows.messages === 0`, with the icon and copy following it.

The rest is an indirection pass over the same surface. The MessageDetail outcome strip was a persistent second home for feedback the toast already carries, and since a fold usually succeeds its common state just echoed the visibly-updated label chips: the append-log surface ADR-0029 (Whispering's dictation-feedback projection) declined to build. It is removed in favor of letting the effect be the receipt (the row leaves the list, the chips update), with the transient toast kept for what the effect does not show. `up.ts`'s `handleApi` became a `const` arrow so it inherits the post-guard non-null narrowing directly, dropping an `rt`/`sess` re-bind and its inaccurate comment. And a dead reset `$effect` (the pane already remounts via `{#key selectedId}`) plus a `lastOutcome` state mirror are gone.

## Changelog
- Fixed: a freshly-synced Local Mail mailbox with an empty inbox now shows "No messages mirrored / run sync" instead of the "no match" message.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785693358&installation_id=128463665&pr_number=2311&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2311&signature=92a2aeeafbb520cca0e77372f6f124a809a06caf3b675ec32003e79ac04e4c29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->