### PR TITLE
feat(inference-picker): refresh discovered custom models

### DIFF
--- a/docs/adr/0104-hosted-models-are-a-build-time-seed-not-discovered-the-runtime-overlay-is-deferred.md
+++ b/docs/adr/0104-hosted-models-are-a-build-time-seed-not-discovered-the-runtime-overlay-is-deferred.md
@@ -1,0 +1,34 @@
+# 0104. Hosted models are a build-time seed catalog, not a discovered one; a runtime overlay is a named deferral
+
+- **Status:** Accepted
+- **Date:** 2026-07-03
+- **Relates:** [ADR-0060](0060-an-inference-connection-is-a-base-url-and-an-optional-bearer-key.md) (custom connections discover their models via `/v1/models`; this decides why hosted does not), [ADR-0050](0050-the-inference-contract-is-openai-compatible.md) (the OpenAI-compatible wire and the free-string model id the gateway routes), [ADR-0054](0054-an-inference-backend-is-the-metered-gateway-or-a-custom-server.md) (the metered gateway hosted points at), [ADR-0100](0100-ai-credits-are-product-units-and-the-charge-shape-follows-when-cost-is-known.md) (the credit price a hosted catalog entry carries)
+
+## Context
+
+[ADR-0060](0060-an-inference-connection-is-a-base-url-and-an-optional-bearer-key.md) made custom OpenAI-compatible endpoints discover their models at runtime through `GET /v1/models`, and left hosted models as a curated catalog (`packages/constants/src/ai-providers.ts`) injected per app. A live pass asked the symmetric question: should the hosted gateway also expose `/v1/models` so hosted models are discovered the same way, dropping the hard-coded catalog? The pull is real because the model landscape moves fast and a bundled catalog means shipping every client to sell a new model. The decision matters because it governs where the hosted catalog lives and whether product metadata (label, credits, per-app default) survives.
+
+## Decision
+
+**Hosted models stay a build-time seed catalog, authored and owned by us. Discovery through `/v1/models` is for connections we do not own; hosted is not discovered. A runtime catalog overlay is a named, trigger-gated extension, not built until catalog-change velocity outpaces client-ship cadence.**
+
+- **Discovery is for facts you do not own.** A custom endpoint is someone else's box, so its model list is genuinely unknown until runtime and must be discovered. The hosted catalog is authored by us; fetching it back from our own gateway is re-learning what we shipped. The two lanes look symmetric but are not: a custom model is a bare id (all `/v1/models` carries), while a hosted model is a *product* (label like "Fast"/"Best", a credit price shown before the call, an app default). `/v1/models` cannot carry the product half, so routing hosted through it either loses the metadata or smuggles non-standard fields through a standard-shaped hole.
+- **The single source is the typed catalog, not a raw JSON file.** `AI_MODELS` stays a typed `as const` literal so `ServableModel`, `SERVABLE_MODELS`, and the arktype enumeration keep their compile-time narrowing. A `.json` import would widen ids to `string`. When a served artifact is needed, it is that typed catalog *projected* to JSON at a URL, never a hand-edited file that drifts from the types.
+- **The catalog is layered as seed / overlay / enrichment.** Layer zero is the bundled seed (`AI_MODELS`, offline, typed, present at first paint). A future runtime *overlay* spreads more entries on top (fetch fails, seed stands, so the picker is never empty). A separate optional *enrichment* layer (models.dev-shaped upstream facts: context window, tool support, modality) decorates both hosted and custom ids for display and never carries our prices.
+- **The commercial catalog is a distinct, owned layer from any community catalog.** What we sell and what we charge is a business fact we author; upstream model facts are a community fact we may consume. They never merge into one source. (OpenCode is the same shape: it reads community metadata from models.dev but keeps its own hosted product's pricing on a separate endpoint.)
+- **The runtime overlay is deferred with a named trigger.** Build it when the hosted catalog changes faster than clients ship. Because `AI_MODELS` is already the seed, the overlay grafts on later with zero rework: add a producer (a gateway catalog route or a served projection) and a merge, validated by one schema. Until then no overlay code exists.
+
+## Consequences
+
+- **A future reader has a settled answer to "why not discover hosted too?"** without re-running the pass. The hosted gateway does not need `GET /v1/models`, reaffirming [ADR-0060](0060-an-inference-connection-is-a-base-url-and-an-optional-bearer-key.md).
+- **Adding a hosted model still ships a client today.** Accepted while the catalog is small and rarely changed; the overlay is the escape hatch when that cost bites, not a thing carried empty now.
+- **Two guards are pre-decided for the overlay so it cannot be built carelessly.** The overlay wins on *presence* (new ids appear) but must not silently rewrite *price*: either the seed wins on credits or the served payload is signed, so a bad deploy cannot re-bill a user mid-session. And the gateway serves a public projection (a DTO), never the internal catalog.
+- **The type cost of the eventual overlay is already priced.** [ADR-0050](0050-the-inference-contract-is-openai-compatible.md) already made the model id a free string the gateway routes (an unservable id is a runtime error, not a compile error), so overlay-added ids being unbounded strings is consistent, not a regression. The seed keeps its literal union.
+- **Nothing in the client changes.** Custom `/v1/models` discovery, the injected hosted transport, and the custom-before-hosted collision tie-break all stand as [ADR-0060](0060-an-inference-connection-is-a-base-url-and-an-optional-bearer-key.md) left them.
+
+## Considered alternatives
+
+- **Expose hosted over the gateway's `/v1/models` and drop the catalog.** Rejected: `/v1/models` carries no label, credit price, or app default, so it deletes the reason the hosted lane exists; and it re-couples the catalog to a boot fetch with an offline failure mode for a fact we already own.
+- **Make the seed a raw `.json` file (importable and servable as one artifact).** Rejected as the *source*: JSON imports widen ids to `string` and lose the literal union without a codegen step not worth its weight at this catalog size. The typed const projected to JSON is the same artifact without the type loss.
+- **Build the runtime overlay now.** Rejected: no producer exists, so a `mergeCatalog`/schema seam would be structure implying a completeness the product lacks. Deferred with a named trigger, non-breaking to add.
+- **Fold the commercial catalog into a community catalog (models.dev-style).** Rejected: our prices and product labels are a business decision, not a community-editable fact; they stay in an owned layer.

--- a/docs/adr/0104-hosted-models-are-a-build-time-seed-not-discovered-the-runtime-overlay-is-deferred.md
+++ b/docs/adr/0104-hosted-models-are-a-build-time-seed-not-discovered-the-runtime-overlay-is-deferred.md
@@ -26,6 +26,15 @@
 - **The type cost of the eventual overlay is already priced.** [ADR-0050](0050-the-inference-contract-is-openai-compatible.md) already made the model id a free string the gateway routes (an unservable id is a runtime error, not a compile error), so overlay-added ids being unbounded strings is consistent, not a regression. The seed keeps its literal union.
 - **Nothing in the client changes.** Custom `/v1/models` discovery, the injected hosted transport, and the custom-before-hosted collision tie-break all stand as [ADR-0060](0060-an-inference-connection-is-a-base-url-and-an-optional-bearer-key.md) left them.
 
+### Refinement (2026-07-03): the overlay read should be query-backed
+
+When the overlay is built, prefer a TanStack Query read over a hand-rolled localStorage cache:
+
+- The hosted query uses `AI_MODELS` as `initialData`. Failed or malformed fetches leave the seed visible, so the group never empties. Cross-session persistence is unnecessary unless the seed-to-overlay blink becomes a real UX problem.
+- The fetched catalog still goes through the overlay guard above: runtime can add ids, but price changes need an explicit server-authority decision (for example, a signed payload or a server-owned app catalog). Do not smuggle that decision into a client cache.
+- The custom lane can use the same query shape later, keyed by each connection's base URL, with `queryFn` = `/v1/models` discovery and `initialData` = the connection's last-discovered ids. That would retire manual refresh state once a query producer exists; until then, the current manual refresh is the smaller fix for stale custom models.
+- **Still open at trigger time:** whether the server owns the per-app catalog subset (a registry) or apps keep client-side curation. A global catalog can replace the seed after validation; per-app subsets need the server to know the app-to-models mapping or the client to keep filtering.
+
 ## Considered alternatives
 
 - **Expose hosted over the gateway's `/v1/models` and drop the catalog.** Rejected: `/v1/models` carries no label, credit price, or app default, so it deletes the reason the hosted lane exists; and it re-couples the catalog to a boot fetch with an offline failure mode for a fact we already own.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -171,5 +171,6 @@ Each option and the one reason it lost. Terse. This is not the spec.
 | [0101](0101-native-typed-row-projection-views-are-earned-serially-board-is-first.md) | Native typed-row projection views are earned serially; board is first | Accepted |
 | [0102](0102-vocab-stores-verbatim-terms-under-a-human-owned-note-and-refuses-glosses-srs-and-provenance.md) | Vocab stores verbatim terms under a human-owned note and refuses glosses, SRS, and provenance | Accepted |
 | [0103](0103-stt-overspend-is-guarded-in-trigger-order-never-by-media-preflight.md) | STT overspend is bounded by cheap guards in trigger order, never by media preflight or a reservation lock | Accepted |
+| [0104](0104-hosted-models-are-a-build-time-seed-not-discovered-the-runtime-overlay-is-deferred.md) | Hosted models are a build-time seed catalog, not a discovered one; a runtime overlay is a named deferral | Accepted |
 
 When you add an ADR, add its row here.

--- a/packages/app-shell/src/inference-picker/connections.svelte.ts
+++ b/packages/app-shell/src/inference-picker/connections.svelte.ts
@@ -10,6 +10,15 @@
  * `localhost` URL is meaningless elsewhere (ADR-0004). The arktype schema here is
  * the single runtime shape; `Connection` (from `@epicenter/client`) is the
  * matching compile-time type.
+ *
+ * Two axes people conflate. A custom connection here (a base URL + optional key)
+ * is device-local and appears the moment it is added; it is unrelated to sign-in
+ * or to which Epicenter instance is connected. The injected hosted entry is always
+ * present, so its picker group renders regardless of sign-in, but its transport is
+ * the audience-scoped `auth.fetch` (ADR-0053) against the Cloud gateway, so it only
+ * functions when signed into Cloud (signed out it is shown-but-inert; the chat
+ * surface's `onSignIn` catches the send). Instance auth (Cloud OAuth vs self-host
+ * token) is a separate decision that never gates this picker.
  */
 
 import {
@@ -21,7 +30,7 @@ import {
 } from '@epicenter/client';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { type } from 'arktype';
-import type { Result } from 'wellcrafted/result';
+import { Err, Ok, type Result } from 'wellcrafted/result';
 
 /**
  * A reactive persisted-state handle: localStorage (web) or chrome.storage
@@ -161,6 +170,24 @@ export function createInferenceConnections({
 			return listModels(
 				resolveConnection({ baseUrl, apiKey: apiKey || undefined }),
 			);
+		},
+
+		/** Re-discover an already-added connection's models and update its cached
+		 * list, for when a user pulled a new model at the endpoint after connecting.
+		 * Best effort: on failure the previously discovered ids stand, so a transient
+		 * outage never empties the group. Connect-time `add` still owns first
+		 * discovery; this is the one path that refreshes a stale list in place. */
+		async refresh(
+			baseUrl: string,
+		): Promise<Result<string[], ListModelsError>> {
+			const connection = stored.current.find((c) => c.baseUrl === baseUrl);
+			if (!connection) return Ok([]);
+			const { data, error } = await listModels(resolveConnection(connection));
+			if (error) return Err(error);
+			stored.current = stored.current.map((c) =>
+				c.baseUrl === baseUrl ? { ...c, models: data } : c,
+			);
+			return Ok(data);
 		},
 
 		/**

--- a/packages/app-shell/src/inference-picker/connections.svelte.ts
+++ b/packages/app-shell/src/inference-picker/connections.svelte.ts
@@ -177,9 +177,7 @@ export function createInferenceConnections({
 		 * Best effort: on failure the previously discovered ids stand, so a transient
 		 * outage never empties the group. Connect-time `add` still owns first
 		 * discovery; this is the one path that refreshes a stale list in place. */
-		async refresh(
-			baseUrl: string,
-		): Promise<Result<string[], ListModelsError>> {
+		async refresh(baseUrl: string): Promise<Result<string[], ListModelsError>> {
 			const connection = stored.current.find((c) => c.baseUrl === baseUrl);
 			if (!connection) return Ok([]);
 			const { data, error } = await listModels(resolveConnection(connection));

--- a/packages/app-shell/src/inference-picker/inference-picker.svelte
+++ b/packages/app-shell/src/inference-picker/inference-picker.svelte
@@ -66,9 +66,10 @@
 	// malformed), or null when discovery has not failed.
 	let discoveryError = $state<string | null>(null);
 
-	// Which connection is re-discovering its models right now (one at a time), for
-	// the per-group refresh spinner. Null when idle.
-	let refreshingBaseUrl = $state<string | null>(null);
+	// Connections currently re-discovering their models, for per-group refresh
+	// spinners. Usually one entry, but keep the state per URL so overlapping refreshes
+	// cannot clear each other's loading state.
+	let refreshingBaseUrls = $state<string[]>([]);
 
 	// Clear all of the connect form's working state. Called on close so a user who
 	// connected one provider lands back on the preset chooser (not a stale sub-form
@@ -144,9 +145,13 @@
 	// Re-discover a connected endpoint's models in place. Best effort: the group's
 	// list updates reactively when the fresh ids land, and stands on error.
 	async function refreshConnection(baseUrl: string) {
-		refreshingBaseUrl = baseUrl;
-		await connections.refresh(baseUrl);
-		refreshingBaseUrl = null;
+		if (refreshingBaseUrls.includes(baseUrl)) return;
+		refreshingBaseUrls = [...refreshingBaseUrls, baseUrl];
+		try {
+			await connections.refresh(baseUrl);
+		} finally {
+			refreshingBaseUrls = refreshingBaseUrls.filter((url) => url !== baseUrl);
+		}
 	}
 
 	function choosePreset(id: PresetId | 'custom') {
@@ -301,9 +306,10 @@
 							{/each}
 							<Command.Item
 								value="refresh {connection.baseUrl}"
+								disabled={refreshingBaseUrls.includes(connection.baseUrl)}
 								onSelect={() => refreshConnection(connection.baseUrl)}
 							>
-								{#if refreshingBaseUrl === connection.baseUrl}
+								{#if refreshingBaseUrls.includes(connection.baseUrl)}
 									<LoaderCircle class="size-4 animate-spin" />
 								{:else}
 									<RefreshCw class="size-4" />

--- a/packages/app-shell/src/inference-picker/inference-picker.svelte
+++ b/packages/app-shell/src/inference-picker/inference-picker.svelte
@@ -31,6 +31,7 @@
 	import HardDrive from '@lucide/svelte/icons/hard-drive';
 	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
 	import Plus from '@lucide/svelte/icons/plus';
+	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
 	import Trash2 from '@lucide/svelte/icons/trash-2';
 	import type { InferenceConnections } from './connections.svelte.js';
 
@@ -64,6 +65,10 @@
 	// A tailored, per-variant message when discovery fails (401 vs unreachable vs
 	// malformed), or null when discovery has not failed.
 	let discoveryError = $state<string | null>(null);
+
+	// Which connection is re-discovering its models right now (one at a time), for
+	// the per-group refresh spinner. Null when idle.
+	let refreshingBaseUrl = $state<string | null>(null);
 
 	// Clear all of the connect form's working state. Called on close so a user who
 	// connected one provider lands back on the preset chooser (not a stale sub-form
@@ -134,6 +139,14 @@
 	function selectModel(id: string) {
 		onSelectModel(id);
 		open = false;
+	}
+
+	// Re-discover a connected endpoint's models in place. Best effort: the group's
+	// list updates reactively when the fresh ids land, and stands on error.
+	async function refreshConnection(baseUrl: string) {
+		refreshingBaseUrl = baseUrl;
+		await connections.refresh(baseUrl);
+		refreshingBaseUrl = null;
 	}
 
 	function choosePreset(id: PresetId | 'custom') {
@@ -286,6 +299,17 @@
 									</span>
 								</Command.Item>
 							{/each}
+							<Command.Item
+								value="refresh {connection.baseUrl}"
+								onSelect={() => refreshConnection(connection.baseUrl)}
+							>
+								{#if refreshingBaseUrl === connection.baseUrl}
+									<LoaderCircle class="size-4 animate-spin" />
+								{:else}
+									<RefreshCw class="size-4" />
+								{/if}
+								<span class="text-xs">Refresh {connectionLabel(connection)}</span>
+							</Command.Item>
 							<Command.Item
 								value="remove {connection.baseUrl}"
 								onSelect={() => connections.remove(connection.baseUrl)}

--- a/packages/constants/src/ai-providers.ts
+++ b/packages/constants/src/ai-providers.ts
@@ -10,6 +10,17 @@
  * gateway (ADR-0050) owns routing, so a model the backend cannot serve is a
  * runtime gateway error, not a compile error here. This catalog is the single
  * source of which ids we sell and what each costs.
+ *
+ * This is the build-time SEED of a layered catalog (ADR-0104): a typed `as const`
+ * so `ServableModel` keeps its literal narrowing, bundled at compile time, offline,
+ * present at first paint. Hosted models are authored here, never discovered: unlike
+ * a custom endpoint (someone else's box, discovered via `/v1/models`, ADR-0060), we
+ * own this list, and `/v1/models` cannot carry the product half (label, credits,
+ * default) anyway. A runtime OVERLAY that spreads more entries on top is deliberately
+ * NOT built: it is deferred until the catalog changes faster than clients ship, and
+ * grafts on then with no rework (add a served projection of this const plus a merge,
+ * seed-wins-on-price). Keep this a typed const, not a raw `.json` (a JSON import
+ * would widen ids to `string` and lose the union).
  */
 
 /**


### PR DESCRIPTION
Custom OpenAI-compatible endpoints can change after a user connects them. Pulling a new Ollama model should not require removing and re-adding the endpoint just to make the picker notice it.

This adds a per-connection refresh action that re-runs `/v1/models` for a saved custom connection and updates its cached model ids in place. Refresh is best effort: failures leave the old list visible, and refresh loading state is tracked per base URL so overlapping refreshes cannot clear each other.

The hosted side stays deliberately unchanged. ADR-0104 records why hosted models remain an authored build-time seed catalog, why `/v1/models` remains custom-endpoint discovery, and how a future runtime overlay should be query-backed only when catalog-change velocity earns it.

## Changelog
- Add a refresh action for custom inference endpoints so newly available models can appear without reconnecting the provider

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785696481&installation_id=128463665&pr_number=2313&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2313&signature=2c7f677d7d94844513f752baa3fce74fcf49af4f95c3178dad57e829151e0b03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->