### PR TITLE
fix(whispering): disable webkit hardware acceleration under remote di…

### DIFF
--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -131,6 +131,37 @@ mod export_bindings {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 #[tokio::main]
 pub async fn run() {
+    #[cfg(target_os = "linux")]
+    {
+        // WebKitGTK can crash with SIGILL (Illegal Instruction) under remote or virtual sessions.
+        // This occurs when llvmpipe or lavapipe JIT compiles unsupported CPU instructions.
+        // Disabling compositing and the DMABUF renderer avoids hardware-accelerated paths.
+        let is_xrdp = std::env::var("XRDP_SESSION").is_ok()
+            || std::env::var("XRDP_SOCKET_PATH").is_ok()
+            || std::env::var("SESMAN_PORT").is_ok();
+
+        let is_vnc = std::env::var("VNCSESSION").is_ok()
+            || std::env::var("VNC_PORT").is_ok();
+
+        let display = std::env::var("DISPLAY").unwrap_or_default();
+        let is_virtual_display = !display.is_empty() && display != ":0" && display != ":0.0";
+
+        let session_type = std::env::var("XDG_SESSION_TYPE").unwrap_or_default();
+        let session_class = std::env::var("XDG_SESSION_CLASS").unwrap_or_default();
+        let is_remote_session = session_type.contains("rdp")
+            || session_type.contains("vnc")
+            || session_class.contains("remote");
+
+        if is_xrdp || is_vnc || is_virtual_display || is_remote_session {
+            if std::env::var("WEBKIT_DISABLE_COMPOSITING_MODE").is_err() {
+                std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+            }
+            if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+                std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+            }
+        }
+    }
+
     // Set up panic hook to capture crash information before the app exits.
     // The previous hook is preserved so default panic reporting still occurs.
     let previous_hook = std::panic::take_hook();


### PR DESCRIPTION
WebKitGTK crashes with SIGILL (Illegal Instruction) when the app is launched inside an XRDP or VNC session on Ubuntu 24.04. The crash happens because the compositing and DMABUF renderer paths attempt to execute hardware-accelerated GPU instructions; software rasterizers like llvmpipe JIT-compile code that exercises instruction set extensions the virtualized CPU does not support, and the process terminates before the webview initializes.

The fix sets WEBKIT_DISABLE_COMPOSITING_MODE and WEBKIT_DISABLE_DMABUF_RENDERER at process start on Linux when the environment signals a remote or virtual display: presence of XRDP_SESSION, VNCSESSION, a non-zero DISPLAY socket (:1, :10, etc.), or XDG_SESSION_CLASS=remote. Both variables are skipped when already set by the user, so anyone who wants to override the behavior still can.

Closes #2082.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785697608&installation_id=128463665&pr_number=2314&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2314&signature=c26b6e596a8dff297f727ffe9eed9c1a78cfa8ab2ad39e4b1d174ff7947f4e7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->