### PR TITLE
fix(local-mail): route /api/session literal through API_ROUTES

### DIFF
--- a/apps/local-mail/package.json
+++ b/apps/local-mail/package.json
@@ -16,6 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
+		"@epicenter/constants": "workspace:*",
 		"@modelcontextprotocol/sdk": "catalog:",
 		"oauth4webapi": "catalog:",
 		"typebox": "catalog:",

--- a/apps/local-mail/src/up.ts
+++ b/apps/local-mail/src/up.ts
@@ -2,6 +2,7 @@ import { Database } from 'bun:sqlite';
 import { randomBytes } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { join, sep } from 'node:path';
+import { API_ROUTES } from '@epicenter/constants/api-routes';
 import { resolveAndModifyMessageLabels } from './modify.ts';
 import { openLocalMailRuntime, openSyncSession } from './runtime.ts';
 import { readMailStatus } from './status.ts';
@@ -200,7 +201,7 @@ export async function runUp(): Promise<number> {
 		const { pathname } = url;
 
 		// The one unauthenticated mutation: exchange the bootstrap for a bearer.
-		if (pathname === '/api/session' && req.method === 'POST') {
+		if (pathname === API_ROUTES.session.pattern && req.method === 'POST') {
 			if (bootstrapToken === null) {
 				return json({ error: 'No bootstrap token is outstanding.' }, 401);
 			}

--- a/apps/local-mail/ui/package.json
+++ b/apps/local-mail/ui/package.json
@@ -28,6 +28,7 @@
 		"vite": "catalog:"
 	},
 	"dependencies": {
+		"@epicenter/constants": "workspace:*",
 		"@tanstack/svelte-query": "catalog:"
 	},
 	"license": "AGPL-3.0-or-later"

--- a/apps/local-mail/ui/src/lib/api.ts
+++ b/apps/local-mail/ui/src/lib/api.ts
@@ -1,3 +1,4 @@
+import { API_ROUTES } from '@epicenter/constants/api-routes';
 import type {
 	MailboxStatus,
 	MailLabel,
@@ -37,7 +38,7 @@ async function bootstrap(): Promise<void> {
 		'',
 		window.location.pathname + window.location.search,
 	);
-	const res = await fetch('/api/session', {
+	const res = await fetch(API_ROUTES.session.pattern, {
 		method: 'POST',
 		headers: { 'content-type': 'application/json' },
 		body: JSON.stringify({ token: bootstrapToken }),

--- a/bun.lock
+++ b/bun.lock
@@ -181,6 +181,7 @@
       "name": "@epicenter/local-mail",
       "version": "0.0.1",
       "dependencies": {
+        "@epicenter/constants": "workspace:*",
         "@modelcontextprotocol/sdk": "catalog:",
         "oauth4webapi": "catalog:",
         "typebox": "catalog:",
@@ -195,6 +196,7 @@
       "name": "@epicenter/local-mail-ui",
       "version": "0.0.1",
       "dependencies": {
+        "@epicenter/constants": "workspace:*",
         "@tanstack/svelte-query": "catalog:",
       },
       "devDependencies": {


### PR DESCRIPTION

Replace the two hardcoded `/api/session` string literals in local-mail with `API_ROUTES.session.pattern` from `@epicenter/constants/api-routes`:

- `apps/local-mail/src/up.ts:203` (the up-shell's bootstrap-token exchange route)
- `apps/local-mail/ui/src/lib/api.ts:41` (the triage SPA's exchange fetch)

Adds `@epicenter/constants` as a `workspace:*` dependency to both `@epicenter/local-mail` and `@epicenter/local-mail-ui`.

The reason for this shape is:

The repo-wide **Reject hardcoded API path literals** quality gate rejects any `'/api/(session|rooms|blobs|ai)'` literal outside the allow-listed route-definition files. These two lines currently fail that gate on `main` (and, via the merge check, on unrelated PRs such as #2304). No wire path changes; only the source of the string moves to the shared constant.

A note for review:

These are local-mail's *own* loopback endpoints on `127.0.0.1`, a coincidental path collision with the Epicenter cloud API's session route, not the same contract. `up.ts` still holds sibling literals (`/api/status`, `/api/labels`, `/api/messages`, `/api/sync`) that the gate does not flag, so only `session` now routes through the shared constant. If local-mail's loopback surface grows, the cleaner long-term shape mirrors `apps/super-chat/src/routes.ts`: a local routes module added to the gate's allow-list. This PR keeps to the smallest diff that turns the gate green.

For verification:

- `bun run --filter '@epicenter/local-mail' typecheck` -> clean
- `bun run --filter '@epicenter/local-mail-ui' typecheck` -> clean
- The exact CI grep from the quality job -> no hardcoded literals

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785697857&installation_id=128463665&pr_number=2315&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2315&signature=60149105bba26479d14522f00c2bd0020da4fd62528803aef0cf303260f09313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->