### PR TITLE
refactor(inference-picker): collapse post-#2313 refresh surface and add reactive-primitive skill rules

### DIFF
--- a/.agents/skills/svelte/SKILL.md
+++ b/.agents/skills/svelte/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: svelte
-description: Svelte 5 component and state-module patterns for Epicenter apps. Use when editing `.svelte`, `.svelte.ts`, or Svelte UI state code involving runes, `$props`, snippets, keyed lifecycles, `{#await}`, TanStack Query, SvelteMap, shadcn-svelte, or workspace observers.
+description: Svelte 5 component and state-module patterns for Epicenter apps. Use when editing `.svelte`, `.svelte.ts`, or Svelte UI state code involving runes, `$props`, snippets, keyed lifecycles, `{#await}`, TanStack Query, `SvelteMap`/`SvelteSet`, `createSubscriber`, `$state.raw`, shadcn-svelte, or workspace observers.
 ---
 
 # Svelte Guidelines
@@ -49,7 +49,7 @@ Use this skill when you need to:
 
 ## Svelte 5 Baseline
 
-- Use `$state` for reactive values that the component mutates. Use `$state.raw` for large reassigned objects or handles that should not be deep-proxied.
+- Use `$state` for reactive values the component mutates in place. Use `$state.raw` for values that are only ever reassigned wholesale (large arrays, replace-only persisted stores, opaque handles): it stores by reference with no deep proxy, does not freeze, and reacts only to reassignment, so an in-place property write mutates the object without triggering reactivity or persistence (not an error, but not reactive either). Reach for it when the deep proxy buys reactivity you never use, and when stable value identity matters (for example a store whose value is JSON-serialized or compared by reference). Exemplar: `createPersistedState` in `packages/svelte-utils`.
 - Prefer `$derived` for computed state. Treat `$effect` as a browser-only escape hatch for DOM integration, analytics, subscriptions, and external systems. A returned cleanup runs before the effect re-runs and when the component is destroyed.
 - Props can change. Values derived from `$props()` should usually be `$derived`, not one-time initialization.
 - Treat props as parent-owned by default. Use callback props for commands and `$bindable` only for intentional two-way APIs such as UI wrappers, `bind:value`, `bind:open`, and `bind:ref`.
@@ -64,6 +64,8 @@ Use this skill when you need to:
 - Inline shallow property aliases and single-use script helpers (a `function`, `$derived`, or one-off `const` used once in the template). Keep one extracted only when it computes, narrows, or stabilizes something useful, or when a justifying comment plus a semantic name makes the template read better. Read [component and UI patterns](references/component-ui-patterns.md).
 - Map finite unions with a `satisfies Record` lookup, not nested ternaries or `$derived.by()` switches.
 - Use `SvelteMap` for ID-keyed collections where `get`, `has`, `size`, or iteration should update reactively. Values inside a `SvelteMap` are not deep-proxied, so store reactive row objects or replace values when nested data changes. Convert maps to stable arrays with `$derived` before passing them to table-like consumers.
+- Use `SvelteSet` for an id set whose membership (`has`, `size`, iteration) is read in a reactive or template context: `add`/`delete` then drive the UI directly, replacing `$state<string[]>` plus spread/filter reassignment. Reach for `SvelteMap` instead the moment the set needs to carry per-key data (a timestamp, a last error). Use a plain `Set`/`Map` (not the reactive class) when the collection is read only in imperative code, such as a subscription's listener bag: a reactive wrapper read outside any effect is cost with no reader (exemplar: the plain `listeners` set in `createPersistedState`).
+- Bridge an external event source (a Y.Doc `update`, `chrome.storage`, `window` events, an auth store) into reactivity with `createSubscriber` from `svelte/reactivity`, not a hand-rolled `$state` plus `$effect` plus listener set: reads inside an effect become reactive and the subscription is ref-counted to effect usage (start on first subscriber, cleanup at zero). Exemplars: `from-kv`, `auth`, `from-table` in `packages/svelte-utils`. Keep a manual listener set only when the same source also serves imperative `.get()`/`.watch()` consumers whose liveness cannot ride on effect ref-counting (again `createPersistedState`).
 - For new reusable DOM behavior on elements, prefer `{@attach}` attachments over new `use:` actions. Keep `use:` for existing code or libraries that only expose actions.
 - Create TanStack Query mutations in `.svelte` files and call `mutation.mutate(...)` directly from template handlers unless the action earns a semantic helper. Read [mutations and workspace inputs](references/mutations-and-workspace-inputs.md).
 - For workspace string fields, prefer commit-on-blur over writing a CRDT transaction on every keystroke.

--- a/packages/app-shell/src/inference-picker/connections.svelte.ts
+++ b/packages/app-shell/src/inference-picker/connections.svelte.ts
@@ -30,7 +30,7 @@ import {
 } from '@epicenter/client';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { type } from 'arktype';
-import { Err, Ok, type Result } from 'wellcrafted/result';
+import type { Result } from 'wellcrafted/result';
 
 /**
  * A reactive persisted-state handle: localStorage (web) or chrome.storage
@@ -174,20 +174,19 @@ export function createInferenceConnections({
 
 		/** Re-discover an already-added connection's models and update its cached
 		 * list, for when a user pulled a new model at the endpoint after connecting.
-		 * Best effort: on failure the previously discovered ids stand, so a transient
-		 * outage never empties the group. Connect-time `add` still owns first
-		 * discovery; this is the one path that refreshes a stale list in place. */
-		async refresh(
-			baseUrl: string,
-		): Promise<Result<string[], ListModelsError>> {
+		 * Best effort by design: on failure the previously discovered ids stand, so a
+		 * transient outage never empties the group, and nothing is returned because the
+		 * caller has nothing to surface (unlike `discover`, whose error builds the
+		 * connect-form hint). Connect-time `add` still owns first discovery; this is the
+		 * one path that refreshes a stale list in place. */
+		async refresh(baseUrl: string): Promise<void> {
 			const connection = stored.current.find((c) => c.baseUrl === baseUrl);
-			if (!connection) return Ok([]);
+			if (!connection) return;
 			const { data, error } = await listModels(resolveConnection(connection));
-			if (error) return Err(error);
+			if (error) return;
 			stored.current = stored.current.map((c) =>
 				c.baseUrl === baseUrl ? { ...c, models: data } : c,
 			);
-			return Ok(data);
 		},
 
 		/**

--- a/packages/app-shell/src/inference-picker/inference-picker.svelte
+++ b/packages/app-shell/src/inference-picker/inference-picker.svelte
@@ -33,6 +33,7 @@
 	import Plus from '@lucide/svelte/icons/plus';
 	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
 	import Trash2 from '@lucide/svelte/icons/trash-2';
+	import { SvelteSet } from 'svelte/reactivity';
 	import type { InferenceConnections } from './connections.svelte.js';
 
 	type Props = {
@@ -67,9 +68,9 @@
 	let discoveryError = $state<string | null>(null);
 
 	// Connections currently re-discovering their models, for per-group refresh
-	// spinners. Usually one entry, but keep the state per URL so overlapping refreshes
-	// cannot clear each other's loading state.
-	let refreshingBaseUrls = $state<string[]>([]);
+	// spinners. Usually one entry, but keep the set keyed per URL so overlapping
+	// refreshes cannot clear each other's loading state.
+	const refreshingBaseUrls = new SvelteSet<string>();
 
 	// Clear all of the connect form's working state. Called on close so a user who
 	// connected one provider lands back on the preset chooser (not a stale sub-form
@@ -145,12 +146,12 @@
 	// Re-discover a connected endpoint's models in place. Best effort: the group's
 	// list updates reactively when the fresh ids land, and stands on error.
 	async function refreshConnection(baseUrl: string) {
-		if (refreshingBaseUrls.includes(baseUrl)) return;
-		refreshingBaseUrls = [...refreshingBaseUrls, baseUrl];
+		if (refreshingBaseUrls.has(baseUrl)) return;
+		refreshingBaseUrls.add(baseUrl);
 		try {
 			await connections.refresh(baseUrl);
 		} finally {
-			refreshingBaseUrls = refreshingBaseUrls.filter((url) => url !== baseUrl);
+			refreshingBaseUrls.delete(baseUrl);
 		}
 	}
 
@@ -306,10 +307,10 @@
 							{/each}
 							<Command.Item
 								value="refresh {connection.baseUrl}"
-								disabled={refreshingBaseUrls.includes(connection.baseUrl)}
+								disabled={refreshingBaseUrls.has(connection.baseUrl)}
 								onSelect={() => refreshConnection(connection.baseUrl)}
 							>
-								{#if refreshingBaseUrls.includes(connection.baseUrl)}
+								{#if refreshingBaseUrls.has(connection.baseUrl)}
 									<LoaderCircle class="size-4 animate-spin" />
 								{:else}
 									<RefreshCw class="size-4" />


### PR DESCRIPTION
A collapse pass over the refresh affordance that shipped in #2313, plus the reactive-primitive skill rules that pass surfaced.

## Inference-picker collapse

Two small simplifications to the merged refresh work, both behavior-preserving:

- `connections.refresh(baseUrl)` returned a `Result<string[], ListModelsError>` that its only caller discarded. The refresh is best-effort by design (a failed discovery leaves the previously discovered ids standing, no toast), so returning a `Result` invited a future caller to surface an error the design deliberately swallows. It now returns `Promise<void>`, which encodes that contract and drops the now-unused `Ok`/`Err` imports. `discover` still returns a `Result` because its caller consumes the error to build the connect-form hint: honest asymmetry between two operations that are used differently.
- `refreshingBaseUrls` was a `$state<string[]>` used only for membership checks plus spread/filter reassignment. It is now a `SvelteSet<string>` (`has`/`add`/`delete`), matching the reactive-id-set idiom already used in `opensidian`, `tab-manager`, and `whispering`. It stays local component state, per ADR-0104, which defers the query-backed overlay until a producer exists.

No user-visible behavior changes; custom-before-hosted resolution and best-effort refresh are preserved.

## Svelte skill: reactive-primitive decision rules

The review exposed that the repo already leans on `createSubscriber` and `SvelteMap` as house style, but the `svelte` skill did not codify when to reach for each. Added three grounded decision rules (each citing a repo exemplar):

- `SvelteSet` for a reactive-membership id set vs a plain `Set` for an imperative-only listener bag (the `createPersistedState` listeners).
- `createSubscriber` as the external-event bridge over a hand-rolled `$state` + `$effect` + listener set, with the exception for sources that also serve imperative `.get()`/`.watch()` consumers.
- A sharper `$state.raw` rule for replace-only stores.

Every claim was verified against `sveltejs/svelte` source (`VariableDeclaration.js`, `set.js`, `create-subscriber.js`) via an independent Codex review, which corrected one overclaim (an in-place write to `$state.raw` mutates the object without triggering reactivity or persistence; it is not a no-op).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785699746&installation_id=128463665&pr_number=2316&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2316&signature=bc8891e1801013e338e12363c9bd3a06e4c5acd38e8ad49af7bb79a8b4a7d1e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->