### PR TITLE
perf(persisted-state): hold the value in $state.raw, not $state

### DIFF
--- a/packages/svelte-utils/src/persisted-state.svelte.ts
+++ b/packages/svelte-utils/src/persisted-state.svelte.ts
@@ -142,7 +142,19 @@ export function createPersistedState<TSchema extends StandardSchemaV1>({
 		return parseRawValue(window.localStorage.getItem(key));
 	}
 
-	let value = $state(readFromStorage());
+	// `$state.raw`, not `$state`: this store is replace-only. The single writer is
+	// `setValue`, which always assigns a whole new value (`value = nextValue`), and
+	// the `.current` setter routes through `setAndPersist`, so nothing ever mutates a
+	// field in place. A deep proxy would therefore cost proxying on every persisted
+	// array/object for reactivity we never use. `$state.raw` also keeps the value
+	// identity stable (the getter returns the exact reference set, which a JSON store
+	// wants) and makes the `Object.is` dedup in `setValue` compare real references. It
+	// stores by reference and does not freeze, so an accidental `store.current.foo = x`
+	// mutates the in-memory object without triggering reactivity or persistence (the
+	// missing UI update surfaces the mistake, and the next storage re-parse overwrites
+	// it), rather than the `$state` trap where the proxy updates the UI yet the write
+	// is never persisted (silent data loss).
+	let value = $state.raw(readFromStorage());
 	let disposed = false;
 	const listeners = new Set<
 		(value: StandardSchemaV1.InferOutput<TSchema>) => void


### PR DESCRIPTION
`createPersistedState` is a replace-only store: its single writer (`setValue`) always assigns a whole new value, and the `.current` setter routes every write through `setAndPersist`, so no field is ever mutated in place. Holding that value in a deeply reactive `$state` therefore proxies every persisted array and object for reactivity the store never uses.

Switching the backing to `$state.raw` stores the value by reference with no proxy. Three consequences, all wins for this store:

- It drops the deep-proxy cost on every persisted value (the inference-connections array, auth session, settings).
- It keeps value identity stable: the getter returns the exact reference that was set, which a JSON-serialized store wants, and which makes the existing `Object.is` dedup in `setValue` compare real references instead of a proxy against a raw object.
- It removes a latent trap. Under `$state`, an accidental `store.current.foo = x` updates the UI through the proxy yet is never persisted, so the mistake is invisible until reload (silent data loss). Under `$state.raw` the same write mutates the in-memory object without triggering reactivity or persistence, so the missing UI update surfaces the mistake and the next storage re-parse overwrites it.

Verified: no consumer in the repo mutates `.current` in place. The behavior was grounded against `sveltejs/svelte` source (`$state.raw` stores by reference, does not freeze, and reacts only to reassignment; whole-value reassignment triggers all readers exactly as `$state` does) and independently reviewed by Codex against the installed compiler and runtime.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785699748&installation_id=128463665&pr_number=2317&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2317&signature=89b657af4afbc1b83fa359b6bd93254ef4d517af036d0bdeae41fd218bf115df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->