### PR TITLE
refactor(local-mail): rename up to app and serve a typed Hono /api

### DIFF
--- a/apps/local-mail/README.md
+++ b/apps/local-mail/README.md
@@ -96,10 +96,10 @@ available.
 Serve the triage UI and its API from one loopback process:
 
 ```sh
-bun run src/bin.ts up
+bun run src/bin.ts app
 ```
 
-`up` runs the sync loop and serves the triage SPA (`ui/`) plus a same-origin
+`app` runs the sync loop and serves the triage SPA (`ui/`) plus a same-origin
 `/api` on `127.0.0.1`, then prints `http://127.0.0.1:PORT/#token=...` and opens
 it. The tab is the app. Security is the up-shell spec's: a single-use bootstrap
 token rides in the URL fragment and is exchanged once at `POST /api/session`
@@ -108,13 +108,14 @@ Host-checked first; the write route is the one `POST /api/messages/modify`
 (`{ ids, addLabels, removeLabels }` -> `ModifyMessageLabelsOutcome`) over the
 same core the CLI verbs and MCP tool use, so archive/read/label all desugar to
 add/remove sets client-side. `LOCAL_MAIL_READ_ONLY` disables writes end to end;
-`LOCAL_MAIL_NO_OPEN=1` prints the URL without launching a browser.
+`--no-open` prints the URL without launching a browser. `--port <n>` pins the
+server port. `LOCAL_MAIL_NO_OPEN=1` and `LOCAL_MAIL_PORT` remain env fallbacks.
 
-Develop the UI against a running `up`:
+Develop the UI against a running `app`:
 
 ```sh
-LOCAL_MAIL_DEV=1 LOCAL_MAIL_TOKEN=devtoken LOCAL_MAIL_PORT=4177 bun run src/bin.ts up
-LOCAL_MAIL_TOKEN=devtoken bun run --cwd ui dev   # same token: Vite proxies /api to up, injecting this bearer
+LOCAL_MAIL_DEV=1 LOCAL_MAIL_TOKEN=devtoken LOCAL_MAIL_PORT=4177 bun run src/bin.ts app
+LOCAL_MAIL_TOKEN=devtoken bun run --cwd ui dev   # same token: Vite proxies /api to app, injecting this bearer
 ```
 
 Serve tools to an MCP host:
@@ -146,10 +147,12 @@ Tools:
 - `LOCAL_MAIL_TOKEN_FILE`: token file override.
 - `LOCAL_MAIL_GMAIL_API_BASE`: test plumbing only; points the Gmail client at
   a mock server in the MCP subprocess test.
-- `LOCAL_MAIL_PORT`: pin the `up` server port (default: ephemeral).
-- `LOCAL_MAIL_DEV` / `LOCAL_MAIL_TOKEN`: dev-mode `up`; the Vite proxy injects
+- `LOCAL_MAIL_PORT`: fallback for pinning the `app` server port; prefer
+  `--port <n>` for normal use.
+- `LOCAL_MAIL_DEV` / `LOCAL_MAIL_TOKEN`: dev-mode `app`; the Vite proxy injects
   the fixed bearer. `bearerAuth` is never disabled in any mode.
-- `LOCAL_MAIL_NO_OPEN`: `up` prints the launch URL without opening a browser.
+- `LOCAL_MAIL_NO_OPEN`: fallback for making `app` print the launch URL without
+  opening a browser; prefer `--no-open` for normal use.
 
 ## Testing
 
@@ -169,7 +172,7 @@ stdio subprocess for the agent-facing protocol surface.
 - HTML mail-body rendering. The detail pane shows the pre-extracted plain-text
   body; rich HTML rendering (the sanitizer + sandboxed srcdoc + CSP + show-images
   proxy) is deferred, which is why the SPA has no mail-body iframe yet.
-- Compile-embed distribution (`bun build --compile`) and the Tauri wrapper. `up`
+- Compile-embed distribution (`bun build --compile`) and the Tauri wrapper. `app`
   serves `ui/dist` from disk; the route table is the seam the distribution wave
   swaps for embedded assets later.
 - Send, reply, compose, drafts, trash, untrash, and permanent delete.

--- a/apps/local-mail/README.md
+++ b/apps/local-mail/README.md
@@ -76,7 +76,7 @@ bun run src/bin.ts query "SELECT subject, sender FROM messages ORDER BY internal
 
 Triage messages. Each verb is a Gmail label change that the mirror folds in
 after Gmail accepts it. Output is human-readable; add `--json` for the typed
-`ModifyMessageLabelsOutcome` that MCP and a future HTTP adapter share.
+`ModifyMessageLabelsOutcome` that MCP and the `app` HTTP API share.
 
 ```sh
 bun run src/bin.ts archive <id...>
@@ -150,7 +150,7 @@ Tools:
 - `LOCAL_MAIL_PORT`: fallback for pinning the `app` server port; prefer
   `--port <n>` for normal use.
 - `LOCAL_MAIL_DEV` / `LOCAL_MAIL_TOKEN`: dev-mode `app`; the Vite proxy injects
-  the fixed bearer. `bearerAuth` is never disabled in any mode.
+  the fixed bearer. The bearer gate is never disabled in any mode.
 - `LOCAL_MAIL_NO_OPEN`: fallback for making `app` print the launch URL without
   opening a browser; prefer `--no-open` for normal use.
 

--- a/apps/local-mail/README.md
+++ b/apps/local-mail/README.md
@@ -101,7 +101,7 @@ bun run src/bin.ts app
 
 `app` runs the sync loop and serves the triage SPA (`ui/`) plus a same-origin
 `/api` on `127.0.0.1`, then prints `http://127.0.0.1:PORT/#token=...` and opens
-it. The tab is the app. Security is the up-shell spec's: a single-use bootstrap
+it. The tab is the app. Security is the loopback shell spec's: a single-use bootstrap
 token rides in the URL fragment and is exchanged once at `POST /api/session`
 for a per-launch session bearer (kept in sessionStorage); every request is
 Host-checked first; the write route is the one `POST /api/messages/modify`

--- a/apps/local-mail/package.json
+++ b/apps/local-mail/package.json
@@ -11,12 +11,18 @@
 		"cdc",
 		"email"
 	],
+	"exports": {
+		"./http/api": "./src/http/api.ts"
+	},
 	"scripts": {
 		"test": "bun test",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
+		"@hono/standard-validator": "catalog:",
 		"@modelcontextprotocol/sdk": "catalog:",
+		"arktype": "catalog:",
+		"hono": "catalog:",
 		"oauth4webapi": "catalog:",
 		"typebox": "catalog:",
 		"wellcrafted": "catalog:"

--- a/apps/local-mail/src/app.ts
+++ b/apps/local-mail/src/app.ts
@@ -143,12 +143,7 @@ export async function runApp(options: {
 		return 1;
 	}
 
-	// Re-bind the non-null values: TS drops the post-guard narrowing of the
-	// destructured `runtime`/`session` bindings inside the fetch/loop/SIGINT
-	// closures below, so capture them here where the narrowing holds.
-	const rt = runtime;
-	const sess = session;
-	const readOnly = rt.config.readOnly;
+	const readOnly = runtime.config.readOnly;
 
 	// The valid-bearer set. Dev pre-seeds the fixed proxy token; prod fills it
 	// only through the bootstrap exchange handled inside the Hono app.
@@ -158,7 +153,7 @@ export async function runApp(options: {
 		const devToken = process.env.LOCAL_MAIL_TOKEN;
 		if (!devToken) {
 			lock.release();
-			sess.close();
+			session.close();
 			console.error(
 				'LOCAL_MAIL_DEV=1 requires LOCAL_MAIL_TOKEN so the Vite proxy can authenticate.',
 			);
@@ -174,8 +169,8 @@ export async function runApp(options: {
 	const controller = new AbortController();
 
 	const api = createApiApp({
-		rt,
-		syncDeps: sess.deps,
+		rt: runtime,
+		syncDeps: session.deps,
 		readOnly,
 		gate,
 		sessionBearers,
@@ -204,7 +199,7 @@ export async function runApp(options: {
 	// The background sync loop, serialized through the same gate as POST /api/sync.
 	(async () => {
 		while (!controller.signal.aborted) {
-			await gate(() => syncMailbox(sess.deps, { forceFull: false })).catch(
+			await gate(() => syncMailbox(session.deps, { forceFull: false })).catch(
 				(cause) => console.error(`[sync] loop pass failed: ${cause}`),
 			);
 			if (controller.signal.aborted) break;
@@ -236,7 +231,7 @@ export async function runApp(options: {
 		process.on('SIGINT', () => {
 			controller.abort();
 			server.stop();
-			sess.close();
+			session.close();
 			lock.release();
 			resolve();
 		});

--- a/apps/local-mail/src/app.ts
+++ b/apps/local-mail/src/app.ts
@@ -1,10 +1,8 @@
 import { Database } from 'bun:sqlite';
-import { randomBytes } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { join, sep } from 'node:path';
-import { resolveAndModifyMessageLabels } from './modify.ts';
+import { createApiApp, mintToken } from './http/api.ts';
 import { openLocalMailRuntime, openSyncSession } from './runtime.ts';
-import { readMailStatus } from './status.ts';
 import { syncMailbox } from './sync.ts';
 
 /**
@@ -24,19 +22,13 @@ import { syncMailbox } from './sync.ts';
  *   a fixed `LOCAL_MAIL_TOKEN` bearer and rewrites Host, so the same checks run
  *   against a developer's real mailbox.
  *
- * Writes go through the exact Phase 3 core the CLI and MCP use
- * (`resolveAndModifyMessageLabels`); no per-intent routes exist.
+ * Routing, the bearer gate, and request validation live in the Hono app
+ * (`http/api.ts`); this module owns the loopback host primitive, static SPA
+ * serving, and the process lifecycle, dispatching `/api/*` to `api.fetch`.
  */
 
 const DEV = process.env.LOCAL_MAIL_DEV === '1';
 const SYNC_INTERVAL_MS = 30_000;
-/** Bound online guessing by another local user against the exchange endpoint. */
-const MAX_FAILED_EXCHANGES = 25;
-
-/** 256 bits of CSPRNG, base64url: well past the spec's 128-bit floor. */
-function mintToken(): string {
-	return randomBytes(32).toString('base64url');
-}
 
 type LockHandle = { db: Database; release(): void };
 
@@ -66,16 +58,6 @@ function acquireAccountLock(dir: string): LockHandle | null {
 			db.close();
 		},
 	};
-}
-
-function json(body: unknown, status = 200): Response {
-	return new Response(JSON.stringify(body), {
-		status,
-		headers: {
-			'content-type': 'application/json',
-			'referrer-policy': 'no-referrer',
-		},
-	});
 }
 
 /**
@@ -130,7 +112,7 @@ export async function runApp(options: {
 }): Promise<number> {
 	const { data: runtime, error: runtimeError } = await openLocalMailRuntime();
 	// Narrow on `runtime` itself, not just the error: the value is captured in
-	// the fetch/handleApi closures below, where only a truthiness guard on the
+	// the fetch/loop/SIGINT closures below, where only a truthiness guard on the
 	// const survives.
 	if (runtimeError || !runtime) {
 		console.error(
@@ -166,11 +148,10 @@ export async function runApp(options: {
 	// closures below, so capture them here where the narrowing holds.
 	const rt = runtime;
 	const sess = session;
-	const { db } = sess.deps;
 	const readOnly = rt.config.readOnly;
 
 	// The valid-bearer set. Dev pre-seeds the fixed proxy token; prod fills it
-	// only through the bootstrap exchange.
+	// only through the bootstrap exchange handled inside the Hono app.
 	const sessionBearers = new Set<string>();
 	let bootstrapToken: string | null = null;
 	if (DEV) {
@@ -187,121 +168,24 @@ export async function runApp(options: {
 	} else {
 		bootstrapToken = mintToken();
 	}
-	let failedExchanges = 0;
 
 	const uiDist = join(import.meta.dir, '..', 'ui', 'dist');
 	const gate = createSyncGate();
 	const controller = new AbortController();
 
-	function bearerOf(req: Request): string | null {
-		const header = req.headers.get('authorization');
-		if (!header?.startsWith('Bearer ')) return null;
-		return header.slice('Bearer '.length);
-	}
-
-	async function handleApi(req: Request, url: URL): Promise<Response> {
-		const { pathname } = url;
-
-		// The one unauthenticated mutation: exchange the bootstrap for a bearer.
-		if (pathname === '/api/session' && req.method === 'POST') {
-			if (bootstrapToken === null) {
-				return json({ error: 'No bootstrap token is outstanding.' }, 401);
-			}
-			if (failedExchanges >= MAX_FAILED_EXCHANGES) {
-				return json({ error: 'Too many exchange attempts.' }, 429);
-			}
-			const body = (await req.json().catch(() => null)) as {
-				token?: string;
-			} | null;
-			if (!body?.token || body.token !== bootstrapToken) {
-				failedExchanges += 1;
-				return json({ error: 'Invalid bootstrap token.' }, 401);
-			}
-			const bearer = mintToken();
-			sessionBearers.add(bearer);
-			bootstrapToken = null; // single use: invalidate at exchange
-			return json({ token: bearer });
-		}
-
-		const bearer = bearerOf(req);
-		if (!bearer || !sessionBearers.has(bearer)) {
-			return json({ error: 'Unauthorized. Restart local-mail app.' }, 401);
-		}
-
-		if (pathname === '/api/status' && req.method === 'GET') {
-			const status = await readMailStatus(rt);
-			return json({
-				accountEmail: status.accountEmail,
-				connected: status.connected,
-				mirror: status.mirror,
-				historyId: status.historyId,
-				lastSyncedAt: status.lastSyncedAt,
-				lastFullPullAt: status.lastFullPullAt,
-				rows: status.rows,
-				readOnly,
-			});
-		}
-
-		if (pathname === '/api/labels' && req.method === 'GET') {
-			return json({ labels: db.listLabels() });
-		}
-
-		if (pathname === '/api/messages' && req.method === 'GET') {
-			const limit = Math.min(Number(url.searchParams.get('limit')) || 100, 200);
-			const offset = Math.max(Number(url.searchParams.get('offset')) || 0, 0);
-			const labelId = url.searchParams.get('label') ?? undefined;
-			const search = url.searchParams.get('q')?.trim() || undefined;
-			return json({
-				messages: db.listMessages({ labelId, search, limit, offset }),
-			});
-		}
-
-		const detailMatch = pathname.match(/^\/api\/messages\/([^/]+)$/);
-		if (detailMatch && req.method === 'GET') {
-			const detail = db.getMessageDetail(
-				decodeURIComponent(detailMatch[1] as string),
-			);
-			if (!detail) return json({ error: 'Message not found.' }, 404);
-			return json(detail);
-		}
-
-		if (pathname === '/api/sync' && req.method === 'POST') {
-			const outcome = await gate(() =>
-				syncMailbox(sess.deps, { forceFull: false }),
-			);
-			return json(outcome);
-		}
-
-		if (pathname === '/api/messages/modify' && req.method === 'POST') {
-			const body = (await req.json().catch(() => null)) as {
-				ids?: string[];
-				addLabels?: string[];
-				removeLabels?: string[];
-			} | null;
-			if (!body || !Array.isArray(body.ids)) {
-				return json(
-					{ error: 'Body must be { ids, addLabels, removeLabels }.' },
-					400,
-				);
-			}
-			const { data, error } = await resolveAndModifyMessageLabels({
-				deps: sess.deps,
-				ids: body.ids,
-				addLabels: body.addLabels ?? [],
-				removeLabels: body.removeLabels ?? [],
-				readOnly,
-			});
-			if (error) return json({ error: error.message }, 400);
-			return json(data);
-		}
-
-		return json({ error: 'Not found.' }, 404);
-	}
+	const api = createApiApp({
+		rt,
+		syncDeps: sess.deps,
+		readOnly,
+		gate,
+		sessionBearers,
+		bootstrapToken,
+	});
 
 	const server = Bun.serve({
 		hostname: '127.0.0.1',
 		port: options.port ?? (Number(process.env.LOCAL_MAIL_PORT) || 0),
-		async fetch(req) {
+		fetch(req) {
 			const url = new URL(req.url);
 
 			// Host check first: the DNS-rebinding kill switch. Every request must
@@ -312,7 +196,7 @@ export async function runApp(options: {
 				return new Response('Forbidden', { status: 403 });
 			}
 
-			if (url.pathname.startsWith('/api/')) return handleApi(req, url);
+			if (url.pathname.startsWith('/api/')) return api.fetch(req);
 			return serveStatic(uiDist, url.pathname);
 		},
 	});
@@ -333,6 +217,7 @@ export async function runApp(options: {
 		console.error(`local-mail app (dev API) listening on ${origin}`);
 		console.error('Run the SPA with: bun run --cwd apps/local-mail/ui dev');
 	} else {
+		const noOpen = options.noOpen || process.env.LOCAL_MAIL_NO_OPEN === '1';
 		const launchUrl = `${origin}/#token=${bootstrapToken}`;
 		console.log(launchUrl);
 		if (!existsSync(uiDist)) {
@@ -340,10 +225,8 @@ export async function runApp(options: {
 				`Note: ${uiDist} does not exist yet. Build the SPA with "bun run --cwd apps/local-mail/ui build".`,
 			);
 		}
-		// `--no-open` (or `LOCAL_MAIL_NO_OPEN=1`) prints the URL without launching
-		// a browser: for headless hosts, CI, and "copy the URL into the browser I
-		// want" workflows.
-		const noOpen = options.noOpen || process.env.LOCAL_MAIL_NO_OPEN === '1';
+		// `--no-open` prints the URL without launching a browser; the env fallback
+		// supports headless hosts, CI, and "copy the URL into the browser I want" workflows.
 		if (!noOpen) {
 			Bun.spawn(['open', launchUrl]).exited.catch(() => {});
 		}

--- a/apps/local-mail/src/app.ts
+++ b/apps/local-mail/src/app.ts
@@ -8,7 +8,7 @@ import { syncMailbox } from './sync.ts';
 /**
  * `local-mail app`: one Bun process that serves the triage SPA and its `/api`
  * over `127.0.0.1`, while the same process keeps the mirror fresh through the
- * sync loop. The security model is the up-shell spec's, condensed:
+ * sync loop. The security model is the loopback shell spec's, condensed:
  *
  * - A single-use bootstrap token rides in the URL fragment (never the query
  *   string, so it never lands in a request line or access log). The SPA reads
@@ -34,7 +34,7 @@ type LockHandle = { db: Database; release(): void };
 
 /**
  * A dedicated `lock.db` held with `BEGIN EXCLUSIVE` for the process lifetime,
- * so a second `up` for the same account is refused instantly. `flock` has no
+ * so a second `app` for the same account is refused instantly. `flock` has no
  * Bun API and an `O_EXCL` lockfile is stale-on-crash; the fcntl lock a live
  * SQLite transaction holds is released by the kernel on `kill -9`.
  */

--- a/apps/local-mail/src/app.ts
+++ b/apps/local-mail/src/app.ts
@@ -8,7 +8,7 @@ import { readMailStatus } from './status.ts';
 import { syncMailbox } from './sync.ts';
 
 /**
- * `local-mail up`: one Bun process that serves the triage SPA and its `/api`
+ * `local-mail app`: one Bun process that serves the triage SPA and its `/api`
  * over `127.0.0.1`, while the same process keeps the mirror fresh through the
  * sync loop. The security model is the up-shell spec's, condensed:
  *
@@ -124,7 +124,10 @@ async function serveStatic(
 	return new Response('Not found', { status: 404 });
 }
 
-export async function runUp(): Promise<number> {
+export async function runApp(options: {
+	noOpen: boolean;
+	port?: number;
+}): Promise<number> {
 	const { data: runtime, error: runtimeError } = await openLocalMailRuntime();
 	// Narrow on `runtime` itself, not just the error: the value is captured in
 	// the fetch/handleApi closures below, where only a truthiness guard on the
@@ -140,7 +143,7 @@ export async function runUp(): Promise<number> {
 	const lock = acquireAccountLock(accountDir);
 	if (!lock) {
 		console.error(
-			`local-mail up is already running for ${runtime.accountEmail}. Stop it first, or open the URL it printed.`,
+			`local-mail app is already running for ${runtime.accountEmail}. Stop it first, or open the URL it printed.`,
 		);
 		return 1;
 	}
@@ -222,7 +225,7 @@ export async function runUp(): Promise<number> {
 
 		const bearer = bearerOf(req);
 		if (!bearer || !sessionBearers.has(bearer)) {
-			return json({ error: 'Unauthorized. Restart local-mail up.' }, 401);
+			return json({ error: 'Unauthorized. Restart local-mail app.' }, 401);
 		}
 
 		if (pathname === '/api/status' && req.method === 'GET') {
@@ -297,7 +300,7 @@ export async function runUp(): Promise<number> {
 
 	const server = Bun.serve({
 		hostname: '127.0.0.1',
-		port: Number(process.env.LOCAL_MAIL_PORT) || 0,
+		port: options.port ?? (Number(process.env.LOCAL_MAIL_PORT) || 0),
 		async fetch(req) {
 			const url = new URL(req.url);
 
@@ -327,7 +330,7 @@ export async function runUp(): Promise<number> {
 
 	const origin = `http://127.0.0.1:${server.port}`;
 	if (DEV) {
-		console.error(`local-mail up (dev API) listening on ${origin}`);
+		console.error(`local-mail app (dev API) listening on ${origin}`);
 		console.error('Run the SPA with: bun run --cwd apps/local-mail/ui dev');
 	} else {
 		const launchUrl = `${origin}/#token=${bootstrapToken}`;
@@ -337,9 +340,11 @@ export async function runUp(): Promise<number> {
 				`Note: ${uiDist} does not exist yet. Build the SPA with "bun run --cwd apps/local-mail/ui build".`,
 			);
 		}
-		// `LOCAL_MAIL_NO_OPEN=1` prints the URL without launching a browser: for
-		// headless hosts, CI, and "copy the URL into the browser I want" workflows.
-		if (process.env.LOCAL_MAIL_NO_OPEN !== '1') {
+		// `--no-open` (or `LOCAL_MAIL_NO_OPEN=1`) prints the URL without launching
+		// a browser: for headless hosts, CI, and "copy the URL into the browser I
+		// want" workflows.
+		const noOpen = options.noOpen || process.env.LOCAL_MAIL_NO_OPEN === '1';
+		if (!noOpen) {
 			Bun.spawn(['open', launchUrl]).exited.catch(() => {});
 		}
 	}

--- a/apps/local-mail/src/cli.test.ts
+++ b/apps/local-mail/src/cli.test.ts
@@ -51,6 +51,16 @@ test('--watch followed by another flag stays flag-only', () => {
 	expect(args.watchIntervalMs).toBeUndefined();
 });
 
+test('app parses browser and port flags', () => {
+	const args = parseArgs(['app', '--no-open', '--port', '4177']);
+	expect(args.command).toBe('app');
+	expect(args.noOpen).toBe(true);
+	expect(args.port).toBe(4177);
+	expect(() => parseArgs(['app', '--port', 'abc'])).toThrow(
+		'--port must be a non-negative integer, got "NaN"',
+	);
+});
+
 test('triage verbs collect ids as positionals', () => {
 	const args = parseArgs(['mark-read', 'm1', 'm2']);
 	expect(args.command).toBe('mark-read');

--- a/apps/local-mail/src/cli.ts
+++ b/apps/local-mail/src/cli.ts
@@ -167,7 +167,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
 			case '--port': {
 				const value = Number(takeValue());
 				if (!Number.isInteger(value) || value < 0) {
-					throw new Error(`--port must be a non-negative integer, got "${value}"`);
+					throw new Error(
+						`--port must be a non-negative integer, got "${value}"`,
+					);
 				}
 				args.port = value;
 				break;

--- a/apps/local-mail/src/cli.ts
+++ b/apps/local-mail/src/cli.ts
@@ -17,6 +17,8 @@ export type ParsedArgs = {
 	full: boolean;
 	watch: boolean;
 	watchIntervalMs?: number;
+	noOpen: boolean;
+	port?: number;
 	clientId?: string;
 	addLabels: string[];
 	removeLabels: string[];
@@ -37,7 +39,7 @@ Usage:
   local-mail query "<sql>"
   local-mail archive|unarchive|mark-read|mark-unread <id...> [--json]
   local-mail label <id...> [--add <label>...] [--remove <label>...] [--json]
-  local-mail up
+  local-mail app [--no-open] [--port <n>]
   local-mail mcp
 
 Commands:
@@ -53,6 +55,7 @@ Commands:
   mark-read    Mark messages read by removing UNREAD.
   mark-unread  Mark messages unread by adding UNREAD.
   label        Add or remove Gmail labels by exact name or id.
+  app          Open your mail: keep the mirror fresh and serve the triage UI + API on 127.0.0.1, then open it in your browser.
   mcp          Serve query/status/sync/modify_labels tools over stdio.
 
 Options:
@@ -61,6 +64,8 @@ Options:
   --watch [intervalMs]  Keep syncing on a loop. Default: 30000.
   --add <label>         Add a Gmail label by exact name or id. Repeatable.
   --remove <label>      Remove a Gmail label by exact name or id. Repeatable.
+  --no-open             Print the launch URL instead of opening a browser (app only).
+  --port <n>            Pin the app server port (app only; default: ephemeral).
   --json                Print typed JSON instead of human text. query is
                         always JSON, so --json is a no-op there.
   -h, --help            Show this help.
@@ -109,6 +114,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
 		positionals: [],
 		full: false,
 		watch: false,
+		noOpen: false,
 		addLabels: [],
 		removeLabels: [],
 		json: false,
@@ -153,6 +159,17 @@ export function parseArgs(argv: string[]): ParsedArgs {
 					i += 1;
 					args.watchIntervalMs = parseWatchInterval(next);
 				}
+				break;
+			}
+			case '--no-open':
+				args.noOpen = true;
+				break;
+			case '--port': {
+				const value = Number(takeValue());
+				if (!Number.isInteger(value) || value < 0) {
+					throw new Error(`--port must be a non-negative integer, got "${value}"`);
+				}
+				args.port = value;
 				break;
 			}
 			case '--add':
@@ -481,9 +498,9 @@ export async function runCli(argv: string[]): Promise<number> {
 				removeLabels: args.removeLabels,
 				done: 'labels updated',
 			});
-		case 'up': {
-			const { runUp } = await import('./up.ts');
-			return runUp();
+		case 'app': {
+			const { runApp } = await import('./app.ts');
+			return runApp({ noOpen: args.noOpen, port: args.port });
 		}
 		case 'mcp': {
 			const { runMcpServer } = await import('./mcp.ts');

--- a/apps/local-mail/src/http/api-errors.ts
+++ b/apps/local-mail/src/http/api-errors.ts
@@ -1,0 +1,63 @@
+import { defineErrors, type InferErrors } from 'wellcrafted/error';
+
+/**
+ * Structured error variants for the loopback `/api` surface of `local-mail app`.
+ *
+ * Every non-2xx response from the Hono app ({@link api.ts}, its only emitter)
+ * comes from one of these variants, so the wire shape is `wellcrafted`'s
+ * envelope `{ data: null, error: { name, message, status } }` and each variant
+ * bakes in its own HTTP `status`. Emit as `c.json(err, err.error.status)`; the
+ * `c-json-errors` biome gate is satisfied because a factory result is not an
+ * inline object literal.
+ *
+ * The one consumer is the same-origin SPA, which surfaces `error.message` in a
+ * toast; it does not branch on `error.name`. The variants exist to keep the
+ * error surface centralized and typed, not because a remote client reads them.
+ *
+ * @example
+ * ```ts
+ * import { ApiError } from './api-errors.ts';
+ * const err = ApiError.MessageNotFound();
+ * return c.json(err, err.error.status); // 404
+ * ```
+ */
+export const ApiError = defineErrors({
+	/** Missing or unknown bearer on a gated `/api` route. */
+	Unauthorized: () => ({
+		message: 'Unauthorized. Restart local-mail app.',
+		status: 401 as const,
+	}),
+	/** A bootstrap exchange arrived after the single-use token was consumed. */
+	NoBootstrapToken: () => ({
+		message: 'No bootstrap token is outstanding.',
+		status: 401 as const,
+	}),
+	/** Exchange attempts exceeded the online-guessing bound. */
+	TooManyExchanges: () => ({
+		message: 'Too many exchange attempts.',
+		status: 429 as const,
+	}),
+	/** The exchanged token did not match the outstanding bootstrap token. */
+	InvalidBootstrapToken: () => ({
+		message: 'Invalid bootstrap token.',
+		status: 401 as const,
+	}),
+	/** No mirror row for the requested message id. */
+	MessageNotFound: () => ({
+		message: 'Message not found.',
+		status: 404 as const,
+	}),
+	/** A label modify was refused before Gmail (read-only mode, unknown label). */
+	ModifyFailed: ({ message }: { message: string }) => ({
+		message,
+		status: 400 as const,
+	}),
+	/** No route matched under `/api`. */
+	NotFound: () => ({
+		message: 'Not found.',
+		status: 404 as const,
+	}),
+});
+
+/** Discriminated union of all `/api` error payloads, keyed by `name`. */
+export type ApiError = InferErrors<typeof ApiError>;

--- a/apps/local-mail/src/http/api.ts
+++ b/apps/local-mail/src/http/api.ts
@@ -57,7 +57,7 @@ const MessageQuery = type({
 	'offset?': 'string',
 });
 
-export type ApiDeps = {
+type ApiDeps = {
 	rt: LocalMailRuntime;
 	syncDeps: SyncDeps;
 	readOnly: boolean;

--- a/apps/local-mail/src/http/api.ts
+++ b/apps/local-mail/src/http/api.ts
@@ -1,7 +1,7 @@
+import { randomBytes } from 'node:crypto';
 import { API_ROUTES } from '@epicenter/constants/api-routes';
 import { sValidator } from '@hono/standard-validator';
 import { type } from 'arktype';
-import { randomBytes } from 'node:crypto';
 import { Hono } from 'hono';
 import type { MailDb } from '../db.ts';
 import { resolveAndModifyMessageLabels } from '../modify.ts';
@@ -86,7 +86,10 @@ export function createApiApp(deps: ApiDeps) {
 		// The skip is an explicit path check, not a registration-order trick, so
 		// it stays correct wherever this middleware sits in the chain.
 		.use('/api/*', async (c, next) => {
-			if (c.req.path === API_ROUTES.session.pattern && c.req.method === 'POST') {
+			if (
+				c.req.path === API_ROUTES.session.pattern &&
+				c.req.method === 'POST'
+			) {
 				return next();
 			}
 			const header = c.req.header('authorization');

--- a/apps/local-mail/src/http/api.ts
+++ b/apps/local-mail/src/http/api.ts
@@ -8,6 +8,7 @@ import { resolveAndModifyMessageLabels } from '../modify.ts';
 import type { LocalMailRuntime } from '../runtime.ts';
 import { readMailStatus } from '../status.ts';
 import { type SyncDeps, syncMailbox } from '../sync.ts';
+import { ApiError } from './api-errors.ts';
 
 /**
  * The `/api` surface of `local-mail app`, as a Hono app. It owns routing, the
@@ -97,22 +98,26 @@ export function createApiApp(deps: ApiDeps) {
 				? header.slice('Bearer '.length)
 				: null;
 			if (!bearer || !sessionBearers.has(bearer)) {
-				return c.json({ error: 'Unauthorized. Restart local-mail app.' }, 401);
+				const err = ApiError.Unauthorized();
+				return c.json(err, err.error.status);
 			}
 			return next();
 		})
 		// The one unauthenticated mutation: exchange the bootstrap for a bearer.
 		.post(API_ROUTES.session.pattern, sValidator('json', SessionBody), (c) => {
 			if (bootstrapToken === null) {
-				return c.json({ error: 'No bootstrap token is outstanding.' }, 401);
+				const err = ApiError.NoBootstrapToken();
+				return c.json(err, err.error.status);
 			}
 			if (failedExchanges >= MAX_FAILED_EXCHANGES) {
-				return c.json({ error: 'Too many exchange attempts.' }, 429);
+				const err = ApiError.TooManyExchanges();
+				return c.json(err, err.error.status);
 			}
 			const { token } = c.req.valid('json');
 			if (token !== bootstrapToken) {
 				failedExchanges += 1;
-				return c.json({ error: 'Invalid bootstrap token.' }, 401);
+				const err = ApiError.InvalidBootstrapToken();
+				return c.json(err, err.error.status);
 			}
 			const bearer = mintToken();
 			sessionBearers.add(bearer);
@@ -147,7 +152,10 @@ export function createApiApp(deps: ApiDeps) {
 		// Hono already URL-decodes path params, so no manual decodeURIComponent.
 		.get('/api/messages/:id', (c) => {
 			const detail = db.getMessageDetail(c.req.param('id'));
-			if (!detail) return c.json({ error: 'Message not found.' }, 404);
+			if (!detail) {
+				const err = ApiError.MessageNotFound();
+				return c.json(err, err.error.status);
+			}
 			return c.json(detail);
 		})
 		.post('/api/sync', async (c) => {
@@ -165,10 +173,16 @@ export function createApiApp(deps: ApiDeps) {
 				removeLabels: removeLabels ?? [],
 				readOnly,
 			});
-			if (error) return c.json({ error: error.message }, 400);
+			if (error) {
+				const err = ApiError.ModifyFailed({ message: error.message });
+				return c.json(err, err.error.status);
+			}
 			return c.json(data);
 		})
-		.notFound((c) => c.json({ error: 'Not found.' }, 404));
+		.notFound((c) => {
+			const err = ApiError.NotFound();
+			return c.json(err, err.error.status);
+		});
 
 	return app;
 }

--- a/apps/local-mail/src/http/api.ts
+++ b/apps/local-mail/src/http/api.ts
@@ -26,7 +26,7 @@ import { type SyncDeps, syncMailbox } from '../sync.ts';
  */
 
 /** Bound online guessing by another local user against the exchange endpoint. */
-export const MAX_FAILED_EXCHANGES = 25;
+const MAX_FAILED_EXCHANGES = 25;
 
 /** 256 bits of CSPRNG, base64url: well past the spec's 128-bit floor. */
 export function mintToken(): string {
@@ -85,7 +85,9 @@ export function createApiApp(deps: ApiDeps) {
 		// The skip is an explicit path check, not a registration-order trick, so
 		// it stays correct wherever this middleware sits in the chain.
 		.use('/api/*', async (c, next) => {
-			if (c.req.path === '/api/session') return next();
+			if (c.req.path === '/api/session' && c.req.method === 'POST') {
+				return next();
+			}
 			const header = c.req.header('authorization');
 			const bearer = header?.startsWith('Bearer ')
 				? header.slice('Bearer '.length)

--- a/apps/local-mail/src/http/api.ts
+++ b/apps/local-mail/src/http/api.ts
@@ -1,0 +1,171 @@
+import { sValidator } from '@hono/standard-validator';
+import { type } from 'arktype';
+import { randomBytes } from 'node:crypto';
+import { Hono } from 'hono';
+import type { MailDb } from '../db.ts';
+import { resolveAndModifyMessageLabels } from '../modify.ts';
+import type { LocalMailRuntime } from '../runtime.ts';
+import { readMailStatus } from '../status.ts';
+import { type SyncDeps, syncMailbox } from '../sync.ts';
+
+/**
+ * The `/api` surface of `local-mail app`, as a Hono app. It owns routing, the
+ * bearer gate, and request validation; the loopback host primitive around it
+ * (`Bun.serve` in `app.ts`) owns the Host-check kill switch and static SPA
+ * serving: `/api/*` falls through to this Hono app, `/*` serves `ui/dist`.
+ *
+ * The app is built by a factory so its per-launch dependencies (the writer db,
+ * the sync gate, the valid-bearer set) are injected rather than captured at
+ * module load, while `export type ApiApp = ReturnType<typeof createApiApp>`
+ * still hands the SPA a precise end-to-end typed `hc` client. Every handler
+ * returns `c.json(...)`, so the client's response types are inferred from the
+ * exact shapes the server returns: the wire contract cannot silently drift.
+ *
+ * Writes go through the same core the CLI and MCP use
+ * (`resolveAndModifyMessageLabels`); there are no per-intent routes.
+ */
+
+/** Bound online guessing by another local user against the exchange endpoint. */
+export const MAX_FAILED_EXCHANGES = 25;
+
+/** 256 bits of CSPRNG, base64url: well past the spec's 128-bit floor. */
+export function mintToken(): string {
+	return randomBytes(32).toString('base64url');
+}
+
+// Request schemas are arktype, the repo's HTTP-boundary validator (paired with
+// `@hono/standard-validator`, as in `packages/server`). typebox stays for the
+// Gmail wire shapes in `schema.ts`; these are two different boundaries.
+
+/** `POST /api/session` body: the single-use bootstrap token being exchanged. */
+const SessionBody = type({ token: 'string >= 1' });
+
+/** `POST /api/messages/modify` body: ids plus the add/remove label sets the UI
+ * desugars its archive/read/label intents into. */
+const ModifyBody = type({
+	ids: 'string[]',
+	'addLabels?': 'string[]',
+	'removeLabels?': 'string[]',
+});
+
+/** `GET /api/messages` query. Values arrive as strings; `limit`/`offset` are
+ * parsed and clamped in the handler, matching the original bounds. */
+const MessageQuery = type({
+	'label?': 'string',
+	'q?': 'string',
+	'limit?': 'string',
+	'offset?': 'string',
+});
+
+export type ApiDeps = {
+	rt: LocalMailRuntime;
+	syncDeps: SyncDeps;
+	readOnly: boolean;
+	/** The one in-process serialize gate: the background loop and `POST /api/sync`
+	 * both enqueue here, so at most one pass touches the mirror at a time. */
+	gate: <T>(fn: () => Promise<T>) => Promise<T>;
+	/** The valid-bearer set, owned by the launcher so dev can pre-seed the fixed
+	 * proxy token. Prod fills it only through the bootstrap exchange below. */
+	sessionBearers: Set<string>;
+	/** The single-use bootstrap token, or `null` in dev (the Vite proxy carries
+	 * the bearer, so no exchange runs). Consumed at first successful exchange. */
+	bootstrapToken: string | null;
+};
+
+export function createApiApp(deps: ApiDeps) {
+	const { rt, syncDeps, readOnly, gate, sessionBearers } = deps;
+	const db: MailDb = syncDeps.db;
+
+	// Per-launch auth state, mutated in place across requests.
+	let bootstrapToken = deps.bootstrapToken;
+	let failedExchanges = 0;
+
+	const app = new Hono()
+		// The bearer gate on every `/api` route except the one public exchange.
+		// The skip is an explicit path check, not a registration-order trick, so
+		// it stays correct wherever this middleware sits in the chain.
+		.use('/api/*', async (c, next) => {
+			if (c.req.path === '/api/session') return next();
+			const header = c.req.header('authorization');
+			const bearer = header?.startsWith('Bearer ')
+				? header.slice('Bearer '.length)
+				: null;
+			if (!bearer || !sessionBearers.has(bearer)) {
+				return c.json({ error: 'Unauthorized. Restart local-mail app.' }, 401);
+			}
+			return next();
+		})
+		// The one unauthenticated mutation: exchange the bootstrap for a bearer.
+		.post('/api/session', sValidator('json', SessionBody), (c) => {
+			if (bootstrapToken === null) {
+				return c.json({ error: 'No bootstrap token is outstanding.' }, 401);
+			}
+			if (failedExchanges >= MAX_FAILED_EXCHANGES) {
+				return c.json({ error: 'Too many exchange attempts.' }, 429);
+			}
+			const { token } = c.req.valid('json');
+			if (token !== bootstrapToken) {
+				failedExchanges += 1;
+				return c.json({ error: 'Invalid bootstrap token.' }, 401);
+			}
+			const bearer = mintToken();
+			sessionBearers.add(bearer);
+			bootstrapToken = null; // single use: invalidate at exchange
+			return c.json({ token: bearer });
+		})
+		.get('/api/status', async (c) => {
+			const status = await readMailStatus(rt);
+			return c.json({
+				accountEmail: status.accountEmail,
+				connected: status.connected,
+				mirror: status.mirror,
+				historyId: status.historyId,
+				lastSyncedAt: status.lastSyncedAt,
+				lastFullPullAt: status.lastFullPullAt,
+				rows: status.rows,
+				readOnly,
+			});
+		})
+		.get('/api/labels', (c) => c.json({ labels: db.listLabels() }))
+		.get('/api/messages', sValidator('query', MessageQuery), (c) => {
+			const { label, q, limit, offset } = c.req.valid('query');
+			return c.json({
+				messages: db.listMessages({
+					labelId: label,
+					search: q?.trim() || undefined,
+					limit: Math.min(Number(limit) || 100, 200),
+					offset: Math.max(Number(offset) || 0, 0),
+				}),
+			});
+		})
+		// Hono already URL-decodes path params, so no manual decodeURIComponent.
+		.get('/api/messages/:id', (c) => {
+			const detail = db.getMessageDetail(c.req.param('id'));
+			if (!detail) return c.json({ error: 'Message not found.' }, 404);
+			return c.json(detail);
+		})
+		.post('/api/sync', async (c) => {
+			const outcome = await gate(() =>
+				syncMailbox(syncDeps, { forceFull: false }),
+			);
+			return c.json(outcome);
+		})
+		.post('/api/messages/modify', sValidator('json', ModifyBody), async (c) => {
+			const { ids, addLabels, removeLabels } = c.req.valid('json');
+			const { data, error } = await resolveAndModifyMessageLabels({
+				deps: syncDeps,
+				ids,
+				addLabels: addLabels ?? [],
+				removeLabels: removeLabels ?? [],
+				readOnly,
+			});
+			if (error) return c.json({ error: error.message }, 400);
+			return c.json(data);
+		})
+		.notFound((c) => c.json({ error: 'Not found.' }, 404));
+
+	return app;
+}
+
+/** The typed shape of the `/api` app, for the SPA's `hc<ApiApp>` client. */
+export type ApiApp = ReturnType<typeof createApiApp>;

--- a/apps/local-mail/src/read-models.test.ts
+++ b/apps/local-mail/src/read-models.test.ts
@@ -1,6 +1,6 @@
 /**
  * The HTTP read surface's projections (db.ts's `listMessages`,
- * `getMessageDetail`, `listLabels`). These are the read models `local-mail up`
+ * `getMessageDetail`, `listLabels`). These are the read models `local-mail app`
  * serves to the triage SPA; the point of the tests is that they project Gmail's
  * own mirrored bytes (label ids, epoch dates, headers, extracted body) without
  * inventing state: label filtering is a `json_each` over the stored `labelIds`,

--- a/apps/local-mail/ui/package.json
+++ b/apps/local-mail/ui/package.json
@@ -12,6 +12,7 @@
 		"typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
 	},
 	"devDependencies": {
+		"@epicenter/local-mail": "workspace:*",
 		"@epicenter/ui": "workspace:*",
 		"@lucide/svelte": "catalog:",
 		"@sveltejs/adapter-static": "catalog:",
@@ -28,7 +29,8 @@
 		"vite": "catalog:"
 	},
 	"dependencies": {
-		"@tanstack/svelte-query": "catalog:"
+		"@tanstack/svelte-query": "catalog:",
+		"hono": "catalog:"
 	},
 	"license": "AGPL-3.0-or-later"
 }

--- a/apps/local-mail/ui/package.json
+++ b/apps/local-mail/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@epicenter/local-mail-ui",
-	"description": "Local Mail triage SPA, served same-origin by `local-mail up`",
+	"description": "Local Mail triage SPA, served same-origin by `local-mail app`",
 	"private": true,
 	"version": "0.0.1",
 	"type": "module",

--- a/apps/local-mail/ui/src/lib/api.ts
+++ b/apps/local-mail/ui/src/lib/api.ts
@@ -73,10 +73,12 @@ const base =
 const client = hc<ApiApp>(base, { fetch: authedFetch });
 
 async function toError(res: Response): Promise<Error> {
+	// Errors arrive as wellcrafted's envelope `{ data: null, error: { name,
+	// message, status } }` from the `/api` app's `defineErrors` variants.
 	const body = (await res.json().catch(() => null)) as {
-		error?: string;
+		error?: { message?: string };
 	} | null;
-	return new Error(body?.error ?? `Request failed (${res.status}).`);
+	return new Error(body?.error?.message ?? `Request failed (${res.status}).`);
 }
 
 type MessageQuery = {

--- a/apps/local-mail/ui/src/lib/api.ts
+++ b/apps/local-mail/ui/src/lib/api.ts
@@ -71,9 +71,6 @@ const base =
 	typeof window === 'undefined' ? 'http://localhost' : window.location.origin;
 const client = hc<ApiApp>(base, { fetch: authedFetch });
 
-/** The typed client, exported so `types.ts` derives the wire shapes from it. */
-export type ApiClient = typeof client;
-
 async function toError(res: Response): Promise<Error> {
 	const body = (await res.json().catch(() => null)) as {
 		error?: string;

--- a/apps/local-mail/ui/src/lib/api.ts
+++ b/apps/local-mail/ui/src/lib/api.ts
@@ -78,7 +78,7 @@ async function toError(res: Response): Promise<Error> {
 	return new Error(body?.error ?? `Request failed (${res.status}).`);
 }
 
-export type MessageQuery = {
+type MessageQuery = {
 	label?: string;
 	search?: string;
 	limit?: number;

--- a/apps/local-mail/ui/src/lib/api.ts
+++ b/apps/local-mail/ui/src/lib/api.ts
@@ -1,18 +1,14 @@
-import type {
-	MailboxStatus,
-	MailLabel,
-	MessageDetail,
-	MessageSummary,
-	ModifyMessageLabelsOutcome,
-	SyncOutcome,
-} from './types';
+import type { ApiApp } from '@epicenter/local-mail/http/api';
+import { hc } from 'hono/client';
 
-// The same-origin `/api` client. The bearer lives in sessionStorage: it
-// survives F5 within the tab, dies with the tab, and is unreadable by any
-// sandboxed mail-body frame. In production the SPA earns the bearer once by
-// exchanging the single-use bootstrap token carried in the URL fragment; in dev
-// the Vite proxy injects a fixed bearer, so no exchange runs and no credential
-// touches the browser.
+// The same-origin `/api` client, typed end to end by `hc<ApiApp>`: its request
+// and response shapes are inferred from the Hono routes in
+// `apps/local-mail/src/http/api.ts`, so the wire contract cannot drift from the
+// server. The bearer lives in sessionStorage: it survives F5 within the tab,
+// dies with the tab, and is unreadable by any sandboxed mail-body frame. In
+// production the SPA earns the bearer once by exchanging the single-use
+// bootstrap token carried in the URL fragment; in dev the Vite proxy injects a
+// fixed bearer, so no exchange runs and no credential touches the browser.
 
 const BEARER_KEY = 'local-mail:session-bearer';
 
@@ -53,20 +49,36 @@ function ensureSession(): Promise<void> {
 	return sessionReady;
 }
 
-async function request<T>(path: string, init?: RequestInit): Promise<T> {
+// Every hc request routes through this: ensure the session exists, then attach
+// the per-launch bearer. The bootstrap exchange above uses a raw fetch, so it
+// never re-enters here. Typed with an explicit signature rather than `typeof
+// fetch` so it does not have to restate Bun's `fetch.preconnect`.
+const authedFetch = async (
+	input: RequestInfo | URL,
+	init?: RequestInit,
+): Promise<Response> => {
 	await ensureSession();
 	const headers = new Headers(init?.headers);
-	headers.set('content-type', 'application/json');
 	const bearer = readBearer();
 	if (bearer) headers.set('authorization', `Bearer ${bearer}`);
-	const res = await fetch(path, { ...init, headers });
-	if (!res.ok) {
-		const body = (await res.json().catch(() => null)) as {
-			error?: string;
-		} | null;
-		throw new Error(body?.error ?? `Request failed (${res.status}).`);
-	}
-	return res.json() as Promise<T>;
+	return fetch(input, { ...init, headers });
+};
+
+// Same-origin: hc needs an absolute base for URL construction, and this module
+// only ever executes in the browser (the SPA is `ssr: false`, `prerender:
+// false`). The localhost fallback keeps a stray import from throwing at load.
+const base =
+	typeof window === 'undefined' ? 'http://localhost' : window.location.origin;
+const client = hc<ApiApp>(base, { fetch: authedFetch });
+
+/** The typed client, exported so `types.ts` derives the wire shapes from it. */
+export type ApiClient = typeof client;
+
+async function toError(res: Response): Promise<Error> {
+	const body = (await res.json().catch(() => null)) as {
+		error?: string;
+	} | null;
+	return new Error(body?.error ?? `Request failed (${res.status}).`);
 }
 
 export type MessageQuery = {
@@ -77,29 +89,45 @@ export type MessageQuery = {
 };
 
 export const api = {
-	status: () => request<MailboxStatus>('/api/status'),
-	labels: () => request<{ labels: MailLabel[] }>('/api/labels'),
-	messages: (query: MessageQuery = {}) => {
-		const params = new URLSearchParams();
-		if (query.label) params.set('label', query.label);
-		if (query.search) params.set('q', query.search);
-		if (query.limit) params.set('limit', String(query.limit));
-		if (query.offset) params.set('offset', String(query.offset));
-		const qs = params.toString();
-		return request<{ messages: MessageSummary[] }>(
-			`/api/messages${qs ? `?${qs}` : ''}`,
-		);
+	status: async () => {
+		const res = await client.api.status.$get();
+		if (!res.ok) throw await toError(res);
+		return res.json();
 	},
-	message: (id: string) =>
-		request<MessageDetail>(`/api/messages/${encodeURIComponent(id)}`),
-	sync: () => request<SyncOutcome>('/api/sync', { method: 'POST' }),
-	modify: (input: {
+	labels: async () => {
+		const res = await client.api.labels.$get();
+		if (!res.ok) throw await toError(res);
+		return res.json();
+	},
+	messages: async (query: MessageQuery = {}) => {
+		const res = await client.api.messages.$get({
+			query: {
+				...(query.label ? { label: query.label } : {}),
+				...(query.search ? { q: query.search } : {}),
+				...(query.limit != null ? { limit: String(query.limit) } : {}),
+				...(query.offset != null ? { offset: String(query.offset) } : {}),
+			},
+		});
+		if (!res.ok) throw await toError(res);
+		return res.json();
+	},
+	message: async (id: string) => {
+		const res = await client.api.messages[':id'].$get({ param: { id } });
+		if (!res.ok) throw await toError(res);
+		return res.json();
+	},
+	sync: async () => {
+		const res = await client.api.sync.$post();
+		if (!res.ok) throw await toError(res);
+		return res.json();
+	},
+	modify: async (input: {
 		ids: string[];
 		addLabels?: string[];
 		removeLabels?: string[];
-	}) =>
-		request<ModifyMessageLabelsOutcome>('/api/messages/modify', {
-			method: 'POST',
-			body: JSON.stringify(input),
-		}),
+	}) => {
+		const res = await client.api.messages.modify.$post({ json: input });
+		if (!res.ok) throw await toError(res);
+		return res.json();
+	},
 };

--- a/apps/local-mail/ui/src/lib/types.ts
+++ b/apps/local-mail/ui/src/lib/types.ts
@@ -8,7 +8,9 @@ import type { api } from './api';
 
 export type MailboxStatus = Awaited<ReturnType<typeof api.status>>;
 
-export type MailLabel = Awaited<ReturnType<typeof api.labels>>['labels'][number];
+export type MailLabel = Awaited<
+	ReturnType<typeof api.labels>
+>['labels'][number];
 
 export type MessageSummary = Awaited<
 	ReturnType<typeof api.messages>

--- a/apps/local-mail/ui/src/lib/types.ts
+++ b/apps/local-mail/ui/src/lib/types.ts
@@ -16,9 +16,4 @@ export type MessageSummary = Awaited<
 
 export type MessageDetail = Awaited<ReturnType<typeof api.message>>;
 
-export type SyncOutcome = Awaited<ReturnType<typeof api.sync>>;
-
 export type ModifyMessageLabelsOutcome = Awaited<ReturnType<typeof api.modify>>;
-
-export type ModifyMessageLabelsResult =
-	ModifyMessageLabelsOutcome['results'][number];

--- a/apps/local-mail/ui/src/lib/types.ts
+++ b/apps/local-mail/ui/src/lib/types.ts
@@ -1,65 +1,24 @@
-// The `/api` wire shapes, mirrored from `apps/local-mail/src` (db.ts read models
-// and modify.ts). Kept as a small hand-copy rather than a cross-package import
-// so the SPA builds standalone; the contract is stable (Phase 3 froze
-// `ModifyMessageLabelsOutcome`, up-shell spec froze the routes).
+// The `/api` wire shapes, derived from the typed `hc` client (which infers them
+// from the Hono routes in `apps/local-mail/src/http/api.ts`). This used to be a
+// hand-copy kept in sync by hand; deriving it means a server response-shape
+// change surfaces here, and then in the components, as a type error rather than
+// a silent drift.
 
-export type MailboxStatus = {
-	accountEmail: string;
-	connected: boolean;
-	mirror: 'empty' | 'building' | 'ready';
-	historyId: string | null;
-	lastSyncedAt: string | null;
-	lastFullPullAt: string | null;
-	rows: { messages: number; labels: number };
-	readOnly: boolean;
-};
+import type { api } from './api';
 
-export type MailLabel = {
-	id: string;
-	name: string | null;
-	type: string | null;
-};
+export type MailboxStatus = Awaited<ReturnType<typeof api.status>>;
 
-export type MessageSummary = {
-	id: string;
-	threadId: string | null;
-	subject: string | null;
-	sender: string | null;
-	snippet: string | null;
-	internalDate: number | null;
-	labelIds: string[];
-};
+export type MailLabel = Awaited<ReturnType<typeof api.labels>>['labels'][number];
 
-export type MessageDetail = MessageSummary & {
-	to: string | null;
-	date: string | null;
-	bodyText: string | null;
-};
+export type MessageSummary = Awaited<
+	ReturnType<typeof api.messages>
+>['messages'][number];
 
-/** Per-id result of one `messages.modify`. `folded: false` means Gmail accepted
- * the change but the mirror row was not patched from the response, so it catches
- * up on the next sync. */
-export type ModifyMessageLabelsResult = {
-	id: string;
-	labelIds: string[] | null;
-	folded: boolean;
-	error: { name: string; message: string } | null;
-};
+export type MessageDetail = Awaited<ReturnType<typeof api.message>>;
 
-/** The one contract shared by CLI, MCP, and this HTTP route. A systemic abort
- * (token, throttle, network) sets `aborted` and stops the remaining ids. */
-export type ModifyMessageLabelsOutcome = {
-	results: ModifyMessageLabelsResult[];
-	aborted: { name: string; message: string } | null;
-};
+export type SyncOutcome = Awaited<ReturnType<typeof api.sync>>;
 
-export type SyncOutcome = {
-	mode: 'FULL' | 'INCREMENTAL';
-	reason: string;
-	cursorBefore: string | null;
-	cursorAfter: string | null;
-	messagesUpserted: number;
-	messagesDeleted: number;
-	labelsPatched: number;
-	failure: { name: string; message: string } | null;
-};
+export type ModifyMessageLabelsOutcome = Awaited<ReturnType<typeof api.modify>>;
+
+export type ModifyMessageLabelsResult =
+	ModifyMessageLabelsOutcome['results'][number];

--- a/apps/local-mail/ui/src/routes/+layout.ts
+++ b/apps/local-mail/ui/src/routes/+layout.ts
@@ -1,4 +1,4 @@
-// The triage UI is a client-only SPA served from disk by `local-mail up`
+// The triage UI is a client-only SPA served from disk by `local-mail app`
 // (adapter-static + fallback). No SSR, no prerender: the browser owns routing
 // and every byte of state comes from `/api` behind the per-launch bearer.
 export const ssr = false;

--- a/apps/local-mail/ui/svelte.config.js
+++ b/apps/local-mail/ui/svelte.config.js
@@ -4,7 +4,7 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		// The SPA is served at the loopback origin root by `local-mail up`, which
+		// The SPA is served at the loopback origin root by `local-mail app`, which
 		// reads bytes from `ui/dist`. `fallback` makes every deep link resolve to
 		// the same shell (client-only routing).
 		adapter: staticAdapter({

--- a/apps/local-mail/ui/vite.config.ts
+++ b/apps/local-mail/ui/vite.config.ts
@@ -7,7 +7,7 @@ import { defineConfig } from 'vite';
 // the SPA and proxies `/api` to the running app process; the proxy injects the
 // dev bearer (`LOCAL_MAIL_TOKEN`) server-side and rewrites Host via
 // `changeOrigin`, so the app server's Host check and bearer check both pass
-// without any credential ever reaching the browser (up-shell spec, Dev mode).
+// without any credential ever reaching the browser (loopback shell spec, Dev mode).
 const SPA_DEV_PORT = 5177;
 
 export default defineConfig(({ command }) => {

--- a/apps/local-mail/ui/vite.config.ts
+++ b/apps/local-mail/ui/vite.config.ts
@@ -2,23 +2,23 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
 
-// The SPA is same-origin with the API. In production `local-mail up` serves
+// The SPA is same-origin with the API. In production `local-mail app` serves
 // both the built SPA and `/api` from one loopback origin. In dev, Vite serves
-// the SPA and proxies `/api` to the running `up` process; the proxy injects the
+// the SPA and proxies `/api` to the running app process; the proxy injects the
 // dev bearer (`LOCAL_MAIL_TOKEN`) server-side and rewrites Host via
-// `changeOrigin`, so the up server's Host check and bearer check both pass
+// `changeOrigin`, so the app server's Host check and bearer check both pass
 // without any credential ever reaching the browser (up-shell spec, Dev mode).
 const SPA_DEV_PORT = 5177;
 
 export default defineConfig(({ command }) => {
-	const UP_PORT = Number(process.env.LOCAL_MAIL_PORT) || 4177;
-	// The proxy must send the exact bearer `up` accepts. No default: a silent
-	// fallback that disagrees with `up` is the "Unauthorized" footgun. Both
+	const APP_PORT = Number(process.env.LOCAL_MAIL_PORT) || 4177;
+	// The proxy must send the exact bearer `app` accepts. No default: a silent
+	// fallback that disagrees with `app` is the "Unauthorized" footgun. Both
 	// processes read the same LOCAL_MAIL_TOKEN, so require it for the dev server.
 	const DEV_TOKEN = process.env.LOCAL_MAIL_TOKEN;
 	if (command === 'serve' && !DEV_TOKEN) {
 		throw new Error(
-			'LOCAL_MAIL_TOKEN is required for the dev server so its /api proxy sends the same bearer as `local-mail up`. Start both with the same token, e.g. LOCAL_MAIL_TOKEN=devtoken.',
+			'LOCAL_MAIL_TOKEN is required for the dev server so its /api proxy sends the same bearer as `local-mail app`. Start both with the same token, e.g. LOCAL_MAIL_TOKEN=devtoken.',
 		);
 	}
 	return {
@@ -28,7 +28,7 @@ export default defineConfig(({ command }) => {
 			strictPort: true,
 			proxy: {
 				'/api': {
-					target: `http://127.0.0.1:${UP_PORT}`,
+					target: `http://127.0.0.1:${APP_PORT}`,
 					changeOrigin: true,
 					configure: (proxy) => {
 						proxy.on('proxyReq', (proxyReq) => {

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",
@@ -181,7 +180,10 @@
       "name": "@epicenter/local-mail",
       "version": "0.0.1",
       "dependencies": {
+        "@hono/standard-validator": "catalog:",
         "@modelcontextprotocol/sdk": "catalog:",
+        "arktype": "catalog:",
+        "hono": "catalog:",
         "oauth4webapi": "catalog:",
         "typebox": "catalog:",
         "wellcrafted": "catalog:",
@@ -196,8 +198,10 @@
       "version": "0.0.1",
       "dependencies": {
         "@tanstack/svelte-query": "catalog:",
+        "hono": "catalog:",
       },
       "devDependencies": {
+        "@epicenter/local-mail": "workspace:*",
         "@epicenter/ui": "workspace:*",
         "@lucide/svelte": "catalog:",
         "@sveltejs/adapter-static": "catalog:",

--- a/specs/20260701T141500-local-mail-up-bun-served-shell.md
+++ b/specs/20260701T141500-local-mail-up-bun-served-shell.md
@@ -2,12 +2,13 @@
 
 **Date**: 2026-07-01
 **Status**: Draft
+**Note (2026-07-03):** the verb shipped as `local-mail app` (renamed from `up`); this spec's body still says `up` in places as historical context.
 **Owner**: Braden
 **Relates**: ADR-0084 (the pattern's origin: Super Chat's shell is a Bun-hosted local server), ADR-0098 (`docs/adr/0098-local-mail-state-round-trips-through-gmail.md`, Accepted: every human-actionable Local Mail concept round-trips through Gmail state), ADR-0080 (desktop host; phone = remote session, not per-app reach), ADR-0082 (poll-only mirror), ADR-0066 (`bun build --compile` binary + Tauri sidecar shape; now the distribution wave, not a v1 gate), `specs/20260701T140000-local-mail-phase-2-engine.md` (prerequisite engine work), `specs/20260630T150000-local-mail-tauri-cdc-mirror.md` (parent spec; its Phase 4 assumed a Tauri shell, this spec replaces that assumption)
 
 ## One Sentence
 
-`local-mail up` runs one Bun process that both syncs the Gmail mirror and serves the mail UI as a same-origin SPA on `127.0.0.1` behind a per-launch session bearer; the v1 product is the engine plus stdio MCP, and the UI ships read-write or not at all (Phase C gates on Phase D write-through), because a read-only mail client actively desynchronizes triage.
+`local-mail app` runs one Bun process that both syncs the Gmail mirror and serves the mail UI as a same-origin SPA on `127.0.0.1` behind a per-launch session bearer; the v1 product is the engine plus stdio MCP, and the UI ships read-write or not at all (Phase C gates on Phase D write-through), because a read-only mail client actively desynchronizes triage.
 
 ## How to read this spec
 
@@ -31,7 +32,7 @@ This creates problems with the old Phase 4 framing:
 
 ```sh
 local-mail connect      # once per device
-local-mail up           # sync loop + UI server; prints http://127.0.0.1:PORT/#token=...
+local-mail app          # sync loop + UI server; prints http://127.0.0.1:PORT/#token=...
                         # and opens the browser; the tab is the app
 local-mail mcp          # agents (unchanged)
 ```


### PR DESCRIPTION
`local-mail app` (renamed from `up`) is one Bun process that serves the triage SPA and its `/api` over `127.0.0.1` while the same process keeps the mirror fresh. This reshapes that surface so `/api` is a typed Hono app the SPA consumes end to end through an `hc` client, instead of a hand-rolled `Bun.serve` fetch switch paired with hand-copied wire types on the client.

## Old shape, new shape

Before, `up.ts` owned everything in one `Bun.serve({ fetch })` switch: routing, the bearer gate, request parsing, the Host-check kill switch, static serving, and lifecycle. The SPA re-declared each request and response shape by hand, so a server change and its client type drifted silently.

```
Before                              After
──────                              ─────
src/up.ts                           src/app.ts        ← loopback host only:
  Bun.serve({ fetch })                Host check, static SPA, sync loop,
    ├─ Host check                     account lock, lifecycle → api.fetch
    ├─ bearer gate                  src/http/api.ts   ← Hono app:
    ├─ parse + route /api             routing, bearer gate, arktype validation
    └─ serve ui/dist                  export type ApiApp = ReturnType<…>
ui hand-writes every wire type      ui/lib/api.ts     ← hc<ApiApp> client
                                    ui/lib/types.ts   ← types derived from it
```

`app.ts` now keeps only the loopback host primitive and dispatches `/api/*` to `api.fetch`. `src/http/api.ts` owns routing, the bearer gate, and arktype request validation (via `@hono/standard-validator`, matching `packages/server`).

## Typed end to end

`createApiApp` is a factory so per-launch dependencies (the writer db, the sync gate, the valid-bearer set, the bootstrap token) are injected rather than captured at module load. Its return type is exported as `ApiApp`, which hands the SPA a precise `hc<ApiApp>` client:

```ts
// ui/src/lib/api.ts
import type { ApiApp } from '@epicenter/local-mail/http/api';
const client = hc<ApiApp>(base, { fetch: authedFetch });

// ui/src/lib/types.ts — wire shapes derived from the client, not hand-copied
export type MessageDetail = Awaited<ReturnType<typeof api.message>>;
```

Every handler returns `c.json(...)`, so a change to a server response shape surfaces as a type error in `types.ts` and the components that consume it, rather than silent drift.

## Command surface

`up` becomes `app`, and its two env knobs are promoted to real flags, `--no-open` and `--port`, with `LOCAL_MAIL_NO_OPEN` and `LOCAL_MAIL_PORT` kept as fallbacks. `app` names the human surface (the tab is the app) and pairs with `mcp` as the machine surface. The security model is unchanged: a single-use bootstrap token rides in the URL fragment and is exchanged once at `POST /api/session` for a per-launch session bearer; every request is Host-checked first; writes go through the same core the CLI verbs and MCP tool use, so `LOCAL_MAIL_READ_ONLY` disables them end to end.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785703289&installation_id=128463665&pr_number=2322&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2322&signature=dca58ac6208c14aa17cd3a91ace7a324e80c74276ca326caa208b3bf9eb4c583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->