### PR TITLE
refactor(whispering): prune GGUF cleanup leftovers

### DIFF
--- a/apps/whispering/src-tauri/src/transcription/catalog.rs
+++ b/apps/whispering/src-tauri/src/transcription/catalog.rs
@@ -130,6 +130,15 @@ fn find(model_id: &str) -> Option<&'static CatalogEntry> {
     CATALOG.iter().find(|entry| entry.id() == model_id)
 }
 
+/// Resolve a model id to its catalog entry, or the `UnknownModel` error the
+/// `download_model`/`delete_model` commands both return for an id not in the
+/// catalog. One place owns that message so the two commands cannot drift.
+fn find_or_unknown(model_id: &str) -> Result<&'static CatalogEntry, CatalogError> {
+    find(model_id).ok_or_else(|| CatalogError::UnknownModel {
+        message: format!("Unknown local model \"{model_id}\"."),
+    })
+}
+
 /// Resolve a stored model id to its on-disk GGUF path, or a user-facing message.
 /// The one place `transcribe_recording`/`prewarm_model` turn a selection into a
 /// path: an unknown id or a not-yet-downloaded model both fail here with a
@@ -253,9 +262,7 @@ pub async fn download_model(
     on_progress: Channel<DownloadProgress>,
     manager: State<'_, DownloadManager>,
 ) -> Result<(), CatalogError> {
-    let entry = find(&model_id).ok_or_else(|| CatalogError::UnknownModel {
-        message: format!("Unknown local model \"{model_id}\"."),
-    })?;
+    let entry = find_or_unknown(&model_id)?;
 
     let api = ApiBuilder::from_env()
         .with_progress(false)
@@ -290,9 +297,7 @@ pub async fn download_model(
 #[tauri::command]
 #[specta::specta]
 pub fn delete_model(model_id: String) -> Result<(), CatalogError> {
-    let entry = find(&model_id).ok_or_else(|| CatalogError::UnknownModel {
-        message: format!("Unknown local model \"{model_id}\"."),
-    })?;
+    let entry = find_or_unknown(&model_id)?;
 
     let Some(pointer) = entry.cached_path() else {
         return Ok(());

--- a/apps/whispering/src-tauri/src/transcription/error.rs
+++ b/apps/whispering/src-tauri/src/transcription/error.rs
@@ -7,9 +7,6 @@ pub enum TranscriptionError {
     #[error("Audio read error: {message}")]
     AudioReadError { message: String },
 
-    #[error("GPU error: {message}")]
-    GpuError { message: String },
-
     #[error("Model load error: {message}")]
     ModelLoadError { message: String },
 

--- a/apps/whispering/src/lib/tauri/bindings.gen.ts
+++ b/apps/whispering/src/lib/tauri/bindings.gen.ts
@@ -718,7 +718,6 @@ export type ShortcutTriggerEvent = {
 
 export type TranscriptionError =
 	| { name: 'AudioReadError'; message: string }
-	| { name: 'GpuError'; message: string }
 	| { name: 'ModelLoadError'; message: string }
 	| { name: 'TranscriptionError'; message: string }
 	/**


### PR DESCRIPTION
The GGUF migration removed the old local runtime split, but left behind two small pieces of cleanup surface.

This drops the unreachable `GpuError` transcription variant. The transcribe-cpp path falls back from GPU initialization to CPU where appropriate and reports load failures through `ModelLoadError`, so the generated frontend union no longer needs a variant that Rust never constructs.

It also routes catalog lookup failures in `download_model` and `delete_model` through one helper, keeping the user-facing `UnknownModel` message owned in one place.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785707807&installation_id=128463665&pr_number=2327&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2327&signature=ee752c5337da321610525a30eabaaebda741c76257b41763ab1f6cb8444704ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->