### PR TITLE
fix(local-books): route /api errors through a defineErrors envelope, derive SPA request types

### DIFF
--- a/apps/local-books/package.json
+++ b/apps/local-books/package.json
@@ -28,6 +28,7 @@
 		"build:binary": "bun build --compile --outfile dist/local-books src/bin.ts"
 	},
 	"dependencies": {
+		"@epicenter/constants": "workspace:*",
 		"@hono/standard-validator": "catalog:",
 		"@modelcontextprotocol/sdk": "catalog:",
 		"arktype": "catalog:",

--- a/apps/local-books/src/http/api-errors.ts
+++ b/apps/local-books/src/http/api-errors.ts
@@ -1,0 +1,90 @@
+import { defineErrors, type InferErrors } from 'wellcrafted/error';
+
+/**
+ * Structured error variants for the loopback `/api` surface of `local-books app`.
+ *
+ * Every non-2xx response from the Hono app ({@link api.ts}, its only emitter)
+ * comes from one of these variants, so the wire shape is `wellcrafted`'s
+ * envelope `{ data: null, error: { name, message, status } }` and each variant
+ * bakes in its own HTTP `status`. Emit as `c.json(err, err.error.status)`; the
+ * `c-json-errors` biome gate is satisfied because a factory result is not an
+ * inline object literal.
+ *
+ * The one consumer is the same-origin SPA, which surfaces `error.message` in a
+ * toast; it does not branch on `error.name`. The variants exist to keep the
+ * error surface centralized and typed, not because a remote client reads them.
+ *
+ * @example
+ * ```ts
+ * import { ApiError } from './api-errors.ts';
+ * const err = ApiError.RowNotFound();
+ * return c.json(err, err.error.status); // 404
+ * ```
+ */
+export const ApiError = defineErrors({
+	/** Missing or unknown bearer on a gated `/api` route. */
+	Unauthorized: () => ({
+		message: 'Unauthorized. Restart local-books app.',
+		status: 401 as const,
+	}),
+	/** A bootstrap exchange arrived after the single-use token was consumed. */
+	NoBootstrapToken: () => ({
+		message: 'No bootstrap token is outstanding.',
+		status: 401 as const,
+	}),
+	/** Exchange attempts exceeded the online-guessing bound. */
+	TooManyExchanges: () => ({
+		message: 'Too many exchange attempts.',
+		status: 429 as const,
+	}),
+	/** The exchanged token did not match the outstanding bootstrap token. */
+	InvalidBootstrapToken: () => ({
+		message: 'Invalid bootstrap token.',
+		status: 401 as const,
+	}),
+	/** A path parameter named an entity the registry does not know. */
+	UnknownEntity: ({ entity }: { entity: string }) => ({
+		message: `Unknown entity "${entity}".`,
+		status: 400 as const,
+	}),
+	/** No mirror row for the requested entity id. */
+	RowNotFound: () => ({
+		message: 'Row not found.',
+		status: 404 as const,
+	}),
+	/** A read-only SQL query failed (bad SQL, or a write refused by the connection). */
+	QueryFailed: ({ message }: { message: string }) => ({
+		message,
+		status: 400 as const,
+	}),
+	/** A background/on-demand sync pass could not run. */
+	SyncFailed: ({ message }: { message: string }) => ({
+		message,
+		status: 502 as const,
+	}),
+	/** A live QuickBooks report read failed upstream. */
+	ReportFailed: ({ message }: { message: string }) => ({
+		message,
+		status: 502 as const,
+	}),
+	/**
+	 * The one QuickBooks write-back was refused or failed. The core owns the
+	 * refusal; the boundary only maps its `error.name` to the HTTP `status`
+	 * (ReadOnly -> 403, NotInMirror -> 404, otherwise 400).
+	 */
+	RecategorizeFailed: ({
+		message,
+		status,
+	}: {
+		message: string;
+		status: 400 | 403 | 404;
+	}) => ({ message, status }),
+	/** No route matched under `/api`. */
+	NotFound: () => ({
+		message: 'Not found.',
+		status: 404 as const,
+	}),
+});
+
+/** Discriminated union of all `/api` error payloads, keyed by `name`. */
+export type ApiError = InferErrors<typeof ApiError>;

--- a/apps/local-books/src/http/api.ts
+++ b/apps/local-books/src/http/api.ts
@@ -2,6 +2,7 @@ import { randomBytes } from 'node:crypto';
 import { sValidator } from '@hono/standard-validator';
 import { type } from 'arktype';
 import { Hono } from 'hono';
+import { ApiError } from './api-errors.ts';
 import type { OpenQbClient } from '../books/qb-access.ts';
 import { queryBooks } from '../books/query.ts';
 import {
@@ -136,22 +137,26 @@ export function createApiApp(deps: ApiDeps) {
 				? header.slice('Bearer '.length)
 				: null;
 			if (!bearer || !sessionBearers.has(bearer)) {
-				return c.json({ error: 'Unauthorized. Restart local-books app.' }, 401);
+				const err = ApiError.Unauthorized();
+				return c.json(err, err.error.status);
 			}
 			return next();
 		})
 		// The one unauthenticated mutation: exchange the bootstrap for a bearer.
 		.post('/api/session', sValidator('json', SessionBody), (c) => {
 			if (bootstrapToken === null) {
-				return c.json({ error: 'No bootstrap token is outstanding.' }, 401);
+				const err = ApiError.NoBootstrapToken();
+				return c.json(err, err.error.status);
 			}
 			if (failedExchanges >= MAX_FAILED_EXCHANGES) {
-				return c.json({ error: 'Too many exchange attempts.' }, 429);
+				const err = ApiError.TooManyExchanges();
+				return c.json(err, err.error.status);
 			}
 			const { token } = c.req.valid('json');
 			if (token !== bootstrapToken) {
 				failedExchanges += 1;
-				return c.json({ error: 'Invalid bootstrap token.' }, 401);
+				const err = ApiError.InvalidBootstrapToken();
+				return c.json(err, err.error.status);
 			}
 			const bearer = mintToken();
 			sessionBearers.add(bearer);
@@ -171,7 +176,8 @@ export function createApiApp(deps: ApiDeps) {
 			// The registry is the SQL-identifier boundary: a name it does not know
 			// never reaches a table string.
 			if (!isKnownEntity(entity)) {
-				return c.json({ error: `Unknown entity "${entity}".` }, 400);
+				const err = ApiError.UnknownEntity({ entity });
+				return c.json(err, err.error.status);
 			}
 			const { limit, offset } = c.req.valid('query');
 			return c.json(
@@ -186,25 +192,35 @@ export function createApiApp(deps: ApiDeps) {
 		.get('/api/entities/:entity/:id', (c) => {
 			const entity = c.req.param('entity');
 			if (!isKnownEntity(entity)) {
-				return c.json({ error: `Unknown entity "${entity}".` }, 400);
+				const err = ApiError.UnknownEntity({ entity });
+				return c.json(err, err.error.status);
 			}
 			const detail = getEntityRow({
 				dbPath,
 				def: entityDef(entity),
 				id: c.req.param('id'),
 			});
-			if (!detail) return c.json({ error: 'Row not found.' }, 404);
+			if (!detail) {
+				const err = ApiError.RowNotFound();
+				return c.json(err, err.error.status);
+			}
 			return c.json(detail);
 		})
 		.post('/api/query', sValidator('json', QueryBody), (c) => {
 			const { sql } = c.req.valid('json');
 			const { data, error } = queryBooks({ dbPath, sql });
-			if (error) return c.json({ error: error.message }, 400);
+			if (error) {
+				const err = ApiError.QueryFailed({ message: error.message });
+				return c.json(err, err.error.status);
+			}
 			return c.json(data);
 		})
 		.post('/api/sync', async (c) => {
 			const result = await gate(syncNow);
-			if ('failed' in result) return c.json({ error: result.failed }, 502);
+			if ('failed' in result) {
+				const err = ApiError.SyncFailed({ message: result.failed });
+				return c.json(err, err.error.status);
+			}
 			return c.json(result.outcome);
 		})
 		.post('/api/report', sValidator('json', ReportBody), async (c) => {
@@ -212,7 +228,10 @@ export function createApiApp(deps: ApiDeps) {
 				openQb,
 				input: c.req.valid('json'),
 			});
-			if (error) return c.json({ error: error.message }, 502);
+			if (error) {
+				const err = ApiError.ReportFailed({ message: error.message });
+				return c.json(err, err.error.status);
+			}
 			return c.json(data);
 		})
 		.post(
@@ -235,12 +254,19 @@ export function createApiApp(deps: ApiDeps) {
 							: error.name === 'NotInMirror'
 								? 404
 								: 400;
-					return c.json({ error: error.message }, status);
+					const err = ApiError.RecategorizeFailed({
+						message: error.message,
+						status,
+					});
+					return c.json(err, err.error.status);
 				}
 				return c.json(data);
 			},
 		)
-		.notFound((c) => c.json({ error: 'Not found.' }, 404));
+		.notFound((c) => {
+			const err = ApiError.NotFound();
+			return c.json(err, err.error.status);
+		});
 
 	return app;
 }

--- a/apps/local-books/src/http/api.ts
+++ b/apps/local-books/src/http/api.ts
@@ -2,7 +2,6 @@ import { randomBytes } from 'node:crypto';
 import { sValidator } from '@hono/standard-validator';
 import { type } from 'arktype';
 import { Hono } from 'hono';
-import { ApiError } from './api-errors.ts';
 import type { OpenQbClient } from '../books/qb-access.ts';
 import { queryBooks } from '../books/query.ts';
 import {
@@ -20,6 +19,7 @@ import type { AppConfig } from '../config.ts';
 import { entityDef, isKnownEntity } from '../entities.ts';
 import type { SyncOutcome } from '../sync.ts';
 import type { TokenStore } from '../token-store.ts';
+import { ApiError } from './api-errors.ts';
 
 /**
  * The `/api` surface of `local-books app`, as a Hono app. It owns routing, the

--- a/apps/local-books/src/http/api.ts
+++ b/apps/local-books/src/http/api.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from 'node:crypto';
+import { API_ROUTES } from '@epicenter/constants/api-routes';
 import { sValidator } from '@hono/standard-validator';
 import { type } from 'arktype';
 import { Hono } from 'hono';
@@ -129,7 +130,10 @@ export function createApiApp(deps: ApiDeps) {
 		// skip is an explicit path check, not a registration-order trick, so it stays
 		// correct wherever this middleware sits in the chain.
 		.use('/api/*', async (c, next) => {
-			if (c.req.path === '/api/session' && c.req.method === 'POST') {
+			if (
+				c.req.path === API_ROUTES.session.pattern &&
+				c.req.method === 'POST'
+			) {
 				return next();
 			}
 			const header = c.req.header('authorization');
@@ -143,7 +147,7 @@ export function createApiApp(deps: ApiDeps) {
 			return next();
 		})
 		// The one unauthenticated mutation: exchange the bootstrap for a bearer.
-		.post('/api/session', sValidator('json', SessionBody), (c) => {
+		.post(API_ROUTES.session.pattern, sValidator('json', SessionBody), (c) => {
 			if (bootstrapToken === null) {
 				const err = ApiError.NoBootstrapToken();
 				return c.json(err, err.error.status);

--- a/apps/local-books/test/app-api.test.ts
+++ b/apps/local-books/test/app-api.test.ts
@@ -302,8 +302,8 @@ describe('local-books app /api', () => {
 			}),
 		);
 		expect(res.status).toBe(403);
-		expect((await res.json()) as { error: string }).toMatchObject({
-			error: expect.stringContaining('read-only'),
+		expect((await res.json()) as { error: { message: string } }).toMatchObject({
+			error: { message: expect.stringContaining('read-only') },
 		});
 	});
 

--- a/apps/local-books/ui/package.json
+++ b/apps/local-books/ui/package.json
@@ -29,6 +29,7 @@
 		"vite": "catalog:"
 	},
 	"dependencies": {
+		"@epicenter/constants": "workspace:*",
 		"@tanstack/svelte-query": "catalog:",
 		"hono": "catalog:"
 	},

--- a/apps/local-books/ui/src/lib/api.ts
+++ b/apps/local-books/ui/src/lib/api.ts
@@ -1,3 +1,4 @@
+import { API_ROUTES } from '@epicenter/constants/api-routes';
 import type { ApiApp } from '@epicenter/local-books/http/api';
 import { hc, type InferRequestType } from 'hono/client';
 
@@ -33,7 +34,7 @@ async function bootstrap(): Promise<void> {
 		'',
 		window.location.pathname + window.location.search,
 	);
-	const res = await fetch('/api/session', {
+	const res = await fetch(API_ROUTES.session.pattern, {
 		method: 'POST',
 		headers: { 'content-type': 'application/json' },
 		body: JSON.stringify({ token: bootstrapToken }),

--- a/apps/local-books/ui/src/lib/api.ts
+++ b/apps/local-books/ui/src/lib/api.ts
@@ -72,10 +72,13 @@ const base =
 const client = hc<ApiApp>(base, { fetch: authedFetch });
 
 async function toError(res: Response): Promise<Error> {
+	// Every `/api` error is the wellcrafted envelope `{ data: null, error: { name,
+	// message, status } }` (see `src/http/api-errors.ts`), so the human string is
+	// `error.message`.
 	const body = (await res.json().catch(() => null)) as {
-		error?: string;
+		error?: { message?: string } | null;
 	} | null;
-	return new Error(body?.error ?? `Request failed (${res.status}).`);
+	return new Error(body?.error?.message ?? `Request failed (${res.status}).`);
 }
 
 // Request shapes derived from the hono client, so they cannot drift from the

--- a/apps/local-books/ui/src/lib/api.ts
+++ b/apps/local-books/ui/src/lib/api.ts
@@ -1,5 +1,5 @@
 import type { ApiApp } from '@epicenter/local-books/http/api';
-import { hc } from 'hono/client';
+import { hc, type InferRequestType } from 'hono/client';
 
 // The same-origin `/api` client, typed end to end by `hc<ApiApp>`: its request and
 // response shapes are inferred from the Hono routes in
@@ -78,26 +78,16 @@ async function toError(res: Response): Promise<Error> {
 	return new Error(body?.error ?? `Request failed (${res.status}).`);
 }
 
-export type ReportInput = {
-	report:
-		| 'ProfitAndLoss'
-		| 'BalanceSheet'
-		| 'CashFlow'
-		| 'AgedReceivables'
-		| 'AgedPayables'
-		| 'TrialBalance';
-	start_date?: string;
-	end_date?: string;
-	accounting_method?: 'Cash' | 'Accrual';
-};
-
-export type RecategorizeInput = {
-	entity: 'Purchase' | 'Bill';
-	id: string;
-	account_id: string;
-	account_name?: string;
-	line_id?: string;
-};
+// Request shapes derived from the hono client, so they cannot drift from the
+// server's arktype `ReportBody` / `RecategorizeBody`. Changing a server schema now
+// surfaces here as a type error rather than silently diverging from a hand union.
+// `ReportPanel` and `RowDetail` import these.
+export type ReportInput = InferRequestType<
+	typeof client.api.report.$post
+>['json'];
+export type RecategorizeInput = InferRequestType<
+	typeof client.api.recategorize.$post
+>['json'];
 
 export const api = {
 	status: async () => {

--- a/apps/local-books/ui/src/lib/components/StatusBar.svelte
+++ b/apps/local-books/ui/src/lib/components/StatusBar.svelte
@@ -23,13 +23,11 @@
 	// token has lapsed (browse still works, sync will fail), "empty" before the
 	// first pull.
 	const tone = $derived(
-		!status
+		!status || !status.mirrorBuilt
 			? 'bg-muted-foreground'
-			: !status.mirrorBuilt
-				? 'bg-muted-foreground'
-				: status.accessToken?.valid || status.refreshToken?.valid
-					? 'bg-emerald-500'
-					: 'bg-amber-500',
+			: status.accessToken?.valid || status.refreshToken?.valid
+				? 'bg-emerald-500'
+				: 'bg-amber-500',
 	);
 	const label = $derived(
 		!status

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",
@@ -165,6 +164,7 @@
         "local-books": "./src/bin.ts",
       },
       "dependencies": {
+        "@epicenter/constants": "workspace:*",
         "@hono/standard-validator": "catalog:",
         "@modelcontextprotocol/sdk": "catalog:",
         "arktype": "catalog:",
@@ -184,6 +184,7 @@
       "name": "@epicenter/local-books-ui",
       "version": "0.0.1",
       "dependencies": {
+        "@epicenter/constants": "workspace:*",
         "@tanstack/svelte-query": "catalog:",
         "hono": "catalog:",
       },


### PR DESCRIPTION
Follow-up on #2326 (the `local-books app` browser SPA). Two commits.

## 1. Fix the red `quality` gate (the important one)

`main` went red on the `quality` check the moment #2326 merged, and has stayed red. The SPA's server shell was copied from `local-mail` but skipped its error-envelope discipline: `apps/local-books/src/http/api.ts` emitted 11 ad-hoc `c.json({ error: string }, 4xx/5xx)` literals, which the repo-wide `scripts/biome/c-json-errors.grit` GritQL plugin rejects. Since `bun run lint:check` scans the whole repo, those 11 errors fail the gate for every PR.

Mirror local-mail's `api-errors.ts`: a local `ApiError = defineErrors({...})` from `wellcrafted/error` (already a dependency, so no new package and `bun build --compile` stays a single binary), each variant baking in its HTTP `status`. Every error path now emits `c.json(err, err.error.status)`, so the wire shape is one wellcrafted envelope `{ data: null, error: { name, message, status } }`. The recategorize path (whose variable `status` the plugin never flagged) is converted too, so all error responses share one shape.

The SPA's `toError` read `body.error` as a string; with the envelope it reads `body.error.message`. Updated the one test that asserted the old string shape.

## 2. Derive the SPA request types from the hono client

`ReportInput` and `RecategorizeInput` were hand-typed, re-declaring the server's arktype enums (the report enum was spelled three times: server `REPORT_NAMES` -> `api.ts` -> `ReportPanel`). This defeated the file's own doctrine, where response shapes derive from `hc<ApiApp>` so they can't drift.

```ts
export type ReportInput = InferRequestType<typeof client.api.report.$post>['json'];
export type RecategorizeInput = InferRequestType<typeof client.api.recategorize.$post>['json'];
```

`ReportPanel` keeps its runtime `REPORTS` array (the SPA imports `ApiApp` as a type only), but its element type is now `ReportInput['report']`. Also collapses `StatusBar`'s `tone` ternary, whose `!status` and `!status.mirrorBuilt` branches returned the same class.

## Not done
A generic `unwrap(res)` helper for the eight `api` methods was evaluated and abandoned: for the validator-bearing routes, `client.api.report.$post(...)` returns a union of `ClientResponse` over each status code whose `json()` return types are incompatible, so a single generic `T` does not unify and the call fails to type-check. The explicit `if (!res.ok) throw` form narrows the union per-call and keeps each success type precise, so it stays.