### PR TITLE
refactor(whispering): finish Privacy & Processing residue cleanup

### DIFF
--- a/apps/whispering/src/lib/components/settings/README.md
+++ b/apps/whispering/src/lib/components/settings/README.md
@@ -29,16 +29,26 @@ Components in this directory:
 
 ```
 settings/
-├── ProviderConfigFields.svelte # Per-provider API key and endpoint fields (deviceConfig)
-├── selectors/              # Various selector components
+├── TranscriptionRuntimeConfig.svelte # Audio stage: transcription service + its config (propless)
+├── CompletionRuntimeConfig.svelte    # Text stage: Polish/Recipes AI provider + its config (propless)
+├── ProviderConfigFields.svelte       # Per-provider API key and endpoint fields (deviceConfig)
+├── TranscriptionServiceSelect.svelte # Grouped local/cloud/self-hosted service picker
+├── LocalModelSelector.svelte         # Local GGUF model picker (deviceConfig)
+├── AdvancedDisclosure.svelte         # Collapsible wrapper for advanced fields
+├── SettingSelect.svelte              # Shared select bound to a settings key
+├── SettingSwitch.svelte              # Shared switch bound to a settings key
+├── selectors/                        # Various selector components
+│   ├── CaptureSurfaceSelector.svelte
 │   ├── ManualDeviceSelector.svelte
-│   ├── VadDeviceSelector.svelte
 │   ├── TranscriptionSelector.svelte
-│   └── CaptureSurfaceSelector.svelte
-├── LocalModelSelector.svelte
-├── TranscriptionServiceSelect.svelte
-└── README.md               # This file
+│   └── VadDeviceSelector.svelte
+└── README.md                         # This file
 ```
+
+The two runtime-config components (`TranscriptionRuntimeConfig`,
+`CompletionRuntimeConfig`) are the Privacy & Processing page's two stages. Each
+owns its own routing decision and takes **no props**, so the page renders them
+as `<TranscriptionRuntimeConfig />` and `<CompletionRuntimeConfig />`.
 
 ## Usage Examples
 

--- a/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
+++ b/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
@@ -9,7 +9,6 @@
 	import { Link } from '@epicenter/ui/link';
 	import * as Select from '@epicenter/ui/select';
 	import { Textarea } from '@epicenter/ui/textarea';
-	import type { Snippet } from 'svelte';
 	import CopyablePre from '$lib/components/copyable/CopyablePre.svelte';
 	import { SUPPORTED_LANGUAGES_OPTIONS } from '$lib/constants/languages';
 	import {
@@ -29,17 +28,10 @@
 	import ProviderConfigFields from './ProviderConfigFields.svelte';
 	import TranscriptionServiceSelect from './TranscriptionServiceSelect.svelte';
 
-	let {
-		id = 'selected-transcription-service',
-		label = 'Transcription Service',
-		description,
-		class: className,
-	}: {
-		id?: string;
-		label?: string;
-		description?: string | Snippet;
-		class?: string;
-	} = $props();
+	// The Audio stage of the capture pipeline: the transcription destination the
+	// recording is sent to. Like {@link CompletionRuntimeConfig}, this surface owns
+	// its own routing decision and takes no props, so the Privacy & Processing page
+	// renders it as `<TranscriptionRuntimeConfig />`.
 
 	const destination = $derived(
 		describeTranscriptionDestinationFromConfig({
@@ -101,11 +93,10 @@
 	);
 </script>
 
-<Field.Group class={className}>
+<Field.Group>
 	<TranscriptionServiceSelect
-		{id}
-		{label}
-		{description}
+		id="selected-transcription-service"
+		label="Service"
 		bind:selected={() => settings.get('transcription.service'),
 			(selected) =>
 				settings.set('transcription.service', selected)}

--- a/apps/whispering/src/lib/operations/completion-target.ts
+++ b/apps/whispering/src/lib/operations/completion-target.ts
@@ -42,6 +42,23 @@ export type InferenceConfigKey =
 	| (typeof INFERENCE)[InferenceProviderId]['apiKeyConfigKey']
 	| NonNullable<(typeof INFERENCE)[InferenceProviderId]['endpointConfigKey']>;
 
+/**
+ * The honest name for where completion text goes. Custom's label
+ * ("Custom (OpenAI-compatible)") names an API shape, not a destination, so the
+ * resolved host is the truthful thing to show; a canonical provider names
+ * itself. This is the single resolver ADR-0101 promises: the Processing
+ * readiness line and the pipeline privacy sentence both call it, so every
+ * surface names the same place and they can never drift apart.
+ */
+function resolveTextDestination(
+	provider: InferenceProviderId,
+	target: CompletionTarget,
+): string {
+	return provider === 'Custom'
+		? hostFromBaseUrl(target.baseUrl)
+		: INFERENCE[provider].label;
+}
+
 type DeviceConfigReader = (key: InferenceConfigKey) => string;
 
 export function resolveCompletionStateFromConfig({
@@ -104,13 +121,7 @@ export function describeCompletionReadiness(
 	if (state.textStaysOnDevice) {
 		return { ready: true, summary: 'Transcript text stays on this device.' };
 	}
-	// Custom's label ("Custom (OpenAI-compatible)") names a shape, not a
-	// destination, so the resolved host is the honest thing to show; a canonical
-	// provider names itself.
-	const destination =
-		provider === 'Custom'
-			? hostFromBaseUrl(state.target.baseUrl)
-			: INFERENCE[provider].label;
+	const destination = resolveTextDestination(provider, state.target);
 	return { ready: true, summary: `Transcript text is sent to ${destination}.` };
 }
 
@@ -140,14 +151,12 @@ export function describePolishDestination(
 		return 'Audio and transcript text both stay on this device.';
 	}
 
-	// Text leaves this device below. Name the resolved host for Custom (whose
-	// label names an API shape, not a destination), mirroring
-	// `describeCompletionReadiness` so every surface names the same place. A
-	// canonical provider names itself.
-	const textDestination =
-		completionProvider === 'Custom'
-			? hostFromBaseUrl(state.target.baseUrl)
-			: INFERENCE[completionProvider].label;
+	// Text leaves this device below; name where it goes through the shared
+	// resolver so this sentence and the Processing surface never disagree.
+	const textDestination = resolveTextDestination(
+		completionProvider,
+		state.target,
+	);
 
 	if (audio.onDevice) {
 		return `Audio is transcribed on-device, but Polish sends transcript text to ${textDestination}.`;

--- a/apps/whispering/src/routes/(app)/(config)/settings/processing/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/processing/+page.svelte
@@ -22,7 +22,7 @@
 			<Field.Description>
 				Where your recording is turned into text.
 			</Field.Description>
-			<TranscriptionRuntimeConfig label="Service" />
+			<TranscriptionRuntimeConfig />
 		</Field.Set>
 
 		<Field.Separator />


### PR DESCRIPTION
Finishes the residue cleanup on the Privacy & Processing settings surface. Three small, self-contained changes.

This change:

- **One text-destination resolver.** Extract the duplicated Custom-provider ternary (`hostFromBaseUrl` vs `INFERENCE[provider].label`) into a single `resolveTextDestination` helper in `completion-target.ts`. Both `describeCompletionReadiness` (the Processing readiness line) and `describePolishDestination` (the pipeline privacy sentence) now resolve the same place, so the two surfaces can never drift apart.
- **`TranscriptionRuntimeConfig` is now propless**, matching `CompletionRuntimeConfig`. Dropped the dead `id`/`label`/`description`/`class` props, hardcoded the select's id and label internally, and the Privacy & Processing page renders it as `<TranscriptionRuntimeConfig />`.
- **Refreshed the settings components README** so the tree lists the current Privacy & Processing components (`TranscriptionRuntimeConfig`, `CompletionRuntimeConfig`, `ProviderConfigFields`, `TranscriptionServiceSelect`, `LocalModelSelector`, `AdvancedDisclosure`, and the shared select/switch).

The scope is intentionally bounded:

Four files, no behavior change to the rendered UI. Does not touch provider lists, API Keys, discovery, local-runtime work, or `isTranscriptionServiceAvailable`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785710199&installation_id=128463665&pr_number=2330&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2330&signature=802781eb5cbf2b47941bbe3507cd6366ccd6db3a0dd3a9f39f8abf0ad0165ed7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->