### PR TITLE
refactor(whispering): collapse dead transcribe-dispatch guards (webview GGUF cleanup)

### DIFF
--- a/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
+++ b/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
@@ -11,7 +11,10 @@
 	import { Textarea } from '@epicenter/ui/textarea';
 	import type { Snippet } from 'svelte';
 	import CopyablePre from '$lib/components/copyable/CopyablePre.svelte';
-	import { SUPPORTED_LANGUAGES_OPTIONS } from '$lib/constants/languages';
+	import {
+		SUPPORTED_LANGUAGES_OPTIONS,
+		type SupportedLanguage,
+	} from '$lib/constants/languages';
 	import {
 		LOCAL_MODEL_UNLOAD_POLICY_OPTIONS,
 		type LocalModelUnloadPolicy,
@@ -384,7 +387,7 @@
 			<Select.Root
 				type="single"
 				bind:value={() => settings.get('transcription.language'),
-					(v) => settings.set('transcription.language', v)}
+					(v) => settings.set('transcription.language', v as SupportedLanguage)}
 				disabled={!currentServiceCapabilities.supportsLanguage}
 			>
 				<Select.Trigger id="spoken-language" class="w-full">

--- a/apps/whispering/src/lib/operations/transcribe.ts
+++ b/apps/whispering/src/lib/operations/transcribe.ts
@@ -12,10 +12,7 @@ import {
 import { Err, Ok, type Result } from 'wellcrafted/result';
 import { customFetch } from '#platform/http';
 import { tauri } from '#platform/tauri';
-import {
-	SUPPORTED_LANGUAGES,
-	type SupportedLanguage,
-} from '$lib/constants/languages';
+import type { SupportedLanguage } from '$lib/constants/languages';
 import { analytics } from '$lib/operations/analytics';
 import { report } from '$lib/report';
 import { services } from '$lib/services';
@@ -161,16 +158,6 @@ const UPLOAD_DISPATCH = {
 			}),
 	},
 } satisfies Record<UploadProviderId, UploadDispatch>;
-
-function getSpokenLanguage(): SupportedLanguage {
-	const language = settings.get('transcription.language');
-	for (const supportedLanguage of SUPPORTED_LANGUAGES) {
-		if (supportedLanguage === language) {
-			return supportedLanguage;
-		}
-	}
-	return 'auto';
-}
 
 /**
  * Materialize the bytes to upload for a cloud transcription. The recording
@@ -344,8 +331,8 @@ async function transcribeLocally(
 
 	// Read-at-use: the per-call spec is built right here, where it is consumed,
 	// so there is no ambient config to go stale. `auto` language and an empty
-	// prompt map to null (the wire's "unset"). The Dictionary terms fold into the
-	// prompt so local recognition spells them the user's way.
+	// prompt map to the wire's "unset" (an omitted optional field). The Dictionary
+	// terms fold into the prompt so local recognition spells them the user's way.
 	const language = settings.get('transcription.language');
 	const prompt = withDictionaryTerms(
 		settings.get('transcription.prompt'),
@@ -353,8 +340,8 @@ async function transcribeLocally(
 	);
 	return commands.transcribeRecording(recordingId, {
 		modelId,
-		language: language === 'auto' ? null : language,
-		initialPrompt: prompt || null,
+		language: language === 'auto' ? undefined : language,
+		initialPrompt: prompt || undefined,
 	});
 }
 
@@ -371,7 +358,7 @@ async function transcribeViaUpload(
 	// and the server answers 401, surfaced as a RequestFailed carrying that detail.
 	// The Dictionary terms fold into the prompt so cloud recognition spells them
 	// the user's way.
-	const spokenLanguage = getSpokenLanguage();
+	const spokenLanguage = settings.get('transcription.language');
 	const prompt = withDictionaryTerms(
 		settings.get('transcription.prompt'),
 		settings.get('dictionary'),

--- a/apps/whispering/src/lib/operations/transcribe.ts
+++ b/apps/whispering/src/lib/operations/transcribe.ts
@@ -24,8 +24,8 @@ import { ElevenLabsTranscriptionServiceLive } from '$lib/services/transcription/
 import { MistralTranscriptionServiceLive } from '$lib/services/transcription/cloud/mistral';
 import {
 	isLocalProviderId,
+	type LocalProviderId,
 	PROVIDERS,
-	type TranscriptionServiceId,
 	type UploadProviderId,
 } from '$lib/services/transcription/providers';
 import { deviceConfig } from '$lib/state/device-config.svelte';
@@ -46,9 +46,6 @@ import { commands } from '$lib/tauri/commands';
 export type TranscriptionError = AnyTaggedError;
 
 const TranscriptionOperationError = defineErrors({
-	NoTranscriptionServiceSelected: () => ({
-		message: 'Please select a transcription service in settings.',
-	}),
 	LocalTranscriptionUnavailableOnWeb: () => ({
 		message:
 			'Local transcription is only available in the desktop app. Choose a cloud or self-hosted provider on web.',
@@ -226,10 +223,12 @@ export async function transcribeAudio(
 		provider: selectedService,
 	});
 
-	const transcriptionResult =
-		PROVIDERS[selectedService].location === 'local'
-			? await transcribeLocally(recordingId, selectedService)
-			: await transcribeViaUpload(recordingId, selectedService);
+	// Narrow the id here, once. The type guard splits `selectedService` into the
+	// local vs upload id sets, so each path receives an already-narrowed id and
+	// neither has to re-check the case the other owns.
+	const transcriptionResult = isLocalProviderId(selectedService)
+		? await transcribeLocally(recordingId, selectedService)
+		: await transcribeViaUpload(recordingId, selectedService);
 
 	const duration = Date.now() - startTime;
 	if (transcriptionResult.error) {
@@ -328,14 +327,10 @@ function withDictionaryTerms(prompt: string, dictionary: string[]): string {
 
 async function transcribeLocally(
 	recordingId: string,
-	selectedService: TranscriptionServiceId,
+	selectedService: LocalProviderId,
 ): Promise<Result<string, TranscriptionError>> {
 	if (!tauri) {
 		return TranscriptionOperationError.LocalTranscriptionUnavailableOnWeb();
-	}
-
-	if (!isLocalProviderId(selectedService)) {
-		return TranscriptionOperationError.NoTranscriptionServiceSelected();
 	}
 
 	// Rust owns model resolution and validation: it resolves this catalog id to a
@@ -365,15 +360,8 @@ async function transcribeLocally(
 
 async function transcribeViaUpload(
 	recordingId: string,
-	selectedService: TranscriptionServiceId,
+	selectedService: UploadProviderId,
 ): Promise<Result<string, TranscriptionError>> {
-	// `transcribeAudio` routes local providers to `transcribeLocally`, so a local id
-	// is the impossible case here; this guard also narrows `selectedService` off the
-	// local ids so it indexes `UPLOAD_DISPATCH`.
-	if (isLocalProviderId(selectedService)) {
-		return TranscriptionOperationError.NoTranscriptionServiceSelected();
-	}
-
 	const { data: audio, error: loadError } =
 		await loadForCloudUpload(recordingId);
 	if (loadError) return Err(loadError);

--- a/apps/whispering/src/lib/state/device-config.svelte.ts
+++ b/apps/whispering/src/lib/state/device-config.svelte.ts
@@ -226,8 +226,9 @@ export const deviceConfig = createPersistedMap({
 
 // Nothing here is migrated from a legacy format; both prior formats take a clean
 // break. Local model selections once lived under `transcription.*.modelPath` as
-// filesystem paths: that key is simply orphaned now and the `transcription.*.model`
-// entry reads its default. Global shortcuts once stored accelerator strings under
+// filesystem paths: those keys are simply orphaned now and the
+// `transcription.local.selectedModel` entry reads its default (empty). Global
+// shortcuts once stored accelerator strings under
 // the same key: a legacy value fails the `globalBinding` schema on read and falls
 // back to the default (see `createPersistedMap`). Either way upgrading users get
 // the new defaults, and we carry no parser for a format nothing writes anymore.

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -14,6 +14,7 @@ import type { KeyBinding } from '$lib/tauri/commands';
 
 import { RECORDING_TRIGGERS } from '$lib/constants/audio/recording-triggers';
 import { INFERENCE_PROVIDER_IDS } from '$lib/constants/inference';
+import { SUPPORTED_LANGUAGES } from '$lib/constants/languages';
 import {
 	PROVIDERS,
 	TRANSCRIPTION_SERVICE_IDS,
@@ -204,7 +205,10 @@ function defineTranscriptionSettings(
 			field.string(),
 			() => PROVIDERS.Mistral.defaultModel as string,
 		),
-		'transcription.language': defineKv(field.string(), () => 'auto'),
+		'transcription.language': defineKv(
+			field.select(SUPPORTED_LANGUAGES),
+			() => 'auto' as const,
+		),
 		'transcription.prompt': defineKv(field.string(), () => ''),
 	} as const;
 }


### PR DESCRIPTION
The mirror-image cleanup of the webview TypeScript local-model / transcription layer, following #2328 (the Rust-side post-GGUF cleanup). The Rust pass established the contract: Rust owns the GGUF catalog, capabilities, cache, and eviction; the webview stores only the selected `modelId` and the unload policy. This pass trims the TS side to match.

The headline is that there was almost nothing to trim. The layer was written tightly during the GGUF migration, and the highest-value lead (orphans left by the removed Rust model-state observability in 55a135b) came up empty: no dead event listeners, no dead query keys, no unreachable UI branches, no `ModelStatus`/`onnx`/`whisper-cpp`/`modelPath` remnants. Two changes earned themselves.

## Narrow the transcribe dispatch once

`transcribeAudio` branched on `PROVIDERS[selectedService].location === 'local'`, which narrows a property access but not the `selectedService` variable. So `transcribeLocally` and `transcribeViaUpload` each re-checked the case the other owns, via an `isLocalProviderId` guard whose failure path was unreachable.

Branching on the `isLocalProviderId` type guard instead narrows the id itself: each path now receives an already-narrowed `LocalProviderId` / `UploadProviderId`, and both guards evaporate. Their sole error variant, `NoTranscriptionServiceSelected`, had no other caller (`transcription.service` is an enum with a default, so "nothing selected" is unreachable), so it goes too. The invariant "the local path only ever gets a local id" is now enforced by the type system at the call site rather than re-asserted defensively inside each function.

## Fix a stale key name in the device-config migration note

The clean-break note claimed the current entry was `transcription.*.model`, a pre-migration key shape that no longer exists and that collides with the unrelated cloud `transcription.openai.model` / `transcription.groq.model` setting keys. Corrected to the real key, `transcription.local.selectedModel`.

The scope is intentionally bounded:

Webview TypeScript + Svelte only. No Rust touched, no command signatures changed, `bindings.gen.ts` untouched. `bun run typecheck` is green (0 errors / 0 warnings on both tsconfigs, including the `commands.test-d.ts` type-tests). No behavior change.

## Own spoken-language validity at the schema

`transcription.language` was `field.string()` over the closed `SUPPORTED_LANGUAGES` set: the one closed-set setting stored as a raw string, unlike its four `field.select()` siblings. Its validity was enforced in three places at once (the UI option list, a `getSpokenLanguage()` re-validation loop on the cloud path, and the local path that trusted the raw string).

Typed as `field.select(SUPPORTED_LANGUAGES)`, `settings.get('transcription.language')` now returns `SupportedLanguage`, and `defineKv`'s documented validate-or-default semantics map a corrupt/synced value to the `'auto'` default: exactly what `getSpokenLanguage` did, now owned once at the schema. `getSpokenLanguage` deletes; both transcription paths read the typed value directly, which also fixes a latent case where the local path forwarded an unvalidated string to Rust. No migration is needed: every stored value is already a member (`'auto'` included), and the KV layer resets any non-member to the default on read.

The local path's unset sentinel is also unified on `undefined` to match the wire path. `TranscriptionSpec` is `language?: string | null`, so `undefined` and `null` both mean `None`; using `undefined` makes the local and cloud unset-mapping read identically.