### PR TITLE
refactor(local-books): collapse runApp to a single app-option object

### DIFF
--- a/apps/local-books/src/app.ts
+++ b/apps/local-books/src/app.ts
@@ -2,8 +2,8 @@ import { Database } from 'bun:sqlite';
 import { existsSync, mkdirSync } from 'node:fs';
 import { join, sep } from 'node:path';
 import { createQbAccess } from './books/qb-access.ts';
-import type { ParsedArgs } from './cli.ts';
 import { resolveCompany } from './commands/context.ts';
+import type { CliConfigOverrides } from './config.ts';
 import { openBooksDb } from './db.ts';
 import { createApiApp, mintToken, type SyncPassResult } from './http/api.ts';
 import { dbPath } from './paths.ts';
@@ -143,13 +143,12 @@ export function createRequestHandler({
 }
 
 export async function runApp(
-	args: ParsedArgs,
-	options: { noOpen: boolean; port?: number },
+	options: CliConfigOverrides & { noOpen?: boolean; port?: number },
 ): Promise<number> {
 	// Resolve the company the same way `sync`/`status` do: config from flags/env,
 	// then the realm (explicit flag, recorded default, or the sole authenticated
 	// one). Ambiguity is an error, not a silent guess.
-	const { data: company, error } = resolveCompany(args);
+	const { data: company, error } = resolveCompany(options);
 	if (error !== null) {
 		console.error(error);
 		return 1;

--- a/apps/local-books/src/cli.ts
+++ b/apps/local-books/src/cli.ts
@@ -244,7 +244,13 @@ export async function runCli(argv: string[]): Promise<number> {
 			return runRecategorize(args);
 		case 'app': {
 			const { runApp } = await import('./app.ts');
-			return runApp(args, { noOpen: args.noOpen, port: args.port });
+			return runApp({
+				dataDir: args.dataDir,
+				environment: args.environment,
+				realm: args.realm,
+				noOpen: args.noOpen,
+				port: args.port,
+			});
 		}
 		case 'demo':
 			return runDemo(args);

--- a/apps/local-books/src/commands/context.ts
+++ b/apps/local-books/src/commands/context.ts
@@ -36,11 +36,7 @@ export type CompanyContext = {
 export function resolveCompany(
 	overrides: CliConfigOverrides,
 ): Result<CompanyContext, string> {
-	const config = loadConfig({
-		dataDir: overrides.dataDir,
-		environment: overrides.environment,
-		realm: overrides.realm,
-	});
+	const config = loadConfig(overrides);
 	const { data: realmId, error } = resolveRealm(config);
 	if (error !== null) return Err(error);
 	return Ok({

--- a/apps/local-books/src/commands/context.ts
+++ b/apps/local-books/src/commands/context.ts
@@ -1,7 +1,10 @@
 import { Err, Ok, type Result } from 'wellcrafted/result';
-import type { ParsedArgs } from '../cli.ts';
 import { resolveRealm } from '../companies.ts';
-import { type AppConfig, loadConfig } from '../config.ts';
+import {
+	type AppConfig,
+	type CliConfigOverrides,
+	loadConfig,
+} from '../config.ts';
 import { createFileTokenStore, type TokenStore } from '../token-store.ts';
 
 /** Human-friendly "in 42m" / "3m ago" for the auth and status commands. */
@@ -31,12 +34,12 @@ export type CompanyContext = {
  * ambiguous or none is authenticated.
  */
 export function resolveCompany(
-	args: ParsedArgs,
+	overrides: CliConfigOverrides,
 ): Result<CompanyContext, string> {
 	const config = loadConfig({
-		dataDir: args.dataDir,
-		environment: args.environment,
-		realm: args.realm,
+		dataDir: overrides.dataDir,
+		environment: overrides.environment,
+		realm: overrides.realm,
 	});
 	const { data: realmId, error } = resolveRealm(config);
 	if (error !== null) return Err(error);


### PR DESCRIPTION
`local-books app` boots through `runApp`, which took the whole CLI `ParsedArgs` bag *and* a separate options object. That forced `app.ts` to import `ParsedArgs` and pin itself to the CLI's parser shape, even though the app server wants none of the parser: it wants a company to resolve and two launch flags.

Old shape:

```ts
// app.ts imports the CLI's parser type
import type { ParsedArgs } from './cli.ts';

export async function runApp(
  args: ParsedArgs,
  options: { noOpen: boolean; port?: number },
): Promise<number> { … }

// cli.ts
return runApp(args, { noOpen: args.noOpen, port: args.port });
```

New shape:

```ts
import type { CliConfigOverrides } from './config.ts';

export async function runApp(
  options: CliConfigOverrides & { noOpen?: boolean; port?: number },
): Promise<number> { … }

// cli.ts constructs exactly what the app consumes
return runApp({
  dataDir: args.dataDir,
  environment: args.environment,
  realm: args.realm,
  noOpen: args.noOpen,
  port: args.port,
});
```

The ownership flips: the type arrow now points `cli -> app` (the CLI constructs the app's input) instead of `app -> cli` (the app reaching back for the parser type). `app.ts` no longer imports `ParsedArgs`.

`resolveCompany` narrows from `ParsedArgs` to `CliConfigOverrides` for the same reason. The command verbs (`sync`, `status`, `query`, `report`, `recategorize`) still pass their full `ParsedArgs`, which is a structural superset, so they compile unchanged.

No behavior change: the dynamic `await import('./app.ts')` subcommand boundary, the loopback security model, and the SPA are all untouched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785712418&installation_id=128463665&pr_number=2334&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2334&signature=a552248c96fc698b6eaa9906f9a8c32186fdf98b6a289d262c715e5913776a1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->