### PR TITLE
fix(whispering): friendly local model name in selector, erase engine fossils from webview

### DIFF
--- a/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
+++ b/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
@@ -83,7 +83,7 @@
 		)?.label,
 	);
 
-	const isLocalEngine = $derived(
+	const isLocalProvider = $derived(
 		Boolean(tauri) &&
 			PROVIDERS[settings.get('transcription.service')].location === 'local',
 	);
@@ -334,7 +334,7 @@
 </Field.Group>
 
 {#snippet advancedFields()}
-	{#if isLocalEngine}
+	{#if isLocalProvider}
 		<Field.Field>
 			<Field.Label for="local-model-unload-policy">
 				Unload Model When Idle

--- a/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
@@ -21,6 +21,7 @@
 		isTranscriptionServiceConfigured,
 	} from '$lib/settings/transcription-validation';
 	import { deviceConfig } from '$lib/state/device-config.svelte';
+	import { localModels } from '$lib/state/local-models.svelte';
 	import { settings } from '$lib/state/settings.svelte';
 	import { tauri } from '#platform/tauri';
 
@@ -87,8 +88,13 @@
 				return settings.get(service.modelSettingKey);
 			case 'self-hosted':
 				return deviceConfig.get(service.endpointConfigKey);
-			case 'local':
-				return deviceConfig.get(service.modelConfigKey);
+			case 'local': {
+				// Resolve the opaque catalog id ("{repo}@{rev}/{file}") to its friendly
+				// name so the Local group's selection subtext reads as a model, not an
+				// HF coordinate. Falls back to the id if the store has not loaded yet.
+				const id = deviceConfig.get(service.modelConfigKey);
+				return localModels.find(id)?.name ?? id;
+			}
 		}
 	}
 

--- a/apps/whispering/src/lib/operations/transcription-target.ts
+++ b/apps/whispering/src/lib/operations/transcription-target.ts
@@ -48,7 +48,7 @@ export function resolveTranscriptionLocalityFromConfig({
 	getDeviceConfig: (key: TranscriptionEndpointKey) => string;
 }): TranscriptionLocality {
 	const provider = PROVIDERS[service];
-	// Local engines transcribe in-process; audio never becomes a network request.
+	// Local transcription runs in-process; audio never becomes a network request.
 	if (provider.location === 'local') {
 		return { onDevice: true, name: provider.label };
 	}

--- a/apps/whispering/src/lib/services/transcription/providers.ts
+++ b/apps/whispering/src/lib/services/transcription/providers.ts
@@ -282,9 +282,9 @@ export type CloudProviderId = {
 }[TranscriptionServiceId];
 
 /**
- * The ids of local engines, derived the same way. `isLocalProviderId` is the
- * one narrowing boundary callers use before reading local-only fields or
- * touching the engine's models folder.
+ * The ids of the local provider, derived the same way. `isLocalProviderId` is
+ * the one narrowing boundary callers use before reading local-only fields like
+ * the selected model's catalog id.
  */
 export type LocalProviderId = {
 	[K in TranscriptionServiceId]: (typeof PROVIDERS)[K]['location'] extends 'local'


### PR DESCRIPTION
The GGUF migration (#2324) collapsed three local transcription engines into one `local` provider backed by the shared Hugging Face cache, and #2328/#2331 did the structural cleanup. Four fossils from that world survived in the webview: JSDoc and comments that still say "engines" or point at a per-engine "models folder" that no longer exists, a derived flag named `isLocalEngine`, and one real UX bug.

The bug: in the transcription service dropdown, the **Local** group's selection subtext showed the raw opaque catalog id (`handy-computer/whisper-small-gguf@main/...`) instead of a readable model name. The `local` case of `getSelectedModelNameOrUrl` returned `deviceConfig.get(modelConfigKey)` directly. Selection is stored as an opaque id by design (per `local-models.svelte`, presence lives in the store and selection in deviceConfig, and "the selector joins them"), so the fix resolves the id through the store at display time, exactly the join the store's doc describes:

```ts
case 'local': {
    const id = deviceConfig.get(service.modelConfigKey);
    return localModels.find(id)?.name ?? id; // graceful fallback to id if not loaded
}
```

The other three commits are naming/comment-only: rewrite the `LocalProviderId` JSDoc to drop "engines" and the dead "models folder" phrase, rename `isLocalEngine` -> `isLocalProvider` (the flag means "local provider selected AND on desktop"), and fix a plural fossil comment in `transcription-target.ts`.

Scope is webview TypeScript/Svelte only. Matching `all three local transcription engines` fossils remain in `src-tauri/**` (audio/decode.rs, audio/mod.rs, recorder/recorder.rs, audio/command.rs, recorder/artifact.rs) and are intentionally left for a separate Rust pass.

## Changelog

- Fixed the transcription service picker showing a downloaded local model's raw Hugging Face coordinate instead of its friendly name.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785713260&installation_id=128463665&pr_number=2336&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2336&signature=565a3ef313bc05bad7d9966b6acd89c8347e88a5cd242298b56e507d26d26d2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->