### PR TITLE
chore(scripts): standardize Tauri app dev scripts on dev:desktop

### DIFF
--- a/.agents/skills/monorepo/SKILL.md
+++ b/.agents/skills/monorepo/SKILL.md
@@ -52,12 +52,18 @@ Use this pattern when you need to:
 
 Apps use either a single `dev` script (when there is only one sensible local
 workflow) or a `dev:local` alias (kept for symmetry with `:remote` db scripts).
-The suffix convention applies primarily to database commands:
+Tauri desktop apps (honeycrisp, whispering, matter) have two dev surfaces and
+name them explicitly instead: `dev` launches the desktop shell (aliasing
+`dev:desktop`), and `dev:web` runs Vite alone, which each app's
+`tauri.conf.json` invokes as its `beforeDevCommand`. The suffix convention
+applies primarily to database commands:
 
 | Script | Meaning |
 | --- | --- |
 | `dev` | The default local workflow. May still require Infisical login for app secrets (e.g. API keys), but only ever talks to local infrastructure at runtime. |
 | `dev:local` | Used when an app keeps the `dev` -> `dev:local` alias for explicit naming. Equivalent to `dev`. |
+| `dev:web` | Tauri apps: the Vite dev server alone, no desktop shell. Invoked by `tauri.conf.json` as `beforeDevCommand`. |
+| `dev:desktop` | Tauri apps: launches the native desktop app (`tauri dev`). `dev` aliases this. |
 | `db:*:local` | Runs against local Postgres. Works without Infisical login. |
 | `db:*:remote` | Wraps with `infisical run --env=prod`. Production data; treat as admin. |
 

--- a/apps/matter/package.json
+++ b/apps/matter/package.json
@@ -5,9 +5,9 @@
 	"version": "0.0.2",
 	"type": "module",
 	"scripts": {
-		"dev": "bun run dev:local",
-		"dev:local": "bun tauri dev --config '{\"identifier\": \"so.epicenter.matter.dev\"}'",
+		"dev": "bun run dev:desktop",
 		"dev:web": "vite dev",
+		"dev:desktop": "bun tauri dev --config '{\"identifier\": \"so.epicenter.matter.dev\"}'",
 		"dev:fixture": "bun scripts/dev-fixture.ts",
 		"build": "vite build",
 		"preview": "vite preview",

--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -70,9 +70,9 @@
 		}
 	},
 	"scripts": {
+		"dev": "bun run dev:desktop",
 		"dev:web": "vite dev",
-		"dev": "bun run dev:local",
-		"dev:local": "bun run scripts/launch-dev.ts",
+		"dev:desktop": "bun run scripts/launch-dev.ts",
 		"dev:doctor": "bun run scripts/dev-doctor.ts",
 		"test": "bun test tests/",
 		"build": "NODE_ENV=production vite build",


### PR DESCRIPTION
All three Tauri apps now expose the same three dev commands in the same order: `bun dev` launches the desktop shell, `bun run dev:web` starts Vite alone (what Tauri runs as `beforeDevCommand`), and `bun run dev:desktop` is the explicit desktop entry.

Whispering and Matter previously drove the desktop dev app through `dev:local`, which reads identically to the Vite-only `dev:local` used by this repo's non-Tauri apps (opensidian, vocab, skills, landing, api/ui). Honeycrisp already switched to `dev:desktop` (#2335). This renames `dev:local` to `dev:desktop` in Whispering and Matter and points `dev` at it, and documents the convention in the monorepo skill so the next Tauri app follows the same shape.

Pure rename, no behavior change: each script runs the exact command it ran before.
- Whispering `dev:desktop` = `bun run scripts/launch-dev.ts` (the cross-platform `tauri dev` launcher).
- Matter `dev:desktop` = `bun tauri dev --config '{"identifier": "so.epicenter.matter.dev"}'`.

No caller depended on the old name:
- `dev:web` (each `tauri.conf.json` `beforeDevCommand`) is untouched.
- The root `dev:tab-manager:ui` targets the extension's own `dev:local`, not these apps.
- Only historical `specs/*` docs referenced the old name; per `AGENTS.md` those are history, not current truth.

Scope is deliberately Tauri-only. Several non-Tauri apps still wrap `dev` -> `dev:local` -> tool where `dev:local` is just the single dev command (a documented alias, `.agents/skills/monorepo` "Dev Scripts"); normalizing those is a valid but separate low-risk follow-up, not part of this PR.

## Changelog
- Standardize Whispering and Matter dev scripts on `dev:desktop` to match Honeycrisp
- Document the Tauri `dev:web` / `dev:desktop` convention in the monorepo skill
