### PR TITLE
fix(workspace): handle IndexedDB eviction without closed-database writes

### DIFF
--- a/packages/workspace/src/document/attach-indexed-db-eviction.test.ts
+++ b/packages/workspace/src/document/attach-indexed-db-eviction.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Regression guard for the closed-IndexedDB write crash.
+ *
+ * When ANOTHER connection deletes a database a live doc still holds open (a
+ * second tab's `wipe()`, any cross-context `clearDocument`), `lib0` fires
+ * `versionchange` and closes our connection. Upstream `IndexeddbPersistence`
+ * left its `update` listener subscribed and `this.db` pointing at the closed
+ * database, so the next Yjs write threw "Can't start a transaction on a closed
+ * database" straight into the caller (chat send, model write). `attachIndexedDb`
+ * now takes over the `versionchange` handler: it tears the connection down
+ * cleanly (unsubscribing that listener) and hands off to `onEvicted` to re-boot.
+ */
+import { expect, test } from 'bun:test';
+import { field } from '@epicenter/field';
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb';
+import { clearDocument } from 'y-indexeddb';
+import * as Y from 'yjs';
+import { attachIndexedDb } from './attach-indexed-db.js';
+import { attachRecords } from './attach-records.js';
+import { defineTable } from './define-table.js';
+import { defineWorkspace } from './workspace.js';
+
+Object.assign(globalThis, { indexedDB, IDBKeyRange });
+
+class FakeBroadcastChannel {
+	onmessage: ((event: MessageEvent) => void) | null = null;
+	constructor(readonly name: string) {}
+	postMessage(_message: unknown): void {}
+	close(): void {}
+}
+Object.assign(globalThis, {
+	BroadcastChannel: FakeBroadcastChannel as unknown as typeof BroadcastChannel,
+});
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 20));
+
+test('external deletion evicts the gateway cleanly instead of crashing later writes', async () => {
+	const name = `evict-${crypto.randomUUID()}`;
+	const doc = new Y.Doc({ guid: name });
+	let evicted = 0;
+	const idb = attachIndexedDb(doc, {
+		databaseName: name,
+		onEvicted: () => {
+			evicted += 1;
+		},
+	});
+	await idb.whenLoaded;
+	doc.getMap('m').set('a', 1);
+	await tick();
+
+	// A second connection (a second tab) deletes this database.
+	await clearDocument(name);
+	await tick();
+
+	expect(evicted).toBe(1);
+	// The still-live doc keeps rendering; its writes must be clean no-ops now,
+	// not synchronous crashes into the caller.
+	expect(() => doc.getMap('m').set('b', 2)).not.toThrow();
+	await idb.whenDisposed;
+
+	doc.destroy();
+});
+
+test('our own clearLocal() deletes the store without counting as a foreign eviction', async () => {
+	// The sign-in migration calls `source.clearLocal()` while its throwaway
+	// source doc is still open; that self-delete must not trigger a page reload.
+	const name = `self-clear-${crypto.randomUUID()}`;
+	const doc = new Y.Doc({ guid: name });
+	let evicted = 0;
+	const idb = attachIndexedDb(doc, {
+		databaseName: name,
+		onEvicted: () => {
+			evicted += 1;
+		},
+	});
+	await idb.whenLoaded;
+	doc.getMap('m').set('a', 1);
+	await tick();
+
+	await idb.clearLocal();
+	await tick();
+
+	expect(evicted).toBe(0);
+	expect(() => doc.getMap('m').set('b', 2)).not.toThrow();
+
+	doc.destroy();
+});
+
+test('our own ydoc.destroy() does not count as an eviction', async () => {
+	const name = `self-${crypto.randomUUID()}`;
+	const doc = new Y.Doc({ guid: name });
+	let evicted = 0;
+	const idb = attachIndexedDb(doc, {
+		databaseName: name,
+		onEvicted: () => {
+			evicted += 1;
+		},
+	});
+	await idb.whenLoaded;
+
+	doc.destroy();
+	await idb.whenDisposed;
+	await tick();
+
+	expect(evicted).toBe(0);
+});
+
+const model = defineWorkspace({
+	id: `eviction-repro-${crypto.randomUUID()}`,
+	name: 'Eviction Repro',
+	tables: {
+		conversations: defineTable({
+			id: field.string(),
+			model: field.string(),
+		}).docs({
+			messages: (ydoc: Y.Doc) =>
+				attachRecords<{ id: string; content: string }>(ydoc),
+		}),
+	},
+	kv: {},
+});
+
+test('a live workspace survives its databases being deleted by another connection', async () => {
+	const workspace = model.connect(null);
+	await workspace.storage.whenLoaded;
+
+	workspace.tables.conversations.set({ id: 'c1', model: 'hosted' });
+	const messages = workspace.tables.conversations.docs.messages.open('c1');
+	await messages.whenLoaded;
+	messages.set('m0', { id: 'm0', content: 'hi' });
+	await tick();
+
+	// Another tab of the same install forgets the device: every database this
+	// workspace holds open is deleted out from under it.
+	await Promise.all([
+		clearDocument(workspace.ydoc.guid),
+		clearDocument(messages.ydoc.guid),
+	]);
+	await tick();
+
+	// The reported symptom: model write (root doc) and message write (child doc)
+	// must not throw the closed-database error into the caller.
+	expect(() => {
+		workspace.tables.conversations.update('c1', { model: 'ollama:qwen3' });
+	}).not.toThrow();
+	expect(() => {
+		messages.set('m1', { id: 'm1', content: 'sent' });
+	}).not.toThrow();
+
+	messages[Symbol.dispose]();
+	workspace[Symbol.dispose]();
+});

--- a/packages/workspace/src/document/attach-indexed-db.ts
+++ b/packages/workspace/src/document/attach-indexed-db.ts
@@ -52,22 +52,14 @@ export function attachIndexedDb(
 		Promise.withResolvers<void>();
 	const whenLoaded: Promise<unknown> = idb.whenSynced;
 
-	// One teardown path, run at most once, whether teardown is triggered by our
-	// own `ydoc.destroy()` (the cascade below), our own `clearLocal()`, or the
-	// browser evicting the connection (the eviction guard below). `idb.destroy()`
-	// closes the db AND unsubscribes y-indexeddb's `update` listener, so once it
-	// runs no later Yjs write can reach the connection.
-	//
-	// `torndown` is a `let` flag, not the `once()` helper, on purpose: the
-	// eviction guard READS it (via `selfDeleting`/`torndown`) to decide whether we
-	// are already going down and so must NOT fire `onEvicted`. That makes it a
-	// liveness flag, not a pure once-guard (`once` explicitly does not replace
-	// such a boolean). `selfDeleting` records that WE deleted this database (our
-	// own `clearLocal()`), so the `versionchange` it triggers on our still-open
-	// connection tears down cleanly rather than re-booting; only a delete from
-	// ANOTHER connection re-boots.
+	// One teardown path, run at most once, whether triggered by our own
+	// `ydoc.destroy()` (the cascade below), our own `clearLocal()`, or a foreign
+	// eviction (the guard below). `idb.destroy()` closes the db AND unsubscribes
+	// y-indexeddb's `update` listener, so once it runs no later Yjs write can
+	// reach the connection. `torndown` is the idempotency guard: upstream
+	// `destroy()` has none of its own, and the eviction guard also reads it to
+	// skip a reboot when we are already going down.
 	let torndown = false;
-	let selfDeleting = false;
 	async function teardown(): Promise<void> {
 		if (torndown) return;
 		torndown = true;
@@ -78,9 +70,13 @@ export function attachIndexedDb(
 		}
 	}
 
-	const clearLocal = (): Promise<void> => {
-		selfDeleting = true;
-		return clearDocument(databaseName);
+	// Delete our local store. Tear our own connection down FIRST (the shape of
+	// y-indexeddb's own `clearData`), so the delete finds none of our connections
+	// open and never trips the eviction guard below; only a delete from ANOTHER
+	// connection reaches that guard.
+	const clearLocal = async (): Promise<void> => {
+		await teardown();
+		await clearDocument(databaseName);
 	};
 
 	ydoc.once('destroy', () => void teardown());
@@ -92,24 +88,23 @@ export function attachIndexedDb(
 	// and `this.db` pointing at the closed database, so the very next Yjs write
 	// calls `transact()` on a dead handle and throws "Can't start a transaction on
 	// a closed database" straight into the caller (the chat send, the model
-	// write). Take the handler over: teardown always runs (it unsubscribes that
-	// listener so writes stop crashing AND closes the connection so the pending
-	// delete can proceed); we re-boot via `onEvicted` only when ANOTHER connection
-	// deleted the store out from under us, not for our own `clearLocal()` or
-	// `ydoc.destroy()`. Registered after `whenSynced` so it replaces lib0's
-	// handler rather than racing it.
+	// write). Take the handler over so teardown runs instead: it unsubscribes that
+	// listener (writes stop crashing) and closes the connection (the pending
+	// delete can proceed), then re-boots. Our own `clearLocal()`/`ydoc.destroy()`
+	// close first and so never reach here; `torndown` skips the reboot for the one
+	// remaining race, a foreign delete landing while our own teardown is in
+	// flight. Registered after `whenSynced` so it replaces lib0's handler rather
+	// than racing it.
 	void idb.whenSynced.then(() => {
 		const db = idb.db;
 		if (db === null) return;
 		db.onversionchange = () => {
-			const evictedByOther = !selfDeleting && !torndown;
+			if (torndown) return;
 			void teardown();
-			if (evictedByOther) {
-				log.info(
-					`Local IndexedDB "${databaseName}" was deleted by another connection; re-booting.`,
-				);
-				onEvicted();
-			}
+			log.info(
+				`Local IndexedDB "${databaseName}" was deleted by another connection; re-booting.`,
+			);
+			onEvicted();
 		};
 	});
 
@@ -125,9 +120,10 @@ export function attachIndexedDb(
 		/** Delete the local IndexedDB document without destroying the Y.Doc. */
 		clearLocal,
 		/**
-		 * Resolves after `ydoc.destroy()` fires the cascade and the IndexedDB
-		 * connection has actually closed, or after an external eviction tore it
-		 * down. Bundle wipe methods await this before deleting persisted data.
+		 * Resolves once teardown completes and the IndexedDB connection has
+		 * actually closed, whatever triggered it: `ydoc.destroy()`'s cascade,
+		 * `clearLocal()`, or an external eviction. Bundle wipe methods await this
+		 * before deleting persisted data.
 		 */
 		whenDisposed,
 	};

--- a/packages/workspace/src/document/attach-indexed-db.ts
+++ b/packages/workspace/src/document/attach-indexed-db.ts
@@ -1,13 +1,38 @@
 /// <reference lib="dom" />
 
+import { createLogger, type Logger } from 'wellcrafted/logger';
 import { clearDocument, IndexeddbPersistence } from 'y-indexeddb';
 import type * as Y from 'yjs';
 
+/**
+ * Re-boot the page when the browser evicts our IndexedDB connection because
+ * another context deleted the database out from under it. The local store is
+ * gone, so continuing on an in-memory-only doc would silently diverge and never
+ * persist again; a reload re-opens whatever store the current auth state selects
+ * (ADR-0088), the same lifecycle-discontinuity response `reloadOnPrincipalChange`
+ * uses. Guarded so a non-browser import (tests, node) is a no-op.
+ */
+function reloadOnEviction(): void {
+	if (typeof window !== 'undefined') window.location.reload();
+}
+
 export function attachIndexedDb(
 	ydoc: Y.Doc,
-	options: { databaseName?: string } = {},
+	options: {
+		databaseName?: string;
+		/**
+		 * Called once if the underlying database is deleted by ANOTHER connection
+		 * (a second tab's `wipe()`, any cross-context `clearDocument`) while this
+		 * doc is live. Defaults to a page reload; injected in tests to observe the
+		 * eviction without navigating.
+		 */
+		onEvicted?: () => void;
+		log?: Logger;
+	} = {},
 ) {
 	const databaseName = options.databaseName ?? ydoc.guid;
+	const onEvicted = options.onEvicted ?? reloadOnEviction;
+	const log = options.log ?? createLogger('workspace/attach-indexed-db');
 	// Corrupt-store healing lives in `patches/y-indexeddb@9.0.12.patch`, not here.
 	// The upstream loader applies persisted updates with no `.catch`, so a single
 	// undecodable update both wedges `whenSynced` forever and floats an uncatchable
@@ -26,14 +51,68 @@ export function attachIndexedDb(
 	const { promise: whenDisposed, resolve: resolveDisposed } =
 		Promise.withResolvers<void>();
 	const whenLoaded: Promise<unknown> = idb.whenSynced;
-	const clearLocal = (): Promise<void> => clearDocument(databaseName);
-	ydoc.once('destroy', async () => {
+
+	// One teardown path, run at most once, whether teardown is triggered by our
+	// own `ydoc.destroy()` (the cascade below), our own `clearLocal()`, or the
+	// browser evicting the connection (the eviction guard below). `idb.destroy()`
+	// closes the db AND unsubscribes y-indexeddb's `update` listener, so once it
+	// runs no later Yjs write can reach the connection.
+	//
+	// `torndown` is a `let` flag, not the `once()` helper, on purpose: the
+	// eviction guard READS it (via `selfDeleting`/`torndown`) to decide whether we
+	// are already going down and so must NOT fire `onEvicted`. That makes it a
+	// liveness flag, not a pure once-guard (`once` explicitly does not replace
+	// such a boolean). `selfDeleting` records that WE deleted this database (our
+	// own `clearLocal()`), so the `versionchange` it triggers on our still-open
+	// connection tears down cleanly rather than re-booting; only a delete from
+	// ANOTHER connection re-boots.
+	let torndown = false;
+	let selfDeleting = false;
+	async function teardown(): Promise<void> {
+		if (torndown) return;
+		torndown = true;
 		try {
 			await idb.destroy();
 		} finally {
 			resolveDisposed();
 		}
+	}
+
+	const clearLocal = (): Promise<void> => {
+		selfDeleting = true;
+		return clearDocument(databaseName);
+	};
+
+	ydoc.once('destroy', () => void teardown());
+
+	// Eviction guard. `lib0`'s `openDB` installs `db.onversionchange = () =>
+	// db.close()`, which fires when ANOTHER connection deletes this database (a
+	// second tab's "Forget device" wipe, or any cross-context `clearDocument`).
+	// That raw close leaves `IndexeddbPersistence`'s `update` listener subscribed
+	// and `this.db` pointing at the closed database, so the very next Yjs write
+	// calls `transact()` on a dead handle and throws "Can't start a transaction on
+	// a closed database" straight into the caller (the chat send, the model
+	// write). Take the handler over: teardown always runs (it unsubscribes that
+	// listener so writes stop crashing AND closes the connection so the pending
+	// delete can proceed); we re-boot via `onEvicted` only when ANOTHER connection
+	// deleted the store out from under us, not for our own `clearLocal()` or
+	// `ydoc.destroy()`. Registered after `whenSynced` so it replaces lib0's
+	// handler rather than racing it.
+	void idb.whenSynced.then(() => {
+		const db = idb.db;
+		if (db === null) return;
+		db.onversionchange = () => {
+			const evictedByOther = !selfDeleting && !torndown;
+			void teardown();
+			if (evictedByOther) {
+				log.info(
+					`Local IndexedDB "${databaseName}" was deleted by another connection; re-booting.`,
+				);
+				onEvicted();
+			}
+		};
 	});
+
 	return {
 		/**
 		 * Resolves when local IndexedDB state has loaded into the Y.Doc: "your
@@ -47,8 +126,8 @@ export function attachIndexedDb(
 		clearLocal,
 		/**
 		 * Resolves after `ydoc.destroy()` fires the cascade and the IndexedDB
-		 * connection has actually closed. Bundle wipe methods await this before
-		 * deleting persisted data.
+		 * connection has actually closed, or after an external eviction tore it
+		 * down. Bundle wipe methods await this before deleting persisted data.
 		 */
 		whenDisposed,
 	};


### PR DESCRIPTION
The problem this addresses is:

After configuring self-host and selecting an Ollama model, writes threw `IDBDatabase.transaction: Can't start a transaction on a closed database`, both when saving `conversation.model` and when writing a chat message. The message could appear sent while the chat input never cleared, because persistence threw before the UI reached `value = ''`.

The reported symptom is one lower-level defect in the persistence gateway, distinct from the self-host auth boot-race mitigation (that lives in #2332).

## Root cause

`lib0`'s `openDB` installs `db.onversionchange = () => db.close()`. When another browser context deletes an IndexedDB database that a live workspace still holds open (a second tab's "Forget device" `wipe()`, any cross-context `clearDocument`), the browser fires `versionchange` and that handler closes our connection. But `y-indexeddb`'s `IndexeddbPersistence` reacts to nothing: it keeps its `_storeUpdate` listener subscribed and `this.db` pointing at the now-closed database. The next Yjs write calls `transact()` on the dead handle and throws synchronously into the caller. The `Y.Doc` stays alive in memory (so the message still renders), only persistence is dead.

Verified against the installed sources: `y-indexeddb`'s `_storeUpdate` guards on `this.db` being non-null but never on closed-state, and `destroy()` synchronously `off()`s that listener before closing.

## Fix

`attachIndexedDb` takes over the `versionchange` handler (registered on `whenSynced`, so it replaces lib0's handler rather than racing it) instead of inheriting lib0's blind close:

- **Teardown always runs.** `idb.destroy()` unsubscribes the `update` listener (so later writes are clean no-ops, not crashes) and closes the connection (so the pending delete can proceed).
- **Re-boot only on a foreign delete.** The local store is gone, so continuing on an in-memory-only doc would silently diverge and never persist again; a reload re-derives boot state, the same lifecycle-discontinuity response `reloadOnPrincipalChange` uses. `onEvicted` is injectable for tests.
- **No false positives.** A `selfDeleting` flag keeps our own `clearLocal()` (the sign-in migration's source cleanup) from tripping the reboot, and `torndown` keeps our own `ydoc.destroy()` cascade from tripping it. Same-tab `wipe()` disposes docs before deleting, so it fires no `versionchange`; only a genuinely foreign delete reboots.

The scope is intentionally bounded:

Change lives in the sole `y-indexeddb` gateway (`packages/workspace`), so it covers every consumer (whispering, vocab, honeycrisp, opensidian, tab-manager). The default `onEvicted` is a page reload, guarded to a no-op outside the browser.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785714613&installation_id=128463665&pr_number=2340&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2340&signature=8807025641317ef874d27e4c6c10006b58696abe5a5e5f4e1da4454fbd4da084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->