### PR TITLE
fix(local-books): carry required fields through recategorize sparse update

### DIFF
--- a/apps/local-books/src/books/recategorize.test.ts
+++ b/apps/local-books/src/books/recategorize.test.ts
@@ -11,7 +11,11 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { makeConfig } from '../../test/helpers.ts';
-import { makePurchase, startMockQbServer } from '../../test/mock-qb-server.ts';
+import {
+	makeBill,
+	makePurchase,
+	startMockQbServer,
+} from '../../test/mock-qb-server.ts';
 import { openBooksDb } from '../db.ts';
 import { entityDef } from '../entities.ts';
 import { createFileTokenStore } from '../token-store.ts';
@@ -22,16 +26,21 @@ import { recategorizeExpense } from './recategorize.ts';
 const NOW = Date.parse('2026-02-01T00:00:00.000Z');
 const now = () => NOW;
 
-/** Boot a mock company with one Purchase, seed its token + mirror, return deps. */
+/** Boot a mock company with one expense object, seed its token + mirror, return deps. */
 async function setup(
-	opts: { mockSyncToken?: string; mirrorSyncToken?: string } = {},
+	opts: {
+		mockSyncToken?: string;
+		mirrorSyncToken?: string;
+		entity?: 'Purchase' | 'Bill';
+		id?: string;
+	} = {},
 ) {
+	const entity = opts.entity ?? 'Purchase';
+	const id = opts.id ?? 'p1';
+	const make = entity === 'Bill' ? makeBill : makePurchase;
 	const dir = mkdtempSync(join(tmpdir(), 'local-books-'));
 	const mock = startMockQbServer({ now });
-	mock.put(
-		'Purchase',
-		makePurchase('p1', { SyncToken: opts.mockSyncToken ?? '0' }),
-	);
+	mock.put(entity, make(id, { SyncToken: opts.mockSyncToken ?? '0' }));
 
 	const tokenFile = join(dir, 'credentials.json');
 	const config = makeConfig({
@@ -39,7 +48,7 @@ async function setup(
 		apiBase: mock.apiBase,
 		tokenUrl: mock.tokenUrl,
 		credentialsPath: tokenFile,
-		entities: ['Purchase'],
+		entities: [entity],
 	});
 	const store = createFileTokenStore(tokenFile);
 	const token: TokenSet = {
@@ -58,10 +67,8 @@ async function setup(
 	db.ingest(
 		[
 			{
-				def: entityDef('Purchase'),
-				objects: [
-					makePurchase('p1', { SyncToken: opts.mirrorSyncToken ?? '0' }),
-				],
+				def: entityDef(entity),
+				objects: [make(id, { SyncToken: opts.mirrorSyncToken ?? '0' })],
 			},
 		],
 		{ syncedAt: '2026-01-20T00:00:00.000Z' },
@@ -107,6 +114,18 @@ describe('recategorizeExpense', () => {
 		expect(data?.changed[0]?.toAccount).toBe('Cloud Infrastructure');
 		expect(mock.hits.update).toBe(1);
 
+		// The sparse body carries Purchase's mandatory top-level fields (a Line-only
+		// body is a 400 ValidationFault, code 2020). AccountRef here is the header
+		// bank/CC account paid from, NOT the line-level expense category being moved.
+		const sent = mock.updates[0];
+		expect(sent?.entity).toBe('Purchase');
+		expect(sent?.body.sparse).toBe(true);
+		expect(sent?.body.PaymentType).toBe('CreditCard');
+		expect(sent?.body.AccountRef).toEqual({
+			value: '35',
+			name: 'Mercury Checking',
+		});
+
 		// QuickBooks (the source of truth) now has the new category + a bumped token.
 		const remote = mock.get('Purchase', 'p1');
 		expect(remote && lineAccount(remote)).toBe('77');
@@ -119,6 +138,54 @@ describe('recategorizeExpense', () => {
 			.get();
 		const mirrored = JSON.parse(row?.raw ?? '{}');
 		expect(lineAccount(mirrored)).toBe('77');
+		expect(mirrored.SyncToken).toBe('1');
+		db.close();
+
+		cleanup();
+	});
+
+	test('recategorizes a Bill, carrying its VendorRef through the sparse update', async () => {
+		const { mock, path, openQb, cleanup } = await setup({
+			entity: 'Bill',
+			id: 'b1',
+		});
+
+		const { data, error } = await recategorizeExpense({
+			openQb,
+			dbPath: path,
+			readOnly: false,
+			input: {
+				entity: 'Bill',
+				id: 'b1',
+				account_id: '24',
+				account_name: 'Utilities',
+			},
+		});
+		expect(error).toBeNull();
+		expect(data?.changed[0]?.toAccount).toBe('Utilities');
+		expect(mock.hits.update).toBe(1);
+
+		// A Bill without VendorRef is a 400 ValidationFault (code 2020); the sparse
+		// body must carry it through unchanged even though only the Line changes.
+		const sent = mock.updates[0];
+		expect(sent?.entity).toBe('Bill');
+		expect(sent?.body.sparse).toBe(true);
+		expect(sent?.body.VendorRef).toEqual({
+			value: '56',
+			name: 'Norton Lumber and Building Materials',
+		});
+
+		// QuickBooks now has the new category + a bumped token, folded into the mirror.
+		const remote = mock.get('Bill', 'b1');
+		expect(remote && lineAccount(remote)).toBe('24');
+		expect(remote?.SyncToken).toBe('1');
+
+		const db = openBooksDb(path);
+		const row = db.raw
+			.query<{ raw: string }, []>(`SELECT raw FROM bills WHERE id = 'b1'`)
+			.get();
+		const mirrored = JSON.parse(row?.raw ?? '{}');
+		expect(lineAccount(mirrored)).toBe('24');
 		expect(mirrored.SyncToken).toBe('1');
 		db.close();
 

--- a/apps/local-books/src/books/recategorize.ts
+++ b/apps/local-books/src/books/recategorize.ts
@@ -37,6 +37,23 @@ const LINE_DETAIL = 'AccountBasedExpenseLineDetail';
 export const RECATEGORIZE_ENTITIES = ['Purchase', 'Bill'] as const;
 export type RecategorizeEntity = (typeof RECATEGORIZE_ENTITIES)[number];
 
+/**
+ * The mandatory top-level fields QuickBooks demands on an expense update even in
+ * sparse mode. A Line-only sparse body is a 400 ValidationFault (code 2020,
+ * "Required parameter <field> is missing"), so the update must carry these
+ * through unchanged from the mirror's raw object alongside the modified Line.
+ *   Purchase: PaymentType (cash/card/check) + AccountRef (the bank/CC account paid from).
+ *   Bill:     VendorRef (the vendor owed).
+ * Whitelisting by field name (not spreading the whole raw object) keeps read-only
+ * and computed fields QuickBooks rejects out of the body. Keying by entity makes
+ * it a compile error to add a recategorize entity without declaring its required
+ * fields, so a new entity cannot silently ship the broken Line-only body.
+ */
+const REQUIRED_UPDATE_FIELDS: Record<RecategorizeEntity, readonly string[]> = {
+	Purchase: ['PaymentType', 'AccountRef'],
+	Bill: ['VendorRef'],
+};
+
 export const RecategorizeError = defineErrors({
 	ReadOnly: () => ({
 		message:
@@ -211,9 +228,16 @@ export async function recategorizeExpense({
 			return RecategorizeError.NotAuthenticated({ detail: openError });
 		}
 
-		// Sparse update: send the full (modified) Line array with Id + the SyncToken
-		// read from the mirror; QuickBooks merges the named fields.
+		// Sparse update: send the modified Line array with Id + the SyncToken read
+		// from the mirror, plus this entity's mandatory top-level fields carried
+		// through by value. QuickBooks does NOT infer them on a sparse update; a
+		// Line-only body is a 400 ValidationFault (code 2020). It preserves the
+		// unnamed writable fields; the named ones must be present, changed or not.
+		const required = Object.fromEntries(
+			REQUIRED_UPDATE_FIELDS[input.entity].map((field) => [field, obj[field]]),
+		);
 		const { data: updated, error } = await qb.update(input.entity, {
+			...required,
 			Id: obj.Id,
 			SyncToken: obj.SyncToken,
 			sparse: true,

--- a/apps/local-books/src/qb-client.ts
+++ b/apps/local-books/src/qb-client.ts
@@ -61,9 +61,11 @@ export type QbClient = {
 	): Promise<Result<CdcResult, QbClientError>>;
 	/**
 	 * Sparse-update one entity (the QuickBooks update POST). `body` carries the
-	 * `Id`, the current `SyncToken`, `sparse: true`, and the changed fields;
-	 * QuickBooks returns the updated object with a bumped `SyncToken`. A stale
-	 * `SyncToken` surfaces as an `Http` error (409), never a silent re-apply.
+	 * `Id`, the current `SyncToken`, `sparse: true`, the changed fields, and the
+	 * entity's mandatory top-level fields, which QuickBooks requires even on a
+	 * sparse update (omit one and it answers 400 ValidationFault code 2020, not a
+	 * merge). QuickBooks returns the updated object with a bumped `SyncToken`. A
+	 * stale `SyncToken` surfaces as an `Http` error (409), never a silent re-apply.
 	 */
 	update(
 		entity: string,

--- a/apps/local-books/test/mock-qb-server.ts
+++ b/apps/local-books/test/mock-qb-server.ts
@@ -27,6 +27,8 @@ export type MockQbServer = {
 		update: number;
 		report: number;
 	};
+	/** Every update (sparse-update POST) body received, in order, for assertions. */
+	updates: { entity: string; body: Record<string, unknown> }[];
 	/** Insert or update a live object; stamps a fresh LastUpdatedTime. */
 	put(entity: string, obj: Record<string, unknown>): void;
 	/** Read a stored object back (post-write assertions). */
@@ -40,6 +42,19 @@ export type MockQbServer = {
 	/** Make the next `n` data requests return 429 (to exercise backoff). */
 	fail429(n: number): void;
 	stop(): void;
+};
+
+/**
+ * The mandatory top-level fields QuickBooks demands on an entity update even in
+ * sparse mode: omit one and QB answers 400 ValidationFault code 2020 ("Required
+ * parameter <field> is missing"), never a merge. Faithful to the live behavior
+ * that broke `recategorize` (Purchase without PaymentType/AccountRef, Bill
+ * without VendorRef), so a Line-only sparse body is rejected here just as it was
+ * against the real sandbox.
+ */
+const UPDATE_REQUIRED_FIELDS: Record<string, readonly string[]> = {
+	Purchase: ['PaymentType', 'AccountRef'],
+	Bill: ['VendorRef'],
 };
 
 function nowIso(ms: number): string {
@@ -73,6 +88,7 @@ export function startMockQbServer(
 
 	const entities = new Map<string, Map<string, StoredObject>>();
 	const hits = { query: 0, cdc: 0, token: 0, update: 0, report: 0 };
+	const updates: { entity: string; body: Record<string, unknown> }[] = [];
 	const rejectedTokens = new Set<string>();
 	let pending429 = 0;
 
@@ -285,6 +301,30 @@ export function startMockQbServer(
 				hits.update += 1;
 				const entity = entityLc.charAt(0).toUpperCase() + entityLc.slice(1);
 				const body = (await request.json()) as Record<string, unknown>;
+				updates.push({ entity, body });
+
+				// A sparse update still carries the entity's mandatory top-level fields;
+				// a Line-only body is a 400 ValidationFault (code 2020), never a merge.
+				const missing = (UPDATE_REQUIRED_FIELDS[entity] ?? []).find(
+					(field) => body[field] == null,
+				);
+				if (missing) {
+					return Response.json(
+						{
+							Fault: {
+								type: 'ValidationFault',
+								Error: [
+									{
+										Message: `Required parameter ${missing} is missing`,
+										code: '2020',
+									},
+								],
+							},
+						},
+						{ status: 400 },
+					);
+				}
+
 				const id = String(body.Id);
 				const stored = store(entity).get(id);
 				if (!stored || stored.deleted) {
@@ -330,6 +370,7 @@ export function startMockQbServer(
 		tokenUrl: `${apiBase}/oauth2/v1/tokens/bearer`,
 		realmId,
 		hits,
+		updates,
 		put,
 		get: (entity, id) => store(entity).get(id)?.obj ?? null,
 		remove,
@@ -385,6 +426,36 @@ export function makePurchase(
 			{
 				Id: '1',
 				Amount: 340,
+				DetailType: 'AccountBasedExpenseLineDetail',
+				AccountBasedExpenseLineDetail: {
+					AccountRef: { value: '60', name: 'Uncategorized Expense' },
+				},
+			},
+		],
+		...overrides,
+	};
+}
+
+/**
+ * Minimal but realistic QuickBooks Bill (a vendor bill): its mandatory
+ * `VendorRef` plus one account-based expense line whose `AccountRef` is the
+ * category the `recategorize` verb moves. The `VendorRef` is what a Line-only
+ * sparse update drops, which is the bug this fixture guards.
+ */
+export function makeBill(
+	id: string,
+	overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+	return {
+		Id: id,
+		SyncToken: '0',
+		TxnDate: '2026-01-15',
+		TotalAmt: 500,
+		VendorRef: { value: '56', name: 'Norton Lumber and Building Materials' },
+		Line: [
+			{
+				Id: '1',
+				Amount: 500,
 				DetailType: 'AccountBasedExpenseLineDetail',
 				AccountBasedExpenseLineDetail: {
 					AccountRef: { value: '60', name: 'Uncategorized Expense' },


### PR DESCRIPTION
`recategorize` never wrote through to QuickBooks. It sent a sparse update whose body was only `{ Id, SyncToken, sparse: true, Line }`, dropping each entity's mandatory top-level fields. QuickBooks requires those even on a sparse update, so every write failed with a 400 ValidationFault (code 2020): a `Purchase` on the missing `PaymentType`, a `Bill` on the missing `VendorRef`. The mirror stayed consistent because the 400 left the row untouched, so it failed safe, but the one approved write verb simply never succeeded.

The update now carries each entity's required fields through by value from the mirror's raw object alongside the modified `Line`. The required set is whitelisted per entity (`Purchase`: `PaymentType` and `AccountRef`; `Bill`: `VendorRef`) rather than spread from the whole raw object, so no read-only or computed field QuickBooks would reject rides along. It is keyed by a `Record<RecategorizeEntity, readonly string[]>`, so adding a recategorize entity is a compile error until its required fields are declared: a new entity cannot silently ship the broken Line-only body.

The bug escaped the suite because the mock QuickBooks server blind-merged any update body. It now enforces the same required fields and answers the real 400 ValidationFault (code 2020), so a Line-only body is rejected in the tests exactly as it is against the sandbox. A `Bill` fixture and a Bill test cover the second entity.

## Changelog

Fixed `local-books recategorize` failing with a 400 error for both Purchase and Bill. The QuickBooks write now carries each entity's required fields, so the recategorization succeeds and folds back into the local mirror.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785717376&installation_id=128463665&pr_number=2346&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2346&signature=a461a907f090761e348a397108986c06164f520962eb18d6a09cc938b11e3cb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->