### PR TITLE
refactor(whispering): clarify transcription access modes

### DIFF
--- a/apps/whispering/src/lib/components/settings/ProviderConfigFields.svelte
+++ b/apps/whispering/src/lib/components/settings/ProviderConfigFields.svelte
@@ -1,6 +1,6 @@
 <script lang="ts" module>
 	import type { InferenceProviderId } from '$lib/constants/inference';
-	import type { ByokProviderId } from '$lib/services/transcription/providers';
+	import type { KeyProviderId } from '$lib/services/transcription/providers';
 	import type { DeviceConfigKey } from '$lib/state/device-config.svelte';
 
 	/** Inline description content: plain text or an external link. */
@@ -17,11 +17,11 @@
 
 	/**
 	 * Every provider whose config (API key, endpoint) lives in deviceConfig:
-	 * inference providers plus BYOK transcription providers. Deriving the
+	 * inference providers plus `key` transcription providers. Deriving the
 	 * union keeps PROVIDER_FIELDS exhaustive: adding a provider to either
 	 * registry is a compile error here until its fields exist.
 	 */
-	export type ProviderConfigId = InferenceProviderId | ByokProviderId;
+	export type ProviderConfigId = InferenceProviderId | KeyProviderId;
 
 	const PROVIDER_FIELDS: Record<ProviderConfigId, ProviderField[]> = {
 		OpenAI: [

--- a/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
+++ b/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
@@ -68,7 +68,7 @@
 	);
 
 	const cloudProvider = $derived(
-		selectedTranscriptionProvider?.access === 'byok'
+		selectedTranscriptionProvider?.access === 'key'
 			? selectedTranscriptionProvider
 			: null,
 	);

--- a/apps/whispering/src/lib/components/settings/TranscriptionServiceSelect.svelte
+++ b/apps/whispering/src/lib/components/settings/TranscriptionServiceSelect.svelte
@@ -29,11 +29,11 @@
 	);
 
 	const cloudServices = $derived(
-		TRANSCRIPTION_PROVIDERS.filter((service) => service.access === 'byok'),
+		TRANSCRIPTION_PROVIDERS.filter((service) => service.access === 'key'),
 	);
 
 	const selfHostedServices = $derived(
-		TRANSCRIPTION_PROVIDERS.filter((service) => service.access === 'byoe'),
+		TRANSCRIPTION_PROVIDERS.filter((service) => service.access === 'endpoint'),
 	);
 
 	const selectedService = $derived(
@@ -125,7 +125,7 @@
 											{service.description}
 										</div>
 									{/if}
-									{#if service.access === 'byok' && service.models.length > 0}
+									{#if service.access === 'key' && service.models.length > 0}
 										<div class="text-xs text-muted-foreground mt-1">
 											{service.models.length}
 											model{service.models.length > 1

--- a/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
@@ -73,7 +73,7 @@
 				: 'Choose transcription model';
 		}
 		if (!selectedService) return 'Select transcription service';
-		return selectedService.access === 'byok'
+		return selectedService.access === 'key'
 			? `${selectedService.label} - ${getSelectedModelNameOrUrl(selectedService)}`
 			: selectedService.label;
 	});
@@ -84,9 +84,9 @@
 
 	function getSelectedModelNameOrUrl(service: TranscriptionProviderEntry) {
 		switch (service.access) {
-			case 'byok':
+			case 'key':
 				return settings.get(service.modelSettingKey);
-			case 'byoe':
+			case 'endpoint':
 				return deviceConfig.get(service.endpointConfigKey);
 			case 'onDevice': {
 				// Resolve the opaque catalog id ("{repo}@{rev}/{file}") to its friendly
@@ -95,23 +95,23 @@
 				const id = deviceConfig.get(service.modelConfigKey);
 				return localModels.find(id)?.name ?? id;
 			}
-			case 'star':
+			case 'session':
 				return undefined;
 		}
 	}
 
-	// Epicenter (star) STT is a network provider, available on web and desktop
+	// Epicenter (`session`) STT is a network provider, available on web and desktop
 	// alike, so it is never gated on tauri the way local engines are.
 	const starServices = $derived(
-		TRANSCRIPTION_PROVIDERS.filter((service) => service.access === 'star'),
+		TRANSCRIPTION_PROVIDERS.filter((service) => service.access === 'session'),
 	);
 
 	const cloudServices = $derived(
-		TRANSCRIPTION_PROVIDERS.filter((service) => service.access === 'byok'),
+		TRANSCRIPTION_PROVIDERS.filter((service) => service.access === 'key'),
 	);
 
 	const customServerServices = $derived(
-		TRANSCRIPTION_PROVIDERS.filter((service) => service.access === 'byoe'),
+		TRANSCRIPTION_PROVIDERS.filter((service) => service.access === 'endpoint'),
 	);
 
 	const onDeviceServices = $derived(

--- a/apps/whispering/src/lib/operations/completion-target.ts
+++ b/apps/whispering/src/lib/operations/completion-target.ts
@@ -129,7 +129,7 @@ export function describeCompletionReadiness(
  * The pipeline-wide privacy sentence for the home chip and Dictation page: where
  * audio goes and where Polish sends transcript text, woven into one line. Audio
  * locality is resolved upstream ({@link TranscriptionLocality}) rather than read
- * from the provider's `access` label, so a BYOE or localhost-overridden
+ * from the provider's `access` label, so an `endpoint` or localhost-overridden
  * transcription endpoint reads on-device here exactly as it does on the
  * Processing surface.
  */

--- a/apps/whispering/src/lib/operations/transcribe.ts
+++ b/apps/whispering/src/lib/operations/transcribe.ts
@@ -70,14 +70,14 @@ const TranscriptionOperationError = defineErrors({
  * `in`-guard: one exhaustive switch on `.kind`.
  *
  * The transport is a `resolve` thunk, not static connection data, so each wire entry
- * owns how it becomes a transport (ADR-0060): a `byok`/`byoe` entry resolves a
- * `{ baseUrl, apiKey }` over `customFetch`, while the `star` Epicenter entry closes
+ * owns how it becomes a transport (ADR-0060): a `key`/`endpoint` entry resolves a
+ * `{ baseUrl, apiKey }` over `customFetch`, while the `session` Epicenter entry closes
  * over the signed-in session `fetch` (never connection data). The switch
  * therefore never branches on what kind of transport it got.
  *
  * A bespoke entry closes over its own key and model (from the literal `PROVIDERS.X`
  * pointers, the SSOT) rather than letting the caller read `PROVIDERS[id]`, because
- * switching on `.kind` does not narrow the id back to a ByokProvider. The wire
+ * switching on `.kind` does not narrow the id back to a KeyProvider. The wire
  * entries read the same pointers; the one fact `PROVIDERS` does not hold is the
  * canonical wire base URL (it used to be each SDK's default), so that literal lives
  * here.
@@ -120,11 +120,11 @@ function secretApiKey(key: SecretKey): string | undefined {
  * Token`, ElevenLabs' `xi-api-key`, Mistral's `context_bias`); ADR-0060 blesses it.
  */
 const UPLOAD_DISPATCH = {
-	// Epicenter (star) STT: the transport is the signed-in session fetch against the
-	// star you are bonded to (`auth.baseURL`, so a self-hosted instance's own gateway
-	// is used when connected to one), never a stored key. Both deployables mount this
-	// gateway on their house key; a hosted star meters it (ADR-0100), a self-host star
-	// does not. The model is fixed by the gateway.
+	// Epicenter (`session`) STT: the transport is the signed-in session fetch against
+	// the deployment you are bonded to (`auth.baseURL`, so a self-hosted instance's own
+	// gateway is used when connected to one), never a stored key. Both deployables mount
+	// this gateway on their house key; a hosted deployment meters it (ADR-0100), a
+	// self-host deployment does not. The model is fixed by the gateway.
 	epicenter: {
 		kind: 'wire',
 		resolve: () => ({
@@ -415,10 +415,10 @@ async function transcribeViaUpload(
 				language: spokenLanguage === 'auto' ? undefined : spokenLanguage,
 				prompt: prompt || undefined,
 			});
-			// Only the `star` wire can meter credits, and only when bonded to a hosted
-			// star, so a 402 there is `InsufficientCredits` (ADR-0100). Remap it to a
-			// credit-aware message; every other wire's 402 (none expected) stays a raw
-			// RequestFailed. A self-host star never meters, so it never 402s here.
+			// Only the `session` wire can meter credits, and only when bonded to a hosted
+			// deployment, so a 402 there is `InsufficientCredits` (ADR-0100). Remap it to
+			// a credit-aware message; every other wire's 402 (none expected) stays a raw
+			// RequestFailed. A self-host deployment never meters, so it never 402s here.
 			if (
 				selectedService === 'epicenter' &&
 				result.error?.name === 'RequestFailed' &&

--- a/apps/whispering/src/lib/operations/transcription-target.ts
+++ b/apps/whispering/src/lib/operations/transcription-target.ts
@@ -12,9 +12,9 @@ import { isLoopbackBaseUrl } from './locality';
  * transcribe call path reads so the surface and the pipeline can never disagree.
  *
  * Locality follows the resolved endpoint host, not the provider's `access`
- * label: a BYOE (Speaches) or BYOK endpoint pointed at loopback keeps
+ * label: an `endpoint` (Speaches) or `key` provider pointed at loopback keeps
  * audio on-device, exactly like a Custom completion at localhost. That is why
- * "BYOE" is not its own locality here; where the bytes go is a property of
+ * `endpoint` is not its own locality here; where the bytes go is a property of
  * the host, and who operates the server is the user's trust call, not a fact this
  * copy can assert.
  */
@@ -52,13 +52,13 @@ export function resolveTranscriptionLocalityFromConfig({
 	if (provider.access === 'onDevice') {
 		return { onDevice: true, name: provider.label };
 	}
-	// BYOK and BYOE providers upload audio to an endpoint. A configured loopback
-	// endpoint keeps it on-device regardless of the provider label. The
+	// `key` and `endpoint` providers upload audio to an endpoint. A configured
+	// loopback endpoint keeps it on-device regardless of the provider label. The
 	// provider type declares `endpointConfigKey` as the wide `DeviceConfigKey`,
 	// but every real value is a `providers.*.endpoint` key.
 	let endpoint = '';
 	if (
-		(provider.access === 'byok' || provider.access === 'byoe') &&
+		(provider.access === 'key' || provider.access === 'endpoint') &&
 		provider.endpointConfigKey
 	) {
 		endpoint = getDeviceConfig(
@@ -68,8 +68,8 @@ export function resolveTranscriptionLocalityFromConfig({
 	if (endpoint && isLoopbackBaseUrl(endpoint)) {
 		return { onDevice: true, name: provider.label };
 	}
-	// A remote BYOE server is the user's own box, not a cloud vendor.
-	if (provider.access === 'byoe') {
+	// A remote `endpoint` server is the user's own box, not a cloud vendor.
+	if (provider.access === 'endpoint') {
 		return { onDevice: false, name: `your ${provider.label} server` };
 	}
 	return { onDevice: false, name: provider.label };

--- a/apps/whispering/src/lib/services/analytics/types.ts
+++ b/apps/whispering/src/lib/services/analytics/types.ts
@@ -4,7 +4,7 @@ import {
 	type InferErrors,
 } from 'wellcrafted/error';
 import type { Result } from 'wellcrafted/result';
-import type { TRANSCRIPTION_SERVICE_IDS } from '$lib/services/transcription/providers';
+import type { TranscriptionServiceId } from '$lib/services/transcription/providers';
 
 export const AnalyticsError = defineErrors({
 	LogEventFailed: ({ cause }: { cause: unknown }) => ({
@@ -13,9 +13,6 @@ export const AnalyticsError = defineErrors({
 	}),
 });
 export type AnalyticsError = InferErrors<typeof AnalyticsError>;
-
-// Use the TranscriptionServiceId type directly
-type TranscriptionServiceId = (typeof TRANSCRIPTION_SERVICE_IDS)[number];
 
 // Settings sections that can be logged
 type SettingsSection =

--- a/apps/whispering/src/lib/services/transcription/providers.ts
+++ b/apps/whispering/src/lib/services/transcription/providers.ts
@@ -26,30 +26,28 @@ type CloudModel = { name: string; description: string; cost: string };
 
 /**
  * `access` is the per-family discriminant every dispatcher, selector, and readiness
- * check branches on. Each member bundles how a provider is reached and what the user
- * must supply to make it usable. Three members name a credential; one (`onDevice`)
- * names where the compute runs, because for the bundled engines "no network, no
- * credential" is the whole relationship. What `isTranscriptionServiceConfigured`
- * reads per member:
+ * check branches on. Each member names what the user supplies to make a provider
+ * usable, so it maps one-to-one to what `isTranscriptionServiceConfigured` reads:
  *
- *   - `byok`     the user's own API key (a secret)         -> OpenAI, Groq, ...
- *   - `byoe`     a server URL + model id the user runs     -> Speaches
- *   - `star`     nothing; the session with the Epicenter   -> Epicenter
+ *   - `key`      the user's own API key (a secret)         -> OpenAI, Groq, ...
+ *   - `endpoint` a server URL + model id the user runs     -> Speaches
+ *   - `session`  a signed-in session; the Epicenter        -> Epicenter
  *                deployment you are bonded to is the key
- *   - `onDevice` an on-device model file, no network       -> Local
+ *   - `onDevice` nothing but the device: an on-device       -> Local
+ *                model file, no network
  *
- * `byok` and `byoe` are the matched "bring your own X" pair: both hand a
- * `{ baseUrl, apiKey? }` to an external OpenAI-compatible box, differing only in
- * whether the user brings a key (the vendor's compute) or an endpoint (their own
- * box). `star` follows the platform's own STAR-vs-SERVICES split (ADR-0068/0069/0070):
- * it is the Epicenter deployment that also holds your synced data, reached by your
- * session, on that deployment's house key. Hosted stars meter it (AI credits);
- * self-host stars proxy it unmetered. `byok`/`byoe` are external services.
+ * `key` and `endpoint` are the matched pair: both hand a `{ baseUrl, apiKey? }` to
+ * an external OpenAI-compatible box, differing only in whether the user brings a
+ * key (the vendor's compute) or an endpoint (their own box). `session` is the
+ * platform relationship: it follows the STAR-vs-SERVICES split (ADR-0068/0069/0070),
+ * reaching the Epicenter deployment that also holds your synced data over your
+ * session, on that deployment's house key. Hosted deployments meter it (AI credits);
+ * self-host deployments proxy it unmetered. `key`/`endpoint` are external services.
  */
-type ProviderAccess = 'byok' | 'byoe' | 'star' | 'onDevice';
+type ProviderAccess = 'key' | 'endpoint' | 'session' | 'onDevice';
 
-type ByokProvider = {
-	access: Extract<ProviderAccess, 'byok'>;
+type KeyProvider = {
+	access: Extract<ProviderAccess, 'key'>;
 	label: string;
 	description: string;
 	capabilities: Capabilities;
@@ -95,8 +93,8 @@ type OnDeviceProvider = {
 	modelConfigKey: DeviceConfigKey;
 };
 
-type ByoeProvider = {
-	access: Extract<ProviderAccess, 'byoe'>;
+type EndpointProvider = {
+	access: Extract<ProviderAccess, 'endpoint'>;
 	label: string;
 	description: string;
 	capabilities: Capabilities;
@@ -105,23 +103,25 @@ type ByoeProvider = {
 };
 
 /**
- * Transcription through the Epicenter star this install is bonded to. Unlike a
- * `byok` provider it carries no key or endpoint config: the transport is the
- * star session's audience-scoped fetch (`auth.fetch`), resolved in the dispatcher
- * against `auth.baseURL` (the hosted cloud by default, or a self-host instance if
- * the user pointed there), and the gateway pins its own house model server-side
- * (ADR-0100). So the only fact this entry holds is the single `model` string the
- * wire requires. "Configured" means signed in, not "has a key" (see
+ * The `session` access member: transcription through the Epicenter deployment
+ * (the platform "star", ADR-0068/0069/0070) this install is bonded to. Unlike a
+ * `key` provider it carries no key or endpoint config; the transport is the
+ * signed-in session's audience-scoped fetch (`auth.fetch`), resolved in the
+ * dispatcher against `auth.baseURL` (the hosted cloud by default, or a self-host
+ * instance if the user pointed there), and the gateway pins its own house model
+ * server-side (ADR-0100). So the only fact this entry holds is the single `model`
+ * string the wire requires. "Configured" means signed in, not "has a key" (see
  * `transcription-validation.ts`).
  *
- * The same `/v1/audio/transcriptions` gateway runs on every star (both deployables
- * mount it on the deployment's house key), so this is genuinely star-neutral.
- * Whether a call spends AI credits is a property of the star, surfaced at runtime:
- * a hosted star meters it (402 when out of credits); a self-host star proxies it
- * unmetered (or 503 until the operator sets a house key). Never fixed here.
+ * The same `/v1/audio/transcriptions` gateway runs on every deployment (both
+ * deployables mount it on the deployment's house key), so this is deployment-neutral.
+ * Whether a call spends AI credits is a property of the deployment, surfaced at
+ * runtime: a hosted deployment meters it (402 when out of credits); a self-host
+ * deployment proxies it unmetered (or 503 until the operator sets a house key).
+ * Never fixed here.
  */
-type StarProvider = {
-	access: Extract<ProviderAccess, 'star'>;
+type SessionProvider = {
+	access: Extract<ProviderAccess, 'session'>;
 	label: string;
 	description: string;
 	capabilities: Capabilities;
@@ -131,22 +131,22 @@ type StarProvider = {
 };
 
 type TranscriptionProvider =
-	| ByokProvider
+	| KeyProvider
 	| OnDeviceProvider
-	| ByoeProvider
-	| StarProvider;
+	| EndpointProvider
+	| SessionProvider;
 
 export const PROVIDERS = {
 	epicenter: {
-		access: 'star',
+		access: 'session',
 		label: 'Epicenter',
 		description:
-			'Transcription through your connected Epicenter star. Sign in required.',
+			'Transcription through your connected Epicenter. Sign in required.',
 		capabilities: { supportsPrompt: true, supportsLanguage: true },
 		model: 'whisper-1',
 	},
 	OpenAI: {
-		access: 'byok',
+		access: 'key',
 		label: 'OpenAI',
 		description: 'Industry-standard Whisper API',
 		capabilities: { supportsPrompt: true, supportsLanguage: true },
@@ -180,7 +180,7 @@ export const PROVIDERS = {
 		],
 	},
 	Groq: {
-		access: 'byok',
+		access: 'key',
 		label: 'Groq',
 		description: 'Lightning-fast cloud transcription',
 		capabilities: { supportsPrompt: true, supportsLanguage: true },
@@ -208,7 +208,7 @@ export const PROVIDERS = {
 		],
 	},
 	ElevenLabs: {
-		access: 'byok',
+		access: 'key',
 		label: 'ElevenLabs',
 		description: 'Voice AI platform with transcription',
 		capabilities: { supportsPrompt: true, supportsLanguage: true },
@@ -242,7 +242,7 @@ export const PROVIDERS = {
 		],
 	},
 	Deepgram: {
-		access: 'byok',
+		access: 'key',
 		label: 'Deepgram',
 		description: 'Real-time speech recognition API',
 		capabilities: { supportsPrompt: true, supportsLanguage: true },
@@ -284,7 +284,7 @@ export const PROVIDERS = {
 		],
 	},
 	Mistral: {
-		access: 'byok',
+		access: 'key',
 		label: 'Mistral AI',
 		description: 'Advanced Voxtral speech understanding',
 		capabilities: { supportsPrompt: true, supportsLanguage: true },
@@ -320,7 +320,7 @@ export const PROVIDERS = {
 	},
 
 	speaches: {
-		access: 'byoe',
+		access: 'endpoint',
 		label: 'Speaches',
 		description: 'Self-hosted transcription server',
 		capabilities: { supportsPrompt: true, supportsLanguage: true },
@@ -332,13 +332,14 @@ export const PROVIDERS = {
 export type TranscriptionServiceId = keyof typeof PROVIDERS;
 
 /**
- * The ids of BYOK providers, derived from PROVIDERS. Consumed by the settings UI
- * to type provider config fields. (Transcription routing no longer keys off this:
- * `operations/transcribe.ts` dispatches over a single `UPLOAD_DISPATCH` table that
- * excludes only the on-device ids.)
+ * The ids of `key` providers (the ones that take a user API key), derived from
+ * PROVIDERS. Consumed by the settings UI to type provider config fields.
+ * (Transcription routing no longer keys off this: `operations/transcribe.ts`
+ * dispatches over a single `UPLOAD_DISPATCH` table that excludes only the
+ * on-device ids.)
  */
-export type ByokProviderId = {
-	[K in TranscriptionServiceId]: (typeof PROVIDERS)[K]['access'] extends 'byok'
+export type KeyProviderId = {
+	[K in TranscriptionServiceId]: (typeof PROVIDERS)[K]['access'] extends 'key'
 		? K
 		: never;
 }[TranscriptionServiceId];
@@ -363,7 +364,7 @@ export function isOnDeviceProviderId(
 
 /**
  * The upload providers: every non-on-device id, reached by uploading audio over the
- * wire (byok, byoe, star) rather than the on-device FFI path. "Upload" is
+ * wire (key, endpoint, session) rather than the on-device FFI path. "Upload" is
  * "not on-device", and on-device-ness is the one facet PROVIDERS declares, so the
  * subtraction reads as English. `UPLOAD_DISPATCH` is keyed by exactly this set.
  */

--- a/apps/whispering/src/lib/settings/transcription-validation.ts
+++ b/apps/whispering/src/lib/settings/transcription-validation.ts
@@ -42,7 +42,7 @@ export function getSelectedTranscriptionService():
 /**
  * Whether a transcription service is usable right now. The required key is the
  * provider's own config key (apiKey / endpoint / model), read from its registry
- * entry. A BYOK provider's key is a secret read through the credential facade,
+ * entry. A `key` provider's API key is a secret read through the credential facade,
  * so "usable" means `available`.
  *
  * @param service - The transcription service to check
@@ -52,13 +52,13 @@ export function isTranscriptionServiceConfigured(
 	service: TranscriptionProviderEntry,
 ): boolean {
 	switch (service.access) {
-		case 'star':
+		case 'session':
 			// No key to configure: the credential is the signed-in session, so
-			// "configured" is "signed in". Metering and top-up live on the star.
+			// "configured" is "signed in". Metering and top-up live on the deployment.
 			return auth.state.status === 'signed-in';
-		case 'byok':
+		case 'key':
 			return secrets.get(service.apiKeyConfigKey).status === 'available';
-		case 'byoe':
+		case 'endpoint':
 			return (
 				hasValue(deviceConfig.get(service.endpointConfigKey)) &&
 				hasValue(deviceConfig.get(service.modelIdConfigKey))
@@ -91,9 +91,9 @@ export function getTranscriptionReadiness(): TranscriptionReadiness {
 	if (!isTranscriptionServiceConfigured(service)) {
 		const primaryIssue = (
 			{
-				star: 'Sign in to Epicenter to use hosted transcription.',
-				byok: `Add your ${service.label} API key.`,
-				byoe: `Set your ${service.label} endpoint and model ID.`,
+				session: 'Sign in to Epicenter to use hosted transcription.',
+				key: `Add your ${service.label} API key.`,
+				endpoint: `Set your ${service.label} endpoint and model ID.`,
 				onDevice: `Download or select a ${service.label} model.`,
 			} as const
 		)[service.access];

--- a/apps/whispering/src/lib/settings/transcription-validation.ts
+++ b/apps/whispering/src/lib/settings/transcription-validation.ts
@@ -19,7 +19,7 @@ export function getSelectedTranscriptionProvider():
 	return TRANSCRIPTION_PROVIDERS.find((s) => s.id === selectedServiceId);
 }
 
-export function isTranscriptionServiceAvailable(
+function isTranscriptionServiceAvailable(
 	service: TranscriptionProviderEntry,
 ): boolean {
 	return Boolean(tauri) || service.access !== 'onDevice';

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -16,8 +16,8 @@ import { RECORDING_TRIGGERS } from '$lib/constants/audio/recording-triggers';
 import { INFERENCE_PROVIDER_IDS } from '$lib/constants/inference';
 import { SUPPORTED_LANGUAGES } from '$lib/constants/languages';
 import {
+	PERSISTED_TRANSCRIPTION_SERVICE_IDS,
 	PROVIDERS,
-	TRANSCRIPTION_SERVICE_IDS,
 	type TranscriptionServiceId,
 } from '$lib/services/transcription/providers';
 
@@ -182,7 +182,12 @@ function defineTranscriptionSettings(
 ) {
 	return {
 		'transcription.service': defineKv(
-			field.select(TRANSCRIPTION_SERVICE_IDS),
+			// Accept legacy multi-engine on-device ids (whispercpp/parakeet/moonshine)
+			// from old synced workspaces so the settings facade can normalize them to
+			// `local` on read; the field stays typed as the canonical id union.
+			Type.Unsafe<TranscriptionServiceId>(
+				field.select(PERSISTED_TRANSCRIPTION_SERVICE_IDS),
+			),
 			() => defaultTranscriptionService,
 		),
 		'transcription.openai.model': defineKv(

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -63,7 +63,7 @@
 	// of rendering a second setup surface here.
 	const inlineKeyProvider = $derived.by(() => {
 		const provider = getSelectedTranscriptionProvider();
-		return provider?.access === 'byok' ? provider : null;
+		return provider?.access === 'key' ? provider : null;
 	});
 	// The verb fragments the hint drops around each key, per mode. `here` and
 	// `anywhere` annotate the in-app and global keys with their reach; `fresh` is the

--- a/docs/articles/star-transcription-is-not-account-transcription.md
+++ b/docs/articles/star-transcription-is-not-account-transcription.md
@@ -26,7 +26,7 @@ Here is the shape we want:
                              |
         +---------+----------+-----------+----------+
         |         |                      |          |
-    onDevice    byok                  byoe        star
+    onDevice     key                 endpoint     session
         |         |                      |          |
    on device   user's key        user's service    Epicenter deployment
                                                 hosted or self-host
@@ -40,7 +40,7 @@ Here is the shape we want:
                          credits can 402                      house key pays
 ```
 
-The important move is that `star` is one provider family. It does not split into
+The important move is that `session` is one provider family. It does not split into
 `hostedAccount` and `selfHostGateway`. Those names would preserve the accident.
 Both deployables expose the same OpenAI-compatible `/v1/audio/transcriptions`
 gateway; they differ in the middleware around it.
@@ -81,26 +81,36 @@ Epicenter accounts or Autumn credits, but it still has a star: the deployment th
 client is bonded to. It still has authenticated access. It can still hold a house
 key and proxy the transcription request.
 
-So the provider should name the thing that survives both deployables:
+So the discriminant (`access`) should name the thing that survives both
+deployables: what the user supplies to reach the provider.
 
 ```txt
-byok:
-  user supplies a provider key
+key:
+  user supplies a provider API key
 
-byoe:
-  user brings their own endpoint, such as Speaches
+endpoint:
+  user brings their own server URL, such as Speaches
 
-star:
+session:
   user is authenticated to the Epicenter deployment they are already using
 
 onDevice:
   no network, no credential, just the device
 ```
 
-That taxonomy is not just prettier. `byok` and `byoe` now form a matched pair:
+That taxonomy is not just prettier. `key` and `endpoint` now form a matched pair:
 bring your own key, or bring your own endpoint. `onDevice` says exactly why that
-family is different. `star` stays the platform relationship. Together, they
+family is different. `session` names the platform relationship. Together, they
 delete a branch.
+
+A note on the names. The discriminant member is `session`, not `star`. `star` is
+the platform concept (ADR-0068/0069/0070): the deployment that also holds your
+synced data. A structural type discriminant should name the mechanism it branches
+on, and the mechanism here is a signed-in session, so `session` sits cleanly
+beside `key` and `endpoint` (each named after the thing the user supplies) while
+`star` stays where it belongs, in the docs and the platform vocabulary. Likewise
+`key`/`endpoint` beat `byok`/`byoe`: no abbreviation to expand, and the same
+"bring your own X" pairing survives in plain words.
 
 The tempting fix would have been to keep `account` and add hosted/self-host
 visibility logic:
@@ -158,9 +168,9 @@ Epicenter transcription means transcription through your connected star.
 
 That keeps the product useful in both worlds. Hosted users get credit-metered
 transcription through Epicenter cloud. Self-host operators get the same route on
-their own instance, paid by their own upstream provider account. BYOK and BYOE
-stay separate because they are separate relationships: the user brings a key, or
-the user brings an endpoint.
+their own instance, paid by their own upstream provider account. `key` and
+`endpoint` stay separate because they are separate relationships: the user brings
+a key, or the user brings an endpoint.
 
 The rule I want to remember is simple:
 
@@ -171,6 +181,6 @@ Let billing, metering, and operator cost be deployment policy.
 
 When the name follows the billing accident, the code starts asking "which kind
 of Epicenter is this?" in places that should not care. When the name follows the
-relationship, the UI can stay flat: onDevice, byok, byoe, star.
+relationship, the UI can stay flat: onDevice, key, endpoint, session.
 
 That is the better shape.


### PR DESCRIPTION
Follow-up to #2341. The hosted Epicenter transcription work left two internal naming and migration edges worth tightening before this taxonomy spreads further.

The provider discriminant now names what the user supplies to make transcription usable: `key`, `endpoint`, `session`, or `onDevice`. That keeps the Epicenter provider structural as `session` while leaving `star` as platform vocabulary in the docs and ADRs.

This also widens the persisted transcription service schema to accept the old on-device ids long enough for the settings facade to repair them to `local`. Without that, workspace KV validation falls back to the default before the legacy repair code can see the raw value.

Came along for the ride: the transcription availability helper is now module-local, and analytics imports the exported `TranscriptionServiceId` type directly instead of re-deriving it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785717368&installation_id=128463665&pr_number=2347&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2347&signature=b1dad1b82a749451691af2c1982c0af6bfd388a78eb3f5045b92c0139b3c04a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->