### PR TITLE
refactor(local-books): collapse indirection in the QuickBooks client

### DIFF
--- a/apps/local-books/src/qb-client.ts
+++ b/apps/local-books/src/qb-client.ts
@@ -25,10 +25,6 @@ export const QbApiError = defineErrors({
 		status,
 		body,
 	}),
-	Unauthorized: ({ body }: { body: string }) => ({
-		message: `QuickBooks API rejected the access token (401): ${body.slice(0, 300)}`,
-		body,
-	}),
 	Throttled: ({ retries }: { retries: number }) => ({
 		message: `QuickBooks API throttled the request (429) after ${retries} retries.`,
 		retries,
@@ -190,7 +186,6 @@ export function createQbClient(deps: QbClientDeps): QbClient {
 			}
 
 			const body = await response.text().catch(() => '');
-			if (response.status === 401) return QbApiError.Unauthorized({ body });
 			return QbApiError.Http({ status: response.status, body });
 		}
 	}

--- a/apps/local-books/src/qb-client.ts
+++ b/apps/local-books/src/qb-client.ts
@@ -15,7 +15,7 @@ import type { TokenError, TokenManager } from './token-manager.ts';
  * lookback. On 429 QuickBooks asks callers to wait ~60s.
  */
 
-export const QbApiError = defineErrors({
+const QbApiError = defineErrors({
 	Network: ({ cause }: { cause: unknown }) => ({
 		message: `Network error calling the QuickBooks API: ${String(cause)}`,
 		cause,
@@ -34,15 +34,15 @@ export const QbApiError = defineErrors({
 		detail,
 	}),
 });
-export type QbApiError = InferErrors<typeof QbApiError>;
+type QbApiError = InferErrors<typeof QbApiError>;
 
 export type QbClientError = QbApiError | TokenError;
 
 /** A page of query results: the objects plus whether more pages may follow. */
-export type QueryPage = { objects: QbObject[]; hasMore: boolean };
+type QueryPage = { objects: QbObject[]; hasMore: boolean };
 
 /** CDC changes grouped by entity name. Deletes are included (status: "Deleted"). */
-export type CdcResult = { changes: Record<string, QbObject[]> };
+type CdcResult = { changes: Record<string, QbObject[]> };
 
 export type QbClient = {
 	readonly realmId: string;
@@ -80,7 +80,7 @@ export type QbClient = {
 	): Promise<Result<Record<string, unknown>, QbClientError>>;
 };
 
-export type QbClientDeps = {
+type QbClientDeps = {
 	config: AppConfig;
 	realmId: string;
 	tokens: TokenManager;
@@ -112,7 +112,7 @@ export function createQbClient(deps: QbClientDeps): QbClient {
 	async function request(
 		path: string,
 		params: Record<string, string>,
-		write?: { method: 'POST'; body: unknown },
+		write?: { body: unknown },
 	): Promise<Result<unknown, QbClientError>> {
 		const url = new URL(`${config.apiBase}/v3/company/${realmId}/${path}`);
 		for (const [key, value] of Object.entries(params))
@@ -129,7 +129,7 @@ export function createQbClient(deps: QbClientDeps): QbClient {
 			let response: Response;
 			try {
 				response = await fetch(url.toString(), {
-					method: write?.method ?? 'GET',
+					method: write ? 'POST' : 'GET',
 					headers: {
 						Authorization: `Bearer ${token.data}`,
 						Accept: 'application/json',
@@ -252,11 +252,7 @@ export function createQbClient(deps: QbClientDeps): QbClient {
 		async update(entity, body) {
 			// The update endpoint is the entity name lowercased; the response wraps
 			// the saved object under its capitalized name (e.g. `{ Purchase: {...} }`).
-			const { data, error } = await request(
-				entity.toLowerCase(),
-				{},
-				{ method: 'POST', body },
-			);
+			const { data, error } = await request(entity.toLowerCase(), {}, { body });
 			if (error) return { data: null, error };
 			const updated = (data as Record<string, unknown>)[entity];
 			if (!updated || typeof updated !== 'object') {
@@ -268,13 +264,10 @@ export function createQbClient(deps: QbClientDeps): QbClient {
 		},
 
 		async report(name, params) {
+			// `request` guarantees an Ok value is a non-null object (it emits
+			// InvalidResponse itself otherwise), so no recheck is needed here.
 			const { data, error } = await request(`reports/${name}`, params);
 			if (error) return { data: null, error };
-			if (data === null || typeof data !== 'object') {
-				return QbApiError.InvalidResponse({
-					detail: `report ${name} response was not a JSON object`,
-				});
-			}
 			return Ok(data as Record<string, unknown>);
 		},
 	};


### PR DESCRIPTION
A collapse pass over the local-books QuickBooks write + client path (`qb-client.ts`, `books/recategorize.ts`, `books/qb-access.ts`), following the recategorize fix in #2346. No behavior change; every finding is traced to zero reachable callers or a provably-dead branch. An independent second read (Codex) confirmed each of these and turned up nothing else.

### Collapse `QbApiError.Unauthorized` into `Http`

The variant fired only at `request()`'s terminal fall-through, reached after the refresh-once path (`if (status === 401 && !refreshed)`) already handled the first 401 and retried. A second, post-refresh 401 is a rare QuickBooks state, and no caller ever branched on it: every `QbClientError` consumer (`sync.ts`, `report.ts`, `/api/report`) reads `error.message` only, and no test asserted the message. Folding it into `Http` keeps the same signal and a bit more of QuickBooks' fault body (500 vs 300 chars):

```ts
// before
const body = await response.text().catch(() => '');
if (response.status === 401) return QbApiError.Unauthorized({ body });
return QbApiError.Http({ status: response.status, body });

// after
const body = await response.text().catch(() => '');
return QbApiError.Http({ status: response.status, body });
```

The retry loop now reads in one direction: happy path, then the recoverable statuses (401-refresh, 429, 5xx), then a single terminal `Http`.

### Drop the always-`POST` `method` field from `request()`

`request(path, params, write?)` typed `write` as `{ method: 'POST'; body: unknown }`, but the one write call site (`update`) always passed `'POST'`, and the QuickBooks Online data API has no write that isn't a POST (create, sparse update, and delete are all POST). The field was a constant dressed as flexibility:

```ts
// before                                  // after
write?: { method: 'POST'; body: unknown }  write?: { body: unknown }
method: write?.method ?? 'GET'             method: write ? 'POST' : 'GET'
request(entity, {}, { method: 'POST', body })  request(entity, {}, { body })
```

### Drop `report()`'s redundant object recheck

`request()` returns `Ok(json)` only after proving `json` is a non-null object (it emits `InvalidResponse` itself otherwise), so `report()`'s downstream `if (data === null || typeof data !== 'object')` was unreachable. `report()` is not a fresh untrusted boundary; it is downstream of the same in-process guarantee. The `InvalidResponse` variant stays, still emitted by `request()` and `update()`.

### Stop exporting four app-internal names

`QbApiError`, `QueryPage`, `CdcResult`, and `QbClientDeps` had zero importers repo-wide, and the package only exports `./http/api`, so none was a reachable consumer surface. `QbClient` / `QbClientError` / `createQbClient` stay exported (consumed by `sync.ts` and `qb-access.ts`).

### Deliberately left alone

- The two `required-fields` maps (prod `REQUIRED_UPDATE_FIELDS` vs the mock's `UPDATE_REQUIRED_FIELDS`) stay duplicated on purpose: the mock is the independent test oracle for #2346, and merging them would make that regression test tautological.
- `REQUIRED_UPDATE_FIELDS` stays in `recategorize.ts` (keyed by the write-verb's `RecategorizeEntity`, not the read-mirror registry in `entities.ts`).
- `extractQueryArray` stays a named helper: it isolates the `as QbObject[]` cast on untrusted QB JSON, so inlining it would spread casts for no first-read gain.

Merge with `--merge` (this app refuses squash).