### PR TITLE
chore(scripts): normalize non-Tauri app dev scripts

### DIFF
--- a/.agents/skills/monorepo/SKILL.md
+++ b/.agents/skills/monorepo/SKILL.md
@@ -50,18 +50,17 @@ Use this pattern when you need to:
 
 ## Dev Scripts
 
-Apps use either a single `dev` script (when there is only one sensible local
-workflow) or a `dev:local` alias (kept for symmetry with `:remote` db scripts).
-Tauri desktop apps (honeycrisp, whispering, matter) have two dev surfaces and
-name them explicitly instead: `dev` launches the desktop shell (aliasing
-`dev:desktop`), and `dev:web` runs Vite alone, which each app's
-`tauri.conf.json` invokes as its `beforeDevCommand`. The suffix convention
-applies primarily to database commands:
+Non-Tauri apps use a single `dev` script that runs the underlying tool
+directly (`vite dev`, `astro dev`, `wrangler dev`, `wxt`). Tauri desktop apps
+(honeycrisp, whispering, matter) have two dev surfaces and name them
+explicitly: `dev` launches the desktop shell (aliasing `dev:desktop`), and
+`dev:web` runs Vite alone, which each app's `tauri.conf.json` invokes as its
+`beforeDevCommand`. The suffix convention applies primarily to database
+commands:
 
 | Script | Meaning |
 | --- | --- |
 | `dev` | The default local workflow. May still require Infisical login for app secrets (e.g. API keys), but only ever talks to local infrastructure at runtime. |
-| `dev:local` | Used when an app keeps the `dev` -> `dev:local` alias for explicit naming. Equivalent to `dev`. |
 | `dev:web` | Tauri apps: the Vite dev server alone, no desktop shell. Invoked by `tauri.conf.json` as `beforeDevCommand`. |
 | `dev:desktop` | Tauri apps: launches the native desktop app (`tauri dev`). `dev` aliases this. |
 | `db:*:local` | Runs against local Postgres. Works without Infisical login. |

--- a/apps/api/ui/README.md
+++ b/apps/api/ui/README.md
@@ -45,7 +45,7 @@ bun run dev
 
 # Then start the dashboard (in another terminal)
 cd apps/api/ui
-bun run dev:local
+bun run dev
 ```
 
 Runs on port 5178. The Vite dev server proxies `/api` and `/auth` to `localhost:8787`.

--- a/apps/api/ui/package.json
+++ b/apps/api/ui/package.json
@@ -5,8 +5,7 @@
 	"version": "0.0.2",
 	"type": "module",
 	"scripts": {
-		"dev": "bun run dev:local",
-		"dev:local": "vite dev",
+		"dev": "vite dev",
 		"build": "NODE_ENV=production vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -5,8 +5,7 @@
 	"type": "module",
 	"version": "0.0.2",
 	"scripts": {
-		"dev": "bun run dev:local",
-		"dev:local": "astro dev",
+		"dev": "astro dev",
 		"build": "astro build",
 		"preview": "astro preview",
 		"astro": "astro",

--- a/apps/opensidian/package.json
+++ b/apps/opensidian/package.json
@@ -10,8 +10,7 @@
 		"./mount": "./mount.ts"
 	},
 	"scripts": {
-		"dev": "bun run dev:local",
-		"dev:local": "vite dev",
+		"dev": "vite dev",
 		"build": "vite build",
 		"deploy": "wrangler deploy",
 		"preview": "vite preview",

--- a/apps/posthog-reverse-proxy/package.json
+++ b/apps/posthog-reverse-proxy/package.json
@@ -5,8 +5,7 @@
 	"description": "PostHog reverse proxy for epicenter.so",
 	"type": "module",
 	"scripts": {
-		"dev": "bun run dev:local",
-		"dev:local": "wrangler dev",
+		"dev": "wrangler dev",
 		"deploy": "wrangler deploy --minify",
 		"tail": "wrangler tail"
 	},

--- a/apps/self-host/package.json
+++ b/apps/self-host/package.json
@@ -9,11 +9,11 @@
 	},
 	"license": "AGPL-3.0-or-later",
 	"scripts": {
+		"dev": "bun --watch server.ts",
 		"typecheck": "tsc --noEmit",
 		"typegen": "wrangler types",
 		"deploy": "wrangler deploy",
-		"gen-token": "bun scripts/gen-token.ts",
-		"dev:bun": "bun --watch server.ts"
+		"gen-token": "bun scripts/gen-token.ts"
 	},
 	"dependencies": {
 		"@epicenter/auth": "workspace:*",

--- a/apps/skills/package.json
+++ b/apps/skills/package.json
@@ -5,8 +5,7 @@
 	"version": "0.0.1",
 	"type": "module",
 	"scripts": {
-		"dev": "bun run dev:local",
-		"dev:local": "vite dev",
+		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/apps/tab-manager/package.json
+++ b/apps/tab-manager/package.json
@@ -9,8 +9,7 @@
 		"./mount": "./mount.ts"
 	},
 	"scripts": {
-		"dev": "bun run dev:local",
-		"dev:local": "wxt",
+		"dev": "wxt",
 		"dev:firefox": "wxt -b firefox",
 		"build": "wxt build",
 		"build:firefox": "wxt build -b firefox",

--- a/apps/vocab/package.json
+++ b/apps/vocab/package.json
@@ -9,8 +9,7 @@
 		"./browser": "./vocab.browser.ts"
 	},
 	"scripts": {
-		"dev": "bun run dev:local",
-		"dev:local": "vite dev",
+		"dev": "vite dev",
 		"build": "NODE_ENV=production vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
 		"dev": "bun run dev:tab-manager",
 		"dev:api": "bun run --cwd apps/api dev",
 		"dev:tab-manager": "bun run --filter @epicenter/api --filter @epicenter/tab-manager dev",
-		"dev:tab-manager:ui": "bun run --cwd apps/tab-manager dev:local",
+		"dev:tab-manager:ui": "bun run --cwd apps/tab-manager dev",
 		"format": "biome check --write --linter-enabled=false",
 		"format:check": "biome ci --linter-enabled=false",
 		"lint": "biome lint --write",


### PR DESCRIPTION
Follow-up to #2335 and #2338, which standardized the API entrypoint and the three Tauri apps. This finishes the dev-script naming cleanup for the non-Tauri apps: `dev` now runs each app's dev tool directly, instead of hopping through an equivalent `dev:local` alias.

## Collapsed `dev -> dev:local -> tool` to `dev -> tool`

Each app's `dev` now runs the underlying tool directly and the `dev:local` line is deleted:

| App | `dev` now runs |
| --- | --- |
| `apps/api/ui` | `vite dev` |
| `apps/landing` | `astro dev` |
| `apps/opensidian` | `vite dev` |
| `apps/posthog-reverse-proxy` | `wrangler dev` |
| `apps/skills` | `vite dev` |
| `apps/tab-manager` | `wxt` |
| `apps/vocab` | `vite dev` |

This matches the shape `apps/todos`, `apps/local-mail/ui`, and `apps/local-books/ui` already used.

## Also: self-host gains a direct `dev`

`apps/self-host` had only `dev:bun` and no plain `dev`, making it the one non-Tauri app missing the universal dev verb. It is now `dev` running the blessed Bun entry directly (`bun --watch server.ts`). Same reasoning: the `:bun` suffix named a runtime distinction with no dev-time sibling (there is no `wrangler dev` script), so it was the same unearned-suffix smell.

The reason for this shape is:

The `:local` / `:remote` suffix is a database blast-radius convention: `:local` runs against local infrastructure with no Infisical login, `:remote` wraps `infisical run --env=prod` for production admin. Using `:local` for a single dev-server mode implied a `:remote` sibling that never existed, so the alias added a hop and a misleading signal without adding a real choice.

## Blast radius and callers

- Root `package.json`: `dev:tab-manager:ui` now calls `... dev` instead of `... dev:local`. Both `dev:tab-manager` and `dev:tab-manager:ui` still resolve to `wxt`.
- `apps/api/ui/README.md`: `bun run dev:local` becomes `bun run dev`.
- Monorepo skill Dev Scripts table (`.agents/skills/monorepo/SKILL.md`): dropped the now-vestigial `dev:local` row; the `dev:web` / `dev:desktop` Tauri rows from #2338 are untouched.

Behavior-preserving: every collapsed `dev` runs the exact command it ran through the alias. No runtime code, dependency, or lockfile changes.

## Deliberately not touched

- **Tauri apps** (`honeycrisp`, `whispering`, `matter`): keep the `dev` / `dev:web` / `dev:desktop` triple from #2338. They have two genuine surfaces; `dev:web` is invoked directly by `tauri.conf.json` as `beforeDevCommand`, so the explicit pair is earned.
- **`apps/super-chat`**: keeps `start`, not `dev`. It is a Tauri sidecar entrypoint (ADR-0084) that reads a per-launch token from stdin and serves on a loopback port; it is not an interactive dev server, so a `dev` verb would be misleading.
- **`apps/api`**: `dev` already runs its orchestrator directly; `dev:bun` / `dev:bun:devauth` / `dev:dashboard` are genuinely distinct surfaces, not alias hops.
- Headless / library packages with no dev server (`apps/local-books`, `apps/local-mail`, `apps/reddit`, `apps/wiki`) get no synthetic `dev`.