### PR TITLE
refactor(whispering): drop unreleased transcription legacy ids

### DIFF
--- a/apps/whispering/README.md
+++ b/apps/whispering/README.md
@@ -691,7 +691,7 @@ We'd love to expand Whispering's capabilities with more transcription and AI ser
 
 The provider registry owns every provider fact, including the names of the config keys that hold its credentials and model selection. The stores own the values. The dispatcher and the settings UI resolve those pointers through the registry, so most of the integration is compile-error driven: once your provider is in the registry, the type checker points at every table that still needs an entry.
 
-Local engines (whisper.cpp, Parakeet, Moonshine) are implemented in Rust behind Tauri commands, so this guide covers cloud and self-hosted services, which live in TypeScript.
+The local GGUF engine is implemented in Rust behind Tauri commands, so this guide covers upload-based services that live in TypeScript: API-key providers and endpoint providers.
 
 1. **Create the service implementation**:
    - **Cloud services**: `src/lib/services/transcription/cloud/` (OpenAI, Groq, Deepgram, ElevenLabs, Mistral)
@@ -761,25 +761,25 @@ Local engines (whisper.cpp, Parakeet, Moonshine) are implemented in Rust behind 
 
    ```typescript
    YourService: {
-	location: 'cloud',
-	label: 'Your Service',
-	description: 'What makes this service worth picking',
-	capabilities: { supportsPrompt: true, supportsLanguage: true },
-	apiKeyConfigKey: 'providers.yourservice.apiKey',
-	modelSettingKey: 'transcription.yourservice.model',
-	endpointConfigKey: null, // or a 'providers.yourservice.endpoint' override key
-	modelsDoc: {
-		label: 'Your Service docs',
-		href: 'https://yourservice.com/docs/speech-to-text',
-	},
-	defaultModel: 'model-v1',
-	models: [
-		{
-			name: 'model-v1',
-			description: 'What makes this model special',
-			cost: '$0.XX/hour',
-		},
-	],
+     access: 'key',
+     label: 'Your Service',
+     description: 'What makes this service worth picking',
+     capabilities: { supportsPrompt: true, supportsLanguage: true },
+     apiKeyConfigKey: 'providers.yourservice.apiKey',
+     modelSettingKey: 'transcription.yourservice.model',
+     endpointConfigKey: null, // or a 'providers.yourservice.endpoint' override key
+     modelsDoc: {
+       label: 'Your Service docs',
+       href: 'https://yourservice.com/docs/speech-to-text',
+     },
+     defaultModel: 'model-v1',
+     models: [
+       {
+         name: 'model-v1',
+         description: 'What makes this model special',
+         cost: '$0.XX/hour',
+       },
+     ],
    },
    ```
 
@@ -787,11 +787,11 @@ Local engines (whisper.cpp, Parakeet, Moonshine) are implemented in Rust behind 
 
 4. **Fix the compile errors the registry entry creates.** Each of these tables is exhaustive over the provider ids, so the type checker walks you to them:
 
-   - `CLOUD_TRANSCRIBERS` in `src/lib/operations/transcribe.ts`: map your id to `YourServiceTranscriptionServiceLive.transcribe`.
+   - `UPLOAD_DISPATCH` in `src/lib/operations/transcribe.ts`: map your id to `YourServiceTranscriptionServiceLive.transcribe`.
    - `PROVIDER_ICONS` in `src/lib/services/transcription/provider-ui.ts`: add your SVG icon.
    - `PROVIDER_FIELDS` in `src/lib/components/settings/ProviderConfigFields.svelte`: declare the API key (and optional endpoint) fields with their labels, placeholders, and docs links. This is where provider-specific copy lives, like where to find the API key.
 
-That's the whole integration. The Privacy & Processing surface, the quick-pick selector, the configuration warning badge, and the dispatcher need no edits; they all render and resolve through the registry entry. Only self-hosted and local providers get bespoke sections in `src/lib/components/settings/TranscriptionRuntimeConfig.svelte`, because their setup instructions are the product copy.
+That's the whole integration. The Privacy & Processing surface, the quick-pick selector, the configuration warning badge, and the dispatcher need no edits; they all render and resolve through the registry entry. Endpoint and on-device providers get bespoke sections in `src/lib/components/settings/TranscriptionRuntimeConfig.svelte`, because their setup instructions are the product copy.
 
 ##### Adding an AI Transformation Adapter
 

--- a/apps/whispering/src-tauri/src/audio/command.rs
+++ b/apps/whispering/src-tauri/src/audio/command.rs
@@ -1,7 +1,7 @@
 //! Tauri command surface for the audio module. One endpoint:
 //! `encode_recording_for_upload(recording_id)` resolves the durable audio
-//! artifact by id, decodes it to mono 16 kHz PCM (same path the local
-//! transcription engines use via `read_artifact_samples`), and re-encodes
+//! artifact by id, decodes it to mono 16 kHz PCM (same path local GGUF
+//! transcription uses via `read_artifact_samples`), and re-encodes
 //! to OGG/Opus for cloud upload.
 
 use log::warn;

--- a/apps/whispering/src-tauri/src/audio/decode.rs
+++ b/apps/whispering/src-tauri/src/audio/decode.rs
@@ -25,8 +25,7 @@ use symphonia::core::{
 use super::error::AudioError;
 use super::resample::resample_mono;
 
-/// Target sample rate for all three local transcription engines
-/// (whisper.cpp, Parakeet, Moonshine).
+/// Target sample rate for local GGUF transcription, which consumes 16 kHz mono.
 const TARGET_RATE: u32 = 16_000;
 
 /// libopus runs at 48 kHz internally; any Opus packet from any container

--- a/apps/whispering/src-tauri/src/audio/mod.rs
+++ b/apps/whispering/src-tauri/src/audio/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Decode any container/codec we plausibly receive (WAV, MP3, M4A/AAC,
 //! FLAC, OGG, WebM, including Opus inside any of those) into a `Vec<f32>`
-//! of 16 kHz mono samples, ready for the local transcription engines.
+//! of 16 kHz mono samples, ready for local GGUF transcription.
 //!
 //! Replaces the old `transcription::audio` module, which dispatched
 //! across three tiers (WAV fast-path, hound + rubato, external sidecar)

--- a/apps/whispering/src-tauri/src/recorder/artifact.rs
+++ b/apps/whispering/src-tauri/src/recorder/artifact.rs
@@ -27,7 +27,7 @@ use crate::audio::decode_to_pcm16k_mono;
 use crate::recorder::error::RecorderError;
 
 /// Target rate for every cpal-written artifact. Matches the recorder's
-/// finalize contract and the rate all local transcription engines want.
+/// finalize contract and the rate local GGUF transcription wants.
 const ARTIFACT_RATE: u32 = 16_000;
 const ARTIFACT_CHANNELS: u16 = 1;
 

--- a/apps/whispering/src-tauri/src/recorder/recorder.rs
+++ b/apps/whispering/src-tauri/src/recorder/recorder.rs
@@ -35,9 +35,8 @@ use crate::recorder::error::RecorderError;
 /// on `error.name` instead of matching message text.
 pub type Result<T> = std::result::Result<T, RecorderError>;
 
-/// Target rate for every recording. All local transcription engines
-/// (whispercpp, parakeet, moonshine) want 16 kHz mono; the cloud
-/// services accept opus encoded from 48 kHz which we get to via a
+/// Target rate for every recording. Local GGUF transcription consumes 16 kHz
+/// mono; the cloud services accept Opus encoded from 48 kHz, reached via a
 /// second resample step inside `audio::encode_pcm_to_opus_ogg`.
 const TARGET_RATE: u32 = 16_000;
 

--- a/apps/whispering/src/lib/services/transcription/providers.ts
+++ b/apps/whispering/src/lib/services/transcription/providers.ts
@@ -377,37 +377,3 @@ export type UploadProviderId = Exclude<
 export const TRANSCRIPTION_SERVICE_IDS = Object.keys(
 	PROVIDERS,
 ) as TranscriptionServiceId[];
-
-// Persisted `transcription.service` values from the removed multi-engine local
-// runtime. These are not providers anymore; the settings facade rewrites them
-// to `local` on read so old synced workspaces keep their on-device intent.
-export const LEGACY_ON_DEVICE_TRANSCRIPTION_SERVICE_IDS = [
-	'whispercpp',
-	'parakeet',
-	'moonshine',
-] as const;
-
-export type LegacyOnDeviceTranscriptionServiceId =
-	(typeof LEGACY_ON_DEVICE_TRANSCRIPTION_SERVICE_IDS)[number];
-
-export const PERSISTED_TRANSCRIPTION_SERVICE_IDS = [
-	...TRANSCRIPTION_SERVICE_IDS,
-	...LEGACY_ON_DEVICE_TRANSCRIPTION_SERVICE_IDS,
-] as const;
-
-export function isLegacyOnDeviceTranscriptionServiceId(
-	value: unknown,
-): value is LegacyOnDeviceTranscriptionServiceId {
-	return (
-		typeof value === 'string' &&
-		(LEGACY_ON_DEVICE_TRANSCRIPTION_SERVICE_IDS as readonly string[]).includes(
-			value,
-		)
-	);
-}
-
-export function normalizePersistedTranscriptionServiceId(
-	value: TranscriptionServiceId | LegacyOnDeviceTranscriptionServiceId,
-): TranscriptionServiceId {
-	return isLegacyOnDeviceTranscriptionServiceId(value) ? 'local' : value;
-}

--- a/apps/whispering/src/lib/state/settings.svelte.ts
+++ b/apps/whispering/src/lib/state/settings.svelte.ts
@@ -1,9 +1,5 @@
 import { SvelteMap } from 'svelte/reactivity';
 import { whispering } from '#platform/whispering';
-import {
-	isLegacyOnDeviceTranscriptionServiceId,
-	normalizePersistedTranscriptionServiceId,
-} from '$lib/services/transcription/providers';
 
 type Kv = typeof whispering.kv;
 
@@ -22,25 +18,13 @@ export type BooleanSettingKey = {
 	[K in keyof SettingsValues]: SettingsValues[K] extends boolean ? K : never;
 }[keyof SettingsValues];
 
-function normalizeSettingValue(key: string, value: unknown) {
-	if (
-		key === 'transcription.service' &&
-		isLegacyOnDeviceTranscriptionServiceId(value)
-	) {
-		const normalized = normalizePersistedTranscriptionServiceId(value);
-		whispering.kv.set('transcription.service', normalized);
-		return normalized;
-	}
-	return value;
-}
-
 function createSettings() {
 	const map = new SvelteMap<string, unknown>();
 
 	// Initialize SvelteMap with current values for ALL KV keys.
 	// kv.get() always returns a valid value (stored value or defaultValue).
 	for (const key of whispering.kv.keys) {
-		map.set(key, normalizeSettingValue(key, whispering.kv.get(key)));
+		map.set(key, whispering.kv.get(key));
 	}
 
 	// Single observer for ALL KV changes (local or remote).
@@ -48,7 +32,7 @@ function createSettings() {
 	whispering.kv.observeAll((changes) => {
 		for (const [key, change] of changes) {
 			if (change.type === 'set') {
-				map.set(key, normalizeSettingValue(key, change.value));
+				map.set(key, change.value);
 			} else if (change.type === 'delete') {
 				// On delete, restore default value so map always has a value
 				map.set(key, whispering.kv.get(key));

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -16,8 +16,8 @@ import { RECORDING_TRIGGERS } from '$lib/constants/audio/recording-triggers';
 import { INFERENCE_PROVIDER_IDS } from '$lib/constants/inference';
 import { SUPPORTED_LANGUAGES } from '$lib/constants/languages';
 import {
-	PERSISTED_TRANSCRIPTION_SERVICE_IDS,
 	PROVIDERS,
+	TRANSCRIPTION_SERVICE_IDS,
 	type TranscriptionServiceId,
 } from '$lib/services/transcription/providers';
 
@@ -182,12 +182,7 @@ function defineTranscriptionSettings(
 ) {
 	return {
 		'transcription.service': defineKv(
-			// Accept legacy multi-engine on-device ids (whispercpp/parakeet/moonshine)
-			// from old synced workspaces so the settings facade can normalize them to
-			// `local` on read; the field stays typed as the canonical id union.
-			Type.Unsafe<TranscriptionServiceId>(
-				field.select(PERSISTED_TRANSCRIPTION_SERVICE_IDS),
-			),
+			field.select(TRANSCRIPTION_SERVICE_IDS),
 			() => defaultTranscriptionService,
 		),
 		'transcription.openai.model': defineKv(

--- a/docs/articles/star-transcription-is-not-account-transcription.md
+++ b/docs/articles/star-transcription-is-not-account-transcription.md
@@ -109,8 +109,8 @@ synced data. A structural type discriminant should name the mechanism it branche
 on, and the mechanism here is a signed-in session, so `session` sits cleanly
 beside `key` and `endpoint` (each named after the thing the user supplies) while
 `star` stays where it belongs, in the docs and the platform vocabulary. Likewise
-`key`/`endpoint` beat `byok`/`byoe`: no abbreviation to expand, and the same
-"bring your own X" pairing survives in plain words.
+`key`/`endpoint` keep the "bring your own X" pairing in plain words, with no
+abbreviation to expand.
 
 The tempting fix would have been to keep `account` and add hosted/self-host
 visibility logic:


### PR DESCRIPTION
Follow-up to #2347. The multi-engine local ids (`whispercpp`, `parakeet`, `moonshine`) never made it into a release tag, and the GGUF collapse deliberately refused a migration reader for them. Keeping a read-time repair path now makes the settings schema carry a compatibility promise for an unreleased shape.

This returns `transcription.service` to the canonical provider id enum, deletes the read-time rewrite to `local`, and sweeps active docs/comments that still referenced the removed local engines or the old transcription registry field names.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785718116&installation_id=128463665&pr_number=2350&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2350&signature=e5598aabb2dc70a1c8cde0a43b21dbc8c325a751b1ba0d662d0784310203bc67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->