### PR TITLE
refactor(auth)!: rename token connection state to verification

### DIFF
--- a/packages/app-shell/src/account-popover/account-popover.svelte
+++ b/packages/app-shell/src/account-popover/account-popover.svelte
@@ -128,24 +128,16 @@
 	);
 	// Optimistic boot (ADR-0075) leaves a self-host user signed-in even when the box
 	// is unreachable, so they usually never see the sign-in panel's verification copy.
-	// Surface the verification failure here instead. `auth.state` still says
-	// signed-in (local workspace identity is known); this line only explains that
-	// the configured server has not accepted the credential in this runtime. Local
-	// work is unaffected, so `unreachable` reads muted and only a `rejected` token
-	// (which also drops `state` to signed-out and reveals the sign-in panel) reads
-	// destructive.
-	const verificationNotice = $derived.by(() => {
+	// Surface the unreachable state here instead. `auth.state` still says signed-in
+	// (local workspace identity is known); this line only explains that the
+	// configured server is offline in this runtime, and local work is unaffected, so
+	// it reads muted. A `rejected` token is not handled here: it drops `state` to
+	// signed-out (see `createInstanceTokenAuth`), which reveals the sign-in panel
+	// that owns the rejected-token copy, so this signed-in surface never sees it.
+	const unreachableNotice = $derived.by(() => {
 		const v = auth.verification?.state;
-		if (!v || v.status !== 'failed') return null;
-		return v.reason === 'rejected'
-			? {
-					text: `${selfHostHost} rejected the saved token. Sign out to reconnect.`,
-					tone: 'text-destructive',
-				}
-			: {
-					text: `Can't reach ${selfHostHost}. You're working locally; sync resumes when it's back.`,
-					tone: 'text-muted-foreground',
-				};
+		if (v?.status !== 'failed' || v.reason !== 'unreachable') return null;
+		return `Can't reach ${selfHostHost}. You're working locally; sync resumes when it's back.`;
 	});
 	// Identity lives on the auth client: `state` carries the principal partition,
 	// and `getProfile()` reads presentational identity (the email) on demand.
@@ -310,10 +302,8 @@
 					{#if selfHostHost}
 						<p class="text-sm font-medium">{selfHostHost}</p>
 						<p class="text-xs text-muted-foreground">Self-hosted instance</p>
-						{#if verificationNotice}
-							<p class="text-xs {verificationNotice.tone}">
-								{verificationNotice.text}
-							</p>
+						{#if unreachableNotice}
+							<p class="text-xs text-muted-foreground">{unreachableNotice}</p>
 						{/if}
 					{:else}
 						<p class="text-sm font-medium">{accountLabel}</p>

--- a/packages/app-shell/src/account-popover/account-popover.svelte
+++ b/packages/app-shell/src/account-popover/account-popover.svelte
@@ -126,6 +126,27 @@
 			? undefined
 			: new URL(instanceConnect.setting.read().baseURL).host,
 	);
+	// Optimistic boot (ADR-0075) leaves a self-host user signed-in even when the box
+	// is unreachable, so they usually never see the sign-in panel's verification copy.
+	// Surface the verification failure here instead. `auth.state` still says
+	// signed-in (local workspace identity is known); this line only explains that
+	// the configured server has not accepted the credential in this runtime. Local
+	// work is unaffected, so `unreachable` reads muted and only a `rejected` token
+	// (which also drops `state` to signed-out and reveals the sign-in panel) reads
+	// destructive.
+	const verificationNotice = $derived.by(() => {
+		const v = auth.verification?.state;
+		if (!v || v.status !== 'failed') return null;
+		return v.reason === 'rejected'
+			? {
+					text: `${selfHostHost} rejected the saved token. Sign out to reconnect.`,
+					tone: 'text-destructive',
+				}
+			: {
+					text: `Can't reach ${selfHostHost}. You're working locally; sync resumes when it's back.`,
+					tone: 'text-muted-foreground',
+				};
+	});
 	// Identity lives on the auth client: `state` carries the principal partition,
 	// and `getProfile()` reads presentational identity (the email) on demand.
 	// TanStack Query owns the reactive cache here, keyed by account, and
@@ -289,6 +310,11 @@
 					{#if selfHostHost}
 						<p class="text-sm font-medium">{selfHostHost}</p>
 						<p class="text-xs text-muted-foreground">Self-hosted instance</p>
+						{#if verificationNotice}
+							<p class="text-xs {verificationNotice.tone}">
+								{verificationNotice.text}
+							</p>
+						{/if}
 					{:else}
 						<p class="text-sm font-medium">{accountLabel}</p>
 					{/if}

--- a/packages/app-shell/src/instance-settings/sign-in-panel.svelte
+++ b/packages/app-shell/src/instance-settings/sign-in-panel.svelte
@@ -73,28 +73,28 @@
 	// "retry / change". Reads the boot snapshot, which only changes across a reload.
 	const configured = $derived(!instance.setting.isDefault());
 
-	// The self-host token client reports why it is not connected; hosted OAuth has
-	// no such channel (`auth.connection` is undefined) and falls back to the
-	// generic startSignIn error rendered below.
+	// The self-host token client reports whether the configured server accepted its
+	// token; hosted OAuth has no such channel (`auth.verification` is undefined) and
+	// falls back to the generic startSignIn error rendered below.
 	const host = $derived(
 		configured ? new URL(instance.setting.read().baseURL).host : undefined,
 	);
-	const connectionState = $derived(auth.connection?.state);
-	const connectionNotice = $derived.by(() => {
-		const c = connectionState;
-		if (!c) return null;
-		switch (c.status) {
+	const verificationState = $derived(auth.verification?.state);
+	const verificationNotice = $derived.by(() => {
+		const v = verificationState;
+		if (!v) return null;
+		switch (v.status) {
 			case 'pending':
 				return { text: `Connecting to ${host}…`, tone: 'text-muted-foreground' };
 			case 'failed':
 				return {
 					text:
-						c.reason === 'rejected'
+						v.reason === 'rejected'
 							? `${host} rejected the saved token.`
 							: `Couldn't reach ${host}. Check the URL and that your server is running.`,
 					tone: 'text-destructive',
 				};
-			case 'connected':
+			case 'verified':
 				return null;
 		}
 	});
@@ -103,7 +103,9 @@
 	// a star that accepts the socket but never answers leaves this on "Connecting…"
 	// until the browser's own timeout fires. Refused connections and 401s fail
 	// fast, so the common failures self-heal into a retryable state.
-	const verifying = $derived(signingIn || connectionState?.status === 'pending');
+	const verifying = $derived(
+		signingIn || verificationState?.status === 'pending',
+	);
 
 	// One sign-in surface: the primary button and the "retry" action are the same
 	// `auth.startSignIn()`, whose meaning (hosted OAuth vs. verifying the persisted
@@ -130,8 +132,8 @@
 	{#if disabledReason}
 		<p class="text-xs text-muted-foreground">{disabledReason}</p>
 	{/if}
-	{#if connectionNotice}
-		<p class="text-xs {connectionNotice.tone}">{connectionNotice.text}</p>
+	{#if verificationNotice}
+		<p class="text-xs {verificationNotice.tone}">{verificationNotice.text}</p>
 	{:else if signInError}
 		<p class="text-xs text-destructive">{signInError}</p>
 	{/if}

--- a/packages/auth/src/auth-contract.ts
+++ b/packages/auth/src/auth-contract.ts
@@ -18,18 +18,20 @@ export type AuthFetch = (
 ) => Promise<Response>;
 
 /**
- * Outcome of verifying a client's credential against its star. Exposed only by
- * clients that perform a remote bearer verification at boot (the self-host token
- * client, {@link createInstanceTokenAuth}). It rides its own channel because the
- * boot identity {@link AuthState} is optimistic (signed-in the moment a token is
- * held, ADR-0075) and most outcomes leave it untouched: an unreachable star keeps
- * the client signed-in for local-first work, and only a rejected token drops it to
- * `signed-out`. So this is the separate signal a UI reads to explain connectivity:
- * still connecting, an unreachable star, or a rejected token.
+ * Outcome of verifying a client's credential against its star: has the configured
+ * server accepted this credential in this runtime? Exposed only by clients that
+ * perform a remote bearer verification at boot (the self-host token client,
+ * {@link createInstanceTokenAuth}). It rides its own channel because the boot
+ * identity {@link AuthState} is optimistic (signed-in the moment a token is held,
+ * ADR-0075) and most outcomes leave it untouched: an unreachable star keeps the
+ * client signed-in for local-first work, and only a rejected token drops it to
+ * `signed-out`. So this is the separate signal a UI reads to explain whether the
+ * server is reachable and the credential accepted: still verifying, an unreachable
+ * star, or a rejected token.
  */
-export type AuthConnectionState =
+export type AuthVerificationState =
 	| { status: 'pending' }
-	| { status: 'connected' }
+	| { status: 'verified' }
 	| {
 			status: 'failed';
 			/**
@@ -41,13 +43,13 @@ export type AuthConnectionState =
 	  };
 
 /**
- * Observable {@link AuthConnectionState}. `onChange` does not replay the current
+ * Observable {@link AuthVerificationState}. `onChange` does not replay the current
  * value, mirroring {@link AuthClient.onStateChange}; read `state` once before
  * subscribing when the boot value matters (the Svelte reactive wrapper does).
  */
-export type AuthConnection = {
-	get state(): AuthConnectionState;
-	onChange(fn: (state: AuthConnectionState) => void): () => void;
+export type AuthVerification = {
+	get state(): AuthVerificationState;
+	onChange(fn: (state: AuthVerificationState) => void): () => void;
 };
 
 export type AuthClient = {
@@ -107,13 +109,17 @@ export type AuthClient = {
 	 */
 	getProfile(): Promise<Result<Principal, AuthError>>;
 	/**
-	 * Connection-verification channel, present only on clients that verify a
-	 * remote bearer at boot (the self-host token client). Absent on hosted OAuth
-	 * (identity resolves through the persisted grant, not a boot bearer check) and
-	 * on the same-origin cookie client (no remote star), so it is an optional
-	 * capability a UI feature-detects, not a universal field.
+	 * Remote credential-verification channel, present only on clients that verify
+	 * a remote bearer at boot (the self-host token client). It answers "has the
+	 * configured server accepted this credential in this runtime?", a fact distinct
+	 * from {@link AuthState}, which answers "who owns the local workspace?": a client
+	 * can be `signed-in` (local identity known) while verification is `failed`
+	 * `unreachable` (server offline). Absent on hosted OAuth (identity resolves
+	 * through the persisted grant, not a boot bearer check) and on the same-origin
+	 * cookie client (no remote star), so it is an optional capability a UI
+	 * feature-detects, not a universal field.
 	 */
-	connection?: AuthConnection;
+	verification?: AuthVerification;
 	[Symbol.dispose](): void;
 };
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -4,10 +4,10 @@ export {
 } from './app-auth-client.js';
 export type {
 	AuthClient,
-	AuthConnection,
-	AuthConnectionState,
 	AuthFetch,
 	AuthState,
+	AuthVerification,
+	AuthVerificationState,
 	SyncAuthClient,
 } from './auth-contract.js';
 export * from './auth-errors.js';

--- a/packages/auth/src/instance-token-auth.test.ts
+++ b/packages/auth/src/instance-token-auth.test.ts
@@ -275,6 +275,10 @@ describe('createInstanceTokenAuth', () => {
 		expect(auth.verification?.state).toEqual({ status: 'verified' });
 
 		await auth.fetch('/api/blobs');
+		// A rejected token always drops `state` to signed-out, not just at boot: the
+		// signed-in account UI relies on this coupling to skip rejected-token copy
+		// (the sign-in panel owns it) and surface only `unreachable`.
+		expect(auth.state.status).toBe('signed-out');
 		expect(auth.verification?.state).toEqual({
 			status: 'failed',
 			reason: 'rejected',

--- a/packages/auth/src/instance-token-auth.test.ts
+++ b/packages/auth/src/instance-token-auth.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { asPrincipalId, INSTANCE_PRINCIPAL_ID } from '@epicenter/identity';
 import { BEARER_SUBPROTOCOL_PREFIX } from '@epicenter/sync';
-import type { AuthConnectionState, AuthFetch } from './auth-contract.js';
+import type { AuthFetch, AuthVerificationState } from './auth-contract.js';
 import { createInstanceTokenAuth } from './instance-token-auth.js';
 
 const baseURL = 'http://localhost:8788';
@@ -182,7 +182,7 @@ describe('createInstanceTokenAuth', () => {
 		const auth = createInstanceTokenAuth({ baseURL, token, fetch });
 		await flush();
 		// An unreachable star leaves the optimistic identity: the self-hoster keeps
-		// their principal-scoped local workspace offline (the `connection` channel,
+		// their principal-scoped local workspace offline (the `verification` channel,
 		// not `state`, carries the "unreachable" signal).
 		expect(auth.state).toEqual({
 			status: 'signed-in',
@@ -211,71 +211,71 @@ describe('createInstanceTokenAuth', () => {
 		});
 	});
 
-	test('connection reports pending at boot then connected on a 200', async () => {
+	test('verification reports pending at boot then verified on a 200', async () => {
 		const fetch: AuthFetch = async () => json(sessionBody());
 		const auth = createInstanceTokenAuth({ baseURL, token, fetch });
-		expect(auth.connection?.state).toEqual({ status: 'pending' });
+		expect(auth.verification?.state).toEqual({ status: 'pending' });
 		await flush();
-		expect(auth.connection?.state).toEqual({ status: 'connected' });
+		expect(auth.verification?.state).toEqual({ status: 'verified' });
 	});
 
-	test('connection fails as rejected when the token is refused (401)', async () => {
+	test('verification fails as rejected when the token is refused (401)', async () => {
 		const fetch: AuthFetch = async () => json({}, 401);
 		const auth = createInstanceTokenAuth({ baseURL, token, fetch });
 		await flush();
 		expect(auth.state.status).toBe('signed-out');
-		expect(auth.connection?.state).toEqual({
+		expect(auth.verification?.state).toEqual({
 			status: 'failed',
 			reason: 'rejected',
 		});
 	});
 
-	test('connection fails as unreachable when the star is offline', async () => {
+	test('verification fails as unreachable when the star is offline', async () => {
 		const fetch: AuthFetch = async () => {
 			throw new Error('offline');
 		};
 		const auth = createInstanceTokenAuth({ baseURL, token, fetch });
 		await flush();
-		expect(auth.connection?.state).toEqual({
+		expect(auth.verification?.state).toEqual({
 			status: 'failed',
 			reason: 'unreachable',
 		});
 	});
 
-	test('connection notifies subscribers and recovers on a retry', async () => {
+	test('verification notifies subscribers and recovers on a retry', async () => {
 		let reachable = false;
 		const fetch: AuthFetch = async () => {
 			if (!reachable) throw new Error('offline');
 			return json(sessionBody());
 		};
 		const auth = createInstanceTokenAuth({ baseURL, token, fetch });
-		const seen: AuthConnectionState['status'][] = [];
-		auth.connection?.onChange((s) => seen.push(s.status));
+		const seen: AuthVerificationState['status'][] = [];
+		auth.verification?.onChange((s) => seen.push(s.status));
 		await flush();
-		expect(auth.connection?.state).toEqual({
+		expect(auth.verification?.state).toEqual({
 			status: 'failed',
 			reason: 'unreachable',
 		});
 
 		reachable = true;
 		await auth.startSignIn();
-		expect(auth.connection?.state).toEqual({ status: 'connected' });
-		// The retry moves pending -> connected, both observed after subscribing.
+		expect(auth.verification?.state).toEqual({ status: 'verified' });
+		// The retry moves pending -> verified, both observed after subscribing.
 		expect(seen).toContain('pending');
-		expect(seen).toContain('connected');
+		expect(seen).toContain('verified');
 	});
 
-	test('a 401 on a resource call marks the connection rejected', async () => {
+	test('a 401 on a resource call marks the verification rejected', async () => {
 		const fetch: AuthFetch = async (input) =>
 			String(input).endsWith('/api/session')
 				? json(sessionBody())
 				: json({}, 401);
 		const auth = createInstanceTokenAuth({ baseURL, token, fetch });
 		await flush();
-		expect(auth.connection?.state).toEqual({ status: 'connected' });
+		expect(auth.verification?.state).toEqual({ status: 'verified' });
 
 		await auth.fetch('/api/blobs');
-		expect(auth.connection?.state).toEqual({
+		expect(auth.verification?.state).toEqual({
 			status: 'failed',
 			reason: 'rejected',
 		});

--- a/packages/auth/src/instance-token-auth.ts
+++ b/packages/auth/src/instance-token-auth.ts
@@ -4,9 +4,9 @@ import { defineErrors } from 'wellcrafted/error';
 import { createLogger, type Logger } from 'wellcrafted/logger';
 import { Ok, type Result } from 'wellcrafted/result';
 import type {
-	AuthConnectionState,
 	AuthFetch,
 	AuthState,
+	AuthVerificationState,
 	SyncAuthClient,
 } from './auth-contract.js';
 import { AuthError } from './auth-errors.js';
@@ -110,10 +110,12 @@ export function createInstanceTokenAuth({
 	const listeners = new Set<(state: AuthState) => void>();
 	// The boot bearer check verifies against a remote star, so it can be in flight
 	// or fail for a reason `AuthState` cannot carry (only a rejected token drops to
-	// `signed-out`). `connection` runs alongside `state` on its own listener set so
-	// a UI can tell "still connecting" from "unreachable" from "rejected token".
-	let connectionState: AuthConnectionState = { status: 'pending' };
-	const connectionListeners = new Set<(state: AuthConnectionState) => void>();
+	// `signed-out`). `verification` runs alongside `state` on its own listener set
+	// so a UI can tell "still verifying" from "unreachable" from "rejected token".
+	let verificationState: AuthVerificationState = { status: 'pending' };
+	const verificationListeners = new Set<
+		(state: AuthVerificationState) => void
+	>();
 
 	function setState(next: AuthState) {
 		state = next;
@@ -126,9 +128,9 @@ export function createInstanceTokenAuth({
 		}
 	}
 
-	function setConnection(next: AuthConnectionState) {
-		connectionState = next;
-		for (const listener of connectionListeners) {
+	function setVerification(next: AuthVerificationState) {
+		verificationState = next;
+		for (const listener of verificationListeners) {
 			try {
 				listener(next);
 			} catch (cause) {
@@ -163,7 +165,7 @@ export function createInstanceTokenAuth({
 	 * only reflects its outcome onto state and the `AuthClient` error contract.
 	 */
 	async function confirmSession(): Promise<Result<undefined, AuthError>> {
-		setConnection({ status: 'pending' });
+		setVerification({ status: 'pending' });
 		const { data: session, error } = await readApiSession({
 			baseURL,
 			token,
@@ -175,14 +177,14 @@ export function createInstanceTokenAuth({
 			// token is a durable "signed-out"; a transient outage leaves state alone
 			// so it does not look like a bad credential.
 			if (error.name === 'Rejected') setState({ status: 'signed-out' });
-			setConnection({
+			setVerification({
 				status: 'failed',
 				reason: error.name === 'Rejected' ? 'rejected' : 'unreachable',
 			});
 			return AuthError.StartSignInFailed({ cause: error });
 		}
 		setState({ status: 'signed-in', principalId: session.principalId });
-		setConnection({ status: 'connected' });
+		setVerification({ status: 'verified' });
 		return Ok(undefined);
 	}
 
@@ -221,7 +223,7 @@ export function createInstanceTokenAuth({
 			state.status === 'signed-in'
 		) {
 			setState({ status: 'signed-out' });
-			setConnection({ status: 'failed', reason: 'rejected' });
+			setVerification({ status: 'failed', reason: 'rejected' });
 		}
 		return response;
 	}
@@ -246,14 +248,14 @@ export function createInstanceTokenAuth({
 		},
 		fetch: authedFetch,
 		getProfile: () => getProfileVia(authedFetch, baseURL),
-		connection: {
+		verification: {
 			get state() {
-				return connectionState;
+				return verificationState;
 			},
 			onChange(fn) {
-				connectionListeners.add(fn);
+				verificationListeners.add(fn);
 				return () => {
-					connectionListeners.delete(fn);
+					verificationListeners.delete(fn);
 				};
 			},
 		},
@@ -267,7 +269,7 @@ export function createInstanceTokenAuth({
 		},
 		[Symbol.dispose]() {
 			listeners.clear();
-			connectionListeners.clear();
+			verificationListeners.clear();
 		},
 	};
 }

--- a/packages/auth/src/node/resolve-machine-auth-client.ts
+++ b/packages/auth/src/node/resolve-machine-auth-client.ts
@@ -92,15 +92,13 @@ export async function resolveMachineAuthClient({
 			fetch,
 			log,
 		});
-		// Settle the connection channel before the daemon reads state. A revoked
-		// token drops to signed-out; an offline star leaves the client optimistically
-		// signed-in (local mounts still serve and cloud sync retries when the network
-		// returns; the `connection` channel carries the "unreachable" reason). Either
-		// way it is a valid daemon state, not an error.
+		// Await the first confirmation so the daemon reads a settled `state` (settle
+		// semantics are in the JSDoc above). A failure here is not fatal: local
+		// mounts still serve, so log it and hand back the client rather than erroring.
 		const { error } = await client.startSignIn();
 		if (error) {
 			log.debug(
-				'Instance token could not be verified against /api/session; the daemon stays signed-out and serves local mounts only.',
+				'Instance token could not be verified against /api/session; the daemon keeps serving local mounts.',
 				{ baseURL, cause: error },
 			);
 		}

--- a/packages/svelte-utils/src/auth.svelte.ts
+++ b/packages/svelte-utils/src/auth.svelte.ts
@@ -38,18 +38,18 @@ function reactiveAuthClient<T extends AuthClient>(auth: T): T {
 			return auth.state;
 		},
 	} as T;
-	// The self-host token client also exposes a connection-verification channel
-	// (pending / unreachable / rejected) that changes without touching `state`, so
-	// give it its own subscriber. Clients without one (hosted OAuth, cookie) skip
+	// The self-host token client also exposes a remote credential-verification
+	// channel (pending / verified / failed) that changes without touching `state`,
+	// so give it its own subscriber. Clients without one (hosted OAuth, cookie) skip
 	// this and keep the plain spread value (undefined).
-	const source = auth.connection;
+	const source = auth.verification;
 	if (source) {
-		const subscribeConnection = createSubscriber((update) =>
+		const subscribeVerification = createSubscriber((update) =>
 			source.onChange(update),
 		);
-		reactive.connection = {
+		reactive.verification = {
 			get state() {
-				subscribeConnection();
+				subscribeVerification();
 				return source.state;
 			},
 			onChange: source.onChange,


### PR DESCRIPTION
The instance-token auth client had two real facts, but only one of them was named clearly. `auth.state` is local identity: it answers which local workspace partition should open, and for self-host that can be known synchronously from the held instance token. The separate remote check answers whether `/api/session` accepted that credential in this runtime. Calling that second signal `connection` made it read like generic transport reachability instead of credential verification.

This renames the self-host token side channel to `verification` and keeps it optional on `AuthClient`, because hosted OAuth and same-origin cookie auth do not implement the same boot-time bearer verification semantics. The new shape is:

```ts
auth.state          // local identity / workspace partition
auth.verification   // pending | verified | failed{rejected|unreachable}
```

The self-host account UI now uses the same signal while signed in. That matters after optimistic boot: an unreachable instance should keep local workspace access available, but the account popover can still explain that the configured server has not accepted the credential in this runtime.

## Breaking

The exported auth verification names changed.

```ts
// Before
auth.connection?.state
type AuthConnectionState
type AuthConnection

// After
auth.verification?.state
type AuthVerificationState
type AuthVerification
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785718862&installation_id=128463665&pr_number=2351&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2351&signature=36e34085ee951d8b47d91d4193fc370e24f97c522adadb6acd948d49d80ce1a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->