### PR TITLE
refactor(local-books): qb-access owns its not-authenticated error

### DIFF
--- a/apps/local-books/src/app.ts
+++ b/apps/local-books/src/app.ts
@@ -202,7 +202,7 @@ export async function runApp(
 	 */
 	async function syncNow(): Promise<SyncPassResult> {
 		const { data: client, error: openError } = await openQb();
-		if (openError !== null) return { failed: openError };
+		if (openError !== null) return { failed: openError.message };
 		const db = openBooksDb(mirrorPath);
 		try {
 			const deps: SyncDeps = {

--- a/apps/local-books/src/books/qb-access.ts
+++ b/apps/local-books/src/books/qb-access.ts
@@ -9,14 +9,28 @@
  * action wrappers it builds over these cores.
  */
 
-import { Err, Ok, type Result } from 'wellcrafted/result';
+import { defineErrors, type InferErrors } from 'wellcrafted/error';
+import { Ok, type Result } from 'wellcrafted/result';
 import type { AppConfig } from '../config.ts';
 import { createQbClient, type QbClient } from '../qb-client.ts';
 import { createTokenManager } from '../token-manager.ts';
 import type { TokenStore } from '../token-store.ts';
 
-/** Opens a QB client for the realm, or a user-facing reason it cannot. */
-export type OpenQbClient = () => Promise<Result<QbClient, string>>;
+/**
+ * The one way opening a client can fail: the realm has no stored credentials.
+ * This membrane owns the failure so its verbs (`report`, `recategorize`) and the
+ * sync loops propagate it as-is instead of each re-typing "openQb returned Err"
+ * into its own variant with a less accurate prefix.
+ */
+export const QbAccessError = defineErrors({
+	NotAuthenticated: ({ realmId }: { realmId: string }) => ({
+		message: `No stored credentials for company ${realmId}. Run "local-books auth".`,
+	}),
+});
+export type QbAccessError = InferErrors<typeof QbAccessError>;
+
+/** Opens a QB client for the realm, or the reason it cannot. */
+export type OpenQbClient = () => Promise<Result<QbClient, QbAccessError>>;
 
 export function createQbAccess({
 	config,
@@ -35,9 +49,7 @@ export function createQbAccess({
 	return async () => {
 		const token = await store.get(realmId);
 		if (!token) {
-			return Err(
-				`No stored credentials for company ${realmId}. Run "local-books auth".`,
-			);
+			return QbAccessError.NotAuthenticated({ realmId });
 		}
 		const tokens = createTokenManager({ config, store, token, now });
 		return Ok(createQbClient({ config, realmId, tokens, log }));

--- a/apps/local-books/src/books/recategorize.ts
+++ b/apps/local-books/src/books/recategorize.ts
@@ -28,7 +28,7 @@ import { Err, Ok, type Result, trySync } from 'wellcrafted/result';
 import { openBooksDb } from '../db.ts';
 import { entityDef } from '../entities.ts';
 import type { QbClientError } from '../qb-client.ts';
-import type { OpenQbClient } from './qb-access.ts';
+import type { OpenQbClient, QbAccessError } from './qb-access.ts';
 
 /** The line shape that carries an account-based expense category. */
 const LINE_DETAIL = 'AccountBasedExpenseLineDetail';
@@ -61,10 +61,6 @@ export const RecategorizeError = defineErrors({
 	}),
 	UnknownEntity: ({ name }: { name: string }) => ({
 		message: `recategorize targets a Purchase (card/cash/check expense) or a Bill (vendor bill), not "${name}".`,
-	}),
-	NotAuthenticated: ({ detail }: { detail: string }) => ({
-		message: `Recategorize could not reach QuickBooks: ${detail}`,
-		detail,
 	}),
 	NotInMirror: ({ entity, id }: { entity: string; id: string }) => ({
 		message: `No ${entity} ${id} in the local mirror. Run "local-books sync" first.`,
@@ -169,7 +165,9 @@ export async function recategorizeExpense({
 	 * read-only invariant.
 	 */
 	readOnly: boolean;
-}): Promise<Result<RecategorizeResult, RecategorizeError | QbClientError>> {
+}): Promise<
+	Result<RecategorizeResult, RecategorizeError | QbAccessError | QbClientError>
+> {
 	if (readOnly) return RecategorizeError.ReadOnly();
 	const def = entityDef(input.entity);
 	const db = openBooksDb(dbPath);
@@ -224,9 +222,7 @@ export async function recategorizeExpense({
 		}
 
 		const { data: qb, error: openError } = await openQb();
-		if (openError !== null) {
-			return RecategorizeError.NotAuthenticated({ detail: openError });
-		}
+		if (openError !== null) return Err(openError);
 
 		// Sparse update: send the modified Line array with Id + the SyncToken read
 		// from the mirror, plus this entity's mandatory top-level fields carried

--- a/apps/local-books/src/books/report.ts
+++ b/apps/local-books/src/books/report.ts
@@ -17,7 +17,7 @@ import Type, { type Static } from 'typebox';
 import { defineErrors, type InferErrors } from 'wellcrafted/error';
 import { Err, Ok, type Result } from 'wellcrafted/result';
 import type { QbClientError } from '../qb-client.ts';
-import type { OpenQbClient } from './qb-access.ts';
+import type { OpenQbClient, QbAccessError } from './qb-access.ts';
 
 /** The reports QuickBooks computes that this verb runs live. */
 export const REPORT_NAMES = [
@@ -31,10 +31,6 @@ export const REPORT_NAMES = [
 export type ReportName = (typeof REPORT_NAMES)[number];
 
 export const ReportError = defineErrors({
-	Unavailable: ({ detail }: { detail: string }) => ({
-		message: `Reports are unavailable: ${detail}`,
-		detail,
-	}),
 	UnknownReport: ({ name }: { name: string }) => ({
 		message: `Unknown report "${name}". Choose one of: ${REPORT_NAMES.join(', ')}.`,
 	}),
@@ -82,11 +78,11 @@ export async function fetchReport({
 }): Promise<
 	Result<
 		{ report: ReportName; data: Record<string, unknown> },
-		ReportError | QbClientError
+		ReportError | QbAccessError | QbClientError
 	>
 > {
 	const { data: qb, error: openError } = await openQb();
-	if (openError !== null) return ReportError.Unavailable({ detail: openError });
+	if (openError !== null) return Err(openError);
 
 	const params: Record<string, string> = {};
 	if (input.start_date) params.start_date = input.start_date;

--- a/apps/local-books/src/commands/mcp.ts
+++ b/apps/local-books/src/commands/mcp.ts
@@ -175,7 +175,7 @@ const TOOLS: ToolDescriptor[] = [
 			// The opener loads the token and returns a ready QB client, or a "run
 			// auth" reason. No bespoke not-connected error.
 			const { data: client, error } = await ctx.openQb();
-			if (error !== null) return Err({ message: error });
+			if (error !== null) return Err(error);
 			const db = openBooksDb(ctx.dbPath);
 			try {
 				const outcome = await syncRealm(

--- a/apps/local-books/test/app-api.test.ts
+++ b/apps/local-books/test/app-api.test.ts
@@ -7,9 +7,8 @@
  */
 
 import { afterEach, describe, expect, test } from 'bun:test';
-import { Err } from 'wellcrafted/result';
 import { createRequestHandler } from '../src/app.ts';
-import type { OpenQbClient } from '../src/books/qb-access.ts';
+import { type OpenQbClient, QbAccessError } from '../src/books/qb-access.ts';
 import { openBooksDb } from '../src/db.ts';
 import { entityDef } from '../src/entities.ts';
 import { createApiApp } from '../src/http/api.ts';
@@ -21,7 +20,8 @@ const BOOT = 'bootstrap-token-abc';
 
 /** An opener that always refuses: report/recategorize live paths are out of scope
  * here (their cores are tested directly), so no test reaches a real QB call. */
-const refusingOpenQb: OpenQbClient = async () => Err('no QuickBooks in tests');
+const refusingOpenQb: OpenQbClient = async () =>
+	QbAccessError.NotAuthenticated({ realmId: 'test-realm' });
 
 /** Seed a mirror with two invoices and one purchase carrying an expense line. */
 function seedMirror(dataDir: string) {


### PR DESCRIPTION
Follow-on collapse pass over Local Books' verb-*exposure* layer (the cores in `src/books/*` and their three delivery surfaces: CLI, MCP, HTTP), applying #2348's membrane lens one level up. One finding paid for itself; the rest of the layer was verified to be at its floor.

This change:

`openQb()` returned a bare user-facing `string` whose only failure mode is a missing token (`qb-access.ts`). Two verb cores each re-typed that one event into a fake-symmetric variant:

- `ReportError.Unavailable` ("Reports are unavailable: ...")
- `RecategorizeError.NotAuthenticated` ("Recategorize could not reach QuickBooks: ...")

while the MCP `sync` tool and `app` `syncNow` just carried the string as-is. No consumer branched on either variant, no test asserted either prefix, and both prefixes were less accurate than the underlying "No stored credentials" message.

This gives the qb-access membrane ownership of its one failure as `QbAccessError.NotAuthenticated`. `OpenQbClient` now returns `Result<QbClient, QbAccessError>`; both cores propagate it with `Err(openError)` instead of re-wrapping, so the credentials message is owned once where it is produced and all four consumers are uniform.

The unchanged parts are intentional:

- The HTTP recategorize handler still routes the not-authenticated case through its `else -> 400` (the variant name is unchanged), so wire status is preserved.
- All other error variants, on-disk/wire shapes, and the credentials message text are untouched.

## Changelog

- refactor(local-books): the QuickBooks client opener owns its own not-authenticated error instead of each verb re-wrapping it, and its message now names the real cause (missing credentials) rather than a vaguer per-verb prefix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785720066&installation_id=128463665&pr_number=2354&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2354&signature=d7b657e01c5a78a66e7a5e8f28501ec0521b9e2d2683785a0d12aedc8c6c4b9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->