### PR TITLE
fix(vocab): auto-detect dictation language and retarget stale docs after the multilingual rewrite

### DIFF
--- a/apps/vocab/README.md
+++ b/apps/vocab/README.md
@@ -1,14 +1,14 @@
 # Vocab
 
-Bilingual Chinese-English chat app for learning Mandarin. Users ask questions in English; the AI responds with mixed English and Chinese. The client automatically annotates Chinese characters with pinyin using `<ruby>` tags. The system prompt tells the AI to never include pinyin itself.
+Multilingual chat tutor. A learner asks about a word, phrase, or sentence; the tutor answers in the language being studied alongside English, inferring that language from the conversation (ADR-0105). The client annotates non-Latin scripts with pronunciation readings (pinyin over Han, romaji over kana, Latin over Cyrillic) using `<ruby>` tags, produced by a deterministic offline registry. The system prompt tells the tutor to write plain text and never include readings itself.
 
 ## How it works
 
 **Live answer in state, finished messages in the doc**: Vocab is capability-free (ADR-0043), so the open browser tab answers its own turns, and the live answer needs nothing durable (re-asking is free). `src/routes/+page.svelte` builds the shared `createAgentChatState()` controller with Vocab's system prompt and default model, and `ConversationView.svelte` renders the active `AgentChatThread`. Only finished messages persist (ADR-0046): the user turn the moment it is sent, the assistant turn on a clean finish, each written once as one JSON blob into the conversation's last-write-wins message store (`attachRecords`, keyed by message id). A stopped or failed turn writes nothing; the durable user turn stays, ready to retry. On open, the controller hydrates from the store and observes it, so a message finished on another device shows up here.
 
-**Markdown + pinyin**: Settled assistant messages render through `@epicenter/ui/markdown`. Vocab injects `pinyinRomanizer` from `src/lib/romanize/pinyin.ts`, which segments Chinese runs with `pinyin-pro`; the shared Markdown component owns sanitization, markdown rendering, and `<ruby>` output.
+**Markdown + readings**: Settled assistant messages render through `@epicenter/ui/markdown` via `ReadingMarkdown.svelte`, which resolves the deterministic per-script romanizers whose script appears in the passage (`src/lib/readings/`, ADR-0105) and composes them behind the shared Markdown component. Readings are a client-side derived view over clean text: pure, offline, lazily loaded per script, with no model call and no network, so a reading can only be missing, never wrong. The shared Markdown component owns sanitization, markdown rendering, and `<ruby>` output. Chinese (`pinyin-pro`), Japanese kana (`wanakana`), and Cyrillic (`transliteration`) ship today; adding a language is one provider file plus one registry line.
 
-**Workspace state**: `vocabWorkspace` in `vocab.ts` is the shared isomorphic definition. It defines `epicenter-vocab`, the `conversations` table (the cheap list: title and timestamps), the `conversations.messages` child doc as a per-id LWW message store (`attachRecords<VocabMessage>`), the `showPinyin` KV value, the Vocab model constant, and the `VocabMessage` shape. Transcripts are not a table; they are per-conversation child docs opened as `vocab.tables.conversations.docs.messages.open(conversationId)`. `openVocabBrowser()` reads auth once at boot: signed out uses bare local IndexedDB storage, signed in uses principal-scoped storage plus relay sync.
+**Workspace state**: `vocabWorkspace` in `vocab.ts` is the shared isomorphic definition. It defines `epicenter-vocab`, the `conversations` table (the cheap list: title and timestamps), the `conversations.messages` child doc as a per-id LWW message store (`attachRecords<VocabMessage>`), the `showReadings` KV value, the Vocab model constant, and the `VocabMessage` shape. Transcripts are not a table; they are per-conversation child docs opened as `vocab.tables.conversations.docs.messages.open(conversationId)`. `openVocabBrowser()` reads auth once at boot: signed out uses bare local IndexedDB storage, signed in uses principal-scoped storage plus relay sync.
 
 ```txt
 defineWorkspace()
@@ -33,15 +33,20 @@ src/
       dictation.svelte.ts              # dictation state and interruption handling
       inference-connections.svelte.ts  # hosted/custom inference connection registry
       recorder.svelte.ts               # speech recorder wiring
-    romanize/
-      pinyin.ts          # pinyinRomanizer(): CJK segmentation and readings
+    readings/
+      registry.ts        # resolveRomanizer(): loads + composes the per-script providers
+      pinyin.ts          # Chinese: per-character pinyin over Han (pinyin-pro)
+      romaji.ts          # Japanese: romaji over kana (wanakana)
+      cyrillic.ts        # Cyrillic: Latin transliteration (transliteration)
+      runs.ts            # shared whole-run walker for run-based providers
   routes/
     +layout.svelte         # Root layout with Toaster
     +layout.ts             # SSR disabled (CSR only)
-    +page.svelte             # Main layout: chat state, sidebar + chat area + pinyin toggle
+    +page.svelte             # Main layout: chat state, sidebar + chat area + readings toggle
     auth/callback/+page.svelte # OAuth callback return to app shell
     components/
       ConversationView.svelte  # Keyed per-conversation view; binds the message store to the inference stream
+      ReadingMarkdown.svelte   # Renders one settled message with its deterministic reading overlay
       DictationButton.svelte   # Speech input control
       VocabSidebar.svelte      # Sidebar conversation list with create/switch/delete
 vocab.ts                    # Shared isomorphic model (tables, KV, VocabMessage shape, conversation child docs)
@@ -54,7 +59,7 @@ vocab.browser.ts            # openVocabBrowser runtime wiring
 - The live answer streams in component `$state`, not the synced doc (ADR-0046): vocab is capability-free, so re-asking is free and only finished messages need to sync. Each finished message is one LWW JSON blob keyed by message id, written the moment a normal app would POST the row.
 - The cloud never writes the doc: it is a blind relay plus a stateless metered inference stream (ADR-0033).
 - SSR is disabled; the app is CSR-only.
-- The system prompt forbids pinyin in AI responses so the client can control annotation rendering and toggle visibility.
+- The system prompt forbids readings (pinyin, romaji, transliteration) in AI responses so the client controls annotation rendering and toggle visibility, and the stored message stays clean for reuse as conversation memory and verbatim terms (ADR-0102, ADR-0105).
 
 ## Scripts
 

--- a/apps/vocab/package.json
+++ b/apps/vocab/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@epicenter/vocab",
-	"description": "Bilingual Chinese-English chat app for learning Mandarin",
+	"description": "Multilingual chat tutor with a deterministic client-side reading overlay",
 	"private": true,
 	"version": "0.0.2",
 	"type": "module",

--- a/apps/vocab/src/lib/state/dictation.svelte.ts
+++ b/apps/vocab/src/lib/state/dictation.svelte.ts
@@ -13,7 +13,7 @@
  *
  * Transcription is a stateless service (the spec's star/service/library model):
  * this holds no preferences and reaches for no sync. It pulls only the device
- * connection registry and Vocab's own app-local model + language constants.
+ * connection registry and Vocab's own app-local model constant.
  *
  * The transport comes from `resolveOrHosted(VOCAB_STT_MODEL)`, the same predicate
  * chat uses. `whisper-1` is not in Vocab's hosted *chat* catalog, so nothing
@@ -30,7 +30,7 @@ import {
 	type DeviceStreamError,
 	type VadRecorderError,
 } from '@epicenter/recorder';
-import { VOCAB_DICTATION_LANGUAGE, VOCAB_STT_MODEL } from '@epicenter/vocab';
+import { VOCAB_STT_MODEL } from '@epicenter/vocab';
 import { Err, Ok, type Result } from 'wellcrafted/result';
 import { inferenceConnections } from './inference-connections.svelte';
 
@@ -99,9 +99,10 @@ function createDictation() {
 							const transport =
 								inferenceConnections.resolveOrHosted(VOCAB_STT_MODEL);
 							onTranscript(
+								// No language hint: a learner may dictate their question in the
+								// language they are studying, so Whisper auto-detects (ADR-0105).
 								await transcribe(blob, transport, {
 									model: VOCAB_STT_MODEL,
-									language: VOCAB_DICTATION_LANGUAGE,
 								}),
 							);
 						})

--- a/apps/vocab/vocab.ts
+++ b/apps/vocab/vocab.ts
@@ -69,14 +69,6 @@ Guidelines:
  */
 export const VOCAB_STT_MODEL = 'whisper-1';
 
-/**
- * The language Vocab dictates in, an ISO-639-1 hint handed to the transcriber.
- * English, because Vocab's input is the English question a learner asks; the
- * answer comes back bilingual. App-local and unsynced, like {@link VOCAB_MODEL}:
- * an app that dictates another language sets its own.
- */
-export const VOCAB_DICTATION_LANGUAGE = 'en';
-
 // ─────────────────────────────────────────────────────────────────────────────
 // Message Model
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up cleanup after #2323 (ADR-0105) repositioned Vocab as a multilingual tutor. A review round found one real behavioral straggler and a set of stale docs the rewrite missed.

## Changes

- **Auto-detect dictation language.** Dictation still pinned Whisper to `language: 'en'`, which mistranscribes a learner dictating their question in the language they are studying. Drop the hint (Whisper auto-detects) and remove the now-dead `VOCAB_DICTATION_LANGUAGE` constant. `transcribe`'s `language` param is optional, so omitting it is a clean auto-detect.
- **Retarget the README and package description.** Both still described a "Bilingual Chinese-English" Mandarin app and pointed at the deleted `src/lib/romanize/pinyin.ts` / `pinyinRomanizer` and the renamed `showPinyin` KV. Updated the framing, the file map (now `src/lib/readings/` plus `ReadingMarkdown.svelte`), and the readings-toggle wording to match the shipped deterministic per-script registry.

The scope is intentionally bounded:

- **`Romanizer` -> `Reader` rename** in `@epicenter/ui/markdown`. The shared seam still names its type `Romanizer` while the app uses reading vocabulary (`Segment.reading`, `showReadings`, `ReadingProvider`). It is a published-package + ADR-0057/0105 rename that moves no structural needle and is not yet wrong (every shipped provider outputs Latin). The earned trigger is when Japanese-kanji furigana (a non-Latin reading) is actually built.
- **`showPinyin` -> `showReadings` KV migration.** The rename orphans the old key, but it is a display-only boolean that defaults to `true`; the only effect is that a user who had explicitly hidden readings sees them once more, re-hidable in a click. A migration for a display toggle is not worth it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785720421&installation_id=128463665&pr_number=2355&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2355&signature=fa5a0b8ca1c0300eb30f02e334cd3f21d9bbb2e94fa130741a19a14326242cb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->