### PR TITLE
refactor(workspace): collapse attachTimeline to a single-text-body API

### DIFF
--- a/.changeset/attach-timeline-single-text-body.md
+++ b/.changeset/attach-timeline-single-text-body.md
@@ -1,0 +1,7 @@
+---
+'@epicenter/workspace': minor
+---
+
+Breaking (pre-1.0): collapse `attachTimeline` to a single-text-body API. Following the ADR-0106 text-path trim, the handle now exposes only `read` / `write` / `appendText` / `asText` / `observe`. The `currentEntry` getter, the exported `TextEntry` type, the `length` getter, and the `batch` method are removed: none had a production consumer, and `currentEntry`/`length` only leaked the internal entry-array that a later single-layout migration (ADR-0106 step 3) will delete. To count stored entries, read `ydoc.getArray('timeline').length` directly; to batch writes, call `ydoc.transact(fn)` (`write`/`appendText` already transact internally).
+
+No data migration: the durable `timeline` slot and stored entry `Y.Map` shape (`type`/`content`/`createdAt`) are frozen and untouched. `pushText` still writes byte-identical entries; `type` and `createdAt` are written for the durable format even though the handle no longer reads them back.

--- a/packages/filesystem/src/file-system.test.ts
+++ b/packages/filesystem/src/file-system.test.ts
@@ -466,7 +466,7 @@ function getTimelineLength(
 	const id = fs.lookupId(path);
 	if (!id) throw new Error(`No file at ${path}`);
 	using handle = contentDocs.open(id);
-	return handle.content.length;
+	return handle.ydoc.getArray('timeline').length;
 }
 
 describe('timeline content storage', () => {

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -1470,7 +1470,7 @@ Pick the attachment that matches the content shape:
 - `attachPlainText(ydoc, name)`: binds a `Y.Text`. Editor gets `bundle.content` as `Y.Text`.
 - `attachRecords(ydoc, name)`: binds a keyed last-write-wins store of whole JSON records, one per id (the shape an agent transcript uses). Bundle field is a `RecordsHandle<T>` with `get / set / delete / entries / observe`.
 - `attachRichText(ydoc, name)`: binds a `Y.XmlFragment` for prosemirror / tiptap / yrs-xml editors.
-- `attachTimeline(ydoc)`: an append-only, single-layout (text) body over `getArray('timeline')`. Exposes `read() / write(text) / appendText(text) / asText() / batch(fn) / observe(...)`. (The polymorphic text/rich-text/sheet surface was refused by ADR-0106; a sheet body is a separate primitive if a product ever earns it.)
+- `attachTimeline(ydoc)`: a single-layout (text) body stored over `getArray('timeline')`. Exposes `read() / write(text) / appendText(text) / asText() / observe(...)`. (The polymorphic text/rich-text/sheet surface was refused by ADR-0106; a sheet body is a separate primitive if a product ever earns it.)
 
 The connected table child opener stores these by `rowId`, so multiple browser
 consumers share one Y.Doc. Use `workspace.tables.<table>.docs.<field>.open(id)` and

--- a/packages/workspace/src/document/attach-timeline/index.ts
+++ b/packages/workspace/src/document/attach-timeline/index.ts
@@ -1,12 +1,12 @@
 /**
  * attach-timeline: an append-only, single-layout (text) document body.
  *
- * `attachTimeline` reserves `ydoc.getArray('timeline')` as a log of typed
- * entries and exposes text accessors (`read`, `write`, `appendText`,
- * `asText`). The durable `timeline` slot and its entry shape are frozen;
- * the polymorphic (rich-text/sheet) surface was refused by ADR-0106.
+ * `attachTimeline` reserves `ydoc.getArray('timeline')` as the storage for a
+ * single text body and exposes text accessors (`read`, `write`, `appendText`,
+ * `asText`, `observe`). The durable `timeline` slot and its entry shape are
+ * frozen; the polymorphic (rich-text/sheet) surface was refused by ADR-0106.
  *
  * @module
  */
 
-export { attachTimeline, type TextEntry, type Timeline } from './timeline.js';
+export { attachTimeline, type Timeline } from './timeline.js';

--- a/packages/workspace/src/document/attach-timeline/timeline.test.ts
+++ b/packages/workspace/src/document/attach-timeline/timeline.test.ts
@@ -2,69 +2,73 @@
  * Timeline Tests
  *
  * Validates the single-layout (text) timeline body: read/write in place,
- * append, empty-timeline seeding via asText, batching, observation, and the
- * key parameter.
+ * append, empty-timeline seeding via asText, observation, and the key
+ * parameter. Entry count is asserted against the durable `Y.Array` directly,
+ * since the handle exposes no count accessor.
  */
 
 import { describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';
 import { attachTimeline } from './timeline.js';
 
-function setup() {
-	return attachTimeline(new Y.Doc());
+function setup(key = 'timeline') {
+	const ydoc = new Y.Doc();
+	return { ydoc, tl: attachTimeline(ydoc, key), key };
+}
+
+/** Number of entries in the durable timeline array. */
+function entryCount(ydoc: Y.Doc, key = 'timeline'): number {
+	return ydoc.getArray(key).length;
 }
 
 describe('attachTimeline - read/write', () => {
 	test('read on empty timeline returns empty string', () => {
-		const tl = setup();
+		const { ydoc, tl } = setup();
 		expect(tl.read()).toBe('');
-		expect(tl.length).toBe(0);
+		expect(entryCount(ydoc)).toBe(0);
 	});
 
 	test('write on empty timeline creates a text entry', () => {
-		const tl = setup();
+		const { ydoc, tl } = setup();
 		tl.write('hello');
 		expect(tl.read()).toBe('hello');
-		expect(tl.length).toBe(1);
-		expect(tl.currentEntry?.type).toBe('text');
+		expect(entryCount(ydoc)).toBe(1);
 	});
 
-	test('write replaces content in place (length unchanged)', () => {
-		const tl = setup();
+	test('write replaces content in place (entry count unchanged)', () => {
+		const { ydoc, tl } = setup();
 		tl.write('first');
-		expect(tl.length).toBe(1);
+		expect(entryCount(ydoc)).toBe(1);
 		tl.write('second');
-		expect(tl.length).toBe(1);
+		expect(entryCount(ydoc)).toBe(1);
 		expect(tl.read()).toBe('second');
 	});
 
-	test('currentEntry exposes the stored Y.Text and createdAt', () => {
-		const tl = setup();
+	test('the stored entry is a text entry holding a Y.Text', () => {
+		const { ydoc, tl } = setup();
 		tl.write('hi');
-		const entry = tl.currentEntry;
-		expect(entry?.content).toBeInstanceOf(Y.Text);
-		expect(entry?.content.toString()).toBe('hi');
-		expect(typeof entry?.createdAt).toBe('number');
+		const entry = ydoc.getArray<Y.Map<unknown>>('timeline').get(0);
+		expect(entry.get('type')).toBe('text');
+		expect(entry.get('content')).toBeInstanceOf(Y.Text);
+		expect((entry.get('content') as Y.Text).toString()).toBe('hi');
 	});
 });
 
 describe('attachTimeline - asText', () => {
 	test('asText on empty timeline pushes an empty text entry', () => {
-		const tl = setup();
+		const { ydoc, tl } = setup();
 		const ytext = tl.asText();
 		expect(ytext).toBeInstanceOf(Y.Text);
 		expect(ytext.toString()).toBe('');
-		expect(tl.length).toBe(1);
-		expect(tl.currentEntry?.type).toBe('text');
+		expect(entryCount(ydoc)).toBe(1);
 	});
 
 	test('asText returns the existing Y.Text without a new entry', () => {
-		const tl = setup();
+		const { ydoc, tl } = setup();
 		tl.write('seed');
-		const before = tl.length;
 		const ytext = tl.asText();
 		expect(ytext.toString()).toBe('seed');
-		expect(tl.length).toBe(before);
+		expect(entryCount(ydoc)).toBe(1);
 		// Same underlying Y.Text: edits are reflected by read().
 		ytext.insert(ytext.length, '!');
 		expect(tl.read()).toBe('seed!');
@@ -73,62 +77,34 @@ describe('attachTimeline - asText', () => {
 
 describe('attachTimeline - appendText', () => {
 	test('appendText on empty timeline creates a text entry', () => {
-		const tl = setup();
+		const { ydoc, tl } = setup();
 		tl.appendText('hello');
-		expect(tl.currentEntry?.type).toBe('text');
 		expect(tl.read()).toBe('hello');
-		expect(tl.length).toBe(1);
+		expect(entryCount(ydoc)).toBe(1);
 	});
 
 	test('appendText on existing text appends without a new entry', () => {
-		const tl = setup();
+		const { ydoc, tl } = setup();
 		tl.write('hello');
-		expect(tl.length).toBe(1);
+		expect(entryCount(ydoc)).toBe(1);
 		tl.appendText(' world');
 		expect(tl.read()).toBe('hello world');
-		expect(tl.length).toBe(1);
+		expect(entryCount(ydoc)).toBe(1);
 	});
 
 	test('multiple appendText calls accumulate content', () => {
-		const tl = setup();
+		const { ydoc, tl } = setup();
 		tl.appendText('a');
 		tl.appendText('b');
 		tl.appendText('c');
 		expect(tl.read()).toBe('abc');
-		expect(tl.length).toBe(1);
-	});
-});
-
-describe('attachTimeline - batch', () => {
-	test('two writes in one batch trigger observe once', () => {
-		const tl = setup();
-		let callCount = 0;
-		tl.observe(() => callCount++);
-		// First write pushes text entry, second replaces in-place.
-		// Yjs collapses nested transactions. Single observe callback.
-		tl.batch(() => {
-			tl.write('first');
-			tl.write('second');
-		});
-		expect(callCount).toBe(1);
-		expect(tl.read()).toBe('second');
-	});
-
-	test('batch does not affect read/write correctness', () => {
-		const tl = setup();
-		tl.batch(() => {
-			tl.write('hello');
-			expect(tl.read()).toBe('hello');
-			tl.write('world');
-			expect(tl.read()).toBe('world');
-		});
-		expect(tl.read()).toBe('world');
+		expect(entryCount(ydoc)).toBe(1);
 	});
 });
 
 describe('attachTimeline - observe', () => {
 	test('fires when a new entry is pushed via write()', () => {
-		const tl = setup();
+		const { tl } = setup();
 		let calls = 0;
 		tl.observe(() => calls++);
 		tl.write('one');
@@ -136,7 +112,7 @@ describe('attachTimeline - observe', () => {
 	});
 
 	test('does NOT fire when write replaces text in-place', () => {
-		const tl = setup();
+		const { tl } = setup();
 		tl.write('one');
 		let calls = 0;
 		tl.observe(() => calls++);
@@ -145,7 +121,7 @@ describe('attachTimeline - observe', () => {
 	});
 
 	test('does NOT fire when content within an existing entry changes', () => {
-		const tl = setup();
+		const { tl } = setup();
 		const ytext = tl.asText();
 		let calls = 0;
 		tl.observe(() => calls++);
@@ -154,7 +130,7 @@ describe('attachTimeline - observe', () => {
 	});
 
 	test('unsubscribe stops notifications', () => {
-		const tl = setup();
+		const { tl } = setup();
 		let calls = 0;
 		const unsubscribe = tl.observe(() => calls++);
 		tl.write('one');
@@ -166,19 +142,14 @@ describe('attachTimeline - observe', () => {
 
 describe('attachTimeline - key parameter', () => {
 	test('default key is "timeline"', () => {
-		const ydoc = new Y.Doc();
-		const tl = attachTimeline(ydoc);
+		const { ydoc, tl } = setup();
 		tl.write('seed');
-
-		// The default timeline array is reachable at key 'timeline'.
 		expect(ydoc.getArray('timeline').length).toBe(1);
 	});
 
 	test('custom key reserves a different Y.Array slot', () => {
-		const ydoc = new Y.Doc();
-		const tl = attachTimeline(ydoc, 'log');
+		const { ydoc, tl } = setup('log');
 		tl.write('seed');
-
 		expect(ydoc.getArray('log').length).toBe(1);
 		// The default 'timeline' slot is untouched.
 		expect(ydoc.getArray('timeline').length).toBe(0);

--- a/packages/workspace/src/document/attach-timeline/timeline.ts
+++ b/packages/workspace/src/document/attach-timeline/timeline.ts
@@ -2,103 +2,64 @@ import * as Y from 'yjs';
 
 type TimelineYMap = Y.Map<unknown>;
 
-// ── Entry types ──────────────────────────────────────────────────────────
-
-/**
- * A timeline entry. The body owns a single layout (text), so there is one
- * entry shape. At runtime an entry is a Y.Map; `pushText` constructs it and
- * `readEntry` validates and extracts it into this shape.
- *
- * The stored `type` discriminant is retained (every stored entry is already
- * `'text'`) so the durable format is untouched: the `timeline` slot and its
- * `type`/`content`/`createdAt` keys are frozen (ADR-0106).
- */
-export type TextEntry = {
-	type: 'text';
-	content: Y.Text;
-	createdAt: number;
-};
-
 export function attachTimeline(ydoc: Y.Doc, key = 'timeline') {
 	const timeline = ydoc.getArray<TimelineYMap>(key);
 
-	// ── State ─────────────────────────────────────────────────────────────
+	// The body owns a single text layout. Entries are stored as Y.Maps with a
+	// frozen shape (`type`/`content`/`createdAt`, ADR-0106); in practice the log
+	// holds one text entry, edited in place. `type` and `createdAt` are written
+	// for the durable format and a future step-3 migration reader, not read here.
 
-	function readEntry(entry: Y.Map<unknown> | undefined): TextEntry | null {
-		if (!entry) return null;
-
-		const type = entry.get('type');
-		const createdAt = (entry.get('createdAt') as number) ?? 0;
-
-		if (type === 'text') {
-			const content = entry.get('content');
-			if (content instanceof Y.Text)
-				return { type: 'text', content, createdAt };
-		}
-
-		return null;
+	/** The current entry's text content, or null when the timeline is empty. */
+	function currentText(): Y.Text | null {
+		if (timeline.length === 0) return null;
+		const entry = timeline.get(timeline.length - 1);
+		if (entry?.get('type') !== 'text') return null;
+		const content = entry.get('content');
+		return content instanceof Y.Text ? content : null;
 	}
-	// ── Primitive push ops (closures, not on returned object) ─────────────
 
-	function pushText(content: string): TextEntry {
+	/** Append a new text entry and return its Y.Text. The stored shape is frozen. */
+	function pushText(content: string): Y.Text {
 		const entry = new Y.Map();
 		entry.set('type', 'text');
 		const ytext = new Y.Text();
 		ytext.insert(0, content);
 		entry.set('content', ytext);
-		const createdAt = Date.now();
-		entry.set('createdAt', createdAt);
+		entry.set('createdAt', Date.now());
 		timeline.push([entry]);
-		return { type: 'text', content: ytext, createdAt };
+		return ytext;
 	}
-	// ── Public API ────────────────────────────────────────────────────────
 
 	return {
-		/** Number of entries in the timeline. */
-		get length() {
-			return timeline.length;
-		},
-		/**
-		 * The current entry, validated and typed. Returns `null` if no entries
-		 * exist. Recomputed on every access, so do not rely on reference equality
-		 * between calls.
-		 */
-		get currentEntry(): TextEntry | null {
-			const last =
-				timeline.length > 0 ? timeline.get(timeline.length - 1) : undefined;
-			return readEntry(last);
-		},
-
 		/** Read the current entry as a plain string. Empty when there is none. */
 		read(): string {
-			const entry = this.currentEntry;
-			return entry ? entry.content.toString() : '';
+			return currentText()?.toString() ?? '';
 		},
 
-		/** Write string content to the current entry in a single transaction. */
+		/** Write string content to the current entry, seeding one if empty. */
 		write(text: string) {
 			ydoc.transact(() => {
-				const entry = this.currentEntry;
-				if (!entry) {
+				const content = currentText();
+				if (!content) {
 					pushText(text);
 					return;
 				}
 				// Overwrite existing Y.Text in-place (select-all + paste)
-				entry.content.delete(0, entry.content.length);
-				entry.content.insert(0, text);
+				content.delete(0, content.length);
+				content.insert(0, text);
 			});
 		},
 
 		/** Append text to the current entry, or seed one if the timeline is empty. */
 		appendText(text: string) {
 			ydoc.transact(() => {
-				const entry = this.currentEntry;
-				if (!entry) {
+				const content = currentText();
+				if (!content) {
 					pushText(text);
 					return;
 				}
-				// Append directly to existing Y.Text. No new entry.
-				entry.content.insert(entry.content.length, text);
+				content.insert(content.length, text);
 			});
 		},
 
@@ -108,19 +69,12 @@ export function attachTimeline(ydoc: Y.Doc, key = 'timeline') {
 		 * hydration before binding (see opensidian's ContentEditor).
 		 */
 		asText(): Y.Text {
-			const entry = this.currentEntry;
-			if (!entry) return ydoc.transact(() => pushText('')).content;
-			return entry.content;
-		},
-
-		/** Batch mutations into a single Yjs transaction. */
-		batch(fn: () => void) {
-			ydoc.transact(fn);
+			return currentText() ?? ydoc.transact(() => pushText(''));
 		},
 
 		/**
 		 * Watch for structural timeline changes, such as entries added or removed.
-		 * Re-read `currentEntry` in the callback to get the new state.
+		 * Re-read via `read()`/`asText()` in the callback to get the new state.
 		 *
 		 * @returns Unsubscribe function.
 		 */


### PR DESCRIPTION
> **ADR-0106 cleanup series (stacked, merge in order):** #2352 → **#2356 (this PR)** → #2357. Builds directly on #2352 (the step-2 text-path trim). Step-3 (durable format migration) is a separate future PR.

Follow-up collapse pass on the merged ADR-0106 step-2 trim (#2352). That PR removed the polymorphic modes; this one removes the surviving public surface that no production code consumed and that only existed because of the underlying entry-array.

**Traced consumers first.** Across `apps` + `packages` (non-test), the only live callers of the timeline handle are `read`/`write`/`appendText` (filesystem `file-system.ts`), `asText` (opensidian `ContentEditor`), `appendText` (opensidian `browser.ts`), and `observe` (mount worker contract). `currentEntry`, the exported `TextEntry`, `length`, and `batch` had **zero** production callers.

## Removed
| Name | Why it goes |
|---|---|
| `currentEntry` getter + `TextEntry` type | `read`/`write`/`appendText`/`asText` only ever needed "the current `Y.Text`, or null". Internalized as a private `currentText()`; `pushText` now returns the `Y.Text`. `TextEntry`'s `type`/`createdAt` were never read back. |
| `length` getter | Only consumer was one filesystem test helper, now reading `ydoc.getArray('timeline').length` directly (the durable invariant, matching the existing key-parameter tests). |
| `batch` method | An inert pass-through over `ydoc.transact`; called only by tests. Callers batch via `ydoc.transact(fn)` (and `write`/`appendText` already transact internally). |

Public API is now **`read` / `write` / `appendText` / `asText` / `observe`** — a single text body with no hint of the entry log. `currentEntry` and `length` only surfaced the internal `Y.Array` that the ADR-0106 **step-3** migration will delete, so dropping them now keeps that migration from also having to retract public surface.

## Frozen (unchanged)
No data migration. The durable `timeline` slot name and stored entry `Y.Map` shape (`type`/`content`/`createdAt`) are untouched. `pushText` writes byte-identical entries; `type`/`createdAt` are still written for the durable format and the future step-3 reader, even though the handle no longer reads them back.

## Not done here (surfaced for a follow-up)
`attach-timeline/` is now the only child-doc primitive that is a directory-with-barrel; every sibling (`attach-records.ts`, `attach-rich-text.ts`, …) is a single file. After the submodule deletions the directory + `index.ts` barrel is vestigial and could fold to `document/attach-timeline.ts`. Left out of this PR because it is a structural file-move, not surface reduction. **Step-3** (durable `Y.Array` → single-layout `Y.Text` body) remains gated on its own ADR + migration reader.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785720709&installation_id=128463665&pr_number=2356&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2356&signature=9524f89ac459e98af1dc34851df33ac9ab3e8e89f5ccd0ad2bac1c25350baac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
