### PR TITLE
fix(whispering): restore Epicenter STT in the transcription setup surface

### DIFF
--- a/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
+++ b/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
@@ -25,6 +25,7 @@
 	import { localModels } from '$lib/state/local-models.svelte';
 	import { settings } from '$lib/state/settings.svelte';
 	import { createCopyFn } from '$lib/utils/createCopyFn';
+	import { auth } from '#platform/auth';
 	import { tauri } from '#platform/tauri';
 	import AdvancedDisclosure from './AdvancedDisclosure.svelte';
 	import LocalModelSelector from './LocalModelSelector.svelte';
@@ -324,6 +325,29 @@
 					(v) => deviceConfig.set('transcription.local.selectedModel', v)}
 			/>
 		</div>
+	{:else if selectedTranscriptionProvider?.access === 'session'}
+		{#if auth.state.status === 'signed-in'}
+			<Card.Root>
+				<Card.Header>
+					<Card.Title class="text-lg">
+						{selectedTranscriptionProvider.label}
+					</Card.Title>
+					<Card.Description>
+						Transcription runs through your connected Epicenter over your
+						signed-in session. The model is managed for you, so there is nothing
+						to configure here. Hosted usage is metered by AI credits; a
+						self-hosted deployment runs it unmetered.
+					</Card.Description>
+				</Card.Header>
+			</Card.Root>
+		{:else}
+			<Alert.Root variant="warning">
+				<Alert.Title>Sign in required</Alert.Title>
+				<Alert.Description>
+					Sign in to Epicenter to use hosted transcription.
+				</Alert.Description>
+			</Alert.Root>
+		{/if}
 	{/if}
 
 	{#if !isSelectedServiceUnavailable}

--- a/apps/whispering/src/lib/components/settings/TranscriptionServiceSelect.svelte
+++ b/apps/whispering/src/lib/components/settings/TranscriptionServiceSelect.svelte
@@ -4,7 +4,7 @@
 	import * as Select from '@epicenter/ui/select';
 	import { cn } from '@epicenter/ui/utils';
 	import {
-		TRANSCRIPTION_PROVIDERS,
+		groupedTranscriptionProviders,
 		type TranscriptionProviderEntry,
 	} from '$lib/services/transcription/provider-ui';
 	import { type TranscriptionServiceId } from '$lib/services/transcription/providers';
@@ -22,24 +22,13 @@
 		recommendedServiceId?: TranscriptionServiceId | null;
 	} = $props();
 
-	const localServices = $derived(
-		tauri
-			? TRANSCRIPTION_PROVIDERS.filter((service) => service.access === 'onDevice')
-			: [],
-	);
-
-	const cloudServices = $derived(
-		TRANSCRIPTION_PROVIDERS.filter((service) => service.access === 'key'),
-	);
-
-	const selfHostedServices = $derived(
-		TRANSCRIPTION_PROVIDERS.filter((service) => service.access === 'endpoint'),
-	);
+	// The one grouping source both selectors iterate. A new `access` family lights
+	// up here automatically; it can never be silently dropped the way `session`
+	// (Epicenter) once was from this dropdown.
+	const groups = $derived(groupedTranscriptionProviders({ tauri: Boolean(tauri) }));
 
 	const selectedService = $derived(
-		[...localServices, ...cloudServices, ...selfHostedServices].find(
-			(service) => service.id === selected,
-		),
+		groups.flatMap((group) => group.services).find((s) => s.id === selected),
 	);
 </script>
 
@@ -71,53 +60,22 @@
 			</div>
 		</Select.Trigger>
 		<Select.Content class="max-h-[400px]">
-			{#if localServices.length > 0}
-				<Select.Group>
-					<Select.GroupHeading>Local (Offline)</Select.GroupHeading>
-					{#each localServices as service}
-						<Select.Item value={service.id} label={service.label}>
-							<div class="flex items-start gap-3 py-1">
-								<div class="mt-0.5">{@render renderServiceIcon(service)}</div>
-								<div class="flex-1 min-w-0">
-									<div class="flex items-center gap-2">
-										<span class="font-medium">{service.label}</span>
-										<Badge variant="secondary" class="text-xs">Local</Badge>
-										{#if service.id === recommendedServiceId}
-											<Badge variant="outline" class="text-xs"
-												>Recommended</Badge
-											>
-										{/if}
-									</div>
-									{#if service.description}
-										<div class="text-xs text-muted-foreground mt-1">
-											{service.description}
-										</div>
-									{/if}
-								</div>
-							</div>
-						</Select.Item>
-					{/each}
-				</Select.Group>
-			{/if}
-
-			{#if cloudServices.length > 0}
-				{#if localServices.length > 0}
+			{#each groups as group, i (group.access)}
+				{#if i > 0}
 					<Select.Separator />
 				{/if}
 				<Select.Group>
-					<Select.GroupHeading>Cloud (API)</Select.GroupHeading>
-					{#each cloudServices as service}
+					<Select.GroupHeading>{group.heading}</Select.GroupHeading>
+					{#each group.services as service (service.id)}
 						<Select.Item value={service.id} label={service.label}>
 							<div class="flex items-start gap-3 py-1">
 								<div class="mt-0.5">{@render renderServiceIcon(service)}</div>
 								<div class="flex-1 min-w-0">
 									<div class="flex items-center gap-2">
 										<span class="font-medium">{service.label}</span>
-										<Badge variant="outline" class="text-xs">API</Badge>
+										<Badge variant="outline" class="text-xs">{group.badge}</Badge>
 										{#if service.id === recommendedServiceId}
-											<Badge variant="outline" class="text-xs"
-												>Recommended</Badge
-											>
+											<Badge variant="outline" class="text-xs">Recommended</Badge>
 										{/if}
 									</div>
 									{#if service.description}
@@ -128,9 +86,7 @@
 									{#if service.access === 'key' && service.models.length > 0}
 										<div class="text-xs text-muted-foreground mt-1">
 											{service.models.length}
-											model{service.models.length > 1
-												? 's'
-												: ''}
+											model{service.models.length > 1 ? 's' : ''}
 											available
 										</div>
 									{/if}
@@ -139,34 +95,7 @@
 						</Select.Item>
 					{/each}
 				</Select.Group>
-			{/if}
-
-			{#if selfHostedServices.length > 0}
-				{#if localServices.length > 0 || cloudServices.length > 0}
-					<Select.Separator />
-				{/if}
-				<Select.Group>
-					<Select.GroupHeading>Self-Hosted</Select.GroupHeading>
-					{#each selfHostedServices as service}
-						<Select.Item value={service.id} label={service.label}>
-							<div class="flex items-start gap-3 py-1">
-								<div class="mt-0.5">{@render renderServiceIcon(service)}</div>
-								<div class="flex-1 min-w-0">
-									<div class="flex items-center gap-2">
-										<span class="font-medium">{service.label}</span>
-										<Badge variant="outline" class="text-xs">Self-Hosted</Badge>
-									</div>
-									{#if service.description}
-										<div class="text-xs text-muted-foreground mt-1">
-											{service.description}
-										</div>
-									{/if}
-								</div>
-							</div>
-						</Select.Item>
-					{/each}
-				</Select.Group>
-			{/if}
+			{/each}
 		</Select.Content>
 	</Select.Root>
 </div>

--- a/apps/whispering/src/lib/operations/transcription-target.ts
+++ b/apps/whispering/src/lib/operations/transcription-target.ts
@@ -72,6 +72,11 @@ export function resolveTranscriptionLocalityFromConfig({
 	if (provider.access === 'endpoint') {
 		return { onDevice: false, name: `your ${provider.label} server` };
 	}
+	// `key` providers not pointed at loopback and `session` (Epicenter) both land
+	// here: audio leaves the device, named by the provider. Session does not yet
+	// inspect `auth.baseURL`, so a self-hosted instance bonded at loopback still
+	// reads as off-device; threading the session base URL through this resolver
+	// (mirroring the endpoint loopback branch above) is the follow-up that fixes it.
 	return { onDevice: false, name: provider.label };
 }
 

--- a/apps/whispering/src/lib/services/transcription/provider-ui.ts
+++ b/apps/whispering/src/lib/services/transcription/provider-ui.ts
@@ -14,7 +14,11 @@ import groqIcon from '$lib/constants/icons/groq.svg?raw';
 import mistralIcon from '$lib/constants/icons/mistral.svg?raw';
 import openaiIcon from '$lib/constants/icons/openai.svg?raw';
 import speachesIcon from '$lib/constants/icons/speaches.svg?raw';
-import { PROVIDERS, type TranscriptionServiceId } from './providers';
+import {
+	PROVIDERS,
+	type ProviderAccess,
+	type TranscriptionServiceId,
+} from './providers';
 
 export const PROVIDER_ICONS = {
 	epicenter: { icon: epicenterIcon, invertInDarkMode: false },
@@ -53,3 +57,46 @@ export const TRANSCRIPTION_PROVIDERS = (
 	...provider,
 	...PROVIDER_ICONS[id],
 })) as TranscriptionProviderEntry[];
+
+/**
+ * The single source of how each `access` family is presented: the group heading
+ * both service selectors show and the short badge the settings dropdown tags each
+ * row with. Declaration order is display order. `satisfies Record<ProviderAccess,
+ * ...>` makes a new access member a compile error here, so a family can never be
+ * silently dropped from a selector the way `session` once was. Group *membership*
+ * lives in the registry (`access`); this map owns only presentation.
+ */
+export const ACCESS_GROUPS = {
+	session: { heading: 'Epicenter', badge: 'Hosted' },
+	onDevice: { heading: 'On-device', badge: 'Local' },
+	key: { heading: 'Provider API', badge: 'API' },
+	endpoint: { heading: 'Custom server', badge: 'Self-Hosted' },
+} as const satisfies Record<ProviderAccess, { heading: string; badge: string }>;
+
+export type TranscriptionServiceGroup = {
+	access: ProviderAccess;
+	heading: string;
+	badge: string;
+	services: TranscriptionProviderEntry[];
+};
+
+/**
+ * The providers grouped by `access` in display order, one entry per non-empty
+ * group. The single derivation both selectors iterate, so their group set, order,
+ * and headings can never disagree. On-device providers transcribe through Rust, so
+ * they are hidden off Tauri (`tauri: false`), matching the readiness check.
+ */
+export function groupedTranscriptionProviders({
+	tauri,
+}: {
+	tauri: boolean;
+}): TranscriptionServiceGroup[] {
+	return (Object.keys(ACCESS_GROUPS) as ProviderAccess[]).flatMap((access) => {
+		if (access === 'onDevice' && !tauri) return [];
+		const services = TRANSCRIPTION_PROVIDERS.filter(
+			(service) => service.access === access,
+		);
+		if (services.length === 0) return [];
+		return [{ access, ...ACCESS_GROUPS[access], services }];
+	});
+}

--- a/apps/whispering/src/lib/services/transcription/providers.ts
+++ b/apps/whispering/src/lib/services/transcription/providers.ts
@@ -44,7 +44,7 @@ type CloudModel = { name: string; description: string; cost: string };
  * session, on that deployment's house key. Hosted deployments meter it (AI credits);
  * self-host deployments proxy it unmetered. `key`/`endpoint` are external services.
  */
-type ProviderAccess = 'key' | 'endpoint' | 'session' | 'onDevice';
+export type ProviderAccess = 'key' | 'endpoint' | 'session' | 'onDevice';
 
 type KeyProvider = {
 	access: Extract<ProviderAccess, 'key'>;


### PR DESCRIPTION
The transcription **setup** surface (`/settings/processing`) never learned the `session` access family that #2341 added for hosted Epicenter STT. `TranscriptionServiceSelect` grouped providers with hand-maintained `.filter(access === ...)` lists covering only `onDevice`/`key`/`endpoint`, and `TranscriptionRuntimeConfig`'s branch chain had no `session` case. So selecting Epicenter STT left the settings picker trigger blank and its config panel empty, and the option could not be reselected there.

The per-use *switcher* was already correct (#2353 rebuilt it around `readyModels()`). This is the untouched, access-sectioned *setup* surface that #2353 explicitly deferred to Phase 2.

This change:
- **One grouping owner.** `ACCESS_GROUPS satisfies Record<ProviderAccess, ...>` plus `groupedTranscriptionProviders()` in `provider-ui.ts` own how each access family is presented (heading + badge, in display order). A new access family is a compile error here instead of a silent omission, so a selector can never drop one again.
- **Settings picker loops the SSOT.** `TranscriptionServiceSelect` renders groups from `groupedTranscriptionProviders()`, so the Epicenter (`session`) group appears automatically (172 to 110 lines).
- **Config panel gains the Epicenter section.** `TranscriptionRuntimeConfig` renders a signed-in note (or a sign-in prompt) for `session`, matching the bespoke per-provider setup sections the README describes.
- Documents a known limitation: `transcription-target` reports `session` audio as off-device even for a self-hosted instance bonded at loopback. Fixing that means threading `auth.baseURL` into the pure resolver, a scoped follow-up.

A note for review:
- Aligns with `apps/whispering/specs/20260703T170000-transcription-selector-post-gguf-reconciliation.md` (the access-sectioned setup catalog). This is an incremental step, not the full Phase 2 rebuild.
- Copy is easy to tune: the settings badge for `session` is "Hosted"; the panel blurb says hosted usage is metered by AI credits and self-hosted runs unmetered.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785721472&installation_id=128463665&pr_number=2358&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2358&signature=0c90208f1b95908c2da061600016583b74a5a25c21632ccaa869e1d6268dcc91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->