### PR TITLE
docs(whispering): fix stale local-engine list in services README

### DIFF
--- a/apps/whispering/src/lib/services/README.md
+++ b/apps/whispering/src/lib/services/README.md
@@ -437,7 +437,7 @@ The manual recorder lives under `services/recorder/index.*.ts` because the recor
 
 ### Multi-provider services
 
-- `transcription/` - Speech-to-text (OpenAI, Groq, ElevenLabs, Speaches, local Whisper/Parakeet/Moonshine)
+- `transcription/` - Speech-to-text (Epicenter, OpenAI, Groq, ElevenLabs, Speaches, local GGUF)
 
 Recording state itself is owned by `$lib/state/manual-recorder.svelte.ts` and `$lib/state/vad-recorder.svelte.ts`, not by services. Services may hold service-local runtime state, like a platform recorder's active session, but app-visible state lives one level up.
 


### PR DESCRIPTION
Follow-up residue sweep after #2350/#2353/#2358. `apps/whispering/src/lib/services/README.md` still described on-device transcription as three separate engines (`Whisper/Parakeet/Moonshine`). Ground truth (`src-tauri/src/transcription/catalog.rs`): one GGUF `local` runtime serving Whisper + Parakeet models, no Moonshine. Also adds the `Epicenter` (`session`) provider that was missing from the list. Docs-only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785722381&installation_id=128463665&pr_number=2359&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2359&signature=832fd967fa3700c0231d46e1f5802fae984aca7277ba64d7466e2e70ca975663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->