### PR TITLE
chore(deps): bump yjs catalog floor to ^13.6.31

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",
@@ -1194,7 +1193,7 @@
     "y-indexeddb": "^9.0.12",
     "y-protocols": "^1.0.7",
     "yargs": "^18.0.0",
-    "yjs": "^13.6.29",
+    "yjs": "^13.6.31",
   },
   "packages": {
     "@1natsu/wait-element": ["@1natsu/wait-element@4.2.0", "", { "dependencies": { "defu": "^6.1.4", "many-keys-map": "^3.0.0" } }, "sha512-Om0Q+WE9mNrpY4AwMTvkFiYHv8VM7TML3PvOqXy+w6kAjLjKhGYHYX+305+a6J8RVpds9s7IF2Z5aOPYwULFNw=="],
@@ -4163,7 +4162,7 @@
 
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
-    "yjs": ["yjs@13.6.30", "", { "dependencies": { "lib0": "^0.2.99" } }, "sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ=="],
+    "yjs": ["yjs@13.6.31", "", { "dependencies": { "lib0": "^0.2.99" } }, "sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw=="],
 
     "yn": ["yn@3.1.1", "", {}, "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="],
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 			"@standard-schema/spec": "^1.1.0",
 			"hono": "^4.12.25",
 			"mime": "^4.0.6",
-			"yjs": "^13.6.29",
+			"yjs": "^13.6.31",
 			"lib0": "^0.2.117",
 			"y-protocols": "^1.0.7",
 			"y-indexeddb": "^9.0.12",


### PR DESCRIPTION
Raises the `yjs` catalog floor from `^13.6.29` to `^13.6.31`, keeping us current on the only supported Yjs line (Yjs supports `13.6.x`; older is unsupported). Patch-level bump inside the existing caret, so nothing else moves: `y-protocols@^1.0.7`, `y-indexeddb@^9.0.12` (still patched), and `lib0@^0.2.117` are already at their latest.

The reason for this shape is:

`yjs@14` is still a rolling beta (`14.0.0-16` under the `beta` tag; `latest` on npm is `13.6.31`). More decisively, **no provider we depend on has shipped a v14-compatible build** — `y-indexeddb`, `y-protocols`, `y-websocket`, and `y-codemirror.next` all peer-require `yjs ^13`, and would reject v14 (risking a second Yjs copy). The v14 headline features (attributed history, track-changes) are editor-collaboration features we don't currently consume, and the binary format is stable across 13→14, so there's no data pressure. v14 is a watch-item gated on the ecosystem, not this bump.

For verification:

- Resolves to a single `yjs@13.6.31` copy (no two-copies hazard)
- `y-indexeddb@9.0.12` heal patch still applies
- `@epicenter/workspace` typecheck clean; yjs-log V2 persistence tests green

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785724059&installation_id=128463665&pr_number=2361&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2361&signature=7ac7a5022de21f19a3f54256c2f4788d226660488afd7c03abcdffed35d04e75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->