### PR TITLE
feat(auth): redesign hosted sign-in page and add Microsoft provider

### DIFF
--- a/packages/server/src/auth-pages/index.tsx
+++ b/packages/server/src/auth-pages/index.tsx
@@ -16,12 +16,17 @@ import { SignedInPage } from './signed-in-page';
 
 export function renderSignInPage({
 	githubEnabled,
+	microsoftEnabled,
 }: {
 	githubEnabled: boolean;
+	microsoftEnabled: boolean;
 }) {
 	return (
 		<AuthLayout title="Sign in: Epicenter">
-			<SignInPage githubEnabled={githubEnabled} />
+			<SignInPage
+				githubEnabled={githubEnabled}
+				microsoftEnabled={microsoftEnabled}
+			/>
 		</AuthLayout>
 	);
 }

--- a/packages/server/src/auth-pages/scripts/sign-in.ts
+++ b/packages/server/src/auth-pages/scripts/sign-in.ts
@@ -3,21 +3,23 @@ import { raw } from 'hono/html';
 /**
  * Client-side script for the sign-in page.
  *
- * Starts a social sign-in (Google, or GitHub when its button is present) via
- * `fetch` and displays errors. Includes `oauth_query` (signed URL params) in
- * the request so Better Auth's after-hook can continue the OAuth flow. On
- * success, navigates to the returned redirect URL or the followed redirect.
- * Local email/password is disabled (see {@link BASE_AUTH_CONFIG}); the GitHub
- * button only exists when the deployment configured GitHub credentials.
+ * Starts a social sign-in (Google, or GitHub / Microsoft when their button is
+ * present) via `fetch` and displays errors. Includes `oauth_query` (signed URL
+ * params) in the request so Better Auth's after-hook can continue the OAuth
+ * flow. On success, navigates to the returned redirect URL or the followed
+ * redirect. Local email/password is disabled (see {@link BASE_AUTH_CONFIG});
+ * the GitHub and Microsoft buttons only exist when the deployment configured
+ * that provider's credentials.
  */
 export const SIGN_IN_SCRIPT = raw(`<script>
 (() => {
 	const googleBtn = document.getElementById('google-btn');
 	const githubBtn = document.getElementById('github-btn');
+	const microsoftBtn = document.getElementById('microsoft-btn');
 	const msg = document.getElementById('msg');
-	const buttons = [googleBtn, githubBtn].filter(Boolean);
+	const buttons = [googleBtn, githubBtn, microsoftBtn].filter(Boolean);
 
-	const LABELS = { google: 'Google', github: 'GitHub' };
+	const LABELS = { google: 'Google', github: 'GitHub', microsoft: 'Microsoft' };
 
 	// Replicate what oauthProviderClient does: parse the signed OAuth
 	// query params from the URL so Better Auth can continue the flow.
@@ -75,5 +77,7 @@ export const SIGN_IN_SCRIPT = raw(`<script>
 
 	googleBtn.addEventListener('click', () => startSocial('google'));
 	if (githubBtn) githubBtn.addEventListener('click', () => startSocial('github'));
+	if (microsoftBtn)
+		microsoftBtn.addEventListener('click', () => startSocial('microsoft'));
 })();
 </script>`);

--- a/packages/server/src/auth-pages/sign-in-page.tsx
+++ b/packages/server/src/auth-pages/sign-in-page.tsx
@@ -24,36 +24,82 @@ const GITHUB_ICON =
 </svg>`);
 
 /**
+ * Microsoft's four-color logo (fixed brand colors, not `currentColor`).
+ */
+const MICROSOFT_ICON =
+	raw(`<svg width="16" height="16" viewBox="0 0 23 23" aria-hidden="true">
+	<path fill="#F25022" d="M1 1h10v10H1z"/>
+	<path fill="#7FBA00" d="M12 1h10v10H12z"/>
+	<path fill="#00A4EF" d="M1 12h10v10H1z"/>
+	<path fill="#FFB900" d="M12 12h10v10H12z"/>
+</svg>`);
+
+/**
  * Server-rendered sign-in page for the OAuth flow.
  *
  * Better Auth redirects here when a user needs to authenticate. Sign-in is via
  * social IdP only (local email/password is disabled, see
- * {@link BASE_AUTH_CONFIG}): Google always, and GitHub when the deployment has
- * configured GitHub credentials (`githubEnabled`). After successful auth,
- * Better Auth returns a redirect URL to continue the OAuth flow; for non-OAuth
- * sign-ins the page reloads.
+ * {@link BASE_AUTH_CONFIG}): Google always, and GitHub / Microsoft when the
+ * deployment has configured that provider's credentials (`githubEnabled`,
+ * `microsoftEnabled`; both register-when-present, so an unconfigured provider
+ * is simply not offered). After successful auth, Better Auth returns a redirect
+ * URL to continue the OAuth flow; for non-OAuth sign-ins the page reloads.
+ *
+ * The Epicenter mark is rendered above these by {@link AuthLayout}; this page
+ * adds the wordmark, so the header reads mark → "epicenter" → subtitle.
  */
-export function SignInPage({ githubEnabled }: { githubEnabled: boolean }) {
+export function SignInPage({
+	githubEnabled,
+	microsoftEnabled,
+}: {
+	githubEnabled: boolean;
+	microsoftEnabled: boolean;
+}) {
 	return (
 		<>
-			<h1 id="heading">Sign in</h1>
-			<p class="subtitle" id="description">
-				Sign in to your Epicenter account.
-			</p>
+			<div class="signin-head">
+				<h1 id="heading" class="wordmark">
+					epicenter
+				</h1>
+				<p class="subtitle" id="description">
+					Sign in to your account.
+				</p>
+			</div>
 
 			<div id="msg" class="msg hidden" />
 
-			<button type="button" class="btn btn-outline" id="google-btn">
-				{GOOGLE_ICON}
-				Continue with Google
-			</button>
-
-			{githubEnabled ? (
-				<button type="button" class="btn btn-outline" id="github-btn">
-					{GITHUB_ICON}
-					Continue with GitHub
+			<div class="providers">
+				<button
+					type="button"
+					class="btn btn-outline btn-provider"
+					id="google-btn"
+				>
+					{GOOGLE_ICON}
+					<span class="btn-label">Continue with Google</span>
 				</button>
-			) : null}
+
+				{githubEnabled ? (
+					<button
+						type="button"
+						class="btn btn-outline btn-provider"
+						id="github-btn"
+					>
+						{GITHUB_ICON}
+						<span class="btn-label">Continue with GitHub</span>
+					</button>
+				) : null}
+
+				{microsoftEnabled ? (
+					<button
+						type="button"
+						class="btn btn-outline btn-provider"
+						id="microsoft-btn"
+					>
+						{MICROSOFT_ICON}
+						<span class="btn-label">Continue with Microsoft</span>
+					</button>
+				) : null}
+			</div>
 
 			{SIGN_IN_SCRIPT}
 		</>

--- a/packages/server/src/auth-pages/styles.ts
+++ b/packages/server/src/auth-pages/styles.ts
@@ -2,12 +2,48 @@
  * Shared CSS for server-rendered auth pages (sign-in, consent, signed-in,
  * cli-callback).
  *
- * Matches the Epicenter design system tokens from `packages/ui/src/app.css`
- * using oklch equivalents, including its system-ui font stack. No external
- * dependencies. This string is inlined in the `<style>` tag by the layout
- * component.
+ * Mirrors the Epicenter design system tokens from `packages/ui/src/app.css`
+ * (its oklch light/dark palettes and system-ui font stack) as plain custom
+ * properties, so these pages theme themselves from `prefers-color-scheme`
+ * without pulling in Tailwind or the UI package. Semantic surfaces (alerts)
+ * derive their fills from the accent via `color-mix`, so each stays legible in
+ * both themes from a single hue token. This string is inlined in the `<style>`
+ * tag by the layout component.
  */
 export const AUTH_STYLES = `
+:root{
+	--bg:oklch(0.9925 0.001 70);
+	--card:oklch(1 0 0);
+	--fg:oklch(0.129 0.042 264.695);
+	--muted-fg:oklch(0.554 0.046 257.417);
+	--border:oklch(0.929 0.013 255.508);
+	--surface-2:oklch(0.968 0.007 247.896);
+	--hover:oklch(0.968 0.007 247.896);
+	--primary:oklch(0.208 0.042 265.755);
+	--primary-fg:oklch(0.984 0.003 247.858);
+	--ring:oklch(0.704 0.04 256.788);
+	--success:oklch(0.448 0.119 151.328);
+	--danger:oklch(0.577 0.245 27.325);
+	--shadow:0 1px 2px rgb(0 0 0 / .04),0 8px 30px rgb(0 0 0 / .06);
+}
+@media (prefers-color-scheme:dark){
+	:root{
+		--bg:oklch(0.129 0.042 264.695);
+		--card:oklch(0.208 0.042 265.755);
+		--fg:oklch(0.984 0.003 247.858);
+		--muted-fg:oklch(0.704 0.04 256.788);
+		--border:oklch(1 0 0 / 12%);
+		--surface-2:oklch(0.279 0.041 260.031);
+		--hover:oklch(0.279 0.041 260.031);
+		--primary:oklch(0.929 0.013 255.508);
+		--primary-fg:oklch(0.208 0.042 265.755);
+		--ring:oklch(0.551 0.027 264.364);
+		--success:oklch(0.696 0.17 162.48);
+		--danger:oklch(0.704 0.191 22.216);
+		--shadow:0 1px 2px rgb(0 0 0 / .4),0 12px 40px rgb(0 0 0 / .5);
+	}
+}
+
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 
 body{
@@ -16,8 +52,8 @@ body{
 	display:flex;
 	align-items:center;
 	justify-content:center;
-	background:#f5f5f5;
-	color:oklch(0.129 0.042 264.695);
+	background:var(--bg);
+	color:var(--fg);
 	padding:1rem;
 	line-height:1.5;
 	-webkit-font-smoothing:antialiased;
@@ -28,27 +64,33 @@ body{
 .logo{
 	display:flex;
 	justify-content:center;
-	margin-bottom:1.5rem;
+	margin-bottom:1rem;
 }
 .logo svg{
-	width:36px;
-	height:36px;
-	border-radius:8px;
+	width:44px;
+	height:44px;
+	border-radius:12px;
 }
 
 /* ── Card ────────────────────────────────────────────────── */
 
 .card{
-	background:#fff;
+	background:var(--card);
+	border:1px solid var(--border);
 	border-radius:16px;
-	padding:2.5rem;
-	max-width:420px;
+	padding:2.5rem 2.25rem;
+	max-width:400px;
 	width:100%;
-	box-shadow:0 2px 8px 0 rgb(0 0 0 / .06),0 0 0 1px rgb(0 0 0 / .04);
+	box-shadow:var(--shadow);
 }
 
 h1{font-size:1.375rem;font-weight:700;letter-spacing:-.01em;margin-bottom:.25rem}
-.subtitle{color:oklch(0.554 0.046 257.417);font-size:.875rem;margin-bottom:1.75rem}
+.subtitle{color:var(--muted-fg);font-size:.875rem;margin-bottom:1.75rem}
+
+/* ── Sign-in header (mark lives in the layout above these) ─── */
+
+.signin-head{display:flex;flex-direction:column;align-items:center;text-align:center}
+.wordmark{font-size:1.375rem;font-weight:650;letter-spacing:-.02em;line-height:1.15;margin-bottom:.25rem}
 
 /* ── Buttons ──────────────────────────────────────────────── */
 
@@ -59,25 +101,41 @@ button,.btn{
 	gap:.5rem;
 	width:100%;
 	padding:.75rem 1rem;
-	border-radius:8px;
+	border-radius:10px;
 	font-size:.875rem;
 	font-weight:500;
 	font-family:inherit;
+	color:var(--fg);
 	cursor:pointer;
 	border:1px solid transparent;
-	transition:opacity .15s,background-color .15s,box-shadow .15s;
+	transition:background-color .15s,border-color .15s,box-shadow .15s,opacity .15s;
 	text-decoration:none;
 }
 button:disabled,.btn:disabled{opacity:.5;cursor:not-allowed}
+button:focus-visible,.btn:focus-visible{outline:2px solid var(--ring);outline-offset:2px}
 
-.btn-primary{background:oklch(0.208 0.042 265.755);color:#fff;border-color:oklch(0.208 0.042 265.755)}
-.btn-primary:hover:not(:disabled){opacity:.85}
+.btn-primary{background:var(--primary);color:var(--primary-fg);border-color:var(--primary)}
+.btn-primary:hover:not(:disabled){opacity:.9}
 
-.btn-outline{background:#fff;color:oklch(0.129 0.042 264.695);border-color:oklch(0.929 0.013 255.508)}
-.btn-outline:hover:not(:disabled){background:#f9fafb}
+.btn-outline{background:var(--card);color:var(--fg);border-color:var(--border)}
+.btn-outline:hover:not(:disabled){background:var(--hover);border-color:var(--muted-fg)}
 
-.btn-danger{background:#fff;color:oklch(0.577 0.245 27.325);border-color:oklch(0.929 0.013 255.508)}
-.btn-danger:hover:not(:disabled){background:oklch(0.971 0.013 17.38)}
+.btn-danger{background:var(--card);color:var(--danger);border-color:var(--border)}
+.btn-danger:hover:not(:disabled){background:color-mix(in oklab,var(--danger) 8%,var(--card))}
+
+/* ── Provider buttons (sign-in): icon column left, label centered ─ */
+
+.providers{display:flex;flex-direction:column;gap:.625rem}
+.btn-provider{
+	display:grid;
+	grid-template-columns:1.25rem 1fr 1.25rem;
+	align-items:center;
+	gap:.625rem;
+	padding:.8rem 1rem;
+	font-weight:550;
+}
+.btn-provider svg{width:18px;height:18px}
+.btn-provider .btn-label{grid-column:2;text-align:center}
 
 /* ── Button row (side-by-side) ────────────────────────────── */
 
@@ -93,8 +151,16 @@ button:disabled,.btn:disabled{opacity:.5;cursor:not-allowed}
 	font-size:.875rem;
 	line-height:1.4;
 }
-.msg.ok{background:oklch(0.962 0.044 156.743);color:oklch(0.448 0.119 151.328);border:1px solid oklch(0.871 0.108 152.314)}
-.msg.err{background:oklch(0.971 0.013 17.38);color:oklch(0.577 0.245 27.325);border:1px solid oklch(0.852 0.071 22.018)}
+.msg.ok{
+	background:color-mix(in oklab,var(--success) 12%,var(--card));
+	color:var(--success);
+	border:1px solid color-mix(in oklab,var(--success) 30%,var(--card));
+}
+.msg.err{
+	background:color-mix(in oklab,var(--danger) 12%,var(--card));
+	color:var(--danger);
+	border:1px solid color-mix(in oklab,var(--danger) 30%,var(--card));
+}
 
 .hidden{display:none}
 
@@ -107,8 +173,8 @@ button:disabled,.btn:disabled{opacity:.5;cursor:not-allowed}
 }
 .scope-list li{
 	padding:.5rem .75rem;
-	background:#f9fafb;
-	border:1px solid oklch(0.929 0.013 255.508);
+	background:var(--surface-2);
+	border:1px solid var(--border);
 	border-radius:6px;
 	font-size:.875rem;
 	margin-bottom:.375rem;
@@ -127,8 +193,8 @@ button:disabled,.btn:disabled{opacity:.5;cursor:not-allowed}
 .code-block{
 	margin:1rem 0;
 	padding:1rem;
-	background:#f9fafb;
-	border:1px solid oklch(0.929 0.013 255.508);
+	background:var(--surface-2);
+	border:1px solid var(--border);
 	border-radius:8px;
 	overflow-x:auto;
 }
@@ -156,7 +222,7 @@ button:disabled,.btn:disabled{opacity:.5;cursor:not-allowed}
 }
 
 .signed-in-info{
-	color:oklch(0.554 0.046 257.417);
+	color:var(--muted-fg);
 	font-size:.875rem;
 	margin-top:.125rem;
 }
@@ -168,4 +234,6 @@ button:disabled,.btn:disabled{opacity:.5;cursor:not-allowed}
 	gap:.5rem;
 	width:100%;
 }
+
+@media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
 `;

--- a/packages/server/src/auth/create-auth.ts
+++ b/packages/server/src/auth/create-auth.ts
@@ -34,6 +34,8 @@ export const CloudAuthBindings = type({
 	'GOOGLE_CLIENT_SECRET?': 'string',
 	'GITHUB_CLIENT_ID?': 'string',
 	'GITHUB_CLIENT_SECRET?': 'string',
+	'MICROSOFT_CLIENT_ID?': 'string',
+	'MICROSOFT_CLIENT_SECRET?': 'string',
 });
 export type CloudAuthBindings = typeof CloudAuthBindings.infer;
 
@@ -46,8 +48,8 @@ export type CloudAuthBindings = typeof CloudAuthBindings.infer;
  *
  * Wires up:
  * - Drizzle adapter (portable Postgres wire; Hyperdrive on Workers, a pool on Node)
- * - Google OAuth, plus GitHub when its credentials are configured
- *   (email/password is disabled; see {@link BASE_AUTH_CONFIG})
+ * - Google OAuth, plus GitHub and Microsoft when their credentials are
+ *   configured (email/password is disabled; see {@link BASE_AUTH_CONFIG})
  * - Plugins: JWT (ES256), OAuth provider (PKCE)
  *
  * `/api/session` is the single Epicenter session surface; this builder no longer
@@ -125,6 +127,21 @@ export function createAuth({
 						github: {
 							clientId: env.GITHUB_CLIENT_ID,
 							clientSecret: env.GITHUB_CLIENT_SECRET,
+						},
+					}
+				: {}),
+			// Microsoft (Entra / personal MSA), register-when-present like GitHub.
+			// tenantId defaults to 'common' so both work/school and personal
+			// accounts can sign in. Like GitHub, Microsoft is deliberately NOT a
+			// trusted linking provider (see BASE_AUTH_CONFIG): a personal MSA email
+			// is not a guaranteed-verified assertion, so an untrusted Microsoft
+			// identity only links to an existing same-email account when Microsoft
+			// itself reports the email verified.
+			...(env.MICROSOFT_CLIENT_ID && env.MICROSOFT_CLIENT_SECRET
+				? {
+						microsoft: {
+							clientId: env.MICROSOFT_CLIENT_ID,
+							clientSecret: env.MICROSOFT_CLIENT_SECRET,
 						},
 					}
 				: {}),

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -76,6 +76,10 @@ export const authApp = new Hono<CloudEnv>()
 					c.var.authSecrets.GITHUB_CLIENT_ID &&
 						c.var.authSecrets.GITHUB_CLIENT_SECRET,
 				),
+				microsoftEnabled: Boolean(
+					c.var.authSecrets.MICROSOFT_CLIENT_ID &&
+						c.var.authSecrets.MICROSOFT_CLIENT_SECRET,
+				),
 			}),
 		);
 	})


### PR DESCRIPTION
The hosted `/sign-in` page is the one credential screen every Epicenter surface funnels into: the in-app `SignInPanel`, the billing dashboard, and Whispering settings all just redirect here through `auth.startSignIn()`. It was a plain left-aligned "Sign in" heading with two buttons and no dark mode, visibly out of step with the rest of the product. This restyles it to the app's design language and extends the provider set.

The page is now a centered card with the Epicenter mark, an `epicenter` wordmark, and stacked provider buttons laid out as a grid (brand icon in a left column, label centered). The shared auth-page CSS is tokenized to CSS custom properties sourced from `packages/ui/src/app.css`'s oklch values, so a `prefers-color-scheme: dark` palette, `:focus-visible` rings, and a `prefers-reduced-motion` guard all come along without pulling Tailwind or the UI package into the server render. Every auth page (consent, signed-in, CLI callback) inherits the tokens and dark mode.

Microsoft joins Google and GitHub as a register-when-present social provider: it is only offered when `MICROSOFT_CLIENT_ID` / `MICROSOFT_CLIENT_SECRET` are configured, so this lands with no deploy or secret changes and simply lights up once those are provisioned. Like GitHub, Microsoft is deliberately kept out of `trustedProviders` because a personal MSA email is not a guaranteed-verified assertion; only Google bypasses the incoming `emailVerified` link check.

Apple and passkey are intentionally left for follow-up PRs rather than folded in here: Apple needs a dynamically generated JWT client secret (Team ID + Key ID + private key) plus `https://appleid.apple.com` in `trustedOrigins`, and passkey needs the WebAuthn ceremony wired into this bundler-free page. No dead flags were added for them.

## Changelog

- Redesigned the sign-in page with a cleaner card layout, the Epicenter wordmark, and automatic dark mode.
- Added **Sign in with Microsoft** (appears once Microsoft credentials are configured).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785724087&installation_id=128463665&pr_number=2362&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2362&signature=55a925c73379a6ca929ff5d2fec89444eafee8c78fc9a184abbbd856580f7c24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->