### PR TITLE
feat(ui): add Item.Button and adopt Item for selectable rows

### DIFF
--- a/apps/local-mail/ui/src/lib/components/LabelRail.svelte
+++ b/apps/local-mail/ui/src/lib/components/LabelRail.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Input } from '@epicenter/ui/input';
+	import * as Item from '@epicenter/ui/item';
 	import { cn } from '@epicenter/ui/utils';
 	import InboxIcon from '@lucide/svelte/icons/inbox';
 	import MailIcon from '@lucide/svelte/icons/mail';
@@ -39,6 +40,26 @@
 	const userLabels = $derived(labels.filter((l) => l.type === 'user'));
 </script>
 
+{#snippet navRow(id: string | null, label: string, Icon: Component)}
+	<Item.Button
+		size="sm"
+		class={cn(
+			'gap-2 rounded px-2 py-1.5 text-sm',
+			selectedLabel === id
+				? 'bg-accent font-medium text-accent-foreground'
+				: 'text-foreground/80 hover:bg-accent/50',
+		)}
+		onclick={() => onSelect(id)}
+	>
+		<Item.Media>
+			<Icon class="size-4 shrink-0 text-muted-foreground" />
+		</Item.Media>
+		<Item.Content>
+			<span class="truncate">{label}</span>
+		</Item.Content>
+	</Item.Button>
+{/snippet}
+
 <nav class="flex w-56 shrink-0 flex-col border-r border-border bg-background">
 	<div class="border-b border-border p-2">
 		<div class="relative">
@@ -58,21 +79,7 @@
 	<div class="flex-1 min-h-0 overflow-y-auto p-2">
 		<ul class="space-y-0.5">
 			{#each quick as item (item.label)}
-				{@const Icon = item.icon}
-				<li>
-					<button
-						class={cn(
-							'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors',
-							selectedLabel === item.id
-								? 'bg-accent font-medium text-accent-foreground'
-								: 'text-foreground/80 hover:bg-accent/50',
-						)}
-						onclick={() => onSelect(item.id)}
-					>
-						<Icon class="size-4 shrink-0 text-muted-foreground" />
-						<span class="truncate">{item.label}</span>
-					</button>
-				</li>
+				<li>{@render navRow(item.id, item.label, item.icon)}</li>
 			{/each}
 		</ul>
 
@@ -83,18 +90,11 @@
 			<ul class="space-y-0.5">
 				{#each categories as label (label.id)}
 					<li>
-						<button
-							class={cn(
-								'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors',
-								selectedLabel === label.id
-									? 'bg-accent font-medium text-accent-foreground'
-									: 'text-foreground/80 hover:bg-accent/50',
-							)}
-							onclick={() => onSelect(label.id)}
-						>
-							<TagIcon class="size-4 shrink-0 text-muted-foreground" />
-							<span class="truncate">{labelDisplayName(label.id, label.name)}</span>
-						</button>
+						{@render navRow(
+							label.id,
+							labelDisplayName(label.id, label.name),
+							TagIcon,
+						)}
 					</li>
 				{/each}
 			</ul>
@@ -107,18 +107,11 @@
 			<ul class="space-y-0.5">
 				{#each userLabels as label (label.id)}
 					<li>
-						<button
-							class={cn(
-								'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors',
-								selectedLabel === label.id
-									? 'bg-accent font-medium text-accent-foreground'
-									: 'text-foreground/80 hover:bg-accent/50',
-							)}
-							onclick={() => onSelect(label.id)}
-						>
-							<TagIcon class="size-4 shrink-0 text-muted-foreground" />
-							<span class="truncate">{labelDisplayName(label.id, label.name)}</span>
-						</button>
+						{@render navRow(
+							label.id,
+							labelDisplayName(label.id, label.name),
+							TagIcon,
+						)}
 					</li>
 				{/each}
 			</ul>

--- a/apps/local-mail/ui/src/lib/components/MessageList.svelte
+++ b/apps/local-mail/ui/src/lib/components/MessageList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Badge } from '@epicenter/ui/badge';
 	import * as Empty from '@epicenter/ui/empty';
+	import * as Item from '@epicenter/ui/item';
 	import { Skeleton } from '@epicenter/ui/skeleton';
 	import { cn } from '@epicenter/ui/utils';
 	import InboxIcon from '@lucide/svelte/icons/inbox';
@@ -94,24 +95,27 @@
 				{@const starred = message.labelIds.includes('STARRED')}
 				{@const chips = chipLabelIds(message.labelIds)}
 				<li>
-					<button
+					<Item.Button
+						size="sm"
 						data-message-id={message.id}
 						class={cn(
-							'flex w-full items-start gap-2.5 px-3 py-2.5 text-left transition-colors',
+							'items-start rounded-none text-left',
 							selectedId === message.id
 								? 'bg-accent'
 								: 'hover:bg-accent/40',
 						)}
 						onclick={() => onSelect(message.id)}
 					>
-						<span
-							class={cn(
-								'mt-1.5 size-2 shrink-0 rounded-full',
-								unread ? 'bg-sky-500' : 'bg-transparent',
-							)}
-							title={unread ? 'Unread' : 'Read'}
-						></span>
-						<span class="min-w-0 flex-1">
+							<Item.Media class="mt-1.5">
+							<span
+								class={cn(
+									'size-2 shrink-0 rounded-full',
+									unread ? 'bg-sky-500' : 'bg-transparent',
+								)}
+								title={unread ? 'Unread' : 'Read'}
+							></span>
+						</Item.Media>
+						<Item.Content class="min-w-0 gap-0">
 							<span class="flex items-center gap-2">
 								<span
 									class={cn(
@@ -154,8 +158,8 @@
 									{/each}
 								</span>
 							{/if}
-						</span>
-					</button>
+						</Item.Content>
+						</Item.Button>
 				</li>
 			{/each}
 		</ul>

--- a/apps/opensidian/src/lib/components/search/SearchPanel.svelte
+++ b/apps/opensidian/src/lib/components/search/SearchPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { Button } from '@epicenter/ui/button';
 	import * as Empty from '@epicenter/ui/empty';
 	import { Input } from '@epicenter/ui/input';
 	import { Loading } from '@epicenter/ui/loading';
@@ -148,19 +149,20 @@
 					<SearchResultGroup {group} defaultOpen={group.matchCount <= 5} />
 				{/each}
 				{#if opensidian.state.sidebarSearch.hasMore}
-					<button
-						type="button"
-						class="flex w-full items-center justify-center gap-1.5 rounded-sm px-3 py-2 text-center text-xs text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+					<Button
+						variant="ghost"
+						size="sm"
+						class="w-full text-xs text-muted-foreground"
 						onclick={() => opensidian.state.sidebarSearch.loadMore()}
 						disabled={opensidian.state.sidebarSearch.isSearching}
 					>
 						{#if opensidian.state.sidebarSearch.isSearching}
 							<Spinner class="size-3" />
-							<span>Loading</span>
+							Loading
 						{:else}
 							Load more results
 						{/if}
-					</button>
+					</Button>
 				{/if}
 			</div>
 		</ScrollArea>

--- a/apps/opensidian/src/lib/components/search/SearchResultGroup.svelte
+++ b/apps/opensidian/src/lib/components/search/SearchResultGroup.svelte
@@ -2,6 +2,7 @@
 	import { asFileId } from '@epicenter/filesystem';
 	import { Badge } from '@epicenter/ui/badge';
 	import * as Collapsible from '@epicenter/ui/collapsible';
+	import * as Item from '@epicenter/ui/item';
 	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
 	import FileTextIcon from '@lucide/svelte/icons/file-text';
 	import { opensidian } from '$lib/opensidian';
@@ -59,15 +60,17 @@
 	<Collapsible.Content>
 		<div class="ml-6 border-l border-border pl-3">
 			{#each group.matches as match, i (i)}
-				<button
-					type="button"
-					class="block w-full cursor-pointer rounded-sm px-2 py-1 text-left text-sm text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+				<Item.Button
+					size="sm"
+					class="cursor-pointer gap-2 px-2 py-1 text-muted-foreground hover:bg-accent/50 hover:text-foreground"
 					onclick={() => handleMatchClick(group.fileId)}
 				>
-					<span class="line-clamp-2 break-all text-xs">
-						{@html sanitizeSnippet(match.snippet)}
-					</span>
-				</button>
+					<Item.Content>
+						<span class="line-clamp-2 break-all text-xs">
+							{@html sanitizeSnippet(match.snippet)}
+						</span>
+					</Item.Content>
+				</Item.Button>
 			{/each}
 		</div>
 	</Collapsible.Content>

--- a/apps/skills/src/lib/components/SkillListItem.svelte
+++ b/apps/skills/src/lib/components/SkillListItem.svelte
@@ -2,6 +2,8 @@
 	import type { Skill } from '@epicenter/skills';
 	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import * as ContextMenu from '@epicenter/ui/context-menu';
+	import * as Item from '@epicenter/ui/item';
+	import { cn } from '@epicenter/ui/utils';
 	import { skillsState } from '$lib/state/skills-state.svelte';
 
 	let {
@@ -18,20 +20,26 @@
 <ContextMenu.Root>
 	<ContextMenu.Trigger>
 		{#snippet child({ props })}
-			<button
+			<Item.Button
 				{...props}
-				class="flex w-full flex-col items-start gap-0.5 rounded-sm px-3 py-2 text-left hover:bg-accent/50 {isSelected
-					? 'bg-accent text-accent-foreground'
-					: ''}"
-				onclick={() => skillsState.selectSkill(skill.id)}
+				size="sm"
+				class={cn(
+					'w-full text-left',
+					isSelected
+						? 'bg-accent text-accent-foreground'
+						: 'hover:bg-accent/50',
+				)}
 				role="option"
 				aria-selected={isSelected}
+				onclick={() => skillsState.selectSkill(skill.id)}
 			>
-				<span class="font-mono text-sm font-medium">{skill.name}</span>
-				<span class="max-w-full truncate text-xs text-muted-foreground">
-					{skill.description}
-				</span>
-			</button>
+				<Item.Content>
+					<Item.Title class="font-mono">{skill.name}</Item.Title>
+					<Item.Description class="block max-w-full truncate text-xs">
+						{skill.description}
+					</Item.Description>
+				</Item.Content>
+			</Item.Button>
 		{/snippet}
 	</ContextMenu.Trigger>
 	<ContextMenu.Content>

--- a/apps/todos/src/routes/+page.svelte
+++ b/apps/todos/src/routes/+page.svelte
@@ -5,6 +5,7 @@
 	import { Checkbox } from '@epicenter/ui/checkbox';
 	import * as Empty from '@epicenter/ui/empty';
 	import { Input } from '@epicenter/ui/input';
+	import * as Item from '@epicenter/ui/item';
 	import { NaturalLanguageCalendarDateInput } from '@epicenter/ui/natural-language-date-input';
 	import * as Popover from '@epicenter/ui/popover';
 	import { Textarea } from '@epicenter/ui/textarea';
@@ -257,19 +258,25 @@
 							<Popover.Content align="start" class="w-56 p-1">
 								<div class="grid gap-0.5">
 									{#each todosState.contexts as context (context.id)}
-										<button
-											type="button"
-											class="hover:bg-accent flex items-center gap-2 rounded-md px-2 py-1.5 text-sm"
+										<Item.Button
+											size="sm"
+											class="hover:bg-accent gap-2 px-2 py-1.5"
 											onclick={() => togglePicked(context.id)}
 										>
-											<span
-												class="size-2 shrink-0 rounded-full {dotClass(context.color)}"
-											></span>
-											<span class="flex-1 truncate text-left">{context.name}</span>
+											<Item.Media>
+												<span
+													class="size-2 shrink-0 rounded-full {dotClass(
+														context.color,
+													)}"
+												></span>
+											</Item.Media>
+											<Item.Content>
+												<span class="truncate text-left">{context.name}</span>
+											</Item.Content>
 											{#if pickedContexts.includes(context.id)}
 												<CheckIcon class="size-4 shrink-0" />
 											{/if}
-										</button>
+										</Item.Button>
 									{/each}
 								</div>
 							</Popover.Content>

--- a/packages/ui/src/item/index.ts
+++ b/packages/ui/src/item/index.ts
@@ -1,5 +1,6 @@
 import Root from './item.svelte';
 import Actions from './item-actions.svelte';
+import Button from './item-button.svelte';
 import Content from './item-content.svelte';
 import Description from './item-description.svelte';
 import Footer from './item-footer.svelte';
@@ -12,6 +13,8 @@ import Title from './item-title.svelte';
 export {
 	Actions,
 	Actions as ItemActions,
+	Button,
+	Button as ItemButton,
 	Content,
 	Content as ItemContent,
 	Description,

--- a/packages/ui/src/item/item-button.svelte
+++ b/packages/ui/src/item/item-button.svelte
@@ -1,0 +1,45 @@
+<script lang="ts" module>
+	import type { HTMLButtonAttributes } from 'svelte/elements';
+	import { type WithElementRef } from '../utils.js';
+	import { type ItemSize, type ItemVariant } from './item.svelte';
+
+	export type ItemButtonProps = WithElementRef<
+		HTMLButtonAttributes,
+		HTMLButtonElement
+	> & {
+		variant?: ItemVariant;
+		size?: ItemSize;
+	};
+</script>
+
+<script lang="ts">
+	import { mergeProps } from 'bits-ui';
+	import { cn } from '../utils.js';
+	import { itemVariants } from './item.svelte';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		variant,
+		size,
+		type = 'button',
+		children,
+		...restProps
+	}: ItemButtonProps = $props();
+
+	// The interactive Item: Item.Root's styling rendered on a real <button>, so
+	// callers stop hand-writing the `{#snippet child}` + `<button {...props}>`
+	// dance. Composes via mergeProps like Button, so a parent trigger's child
+	// props (e.g. ContextMenu.Trigger) merge instead of clobbering handlers/ref.
+	// Hover/selected styling stays the caller's job (set it in `class`).
+	const itemProps = $derived({
+		class: cn(itemVariants({ variant, size }), className),
+		'data-slot': 'item',
+		'data-variant': variant,
+		'data-size': size,
+	});
+</script>
+
+<button bind:this={ref} {type} {...mergeProps(itemProps, restProps)}>
+	{@render children?.()}
+</button>


### PR DESCRIPTION
Several apps hand-rolled the same "selectable row" markup (a full-width `<button>` with an icon, a label, and trailing metadata) and drifted from the shadcn `Item` family that `@epicenter/ui` already vendors. This adopts `Item` for those rows and adds the interactive primitive that made the adoption clean.

`Item.Root` is a `<div>`, so making a whole row clickable meant hand-writing its `child` snippet plus a `<button {...props}>` at every call site:

```svelte
<Item.Root size="sm" class={rowClass}>
  {#snippet child({ props })}
    <button {...props} onclick={select}>
      <Item.Media><Icon /></Item.Media>
      <Item.Content>{label}</Item.Content>
    </button>
  {/snippet}
</Item.Root>
```

`Item.Button` renders `Item.Root`'s styling directly on a real `<button>`, so the same row is just:

```svelte
<Item.Button size="sm" class={rowClass} onclick={select}>
  <Item.Media><Icon /></Item.Media>
  <Item.Content>{label}</Item.Content>
</Item.Button>
```

Like the existing `Button`, it composes props through `mergeProps`, so a parent trigger's child props (for example `ContextMenu.Trigger`) merge instead of clobbering handlers, and it binds `ref` to the button. Hover stays a caller concern: rows set their own hover and selected classes, so a selected row's `bg-accent` is never overridden by a generic button hover.

Adopted across `skills` (skill list), `todos` (context picker), `opensidian` (search matches, plus the neighboring "load more" moved to a ghost `Button` since it is an action), and `local-mail` (the label rail, which also collapses three duplicated blocks into one snippet, and the message list).

Applied per site: a row becomes an `Item.Button` when the whole row is one selectable control with a content silhouette (media plus label, or title plus description). Rows denser than `Item`'s smallest size keep it through a size override. Raw `<button>`s stay for actions, chips, cell editors, and disclosure toggles.
