### PR TITLE
refactor(ui): use Button tooltip prop for icon-button tooltips

### DIFF
--- a/apps/opensidian/src/lib/components/SidebarHeader.svelte
+++ b/apps/opensidian/src/lib/components/SidebarHeader.svelte
@@ -1,72 +1,48 @@
 <script lang="ts">
 	import { Button } from '@epicenter/ui/button';
-	import * as Tooltip from '@epicenter/ui/tooltip';
 	import FilePlusIcon from '@lucide/svelte/icons/file-plus';
 	import FolderPlusIcon from '@lucide/svelte/icons/folder-plus';
 	import SearchIcon from '@lucide/svelte/icons/search';
 	import { opensidian } from '$lib/opensidian';
 </script>
 
-<Tooltip.Provider>
-	<div class="flex h-8 shrink-0 items-center justify-between border-b px-2">
-		<div class="flex items-center gap-1.5">
-			<div class="flex size-5 items-center justify-center rounded bg-black">
-				<img src="/logo.svg" alt="Epicenter" class="size-3.5">
-			</div>
-			<span class="text-xs font-semibold tracking-tight">opensidian</span>
+<div class="flex h-8 shrink-0 items-center justify-between border-b px-2">
+	<div class="flex items-center gap-1.5">
+		<div class="flex size-5 items-center justify-center rounded bg-black">
+			<img src="/logo.svg" alt="Epicenter" class="size-3.5">
 		</div>
-		<div class="flex items-center gap-0.5">
-			<Tooltip.Root>
-				<Tooltip.Trigger>
-					{#snippet child({ props })}
-						<Button
-							{...props}
-							variant={opensidian.state.sidebarSearch.leftPaneView === 'search' ? 'secondary': 'ghost'}
-							size="icon-xs"
-							onclick={() => {
-							if (opensidian.state.sidebarSearch.leftPaneView === 'search') {
-								opensidian.state.sidebarSearch.closeSearch();
-							} else {
-								opensidian.state.sidebarSearch.openSearch();
-							}
-							}}
-						>
-							<SearchIcon class="size-3.5" />
-						</Button>
-					{/snippet}
-				</Tooltip.Trigger>
-				<Tooltip.Content>Search files (⌘⇧F)</Tooltip.Content>
-			</Tooltip.Root>
-			<Tooltip.Root>
-				<Tooltip.Trigger>
-					{#snippet child({ props })}
-						<Button
-							{...props}
-							variant="ghost"
-							size="icon-xs"
-							onclick={() => opensidian.state.files.startCreate('folder')}
-						>
-							<FolderPlusIcon class="size-3.5" />
-						</Button>
-					{/snippet}
-				</Tooltip.Trigger>
-				<Tooltip.Content>New folder</Tooltip.Content>
-			</Tooltip.Root>
-			<Tooltip.Root>
-				<Tooltip.Trigger>
-					{#snippet child({ props })}
-						<Button
-							{...props}
-							variant="ghost"
-							size="icon-xs"
-							onclick={() => opensidian.state.files.startCreate('file')}
-						>
-							<FilePlusIcon class="size-3.5" />
-						</Button>
-					{/snippet}
-				</Tooltip.Trigger>
-				<Tooltip.Content>New file</Tooltip.Content>
-			</Tooltip.Root>
-		</div>
+		<span class="text-xs font-semibold tracking-tight">opensidian</span>
 	</div>
-</Tooltip.Provider>
+	<div class="flex items-center gap-0.5">
+		<Button
+			tooltip="Search files (⌘⇧F)"
+			variant={opensidian.state.sidebarSearch.leftPaneView === 'search' ? 'secondary': 'ghost'}
+			size="icon-xs"
+			onclick={() => {
+				if (opensidian.state.sidebarSearch.leftPaneView === 'search') {
+					opensidian.state.sidebarSearch.closeSearch();
+				} else {
+					opensidian.state.sidebarSearch.openSearch();
+				}
+			}}
+		>
+			<SearchIcon class="size-3.5" />
+		</Button>
+		<Button
+			tooltip="New folder"
+			variant="ghost"
+			size="icon-xs"
+			onclick={() => opensidian.state.files.startCreate('folder')}
+		>
+			<FolderPlusIcon class="size-3.5" />
+		</Button>
+		<Button
+			tooltip="New file"
+			variant="ghost"
+			size="icon-xs"
+			onclick={() => opensidian.state.files.startCreate('file')}
+		>
+			<FilePlusIcon class="size-3.5" />
+		</Button>
+	</div>
+</div>

--- a/apps/skills/src/lib/components/dialogs/NewSkillDialog.svelte
+++ b/apps/skills/src/lib/components/dialogs/NewSkillDialog.svelte
@@ -4,7 +4,6 @@
 	import { Input } from '@epicenter/ui/input';
 	import { Label } from '@epicenter/ui/label';
 	import { toast } from '@epicenter/ui/sonner';
-	import * as Tooltip from '@epicenter/ui/tooltip';
 	import PlusIcon from '@lucide/svelte/icons/plus';
 	import { skillsState } from '$lib/state/skills-state.svelte';
 	import { validateSkill } from '$lib/utils/validation';
@@ -36,21 +35,14 @@
 </script>
 
 <Dialog.Root bind:open={isOpen}>
-	<Tooltip.Root>
-		<Tooltip.Trigger>
-			{#snippet child({ props })}
-				<Button
-					{...props}
-					variant="ghost"
-					size="icon-xs"
-					onclick={() => (isOpen = true)}
-				>
-					<PlusIcon class="size-3.5" />
-				</Button>
-			{/snippet}
-		</Tooltip.Trigger>
-		<Tooltip.Content>New skill</Tooltip.Content>
-	</Tooltip.Root>
+	<Button
+		tooltip="New skill"
+		variant="ghost"
+		size="icon-xs"
+		onclick={() => (isOpen = true)}
+	>
+		<PlusIcon class="size-3.5" />
+	</Button>
 	<Dialog.Content class="max-w-sm">
 		<Dialog.Header>
 			<Dialog.Title>New Skill</Dialog.Title>


### PR DESCRIPTION
Replaces hand-rolled `<Tooltip.Root><Tooltip.Trigger>{#snippet child}...` wrappers around ghost icon buttons with the `Button` `tooltip` prop (shipped alongside the Item family in #2365).

Touched:
- `apps/opensidian/.../SidebarHeader.svelte` — search / new folder / new file buttons. The component's local `<Tooltip.Provider>` is now redundant (the root `+layout.svelte` already wraps children in one) and is removed.
- `apps/skills/.../dialogs/NewSkillDialog.svelte` — the new-skill trigger button. Root `Tooltip.Provider` lives in `AppShell.svelte`.

Behavior is unchanged; the tooltip text and button variants/handlers are preserved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785743559&installation_id=128463665&pr_number=2366&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2366&signature=623a5747f544c041990708fffead870241e86d6bd1dea1daf496b31d38ef9c18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->