### PR TITLE
fix(whispering): describe loopback-bonded session transcription as on-device

### DIFF
--- a/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
+++ b/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
@@ -41,10 +41,9 @@
 		describeTranscriptionDestinationFromConfig({
 			service: settings.get('transcription.service'),
 			getDeviceConfig: deviceConfig.get,
-			// Session locality follows the bonded deployment: a signed-in session at a
-			// loopback base URL is this machine, so audio stays on-device.
-			sessionBaseUrl:
-				auth.state.status === 'signed-in' ? auth.baseURL : undefined,
+			// Session locality follows the bonded deployment. Sign-in status decides
+			// usability elsewhere; locality only needs the base URL.
+			sessionBaseUrl: auth.baseURL,
 		}),
 	);
 

--- a/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
+++ b/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
@@ -41,6 +41,10 @@
 		describeTranscriptionDestinationFromConfig({
 			service: settings.get('transcription.service'),
 			getDeviceConfig: deviceConfig.get,
+			// Session locality follows the bonded deployment: a signed-in session at a
+			// loopback base URL is this machine, so audio stays on-device.
+			sessionBaseUrl:
+				auth.state.status === 'signed-in' ? auth.baseURL : undefined,
 		}),
 	);
 

--- a/apps/whispering/src/lib/operations/run-polish.ts
+++ b/apps/whispering/src/lib/operations/run-polish.ts
@@ -4,6 +4,7 @@ import {
 	type InferErrors,
 } from 'wellcrafted/error';
 import { isErr, Ok, type Result } from 'wellcrafted/result';
+import { auth } from '#platform/auth';
 import { buildPolishSystemPrompt } from '$lib/operations/build-system-prompt';
 import {
 	completeWithGlobalDefault,
@@ -13,7 +14,6 @@ import { describePolishDestination } from '$lib/operations/completion-target';
 import { resolveTranscriptionLocalityFromConfig } from '$lib/operations/transcription-target';
 import { deviceConfig } from '$lib/state/device-config.svelte';
 import { settings } from '$lib/state/settings.svelte';
-import { auth } from '#platform/auth';
 
 export const RunPolishError = defineErrors({
 	/**

--- a/apps/whispering/src/lib/operations/run-polish.ts
+++ b/apps/whispering/src/lib/operations/run-polish.ts
@@ -13,6 +13,7 @@ import { describePolishDestination } from '$lib/operations/completion-target';
 import { resolveTranscriptionLocalityFromConfig } from '$lib/operations/transcription-target';
 import { deviceConfig } from '$lib/state/device-config.svelte';
 import { settings } from '$lib/state/settings.svelte';
+import { auth } from '#platform/auth';
 
 export const RunPolishError = defineErrors({
 	/**
@@ -61,6 +62,8 @@ export function polishDestination(): string {
 		resolveTranscriptionLocalityFromConfig({
 			service: settings.get('transcription.service'),
 			getDeviceConfig: deviceConfig.get,
+			sessionBaseUrl:
+				auth.state.status === 'signed-in' ? auth.baseURL : undefined,
 		}),
 		settings.get('completion.provider'),
 		resolveCompletionState(),

--- a/apps/whispering/src/lib/operations/run-polish.ts
+++ b/apps/whispering/src/lib/operations/run-polish.ts
@@ -62,8 +62,7 @@ export function polishDestination(): string {
 		resolveTranscriptionLocalityFromConfig({
 			service: settings.get('transcription.service'),
 			getDeviceConfig: deviceConfig.get,
-			sessionBaseUrl:
-				auth.state.status === 'signed-in' ? auth.baseURL : undefined,
+			sessionBaseUrl: auth.baseURL,
 		}),
 		settings.get('completion.provider'),
 		resolveCompletionState(),

--- a/apps/whispering/src/lib/operations/transcription-target.test.ts
+++ b/apps/whispering/src/lib/operations/transcription-target.test.ts
@@ -8,6 +8,8 @@
  * - Locality follows the resolved endpoint host (loopback), not the provider's
  *   `location` label, so a self-hosted or cloud endpoint at localhost is on-device
  * - A remote self-hosted server reads as the user's own server, not a cloud vendor
+ * - A session (Epicenter) bonded at a loopback base URL is this machine, so audio
+ *   stays on-device; a remote base URL or no session reads as sent to Epicenter
  */
 import { describe, expect, test } from 'bun:test';
 import type { DeviceConfigKey } from '../state/device-config.svelte';
@@ -82,5 +84,34 @@ describe('describeTranscriptionDestinationFromConfig', () => {
 			onDevice: false,
 			summary: 'Audio is sent to your Speaches server.',
 		});
+	});
+
+	test('session bonded at a loopback base URL keeps audio on device', () => {
+		expect(
+			describeTranscriptionDestinationFromConfig({
+				service: 'epicenter',
+				getDeviceConfig: config({}),
+				sessionBaseUrl: 'http://localhost:8788',
+			}),
+		).toEqual({ onDevice: true, summary: 'Audio stays on this device.' });
+	});
+
+	test('session bonded at a remote base URL is sent to Epicenter', () => {
+		expect(
+			describeTranscriptionDestinationFromConfig({
+				service: 'epicenter',
+				getDeviceConfig: config({}),
+				sessionBaseUrl: 'https://api.epicenter.so',
+			}),
+		).toEqual({ onDevice: false, summary: 'Audio is sent to Epicenter.' });
+	});
+
+	test('signed-out session (no base URL) keeps the sent-to-Epicenter copy', () => {
+		expect(
+			describeTranscriptionDestinationFromConfig({
+				service: 'epicenter',
+				getDeviceConfig: config({}),
+			}),
+		).toEqual({ onDevice: false, summary: 'Audio is sent to Epicenter.' });
 	});
 });

--- a/apps/whispering/src/lib/operations/transcription-target.test.ts
+++ b/apps/whispering/src/lib/operations/transcription-target.test.ts
@@ -9,7 +9,7 @@
  *   `location` label, so a self-hosted or cloud endpoint at localhost is on-device
  * - A remote self-hosted server reads as the user's own server, not a cloud vendor
  * - A session (Epicenter) bonded at a loopback base URL is this machine, so audio
- *   stays on-device; a remote or missing base URL reads as sent to Epicenter
+ *   stays on-device; a remote base URL reads as sent to Epicenter
  */
 import { describe, expect, test } from 'bun:test';
 import type { DeviceConfigKey } from '../state/device-config.svelte';
@@ -19,12 +19,15 @@ function config(values: Partial<Record<DeviceConfigKey, string>>) {
 	return (key: DeviceConfigKey) => values[key] ?? '';
 }
 
+const REMOTE_SESSION_BASE_URL = 'https://api.epicenter.so';
+
 describe('describeTranscriptionDestinationFromConfig', () => {
 	test('local runtime keeps audio on device', () => {
 		expect(
 			describeTranscriptionDestinationFromConfig({
 				service: 'local',
 				getDeviceConfig: config({}),
+				sessionBaseUrl: REMOTE_SESSION_BASE_URL,
 			}),
 		).toEqual({ onDevice: true, summary: 'Audio stays on this device.' });
 	});
@@ -34,6 +37,7 @@ describe('describeTranscriptionDestinationFromConfig', () => {
 			describeTranscriptionDestinationFromConfig({
 				service: 'OpenAI',
 				getDeviceConfig: config({}),
+				sessionBaseUrl: REMOTE_SESSION_BASE_URL,
 			}),
 		).toEqual({ onDevice: false, summary: 'Audio is sent to OpenAI.' });
 	});
@@ -45,6 +49,7 @@ describe('describeTranscriptionDestinationFromConfig', () => {
 				getDeviceConfig: config({
 					'providers.openai.endpoint': 'http://localhost:1234/v1',
 				}),
+				sessionBaseUrl: REMOTE_SESSION_BASE_URL,
 			}),
 		).toEqual({ onDevice: true, summary: 'Audio stays on this device.' });
 	});
@@ -56,6 +61,7 @@ describe('describeTranscriptionDestinationFromConfig', () => {
 				getDeviceConfig: config({
 					'providers.speaches.endpoint': 'http://localhost:8000',
 				}),
+				sessionBaseUrl: REMOTE_SESSION_BASE_URL,
 			}),
 		).toEqual({ onDevice: true, summary: 'Audio stays on this device.' });
 	});
@@ -67,6 +73,7 @@ describe('describeTranscriptionDestinationFromConfig', () => {
 				getDeviceConfig: config({
 					'providers.speaches.endpoint': 'https://speaches.mybox.example',
 				}),
+				sessionBaseUrl: REMOTE_SESSION_BASE_URL,
 			}),
 		).toEqual({
 			onDevice: false,
@@ -79,6 +86,7 @@ describe('describeTranscriptionDestinationFromConfig', () => {
 			describeTranscriptionDestinationFromConfig({
 				service: 'speaches',
 				getDeviceConfig: config({}),
+				sessionBaseUrl: REMOTE_SESSION_BASE_URL,
 			}),
 		).toEqual({
 			onDevice: false,
@@ -101,16 +109,7 @@ describe('describeTranscriptionDestinationFromConfig', () => {
 			describeTranscriptionDestinationFromConfig({
 				service: 'epicenter',
 				getDeviceConfig: config({}),
-				sessionBaseUrl: 'https://api.epicenter.so',
-			}),
-		).toEqual({ onDevice: false, summary: 'Audio is sent to Epicenter.' });
-	});
-
-	test('session with no base URL keeps the sent-to-Epicenter copy', () => {
-		expect(
-			describeTranscriptionDestinationFromConfig({
-				service: 'epicenter',
-				getDeviceConfig: config({}),
+				sessionBaseUrl: REMOTE_SESSION_BASE_URL,
 			}),
 		).toEqual({ onDevice: false, summary: 'Audio is sent to Epicenter.' });
 	});

--- a/apps/whispering/src/lib/operations/transcription-target.test.ts
+++ b/apps/whispering/src/lib/operations/transcription-target.test.ts
@@ -9,7 +9,7 @@
  *   `location` label, so a self-hosted or cloud endpoint at localhost is on-device
  * - A remote self-hosted server reads as the user's own server, not a cloud vendor
  * - A session (Epicenter) bonded at a loopback base URL is this machine, so audio
- *   stays on-device; a remote base URL or no session reads as sent to Epicenter
+ *   stays on-device; a remote or missing base URL reads as sent to Epicenter
  */
 import { describe, expect, test } from 'bun:test';
 import type { DeviceConfigKey } from '../state/device-config.svelte';
@@ -106,7 +106,7 @@ describe('describeTranscriptionDestinationFromConfig', () => {
 		).toEqual({ onDevice: false, summary: 'Audio is sent to Epicenter.' });
 	});
 
-	test('signed-out session (no base URL) keeps the sent-to-Epicenter copy', () => {
+	test('session with no base URL keeps the sent-to-Epicenter copy', () => {
 		expect(
 			describeTranscriptionDestinationFromConfig({
 				service: 'epicenter',

--- a/apps/whispering/src/lib/operations/transcription-target.ts
+++ b/apps/whispering/src/lib/operations/transcription-target.ts
@@ -43,14 +43,35 @@ type TranscriptionEndpointKey = Extract<
 export function resolveTranscriptionLocalityFromConfig({
 	service,
 	getDeviceConfig,
+	sessionBaseUrl,
 }: {
 	service: TranscriptionServiceId;
 	getDeviceConfig: (key: TranscriptionEndpointKey) => string;
+	/**
+	 * The signed-in session's bonded deployment origin (`auth.baseURL`), or
+	 * `undefined` when signed out. Read only for the `session` (Epicenter) access:
+	 * a loopback origin means the bonded deployment is this machine (a self-host
+	 * instance bonded at localhost), so session audio stays on-device. The pure
+	 * module classifies the host itself rather than importing auth, mirroring how
+	 * the endpoint branch reads its configured `providers.*.endpoint`.
+	 */
+	sessionBaseUrl?: string;
 }): TranscriptionLocality {
 	const provider = PROVIDERS[service];
 	// Local transcription runs in-process; audio never becomes a network request.
 	if (provider.access === 'onDevice') {
 		return { onDevice: true, name: provider.label };
+	}
+	// `session` (Epicenter) serves audio from the bonded deployment reached at the
+	// signed-in base URL. A loopback base URL is this machine (a self-host instance
+	// bonded at localhost), so audio never leaves the device; a remote base URL or
+	// no session at all keeps the "sent to Epicenter" copy. This is the session
+	// twin of the endpoint loopback branch below.
+	if (provider.access === 'session') {
+		if (sessionBaseUrl && isLoopbackBaseUrl(sessionBaseUrl)) {
+			return { onDevice: true, name: provider.label };
+		}
+		return { onDevice: false, name: provider.label };
 	}
 	// `key` and `endpoint` providers upload audio to an endpoint. A configured
 	// loopback endpoint keeps it on-device regardless of the provider label. The
@@ -72,17 +93,17 @@ export function resolveTranscriptionLocalityFromConfig({
 	if (provider.access === 'endpoint') {
 		return { onDevice: false, name: `your ${provider.label} server` };
 	}
-	// `key` providers not pointed at loopback and `session` (Epicenter) both land
-	// here: audio leaves the device, named by the provider. Session does not yet
-	// inspect `auth.baseURL`, so a self-hosted instance bonded at loopback still
-	// reads as off-device; threading the session base URL through this resolver
-	// (mirroring the endpoint loopback branch above) is the follow-up that fixes it.
+	// `key` providers not pointed at loopback land here: audio leaves the device,
+	// named by the provider. (`session` resolved above; `onDevice` and `endpoint`
+	// resolved earlier.)
 	return { onDevice: false, name: provider.label };
 }
 
 export function describeTranscriptionDestinationFromConfig(args: {
 	service: TranscriptionServiceId;
 	getDeviceConfig: (key: TranscriptionEndpointKey) => string;
+	/** Signed-in session origin; see {@link resolveTranscriptionLocalityFromConfig}. */
+	sessionBaseUrl?: string;
 }): TranscriptionDestination {
 	const { onDevice, name } = resolveTranscriptionLocalityFromConfig(args);
 	if (onDevice) return { onDevice, summary: 'Audio stays on this device.' };

--- a/apps/whispering/src/lib/operations/transcription-target.ts
+++ b/apps/whispering/src/lib/operations/transcription-target.ts
@@ -55,7 +55,7 @@ export function resolveTranscriptionLocalityFromConfig({
 	 * auth, mirroring how the endpoint branch reads its configured
 	 * `providers.*.endpoint`.
 	 */
-	sessionBaseUrl?: string;
+	sessionBaseUrl: string;
 }): TranscriptionLocality {
 	const provider = PROVIDERS[service];
 	// Local transcription runs in-process; audio never becomes a network request.
@@ -64,14 +64,14 @@ export function resolveTranscriptionLocalityFromConfig({
 	}
 	// `session` (Epicenter) serves audio from the bonded deployment reached at the
 	// auth base URL. A loopback base URL is this machine (a self-host instance
-	// bonded at localhost), so audio never leaves the device; a remote or missing
-	// base URL keeps the "sent to Epicenter" copy. This is the session twin of the
-	// endpoint loopback branch below.
+	// bonded at localhost), so audio never leaves the device; a remote base URL
+	// keeps the "sent to Epicenter" copy. This is the session twin of the endpoint
+	// loopback branch below.
 	if (provider.access === 'session') {
-		if (sessionBaseUrl && isLoopbackBaseUrl(sessionBaseUrl)) {
-			return { onDevice: true, name: provider.label };
-		}
-		return { onDevice: false, name: provider.label };
+		return {
+			onDevice: isLoopbackBaseUrl(sessionBaseUrl),
+			name: provider.label,
+		};
 	}
 	// `key` and `endpoint` providers upload audio to an endpoint. A configured
 	// loopback endpoint keeps it on-device regardless of the provider label. The
@@ -103,7 +103,7 @@ export function describeTranscriptionDestinationFromConfig(args: {
 	service: TranscriptionServiceId;
 	getDeviceConfig: (key: TranscriptionEndpointKey) => string;
 	/** Bonded session origin; see {@link resolveTranscriptionLocalityFromConfig}. */
-	sessionBaseUrl?: string;
+	sessionBaseUrl: string;
 }): TranscriptionDestination {
 	const { onDevice, name } = resolveTranscriptionLocalityFromConfig(args);
 	if (onDevice) return { onDevice, summary: 'Audio stays on this device.' };

--- a/apps/whispering/src/lib/operations/transcription-target.ts
+++ b/apps/whispering/src/lib/operations/transcription-target.ts
@@ -48,12 +48,12 @@ export function resolveTranscriptionLocalityFromConfig({
 	service: TranscriptionServiceId;
 	getDeviceConfig: (key: TranscriptionEndpointKey) => string;
 	/**
-	 * The signed-in session's bonded deployment origin (`auth.baseURL`), or
-	 * `undefined` when signed out. Read only for the `session` (Epicenter) access:
-	 * a loopback origin means the bonded deployment is this machine (a self-host
-	 * instance bonded at localhost), so session audio stays on-device. The pure
-	 * module classifies the host itself rather than importing auth, mirroring how
-	 * the endpoint branch reads its configured `providers.*.endpoint`.
+	 * The bonded deployment origin (`auth.baseURL`). Read only for the `session`
+	 * (Epicenter) access: a loopback origin means the bonded deployment is this
+	 * machine (a self-host instance bonded at localhost), so session audio stays
+	 * on-device. The pure module classifies the host itself rather than importing
+	 * auth, mirroring how the endpoint branch reads its configured
+	 * `providers.*.endpoint`.
 	 */
 	sessionBaseUrl?: string;
 }): TranscriptionLocality {
@@ -63,10 +63,10 @@ export function resolveTranscriptionLocalityFromConfig({
 		return { onDevice: true, name: provider.label };
 	}
 	// `session` (Epicenter) serves audio from the bonded deployment reached at the
-	// signed-in base URL. A loopback base URL is this machine (a self-host instance
-	// bonded at localhost), so audio never leaves the device; a remote base URL or
-	// no session at all keeps the "sent to Epicenter" copy. This is the session
-	// twin of the endpoint loopback branch below.
+	// auth base URL. A loopback base URL is this machine (a self-host instance
+	// bonded at localhost), so audio never leaves the device; a remote or missing
+	// base URL keeps the "sent to Epicenter" copy. This is the session twin of the
+	// endpoint loopback branch below.
 	if (provider.access === 'session') {
 		if (sessionBaseUrl && isLoopbackBaseUrl(sessionBaseUrl)) {
 			return { onDevice: true, name: provider.label };
@@ -102,7 +102,7 @@ export function resolveTranscriptionLocalityFromConfig({
 export function describeTranscriptionDestinationFromConfig(args: {
 	service: TranscriptionServiceId;
 	getDeviceConfig: (key: TranscriptionEndpointKey) => string;
-	/** Signed-in session origin; see {@link resolveTranscriptionLocalityFromConfig}. */
+	/** Bonded session origin; see {@link resolveTranscriptionLocalityFromConfig}. */
 	sessionBaseUrl?: string;
 }): TranscriptionDestination {
 	const { onDevice, name } = resolveTranscriptionLocalityFromConfig(args);


### PR DESCRIPTION
A self-host Epicenter instance bonded at loopback is still this machine. Before this PR, Whispering treated every `session` transcription as remote and showed "Audio is sent to Epicenter," even when `auth.baseURL` was `http://localhost:...` or `127.0.0.1`.

The resolver now receives the bonded deployment origin and classifies `session` with the same loopback rule already used for endpoint providers. `localhost`, `127.0.0.1`, and `[::1]` read as on-device; hosted URLs, LAN IPs, and other remote origins still read as sent to Epicenter.

The important cleanup is that locality no longer depends on sign-in state. Both production callers pass `auth.baseURL` directly, and `sessionBaseUrl` is required in the pure resolver API so a future caller cannot accidentally omit the origin and recreate the old remote-only behavior. Sign-in remains a usability question elsewhere; this code only answers where the audio goes.
