### PR TITLE
refactor(ui): use Empty / Loading / Spinner for raw status text

### DIFF
--- a/apps/local-books/ui/src/lib/components/RowDetail.svelte
+++ b/apps/local-books/ui/src/lib/components/RowDetail.svelte
@@ -1,12 +1,16 @@
 <script lang="ts">
 	import { Badge } from '@epicenter/ui/badge';
 	import { Button } from '@epicenter/ui/button';
+	import * as Empty from '@epicenter/ui/empty';
 	import { Input } from '@epicenter/ui/input';
+	import { Loading } from '@epicenter/ui/loading';
 	import {
 		createMutation,
 		createQuery,
 		useQueryClient,
 	} from '@tanstack/svelte-query';
+	import MousePointerClickIcon from '@lucide/svelte/icons/mouse-pointer-click';
+	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 	import { toast } from 'svelte-sonner';
 	import { api } from '$lib/api';
 	import { columnLabel, formatCell, shortTimestamp } from '$lib/format';
@@ -70,11 +74,23 @@
 
 <aside class="flex w-96 shrink-0 flex-col overflow-hidden border-l border-border bg-background">
 	{#if !entity || !id}
-		<p class="p-4 text-sm text-muted-foreground">Select a row to inspect it.</p>
+		<Empty.Root class="flex-1 border-0">
+			<Empty.Media variant="icon">
+				<MousePointerClickIcon class="size-5" />
+			</Empty.Media>
+			<Empty.Title>No row selected</Empty.Title>
+			<Empty.Description>Select a row to inspect it.</Empty.Description>
+		</Empty.Root>
 	{:else if detail.isPending}
-		<p class="p-4 text-sm text-muted-foreground">Loading…</p>
+		<Loading class="flex-1" label="Loading row" />
 	{:else if detail.error}
-		<p class="p-4 text-sm text-destructive">{detail.error.message}</p>
+		<Empty.Root class="flex-1 border-0">
+			<Empty.Media variant="icon">
+				<TriangleAlertIcon class="size-5 text-destructive" />
+			</Empty.Media>
+			<Empty.Title>Could not load row</Empty.Title>
+			<Empty.Description>{detail.error.message}</Empty.Description>
+		</Empty.Root>
 	{:else if detail.data}
 		<div class="flex min-h-0 flex-1 flex-col overflow-y-auto">
 			<header class="border-b border-border px-4 py-3">

--- a/apps/local-books/ui/src/lib/components/RowTable.svelte
+++ b/apps/local-books/ui/src/lib/components/RowTable.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
+	import * as Empty from '@epicenter/ui/empty';
+	import { Loading } from '@epicenter/ui/loading';
 	import * as Table from '@epicenter/ui/table';
+	import DatabaseIcon from '@lucide/svelte/icons/database';
+	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 	import { columnLabel, formatCell, numberFmt } from '$lib/format';
 	import type { EntityRowsPage } from '$lib/types';
 
@@ -35,13 +39,23 @@
 
 	<div class="min-h-0 flex-1 overflow-auto">
 		{#if error}
-			<p class="p-4 text-sm text-destructive">{error}</p>
+			<Empty.Root class="h-full border-0">
+				<Empty.Media variant="icon">
+					<TriangleAlertIcon class="size-5 text-destructive" />
+				</Empty.Media>
+				<Empty.Title>Could not load rows</Empty.Title>
+				<Empty.Description>{error}</Empty.Description>
+			</Empty.Root>
 		{:else if loading}
-			<p class="p-4 text-sm text-muted-foreground">Loading…</p>
+			<Loading class="h-full" label="Loading rows" />
 		{:else if rows.length === 0}
-			<p class="p-4 text-sm text-muted-foreground">
-				No rows. This record type may not be synced yet.
-			</p>
+			<Empty.Root class="h-full border-0">
+				<Empty.Media variant="icon">
+					<DatabaseIcon class="size-5" />
+				</Empty.Media>
+				<Empty.Title>No rows</Empty.Title>
+				<Empty.Description>This record type may not be synced yet.</Empty.Description>
+			</Empty.Root>
 		{:else}
 			<Table.Root class="text-sm">
 				<Table.Header>

--- a/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
@@ -3,6 +3,7 @@
 	import * as Command from '@epicenter/ui/command';
 	import * as Empty from '@epicenter/ui/empty';
 	import { useCombobox } from '@epicenter/ui/hooks';
+	import { Loading } from '@epicenter/ui/loading';
 	import * as Popover from '@epicenter/ui/popover';
 	import { Progress } from '@epicenter/ui/progress';
 	import { toast } from '@epicenter/ui/sonner';
@@ -243,9 +244,7 @@
 					</Empty.Content>
 				</Empty.Root>
 			{:else if tauri && !localModels.loaded}
-				<div class="p-6 text-center text-sm text-muted-foreground">
-					Loading on-device models…
-				</div>
+				<Loading class="py-8" label="Loading on-device models" />
 			{:else}
 				<Empty.Root class="py-8">
 					<Empty.Media variant="icon">

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/ManualSelectRecordingDevice.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/ManualSelectRecordingDevice.svelte
@@ -2,6 +2,7 @@
 	import { Button } from '@epicenter/ui/button';
 	import * as Field from '@epicenter/ui/field';
 	import * as Select from '@epicenter/ui/select';
+	import { Spinner } from '@epicenter/ui/spinner';
 	import { createQuery } from '@tanstack/svelte-query';
 	import { report } from '$lib/report';
 	import type { DeviceIdentifier } from '@epicenter/recorder';
@@ -53,11 +54,11 @@
 		<Field.Label for="manual-recording-device">Recording Device</Field.Label>
 		<Select.Root type="single" disabled>
 			<Select.Trigger id="manual-recording-device" class="w-full">
-				Loading devices...
+				<span class="flex items-center gap-2 text-muted-foreground">
+					<Spinner class="size-3.5" />
+					Loading devices
+				</span>
 			</Select.Trigger>
-			<Select.Content>
-				<Select.Item value="" label="Loading devices..." />
-			</Select.Content>
 		</Select.Root>
 	</Field.Field>
 {:else if getDevicesQuery.isError}

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/VadSelectRecordingDevice.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/VadSelectRecordingDevice.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import * as Field from '@epicenter/ui/field';
 	import * as Select from '@epicenter/ui/select';
+	import { Spinner } from '@epicenter/ui/spinner';
 	import { createQuery } from '@tanstack/svelte-query';
 	import { report } from '$lib/report';
 	import type { DeviceIdentifier } from '@epicenter/recorder';
@@ -41,11 +42,11 @@
 		<Field.Label for="vad-recording-device">VAD Recording Device</Field.Label>
 		<Select.Root type="single" disabled>
 			<Select.Trigger id="vad-recording-device" class="w-full">
-				Loading devices...
+				<span class="flex items-center gap-2 text-muted-foreground">
+					<Spinner class="size-3.5" />
+					Loading devices
+				</span>
 			</Select.Trigger>
-			<Select.Content>
-				<Select.Item value="" label="Loading devices..." />
-			</Select.Content>
 		</Select.Root>
 	</Field.Field>
 {:else if getDevicesQuery.isError}


### PR DESCRIPTION
Replaces hand-rolled loading / empty / error status markup with the `@epicenter/ui` state primitives (`Empty.*`, `Loading`, `Spinner`), following the `epicenter-ui` skill and the existing `local-mail` `MessageList` convention (`Empty.Root` + destructive `TriangleAlert` for failed surfaces).

- `apps/local-books/.../RowTable.svelte` — the table pane's `error` / `loading` / `no-rows` `<p>` branches become `Empty.*` (error + empty) and `Loading` (pending).
- `apps/local-books/.../RowDetail.svelte` — the detail aside's `select-a-row` / `loading` / `error` `<p>` branches become `Empty.*` / `Loading`.
- `apps/whispering/.../TranscriptionSelector.svelte` — the on-device-models loading `<div>` becomes `Loading class="py-8"`, matching the sibling `Empty.Root` branches in the same combobox.
- `apps/whispering/.../{Manual,Vad}SelectRecordingDevice.svelte` — the duplicated `Loading devices...` disabled-select text is paired with a `Spinner`, and the dead `Select.Content`/`Select.Item` (a disabled `Select` never opens) is removed.

Error branches in the device pickers (outside the named pending ranges) are intentionally left untouched to keep this scoped to loading/empty status text.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785744237&installation_id=128463665&pr_number=2369&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2369&signature=c44e05d1b89202b2ca4f26fc2371743bb3a174a7c55c8ff89131fe4342dd503f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->