### PR TITLE
feat(auth): add passkey sign-in and registration

### DIFF
--- a/apps/api/drizzle/0003_fantastic_doomsday.sql
+++ b/apps/api/drizzle/0003_fantastic_doomsday.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "passkey" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text,
+	"public_key" text NOT NULL,
+	"user_id" text NOT NULL,
+	"credential_id" text NOT NULL,
+	"counter" integer NOT NULL,
+	"device_type" text NOT NULL,
+	"backed_up" boolean NOT NULL,
+	"transports" text,
+	"created_at" timestamp,
+	"aaguid" text
+);
+--> statement-breakpoint
+ALTER TABLE "passkey" ADD CONSTRAINT "passkey_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "passkey_userId_idx" ON "passkey" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "passkey_credentialID_idx" ON "passkey" USING btree ("credential_id");

--- a/apps/api/drizzle/meta/0003_snapshot.json
+++ b/apps/api/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1192 @@
+{
+	"id": "edfa4ce2-d43f-4ffd-ae99-ab94c5eb0498",
+	"prevId": "1462a78c-bd6b-4f7f-bf8f-df88be412bd9",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"account_userId_idx": {
+					"name": "account_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.jwks": {
+			"name": "jwks",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"public_key": {
+					"name": "public_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"private_key": {
+					"name": "private_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.oauth_access_token": {
+			"name": "oauth_access_token",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_id": {
+					"name": "refresh_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"oauthAccessToken_clientId_idx": {
+					"name": "oauthAccessToken_clientId_idx",
+					"columns": [
+						{
+							"expression": "client_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"oauthAccessToken_sessionId_idx": {
+					"name": "oauthAccessToken_sessionId_idx",
+					"columns": [
+						{
+							"expression": "session_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"oauthAccessToken_userId_idx": {
+					"name": "oauthAccessToken_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"oauthAccessToken_refreshId_idx": {
+					"name": "oauthAccessToken_refreshId_idx",
+					"columns": [
+						{
+							"expression": "refresh_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"oauth_access_token_client_id_oauth_client_client_id_fk": {
+					"name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+					"tableFrom": "oauth_access_token",
+					"tableTo": "oauth_client",
+					"columnsFrom": ["client_id"],
+					"columnsTo": ["client_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"oauth_access_token_session_id_session_id_fk": {
+					"name": "oauth_access_token_session_id_session_id_fk",
+					"tableFrom": "oauth_access_token",
+					"tableTo": "session",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"oauth_access_token_user_id_user_id_fk": {
+					"name": "oauth_access_token_user_id_user_id_fk",
+					"tableFrom": "oauth_access_token",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+					"name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+					"tableFrom": "oauth_access_token",
+					"tableTo": "oauth_refresh_token",
+					"columnsFrom": ["refresh_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"oauth_access_token_token_unique": {
+					"name": "oauth_access_token_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.oauth_client": {
+			"name": "oauth_client",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_secret": {
+					"name": "client_secret",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"disabled": {
+					"name": "disabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"skip_consent": {
+					"name": "skip_consent",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"enable_end_session": {
+					"name": "enable_end_session",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"subject_type": {
+					"name": "subject_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"uri": {
+					"name": "uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"icon": {
+					"name": "icon",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"contacts": {
+					"name": "contacts",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tos": {
+					"name": "tos",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"policy": {
+					"name": "policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"software_id": {
+					"name": "software_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"software_version": {
+					"name": "software_version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"software_statement": {
+					"name": "software_statement",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"redirect_uris": {
+					"name": "redirect_uris",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"post_logout_redirect_uris": {
+					"name": "post_logout_redirect_uris",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"token_endpoint_auth_method": {
+					"name": "token_endpoint_auth_method",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"grant_types": {
+					"name": "grant_types",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"response_types": {
+					"name": "response_types",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"require_pkce": {
+					"name": "require_pkce",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"oauthClient_userId_idx": {
+					"name": "oauthClient_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"oauth_client_user_id_user_id_fk": {
+					"name": "oauth_client_user_id_user_id_fk",
+					"tableFrom": "oauth_client",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"oauth_client_client_id_unique": {
+					"name": "oauth_client_client_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["client_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.oauth_consent": {
+			"name": "oauth_consent",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"oauthConsent_clientId_idx": {
+					"name": "oauthConsent_clientId_idx",
+					"columns": [
+						{
+							"expression": "client_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"oauthConsent_userId_idx": {
+					"name": "oauthConsent_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"oauth_consent_client_id_oauth_client_client_id_fk": {
+					"name": "oauth_consent_client_id_oauth_client_client_id_fk",
+					"tableFrom": "oauth_consent",
+					"tableTo": "oauth_client",
+					"columnsFrom": ["client_id"],
+					"columnsTo": ["client_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"oauth_consent_user_id_user_id_fk": {
+					"name": "oauth_consent_user_id_user_id_fk",
+					"tableFrom": "oauth_consent",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.oauth_refresh_token": {
+			"name": "oauth_refresh_token",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked": {
+					"name": "revoked",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"auth_time": {
+					"name": "auth_time",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"oauthRefreshToken_clientId_idx": {
+					"name": "oauthRefreshToken_clientId_idx",
+					"columns": [
+						{
+							"expression": "client_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"oauthRefreshToken_sessionId_idx": {
+					"name": "oauthRefreshToken_sessionId_idx",
+					"columns": [
+						{
+							"expression": "session_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"oauthRefreshToken_userId_idx": {
+					"name": "oauthRefreshToken_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+					"name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+					"tableFrom": "oauth_refresh_token",
+					"tableTo": "oauth_client",
+					"columnsFrom": ["client_id"],
+					"columnsTo": ["client_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"oauth_refresh_token_session_id_session_id_fk": {
+					"name": "oauth_refresh_token_session_id_session_id_fk",
+					"tableFrom": "oauth_refresh_token",
+					"tableTo": "session",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"oauth_refresh_token_user_id_user_id_fk": {
+					"name": "oauth_refresh_token_user_id_user_id_fk",
+					"tableFrom": "oauth_refresh_token",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"oauth_refresh_token_token_unique": {
+					"name": "oauth_refresh_token_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.passkey": {
+			"name": "passkey",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"public_key": {
+					"name": "public_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"counter": {
+					"name": "counter",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"device_type": {
+					"name": "device_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"backed_up": {
+					"name": "backed_up",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"transports": {
+					"name": "transports",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"aaguid": {
+					"name": "aaguid",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"passkey_userId_idx": {
+					"name": "passkey_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"passkey_credentialID_idx": {
+					"name": "passkey_credentialID_idx",
+					"columns": [
+						{
+							"expression": "credential_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"passkey_user_id_user_id_fk": {
+					"name": "passkey_user_id_user_id_fk",
+					"tableFrom": "passkey",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"session_userId_idx": {
+					"name": "session_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"verification_identifier_idx": {
+					"name": "verification_identifier_idx",
+					"columns": [
+						{
+							"expression": "identifier",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
 			"when": 1783290424779,
 			"tag": "0002_fearless_lady_ursula",
 			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1783290659326,
+			"tag": "0003_fantastic_doomsday",
+			"breakpoints": true
 		}
 	]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -923,6 +923,7 @@
       "dependencies": {
         "@better-auth/drizzle-adapter": "catalog:",
         "@better-auth/oauth-provider": "catalog:",
+        "@better-auth/passkey": "catalog:",
         "@epicenter/auth": "workspace:*",
         "@epicenter/constants": "workspace:*",
         "@epicenter/identity": "workspace:*",
@@ -1142,6 +1143,7 @@
   "catalog": {
     "@better-auth/drizzle-adapter": "^1.6.23",
     "@better-auth/oauth-provider": "^1.6.23",
+    "@better-auth/passkey": "^1.6.23",
     "@biomejs/biome": "^2.4.10",
     "@hono/standard-validator": "^0.2.2",
     "@lucide/svelte": "^0.561.0",
@@ -1265,6 +1267,8 @@
     "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.6.23", "", { "peerDependencies": { "@better-auth/core": "^1.6.23", "@better-auth/utils": "0.4.2", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-7+QdevitGlKBbP6JbiSk5SBnzPsKV/mDrQBGBn8hwByQLeJwqpqbuBPw7ZI8vzUlFfAAnyFiqwP3Eb8mxnp7pA=="],
 
     "@better-auth/oauth-provider": ["@better-auth/oauth-provider@1.6.23", "", { "dependencies": { "jose": "^6.1.3", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.23", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "better-auth": "^1.6.23", "better-call": "1.3.7" } }, "sha512-1sDN+N4Sztmpk8ziCU3MXicxOTfvYoHvHvhJMQ7PSfr+pLXnYN+dJFI9S3zBRwstmTeJx/OhRIZWrwFJ0TgBnA=="],
+
+    "@better-auth/passkey": ["@better-auth/passkey@1.6.23", "", { "dependencies": { "@simplewebauthn/browser": "^13.2.2", "@simplewebauthn/server": "^13.2.3", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.23", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "better-auth": "^1.6.23", "better-call": "1.3.7", "nanostores": "^1.0.1" } }, "sha512-nr5tKaNd/huUwTYX4DUm4HcXgBkixj0lXrRHdy9azY4fFjF49Tyif4sPyRMWnQJYxlRJ1HVEMJq2nGyr5CLXQg=="],
 
     "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.6.23", "", { "peerDependencies": { "@better-auth/core": "^1.6.23", "@better-auth/utils": "0.4.2", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-2qSdzidq4tkb1eS5TTqb4Nzg0mdZWm3Qky9SYeXeb8PpVQbC2sxqJhEM5mK7y12uU6I8hc64wO9f7AFVNL+6UQ=="],
 
@@ -1558,6 +1562,8 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
+    "@hexagon/base64": ["@hexagon/base64@1.1.28", "", {}, "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="],
+
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@hono/standard-validator": ["@hono/standard-validator@0.2.2", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "hono": ">=3.9.0" } }, "sha512-mJ7W84Bt/rSvoIl63Ynew+UZOHAzzRAoAXb3JaWuxAkM/Lzg+ZHTCUiz77KOtn2e623WNN8LkD57Dk0szqUrIw=="],
@@ -1675,6 +1681,8 @@
     "@layerstack/tailwind": ["@layerstack/tailwind@1.0.1", "", { "dependencies": { "@layerstack/utils": "^1.0.1", "clsx": "^2.1.1", "culori": "^4.0.1", "d3-array": "^3.2.4", "date-fns": "^4.1.0", "lodash-es": "^4.17.21", "tailwind-merge": "^2.5.4", "tailwindcss": "^3.4.15" } }, "sha512-nlshEkUCfaV0zYzrFXVVYRnS8bnBjs4M7iui6l/tu6NeBBlxDivIyRraJkdYGCSL1lZHi6FqacLQ3eerHtz90A=="],
 
     "@layerstack/utils": ["@layerstack/utils@1.0.1", "", { "dependencies": { "d3-array": "^3.2.4", "date-fns": "^4.1.0", "lodash-es": "^4.17.21" } }, "sha512-sWP9b+SFMkJYMZyYFI01aLxbg2ZUrix6Tv+BCDmeOrcLNxtWFsMYAomMhALzTMHbb+Vis/ua5vXhpdNXEw8a2Q=="],
+
+    "@levischuck/tiny-cbor": ["@levischuck/tiny-cbor@0.2.11", "", {}, "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="],
 
     "@lezer/common": ["@lezer/common@1.5.1", "", {}, "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw=="],
 
@@ -1810,6 +1818,32 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.114.0", "", {}, "sha512-//nBfbzHQHvJs8oFIjv6coZ6uxQ4alLfiPe6D5vit6c4pmxATHHlVwgB1k+Hv4yoAMyncdxgRBF5K4BYWUCzvA=="],
 
+    "@peculiar/asn1-android": ["@peculiar/asn1-android@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-skLbS+IOGv1lUgDqtChr8xvtvEr3HMse/JGBaL2r1J1o/n7a8wqOrovMtlRq/UXLhxvmLaONP67hwtshgzwfzA=="],
+
+    "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "@peculiar/asn1-x509-attr": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA=="],
+
+    "@peculiar/asn1-csr": ["@peculiar/asn1-csr@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg=="],
+
+    "@peculiar/asn1-ecc": ["@peculiar/asn1-ecc@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ=="],
+
+    "@peculiar/asn1-pfx": ["@peculiar/asn1-pfx@2.8.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.8.0", "@peculiar/asn1-pkcs8": "^2.8.0", "@peculiar/asn1-rsa": "^2.8.0", "@peculiar/asn1-schema": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg=="],
+
+    "@peculiar/asn1-pkcs8": ["@peculiar/asn1-pkcs8@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA=="],
+
+    "@peculiar/asn1-pkcs9": ["@peculiar/asn1-pkcs9@2.8.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.8.0", "@peculiar/asn1-pfx": "^2.8.0", "@peculiar/asn1-pkcs8": "^2.8.0", "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "@peculiar/asn1-x509-attr": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ=="],
+
+    "@peculiar/asn1-rsa": ["@peculiar/asn1-rsa@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg=="],
+
+    "@peculiar/asn1-schema": ["@peculiar/asn1-schema@2.8.0", "", { "dependencies": { "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q=="],
+
+    "@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg=="],
+
+    "@peculiar/asn1-x509-attr": ["@peculiar/asn1-x509-attr@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA=="],
+
+    "@peculiar/utils": ["@peculiar/utils@2.0.3", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ=="],
+
+    "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
+
     "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
     "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
@@ -1925,6 +1959,10 @@
     "@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@simplewebauthn/browser": ["@simplewebauthn/browser@13.3.0", "", {}, "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ=="],
+
+    "@simplewebauthn/server": ["@simplewebauthn/server@13.3.2", "", { "dependencies": { "@hexagon/base64": "^1.1.27", "@levischuck/tiny-cbor": "^0.2.2", "@peculiar/asn1-android": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.1", "@peculiar/asn1-rsa": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/x509": "^1.14.3" } }, "sha512-KEDhfcGP1PAKRVSDjA3npTQFqS2b/srm+ipoNBNHdkzrHAlaRQUTE+a5f4ywsx6thxAw1NU2rYcLEY1949RGbQ=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
 
@@ -2203,6 +2241,8 @@
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
     "asn1.js": ["asn1.js@4.10.1", "", { "dependencies": { "bn.js": "^4.0.0", "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0" } }, "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw=="],
+
+    "asn1js": ["asn1js@3.0.10", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.5", "tslib": "^2.8.1" } }, "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg=="],
 
     "assert": ["assert@2.1.0", "", { "dependencies": { "call-bind": "^1.0.2", "is-nan": "^1.3.2", "object-is": "^1.1.5", "object.assign": "^4.1.4", "util": "^0.12.5" } }, "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw=="],
 
@@ -3588,6 +3628,10 @@
 
     "pupa": ["pupa@3.3.0", "", { "dependencies": { "escape-goat": "^4.0.0" } }, "sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA=="],
 
+    "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
+
+    "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
+
     "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
@@ -3637,6 +3681,8 @@
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
+
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
@@ -3939,6 +3985,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
 
     "tty-browserify": ["tty-browserify@0.0.1", "", {}, "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="],
 
@@ -4551,6 +4599,8 @@
     "to-regex-range/is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "tsx/get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
+
+    "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "tunnel-agent/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
 			"better-auth": "^1.6.23",
 			"@better-auth/oauth-provider": "^1.6.23",
 			"@better-auth/drizzle-adapter": "^1.6.23",
+			"@better-auth/passkey": "^1.6.23",
 			"jose": "^6.2.2",
 			"jsrepo": "^3.6.2",
 			"@tailwindcss/vite": "^4.1.11",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -16,6 +16,7 @@
 	"dependencies": {
 		"@better-auth/drizzle-adapter": "catalog:",
 		"@better-auth/oauth-provider": "catalog:",
+		"@better-auth/passkey": "catalog:",
 		"@epicenter/auth": "workspace:*",
 		"@epicenter/constants": "workspace:*",
 		"@epicenter/identity": "workspace:*",

--- a/packages/server/src/auth-pages/scripts/passkey.ts
+++ b/packages/server/src/auth-pages/scripts/passkey.ts
@@ -1,0 +1,197 @@
+import { raw } from 'hono/html';
+
+/**
+ * Vanilla WebAuthn ceremony for the server-rendered auth pages.
+ *
+ * These pages have no bundler, so this reimplements the small slice of
+ * `@simplewebauthn/browser` the Better Auth passkey client would normally
+ * provide: the base64url <-> ArrayBuffer conversions plus the two ceremonies,
+ * driven directly against the plugin's REST endpoints (verified against
+ * `@better-auth/passkey` 1.6.23):
+ *
+ *   authenticate: GET  /auth/passkey/generate-authenticate-options  (no session)
+ *                 navigator.credentials.get()
+ *                 POST /auth/passkey/verify-authentication  { response }
+ *                 -> sets a standard session cookie; caller reloads so the
+ *                    OAuth loginPage continues the authorize flow.
+ *
+ *   register:     GET  /auth/passkey/generate-register-options  (needs session)
+ *                 navigator.credentials.create()
+ *                 POST /auth/passkey/verify-registration  { response }
+ *
+ * The verify endpoints wrap the WebAuthn credential JSON under a `response`
+ * key, so the credential (which itself has a nested `response`) is sent as
+ * `{ response: <AuthenticationResponseJSON | RegistrationResponseJSON> }`.
+ *
+ * Exposes `window.epicenterPasskey = { supported, authenticate, register }`.
+ * Each ceremony resolves `{ ok: true }` or `{ ok: false, error }` and never
+ * throws, so callers stay simple.
+ */
+export const PASSKEY_SCRIPT = raw(`<script>
+window.epicenterPasskey = (() => {
+	const decode = (value) => {
+		const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+		const padded = normalized.padEnd(
+			normalized.length + ((4 - (normalized.length % 4)) % 4),
+			'=',
+		);
+		const binary = atob(padded);
+		const bytes = new Uint8Array(binary.length);
+		for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+		return bytes.buffer;
+	};
+
+	const encode = (buffer) => {
+		const bytes = new Uint8Array(buffer);
+		let binary = '';
+		for (let i = 0; i < bytes.length; i++)
+			binary += String.fromCharCode(bytes[i]);
+		return btoa(binary)
+			.replace(/\\+/g, '-')
+			.replace(/\\//g, '_')
+			.replace(/=+$/, '');
+	};
+
+	const supported = () =>
+		typeof window.PublicKeyCredential === 'function' &&
+		!!(navigator.credentials && navigator.credentials.get);
+
+	const cancelled = (err) => err && err.name === 'NotAllowedError';
+
+	const authenticate = async () => {
+		let options;
+		try {
+			const res = await fetch('/auth/passkey/generate-authenticate-options', {
+				method: 'GET',
+				credentials: 'include',
+				headers: { Accept: 'application/json' },
+			});
+			if (!res.ok) return { ok: false, error: 'Could not start passkey sign-in.' };
+			options = await res.json();
+		} catch {
+			return { ok: false, error: 'Network error starting passkey sign-in.' };
+		}
+
+		const publicKey = Object.assign({}, options, {
+			challenge: decode(options.challenge),
+			allowCredentials: (options.allowCredentials || []).map((cred) =>
+				Object.assign({}, cred, { id: decode(cred.id) }),
+			),
+		});
+
+		let credential;
+		try {
+			credential = await navigator.credentials.get({ publicKey });
+		} catch (err) {
+			return {
+				ok: false,
+				error: cancelled(err)
+					? 'Passkey sign-in was cancelled.'
+					: 'Passkey sign-in failed.',
+			};
+		}
+		if (!credential) return { ok: false, error: 'No passkey was selected.' };
+
+		const response = {
+			id: credential.id,
+			rawId: encode(credential.rawId),
+			type: credential.type,
+			authenticatorAttachment: credential.authenticatorAttachment || undefined,
+			clientExtensionResults: credential.getClientExtensionResults
+				? credential.getClientExtensionResults()
+				: {},
+			response: {
+				authenticatorData: encode(credential.response.authenticatorData),
+				clientDataJSON: encode(credential.response.clientDataJSON),
+				signature: encode(credential.response.signature),
+				userHandle: credential.response.userHandle
+					? encode(credential.response.userHandle)
+					: undefined,
+			},
+		};
+
+		try {
+			const res = await fetch('/auth/passkey/verify-authentication', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				credentials: 'include',
+				body: JSON.stringify({ response }),
+			});
+			if (!res.ok) return { ok: false, error: 'Passkey could not be verified.' };
+		} catch {
+			return { ok: false, error: 'Network error verifying passkey.' };
+		}
+		return { ok: true };
+	};
+
+	const register = async (name) => {
+		let options;
+		try {
+			const query = name ? '?name=' + encodeURIComponent(name) : '';
+			const res = await fetch('/auth/passkey/generate-register-options' + query, {
+				method: 'GET',
+				credentials: 'include',
+				headers: { Accept: 'application/json' },
+			});
+			if (!res.ok)
+				return { ok: false, error: 'Could not start passkey setup. Are you still signed in?' };
+			options = await res.json();
+		} catch {
+			return { ok: false, error: 'Network error starting passkey setup.' };
+		}
+
+		const publicKey = Object.assign({}, options, {
+			challenge: decode(options.challenge),
+			user: Object.assign({}, options.user, { id: decode(options.user.id) }),
+			excludeCredentials: (options.excludeCredentials || []).map((cred) =>
+				Object.assign({}, cred, { id: decode(cred.id) }),
+			),
+		});
+
+		let credential;
+		try {
+			credential = await navigator.credentials.create({ publicKey });
+		} catch (err) {
+			return {
+				ok: false,
+				error: cancelled(err)
+					? 'Passkey setup was cancelled.'
+					: 'Passkey setup failed.',
+			};
+		}
+		if (!credential) return { ok: false, error: 'Passkey was not created.' };
+
+		const response = {
+			id: credential.id,
+			rawId: encode(credential.rawId),
+			type: credential.type,
+			authenticatorAttachment: credential.authenticatorAttachment || undefined,
+			clientExtensionResults: credential.getClientExtensionResults
+				? credential.getClientExtensionResults()
+				: {},
+			response: {
+				attestationObject: encode(credential.response.attestationObject),
+				clientDataJSON: encode(credential.response.clientDataJSON),
+				transports: credential.response.getTransports
+					? credential.response.getTransports()
+					: undefined,
+			},
+		};
+
+		try {
+			const res = await fetch('/auth/passkey/verify-registration', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				credentials: 'include',
+				body: JSON.stringify({ response }),
+			});
+			if (!res.ok) return { ok: false, error: 'Passkey could not be saved.' };
+		} catch {
+			return { ok: false, error: 'Network error saving passkey.' };
+		}
+		return { ok: true };
+	};
+
+	return { supported, authenticate, register };
+})();
+</script>`);

--- a/packages/server/src/auth-pages/scripts/passkey.ts
+++ b/packages/server/src/auth-pages/scripts/passkey.ts
@@ -133,8 +133,13 @@ window.epicenterPasskey = (() => {
 				credentials: 'include',
 				headers: { Accept: 'application/json' },
 			});
-			if (!res.ok)
-				return { ok: false, error: 'Could not start passkey setup. Are you still signed in?' };
+			// Registration needs a FRESH session (Better Auth freshSessionMiddleware,
+			// freshAge default 24h), so a user can be visibly signed in with a
+			// week-old session and still get refused here. Both refusals (401 no
+			// session, 403 stale session) have the same remedy: sign in again.
+			if (res.status === 401 || res.status === 403)
+				return { ok: false, error: 'Sign in again to add a passkey.' };
+			if (!res.ok) return { ok: false, error: 'Could not start passkey setup.' };
 			options = await res.json();
 		} catch {
 			return { ok: false, error: 'Network error starting passkey setup.' };

--- a/packages/server/src/auth-pages/scripts/sign-in.ts
+++ b/packages/server/src/auth-pages/scripts/sign-in.ts
@@ -81,5 +81,28 @@ export const SIGN_IN_SCRIPT = raw(`<script>
 	if (microsoftBtn)
 		microsoftBtn.addEventListener('click', () => startSocial('microsoft'));
 	if (appleBtn) appleBtn.addEventListener('click', () => startSocial('apple'));
+
+	// Passkey is a returning-user path: only reveal it when the browser can do
+	// WebAuthn, so first-time users are not offered a dead button. On success
+	// the session cookie is set, so a reload lets the server continue the OAuth
+	// authorize flow (the '?sig=' branch) exactly as a social sign-in would.
+	const passkeySection = document.getElementById('passkey-section');
+	const passkeyBtn = document.getElementById('passkey-btn');
+	if (passkeySection && passkeyBtn && window.epicenterPasskey?.supported()) {
+		passkeySection.classList.remove('hidden');
+		passkeyBtn.addEventListener('click', async () => {
+			clearError();
+			setBusy(true);
+			passkeyBtn.disabled = true;
+			const result = await window.epicenterPasskey.authenticate();
+			if (result.ok) {
+				window.location.reload();
+				return;
+			}
+			showError(result.error);
+			setBusy(false);
+			passkeyBtn.disabled = false;
+		});
+	}
 })();
 </script>`);

--- a/packages/server/src/auth-pages/sign-in-page.tsx
+++ b/packages/server/src/auth-pages/sign-in-page.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource hono/jsx */
 
 import { raw } from 'hono/html';
+import { PASSKEY_SCRIPT } from './scripts/passkey';
 import { SIGN_IN_SCRIPT } from './scripts/sign-in';
 
 /**
@@ -40,6 +41,17 @@ const MICROSOFT_ICON =
 const APPLE_ICON =
 	raw(`<svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor">
 	<path d="M17.05 12.53c-.02-2.02 1.65-2.99 1.72-3.04-.94-1.37-2.4-1.56-2.92-1.58-1.24-.13-2.42.73-3.05.73-.63 0-1.6-.71-2.63-.69-1.35.02-2.6.79-3.3 2-1.4 2.44-.36 6.05 1 8.03.67.97 1.47 2.06 2.5 2.02 1-.04 1.38-.65 2.6-.65 1.2 0 1.55.65 2.6.63 1.08-.02 1.76-.99 2.42-1.96.76-1.12 1.07-2.2 1.09-2.26-.02-.01-2.09-.8-2.11-3.18zM15.1 6.3c.55-.67.92-1.6.82-2.53-.79.03-1.76.53-2.33 1.19-.51.59-.96 1.54-.84 2.44.88.07 1.79-.44 2.35-1.1z"/>
+</svg>`);
+
+/**
+ * Passkey / fingerprint mark. Inherits the button text color via `currentColor`.
+ */
+const PASSKEY_ICON =
+	raw(`<svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+	<circle cx="10" cy="8" r="4"/>
+	<path d="M10.3 14H8a5 5 0 0 0-5 5v1h9"/>
+	<circle cx="17.5" cy="14.5" r="2.5"/>
+	<path d="M17.5 17v5l-1.2-1.2 1.2-1.2"/>
 </svg>`);
 
 /**
@@ -123,6 +135,21 @@ export function SignInPage({
 				) : null}
 			</div>
 
+			{/* Returning-user path. Hidden until the inline script confirms the
+			    browser supports WebAuthn (see scripts/passkey + sign-in). */}
+			<div id="passkey-section" class="passkey-section hidden">
+				<div class="divider">or</div>
+				<button
+					type="button"
+					class="btn btn-outline btn-provider"
+					id="passkey-btn"
+				>
+					{PASSKEY_ICON}
+					<span class="btn-label">Sign in with a passkey</span>
+				</button>
+			</div>
+
+			{PASSKEY_SCRIPT}
 			{SIGN_IN_SCRIPT}
 		</>
 	);

--- a/packages/server/src/auth-pages/signed-in-page.tsx
+++ b/packages/server/src/auth-pages/signed-in-page.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource hono/jsx */
 
 import { raw } from 'hono/html';
+import { PASSKEY_SCRIPT } from './scripts/passkey';
 
 /**
  * Green checkmark circle SVG for the signed-in success state.
@@ -13,27 +14,65 @@ const CHECK_ICON =
 </svg>`);
 
 /**
+ * Passkey / fingerprint mark. Inherits the button text color via `currentColor`.
+ */
+const PASSKEY_ICON =
+	raw(`<svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+	<circle cx="10" cy="8" r="4"/>
+	<path d="M10.3 14H8a5 5 0 0 0-5 5v1h9"/>
+	<circle cx="17.5" cy="14.5" r="2.5"/>
+	<path d="M17.5 17v5l-1.2-1.2 1.2-1.2"/>
+</svg>`);
+
+/**
  * Client-side script for the signed-in page.
  *
- * Handles the sign-out button: POST to `/auth/sign-out`, then reload
- * so the server renders the sign-in form.
+ * Handles sign-out (POST `/auth/sign-out`, then reload so the server renders
+ * the sign-in form) and passkey registration (revealed only when the browser
+ * supports WebAuthn; runs the register ceremony against this same-origin
+ * session cookie via `window.epicenterPasskey`).
  */
 const SIGNED_IN_SCRIPT = raw(`<script>
 (() => {
 	const signOutBtn = document.getElementById('sign-out');
-	if (!signOutBtn) return;
+	if (signOutBtn) {
+		signOutBtn.addEventListener('click', async () => {
+			signOutBtn.disabled = true;
+			signOutBtn.textContent = 'Signing out\u2026';
+			try {
+				await fetch('/auth/sign-out', {
+					method: 'POST',
+					credentials: 'include',
+				});
+			} catch {}
+			window.location.reload();
+		});
+	}
 
-	signOutBtn.addEventListener('click', async () => {
-		signOutBtn.disabled = true;
-		signOutBtn.textContent = 'Signing out\u2026';
-		try {
-			await fetch('/auth/sign-out', {
-				method: 'POST',
-				credentials: 'include',
-			});
-		} catch {}
-		window.location.reload();
-	});
+	const passkeyRow = document.getElementById('add-passkey-row');
+	const addPasskeyBtn = document.getElementById('add-passkey');
+	const passkeyMsg = document.getElementById('passkey-msg');
+	if (passkeyRow && addPasskeyBtn && window.epicenterPasskey?.supported()) {
+		passkeyRow.classList.remove('hidden');
+		addPasskeyBtn.addEventListener('click', async () => {
+			passkeyMsg.className = 'msg hidden';
+			addPasskeyBtn.disabled = true;
+			const label = addPasskeyBtn.querySelector('.btn-label');
+			const original = label ? label.textContent : '';
+			if (label) label.textContent = 'Follow your browser\u2026';
+			const result = await window.epicenterPasskey.register();
+			if (result.ok) {
+				passkeyMsg.textContent = 'Passkey added. You can use it to sign in next time.';
+				passkeyMsg.className = 'msg ok';
+				if (label) label.textContent = 'Add another passkey';
+			} else {
+				passkeyMsg.textContent = result.error;
+				passkeyMsg.className = 'msg err';
+				if (label) label.textContent = original;
+			}
+			addPasskeyBtn.disabled = false;
+		});
+	}
 })();
 </script>`);
 
@@ -60,12 +99,26 @@ export function SignedInPage({
 			</p>
 			<p class="signed-in-info">{email}</p>
 
+			<div id="passkey-msg" class="msg hidden" />
+
 			<div class="signed-in-actions">
+				{/* Revealed by the script only when WebAuthn is supported. */}
+				<div id="add-passkey-row" class="hidden">
+					<button
+						type="button"
+						class="btn btn-outline btn-provider"
+						id="add-passkey"
+					>
+						{PASSKEY_ICON}
+						<span class="btn-label">Add a passkey</span>
+					</button>
+				</div>
 				<button type="button" class="btn btn-outline" id="sign-out">
 					Sign out
 				</button>
 			</div>
 
+			{PASSKEY_SCRIPT}
 			{SIGNED_IN_SCRIPT}
 		</div>
 	);

--- a/packages/server/src/auth-pages/styles.ts
+++ b/packages/server/src/auth-pages/styles.ts
@@ -3,7 +3,7 @@
  * cli-callback).
  *
  * Mirrors the Epicenter design system tokens from `packages/ui/src/app.css`
- * (its oklch light/dark palettes and system-ui font stack) as plain custom
+ * (its oklch light/dark palettes and sans-serif font stack) as plain custom
  * properties, so these pages theme themselves from `prefers-color-scheme`
  * without pulling in Tailwind or the UI package. Semantic surfaces (alerts)
  * derive their fills from the accent via `color-mix`, so each stays legible in
@@ -25,6 +25,7 @@ export const AUTH_STYLES = `
 	--success:oklch(0.448 0.119 151.328);
 	--danger:oklch(0.577 0.245 27.325);
 	--shadow:0 1px 2px rgb(0 0 0 / .04),0 8px 30px rgb(0 0 0 / .06);
+	--font-sans:system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,sans-serif;
 }
 @media (prefers-color-scheme:dark){
 	:root{
@@ -47,7 +48,7 @@ export const AUTH_STYLES = `
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 
 body{
-	font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+	font-family:var(--font-sans);
 	min-height:100vh;
 	display:flex;
 	align-items:center;
@@ -84,13 +85,13 @@ body{
 	box-shadow:var(--shadow);
 }
 
-h1{font-size:1.375rem;font-weight:700;letter-spacing:-.01em;margin-bottom:.25rem}
+h1{font-family:var(--font-sans);font-size:1.375rem;font-weight:700;letter-spacing:-.01em;margin-bottom:.25rem}
 .subtitle{color:var(--muted-fg);font-size:.875rem;margin-bottom:1.75rem}
 
 /* ── Sign-in header (mark lives in the layout above these) ─── */
 
 .signin-head{display:flex;flex-direction:column;align-items:center;text-align:center}
-.wordmark{font-size:1.375rem;font-weight:650;letter-spacing:-.02em;line-height:1.15;margin-bottom:.25rem}
+.wordmark{font-family:var(--font-sans);font-size:1.375rem;font-weight:650;letter-spacing:-.02em;line-height:1.15;margin-bottom:.25rem}
 
 /* ── Buttons ──────────────────────────────────────────────── */
 
@@ -104,7 +105,7 @@ button,.btn{
 	border-radius:10px;
 	font-size:.875rem;
 	font-weight:500;
-	font-family:inherit;
+	font-family:var(--font-sans);
 	color:var(--fg);
 	cursor:pointer;
 	border:1px solid transparent;

--- a/packages/server/src/auth-pages/styles.ts
+++ b/packages/server/src/auth-pages/styles.ts
@@ -137,6 +137,22 @@ button:focus-visible,.btn:focus-visible{outline:2px solid var(--ring);outline-of
 .btn-provider svg{width:18px;height:18px}
 .btn-provider .btn-label{grid-column:2;text-align:center}
 
+/* ── Passkey (returning-user) section ─────────────────────── */
+/* No display rule here on purpose: the section carries .hidden until the
+   inline script confirms WebAuthn support, and .hidden must win. */
+.passkey-section{margin-top:.75rem}
+.divider{
+	display:flex;
+	align-items:center;
+	gap:.75rem;
+	margin:.5rem 0 .75rem;
+	color:var(--muted-fg);
+	font-size:.6875rem;
+	letter-spacing:.08em;
+	text-transform:uppercase;
+}
+.divider::before,.divider::after{content:"";flex:1;height:1px;background:var(--border)}
+
 /* ── Button row (side-by-side) ────────────────────────────── */
 
 .actions{display:flex;gap:.5rem;margin-top:1.25rem}

--- a/packages/server/src/auth/create-auth.ts
+++ b/packages/server/src/auth/create-auth.ts
@@ -52,6 +52,54 @@ export const CloudAuthBindings = type({
 export type CloudAuthBindings = typeof CloudAuthBindings.infer;
 
 /**
+ * The single owner of "which OAuth providers is this deployment offering":
+ * each provider resolves to its credentials when fully configured and `null`
+ * otherwise. Both readers that must agree consume this one value, so the
+ * presence predicates cannot drift: {@link createAuth} registers exactly the
+ * non-null providers, and the sign-in page (routes/auth.ts) shows a button for
+ * exactly the same set. Apple is present only when all four parts of its
+ * signing material are (the client-secret JWT is minted per request from
+ * them; see {@link generateAppleClientSecret}).
+ */
+export function configuredProviders(env: CloudAuthBindings) {
+	return {
+		google:
+			env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET
+				? {
+						clientId: env.GOOGLE_CLIENT_ID,
+						clientSecret: env.GOOGLE_CLIENT_SECRET,
+					}
+				: null,
+		github:
+			env.GITHUB_CLIENT_ID && env.GITHUB_CLIENT_SECRET
+				? {
+						clientId: env.GITHUB_CLIENT_ID,
+						clientSecret: env.GITHUB_CLIENT_SECRET,
+					}
+				: null,
+		microsoft:
+			env.MICROSOFT_CLIENT_ID && env.MICROSOFT_CLIENT_SECRET
+				? {
+						clientId: env.MICROSOFT_CLIENT_ID,
+						clientSecret: env.MICROSOFT_CLIENT_SECRET,
+					}
+				: null,
+		apple:
+			env.APPLE_CLIENT_ID &&
+			env.APPLE_TEAM_ID &&
+			env.APPLE_KEY_ID &&
+			env.APPLE_PRIVATE_KEY
+				? {
+						clientId: env.APPLE_CLIENT_ID,
+						teamId: env.APPLE_TEAM_ID,
+						keyId: env.APPLE_KEY_ID,
+						privateKey: env.APPLE_PRIVATE_KEY,
+					}
+				: null,
+	};
+}
+
+/**
  * Assemble and return a configured `betterAuth()` instance from runtime deps.
  *
  * Cloudflare Workers doesn't expose `env` or database connections at module scope,
@@ -94,15 +142,12 @@ export function createAuth({
 			'BETTER_AUTH_SECRET is not set: refusing to construct Better Auth with an empty signing secret, which would fall back to a public default and sign forgeable sessions.',
 		);
 	}
-	// Apple needs all four parts of its signing material to be offered at all;
-	// the same flag gates both the provider registration and the trusted-origin
-	// addition below (Apple posts its callback from appleid.apple.com).
-	const appleConfigured = Boolean(
-		env.APPLE_CLIENT_ID &&
-			env.APPLE_TEAM_ID &&
-			env.APPLE_KEY_ID &&
-			env.APPLE_PRIVATE_KEY,
-	);
+	// One presence predicate for all four providers (see configuredProviders).
+	// `apple` is bound to a local so its narrowing survives into the async
+	// client-secret factory below; the same value gates the trusted-origin
+	// addition (Apple posts its callback from appleid.apple.com).
+	const providers = configuredProviders(env);
+	const apple = providers.apple;
 	return betterAuth({
 		...BASE_AUTH_CONFIG,
 		database: drizzleAdapter(db, { provider: 'pg', schema }),
@@ -135,22 +180,8 @@ export function createAuth({
 		// provider (see BASE_AUTH_CONFIG): an unverified GitHub email must not link
 		// into an existing account.
 		socialProviders: {
-			...(env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET
-				? {
-						google: {
-							clientId: env.GOOGLE_CLIENT_ID,
-							clientSecret: env.GOOGLE_CLIENT_SECRET,
-						},
-					}
-				: {}),
-			...(env.GITHUB_CLIENT_ID && env.GITHUB_CLIENT_SECRET
-				? {
-						github: {
-							clientId: env.GITHUB_CLIENT_ID,
-							clientSecret: env.GITHUB_CLIENT_SECRET,
-						},
-					}
-				: {}),
+			...(providers.google ? { google: providers.google } : {}),
+			...(providers.github ? { github: providers.github } : {}),
 			// Microsoft (Entra / personal MSA), register-when-present like GitHub.
 			// tenantId defaults to 'common' so both work/school and personal
 			// accounts can sign in. Like GitHub, Microsoft is deliberately NOT a
@@ -158,36 +189,18 @@ export function createAuth({
 			// is not a guaranteed-verified assertion, so an untrusted Microsoft
 			// identity only links to an existing same-email account when Microsoft
 			// itself reports the email verified.
-			...(env.MICROSOFT_CLIENT_ID && env.MICROSOFT_CLIENT_SECRET
-				? {
-						microsoft: {
-							clientId: env.MICROSOFT_CLIENT_ID,
-							clientSecret: env.MICROSOFT_CLIENT_SECRET,
-						},
-					}
-				: {}),
+			...(providers.microsoft ? { microsoft: providers.microsoft } : {}),
 			// Apple's clientSecret is a per-request-minted ES256 JWT, so this is
-			// an async factory rather than a static pair. `appleConfigured`
-			// guarantees the four inputs are present (the `!` are safe under it).
-			// Like GitHub and Microsoft, Apple is NOT a trusted linking provider:
-			// it can issue a private-relay email, so an untrusted Apple identity
-			// only links to an existing same-email account when Apple reports the
-			// email verified.
-			...(appleConfigured
+			// an async factory rather than a static pair over the configured
+			// signing material. Like GitHub and Microsoft, Apple is NOT a trusted
+			// linking provider: it can issue a private-relay email, so an
+			// untrusted Apple identity only links to an existing same-email
+			// account when Apple reports the email verified.
+			...(apple
 				? {
 						apple: async () => ({
-							// biome-ignore lint/style/noNonNullAssertion: guarded by appleConfigured
-							clientId: env.APPLE_CLIENT_ID!,
-							clientSecret: await generateAppleClientSecret({
-								// biome-ignore lint/style/noNonNullAssertion: guarded by appleConfigured
-								clientId: env.APPLE_CLIENT_ID!,
-								// biome-ignore lint/style/noNonNullAssertion: guarded by appleConfigured
-								teamId: env.APPLE_TEAM_ID!,
-								// biome-ignore lint/style/noNonNullAssertion: guarded by appleConfigured
-								keyId: env.APPLE_KEY_ID!,
-								// biome-ignore lint/style/noNonNullAssertion: guarded by appleConfigured
-								privateKey: env.APPLE_PRIVATE_KEY!,
-							}),
+							clientId: apple.clientId,
+							clientSecret: await generateAppleClientSecret(apple),
 						}),
 					}
 				: {}),
@@ -220,7 +233,7 @@ export function createAuth({
 		// Apple posts its OAuth callback from appleid.apple.com (response_mode=
 		// form_post), so that origin must be trusted for the flow to complete.
 		// Only added when Apple is configured, to avoid widening the allow-list.
-		trustedOrigins: appleConfigured
+		trustedOrigins: apple
 			? [...trustedOrigins, APPLE_AUDIENCE]
 			: trustedOrigins,
 		// Postgres is the only auth store: sessions and OAuth verification

--- a/packages/server/src/auth/plugins.test.ts
+++ b/packages/server/src/auth/plugins.test.ts
@@ -10,6 +10,9 @@
  * - Trusted clients skip consent during authorization
  * - Registered non-trusted clients still require consent
  * - A clean JWKS table mints an ES256/P-256 signing key
+ * - Passkey options endpoints keep the REST contract the bundler-free
+ *   auth-pages WebAuthn script (auth-pages/scripts/passkey.ts) is hand-wired
+ *   against
  */
 
 import { expect, test } from 'bun:test';
@@ -200,6 +203,63 @@ test('buildTrustedOAuthClients gives Honeycrisp its Tauri deep-link callback', (
 	);
 });
 
+// The auth pages have no bundler, so auth-pages/scripts/passkey.ts drives the
+// passkey plugin's REST endpoints directly instead of using the plugin's
+// bundled client. These tests pin the slice of that contract a plugin upgrade
+// could silently move: the endpoint paths, the sessionless authenticate
+// ceremony, the session-gated register ceremony, the base64url challenge
+// encoding, and the RP id derived from the API base URL. If one of these
+// fails after a bump, re-verify the inline script against the new dist.
+
+test('passkey authenticate options are mintable without a session', async () => {
+	const setup = createTrustedClientTestAuth();
+
+	const response = await setup.auth.handler(
+		new Request(`${setup.baseURL}/auth/passkey/generate-authenticate-options`),
+	);
+	const body = (await response.json()) as {
+		challenge?: unknown;
+		rpId?: unknown;
+	};
+
+	expect(response.status).toBe(200);
+	expect(body.rpId).toBe('localhost');
+	expect(typeof body.challenge).toBe('string');
+	expect(body.challenge as string).toMatch(/^[A-Za-z0-9_-]+$/);
+});
+
+test('passkey register options require a session', async () => {
+	const setup = createTrustedClientTestAuth();
+
+	const response = await setup.auth.handler(
+		new Request(`${setup.baseURL}/auth/passkey/generate-register-options`),
+	);
+
+	expect(response.status).toBe(401);
+});
+
+test('fresh session mints passkey register options bound to the user', async () => {
+	const setup = createTrustedClientTestAuth();
+
+	const cookie = await signUpTestUser(setup.auth, setup.baseURL);
+	const response = await setup.auth.handler(
+		new Request(`${setup.baseURL}/auth/passkey/generate-register-options`, {
+			headers: { cookie },
+		}),
+	);
+	const body = (await response.json()) as {
+		challenge?: unknown;
+		rp?: { id?: unknown };
+		user?: { id?: unknown };
+	};
+
+	expect(response.status).toBe(200);
+	expect(body.rp?.id).toBe('localhost');
+	expect(typeof body.challenge).toBe('string');
+	expect(body.challenge as string).toMatch(/^[A-Za-z0-9_-]+$/);
+	expect(typeof body.user?.id).toBe('string');
+});
+
 test('registered non-trusted OAuth client requires consent', async () => {
 	const setup = createTrustedClientTestAuth();
 
@@ -244,6 +304,7 @@ function createTrustedClientTestAuth({
 		oauthConsent: [],
 		oauthRefreshToken: [],
 		jwks: [],
+		passkey: [],
 	};
 
 	const auth = betterAuth({

--- a/packages/server/src/auth/plugins.ts
+++ b/packages/server/src/auth/plugins.ts
@@ -1,4 +1,5 @@
 import { oauthProvider } from '@better-auth/oauth-provider';
+import { passkey } from '@better-auth/passkey';
 import { EPICENTER_OAUTH_SCOPES } from '@epicenter/constants/oauth-clients';
 import { buildTrustedOAuthClients } from '@epicenter/constants/oauth-seed';
 import type { BetterAuthOptions } from 'better-auth';
@@ -19,6 +20,15 @@ export function authPlugins(apiBaseURL: string) {
 	const trustedOAuthClientIds = new Set(
 		buildTrustedOAuthClients(apiBaseURL).map((client) => client.clientId),
 	);
+	// WebAuthn binds credentials to a Relying Party. Passkeys are only ever
+	// created and used on the hosted auth pages, which the API serves at its own
+	// origin, so the RP is exactly this deployment: `rpID` is the API hostname
+	// (`localhost` in dev, the deployment host in prod) and `origin` is the full
+	// base URL with no trailing slash (what the browser reports and the plugin
+	// checks as `expectedOrigin`). Both derive from `apiBaseURL`, so a preview or
+	// self-host deployment gets a correct RP without extra config.
+	const origin = apiBaseURL.replace(/\/$/, '');
+	const rpID = new URL(origin).hostname;
 	return [
 		// `JWT_SIGNING_ALG` (ES256, P-256 ECDSA) signs the id_token and JWT
 		// access tokens. `id_token_signing_alg_values_supported` on
@@ -75,5 +85,11 @@ export function authPlugins(apiBaseURL: string) {
 			// We already mount both discovery endpoints manually in app.ts.
 			silenceWarnings: { oauthAuthServerConfig: true, openidConfig: true },
 		}),
+		// Passkey (WebAuthn) as a returning-user sign-in method. Registration
+		// requires a session (the plugin default), so it lives on the signed-in
+		// auth page; authentication runs on the sign-in page and, on success,
+		// sets a standard session cookie that the oauthProvider above then uses to
+		// continue the authorize flow. Adds a `passkey` table to the schema.
+		passkey({ rpID, rpName: 'Epicenter', origin }),
 	] satisfies NonNullable<BetterAuthOptions['plugins']>;
 }

--- a/packages/server/src/db/schema/auth.ts
+++ b/packages/server/src/db/schema/auth.ts
@@ -1,320 +1,320 @@
-import { relations } from "drizzle-orm";
+import { relations } from 'drizzle-orm';
 import {
-  pgTable,
-  text,
-  timestamp,
-  boolean,
-  integer,
-  jsonb,
-  index,
-} from "drizzle-orm/pg-core";
+	boolean,
+	index,
+	integer,
+	jsonb,
+	pgTable,
+	text,
+	timestamp,
+} from 'drizzle-orm/pg-core';
 
-export const user = pgTable("user", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  email: text("email").notNull().unique(),
-  emailVerified: boolean("email_verified").default(false).notNull(),
-  image: text("image"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at")
-    .defaultNow()
-    .$onUpdate(() => /* @__PURE__ */ new Date())
-    .notNull(),
+export const user = pgTable('user', {
+	id: text('id').primaryKey(),
+	name: text('name').notNull(),
+	email: text('email').notNull().unique(),
+	emailVerified: boolean('email_verified').default(false).notNull(),
+	image: text('image'),
+	createdAt: timestamp('created_at').defaultNow().notNull(),
+	updatedAt: timestamp('updated_at')
+		.defaultNow()
+		.$onUpdate(() => /* @__PURE__ */ new Date())
+		.notNull(),
 });
 
 export const session = pgTable(
-  "session",
-  {
-    id: text("id").primaryKey(),
-    expiresAt: timestamp("expires_at").notNull(),
-    token: text("token").notNull().unique(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
-      .$onUpdate(() => /* @__PURE__ */ new Date())
-      .notNull(),
-    ipAddress: text("ip_address"),
-    userAgent: text("user_agent"),
-    userId: text("user_id")
-      .notNull()
-      .references(() => user.id, { onDelete: "cascade" }),
-  },
-  (table) => [index("session_userId_idx").on(table.userId)],
+	'session',
+	{
+		id: text('id').primaryKey(),
+		expiresAt: timestamp('expires_at').notNull(),
+		token: text('token').notNull().unique(),
+		createdAt: timestamp('created_at').defaultNow().notNull(),
+		updatedAt: timestamp('updated_at')
+			.$onUpdate(() => /* @__PURE__ */ new Date())
+			.notNull(),
+		ipAddress: text('ip_address'),
+		userAgent: text('user_agent'),
+		userId: text('user_id')
+			.notNull()
+			.references(() => user.id, { onDelete: 'cascade' }),
+	},
+	(table) => [index('session_userId_idx').on(table.userId)],
 );
 
 export const account = pgTable(
-  "account",
-  {
-    id: text("id").primaryKey(),
-    accountId: text("account_id").notNull(),
-    providerId: text("provider_id").notNull(),
-    userId: text("user_id")
-      .notNull()
-      .references(() => user.id, { onDelete: "cascade" }),
-    accessToken: text("access_token"),
-    refreshToken: text("refresh_token"),
-    idToken: text("id_token"),
-    accessTokenExpiresAt: timestamp("access_token_expires_at"),
-    refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
-    scope: text("scope"),
-    password: text("password"),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
-      .$onUpdate(() => /* @__PURE__ */ new Date())
-      .notNull(),
-  },
-  (table) => [index("account_userId_idx").on(table.userId)],
+	'account',
+	{
+		id: text('id').primaryKey(),
+		accountId: text('account_id').notNull(),
+		providerId: text('provider_id').notNull(),
+		userId: text('user_id')
+			.notNull()
+			.references(() => user.id, { onDelete: 'cascade' }),
+		accessToken: text('access_token'),
+		refreshToken: text('refresh_token'),
+		idToken: text('id_token'),
+		accessTokenExpiresAt: timestamp('access_token_expires_at'),
+		refreshTokenExpiresAt: timestamp('refresh_token_expires_at'),
+		scope: text('scope'),
+		password: text('password'),
+		createdAt: timestamp('created_at').defaultNow().notNull(),
+		updatedAt: timestamp('updated_at')
+			.$onUpdate(() => /* @__PURE__ */ new Date())
+			.notNull(),
+	},
+	(table) => [index('account_userId_idx').on(table.userId)],
 );
 
 export const verification = pgTable(
-  "verification",
-  {
-    id: text("id").primaryKey(),
-    identifier: text("identifier").notNull(),
-    value: text("value").notNull(),
-    expiresAt: timestamp("expires_at").notNull(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
-      .defaultNow()
-      .$onUpdate(() => /* @__PURE__ */ new Date())
-      .notNull(),
-  },
-  (table) => [index("verification_identifier_idx").on(table.identifier)],
+	'verification',
+	{
+		id: text('id').primaryKey(),
+		identifier: text('identifier').notNull(),
+		value: text('value').notNull(),
+		expiresAt: timestamp('expires_at').notNull(),
+		createdAt: timestamp('created_at').defaultNow().notNull(),
+		updatedAt: timestamp('updated_at')
+			.defaultNow()
+			.$onUpdate(() => /* @__PURE__ */ new Date())
+			.notNull(),
+	},
+	(table) => [index('verification_identifier_idx').on(table.identifier)],
 );
 
-export const jwks = pgTable("jwks", {
-  id: text("id").primaryKey(),
-  publicKey: text("public_key").notNull(),
-  privateKey: text("private_key").notNull(),
-  createdAt: timestamp("created_at").notNull(),
-  expiresAt: timestamp("expires_at"),
+export const jwks = pgTable('jwks', {
+	id: text('id').primaryKey(),
+	publicKey: text('public_key').notNull(),
+	privateKey: text('private_key').notNull(),
+	createdAt: timestamp('created_at').notNull(),
+	expiresAt: timestamp('expires_at'),
 });
 
 export const oauthClient = pgTable(
-  "oauth_client",
-  {
-    id: text("id").primaryKey(),
-    clientId: text("client_id").notNull().unique(),
-    clientSecret: text("client_secret"),
-    disabled: boolean("disabled").default(false),
-    skipConsent: boolean("skip_consent"),
-    enableEndSession: boolean("enable_end_session"),
-    subjectType: text("subject_type"),
-    scopes: text("scopes").array(),
-    userId: text("user_id").references(() => user.id, { onDelete: "cascade" }),
-    createdAt: timestamp("created_at"),
-    updatedAt: timestamp("updated_at"),
-    name: text("name"),
-    uri: text("uri"),
-    icon: text("icon"),
-    contacts: text("contacts").array(),
-    tos: text("tos"),
-    policy: text("policy"),
-    softwareId: text("software_id"),
-    softwareVersion: text("software_version"),
-    softwareStatement: text("software_statement"),
-    redirectUris: text("redirect_uris").array().notNull(),
-    postLogoutRedirectUris: text("post_logout_redirect_uris").array(),
-    tokenEndpointAuthMethod: text("token_endpoint_auth_method"),
-    grantTypes: text("grant_types").array(),
-    responseTypes: text("response_types").array(),
-    public: boolean("public"),
-    type: text("type"),
-    requirePKCE: boolean("require_pkce"),
-    referenceId: text("reference_id"),
-    metadata: jsonb("metadata"),
-  },
-  (table) => [index("oauthClient_userId_idx").on(table.userId)],
+	'oauth_client',
+	{
+		id: text('id').primaryKey(),
+		clientId: text('client_id').notNull().unique(),
+		clientSecret: text('client_secret'),
+		disabled: boolean('disabled').default(false),
+		skipConsent: boolean('skip_consent'),
+		enableEndSession: boolean('enable_end_session'),
+		subjectType: text('subject_type'),
+		scopes: text('scopes').array(),
+		userId: text('user_id').references(() => user.id, { onDelete: 'cascade' }),
+		createdAt: timestamp('created_at'),
+		updatedAt: timestamp('updated_at'),
+		name: text('name'),
+		uri: text('uri'),
+		icon: text('icon'),
+		contacts: text('contacts').array(),
+		tos: text('tos'),
+		policy: text('policy'),
+		softwareId: text('software_id'),
+		softwareVersion: text('software_version'),
+		softwareStatement: text('software_statement'),
+		redirectUris: text('redirect_uris').array().notNull(),
+		postLogoutRedirectUris: text('post_logout_redirect_uris').array(),
+		tokenEndpointAuthMethod: text('token_endpoint_auth_method'),
+		grantTypes: text('grant_types').array(),
+		responseTypes: text('response_types').array(),
+		public: boolean('public'),
+		type: text('type'),
+		requirePKCE: boolean('require_pkce'),
+		referenceId: text('reference_id'),
+		metadata: jsonb('metadata'),
+	},
+	(table) => [index('oauthClient_userId_idx').on(table.userId)],
 );
 
 export const oauthRefreshToken = pgTable(
-  "oauth_refresh_token",
-  {
-    id: text("id").primaryKey(),
-    token: text("token").notNull().unique(),
-    clientId: text("client_id")
-      .notNull()
-      .references(() => oauthClient.clientId, { onDelete: "cascade" }),
-    sessionId: text("session_id").references(() => session.id, {
-      onDelete: "set null",
-    }),
-    userId: text("user_id")
-      .notNull()
-      .references(() => user.id, { onDelete: "cascade" }),
-    referenceId: text("reference_id"),
-    expiresAt: timestamp("expires_at"),
-    createdAt: timestamp("created_at"),
-    revoked: timestamp("revoked"),
-    authTime: timestamp("auth_time"),
-    scopes: text("scopes").array().notNull(),
-  },
-  (table) => [
-    index("oauthRefreshToken_clientId_idx").on(table.clientId),
-    index("oauthRefreshToken_sessionId_idx").on(table.sessionId),
-    index("oauthRefreshToken_userId_idx").on(table.userId),
-  ],
+	'oauth_refresh_token',
+	{
+		id: text('id').primaryKey(),
+		token: text('token').notNull().unique(),
+		clientId: text('client_id')
+			.notNull()
+			.references(() => oauthClient.clientId, { onDelete: 'cascade' }),
+		sessionId: text('session_id').references(() => session.id, {
+			onDelete: 'set null',
+		}),
+		userId: text('user_id')
+			.notNull()
+			.references(() => user.id, { onDelete: 'cascade' }),
+		referenceId: text('reference_id'),
+		expiresAt: timestamp('expires_at'),
+		createdAt: timestamp('created_at'),
+		revoked: timestamp('revoked'),
+		authTime: timestamp('auth_time'),
+		scopes: text('scopes').array().notNull(),
+	},
+	(table) => [
+		index('oauthRefreshToken_clientId_idx').on(table.clientId),
+		index('oauthRefreshToken_sessionId_idx').on(table.sessionId),
+		index('oauthRefreshToken_userId_idx').on(table.userId),
+	],
 );
 
 export const oauthAccessToken = pgTable(
-  "oauth_access_token",
-  {
-    id: text("id").primaryKey(),
-    token: text("token").unique(),
-    clientId: text("client_id")
-      .notNull()
-      .references(() => oauthClient.clientId, { onDelete: "cascade" }),
-    sessionId: text("session_id").references(() => session.id, {
-      onDelete: "set null",
-    }),
-    userId: text("user_id").references(() => user.id, { onDelete: "cascade" }),
-    referenceId: text("reference_id"),
-    refreshId: text("refresh_id").references(() => oauthRefreshToken.id, {
-      onDelete: "cascade",
-    }),
-    expiresAt: timestamp("expires_at"),
-    createdAt: timestamp("created_at"),
-    scopes: text("scopes").array().notNull(),
-  },
-  (table) => [
-    index("oauthAccessToken_clientId_idx").on(table.clientId),
-    index("oauthAccessToken_sessionId_idx").on(table.sessionId),
-    index("oauthAccessToken_userId_idx").on(table.userId),
-    index("oauthAccessToken_refreshId_idx").on(table.refreshId),
-  ],
+	'oauth_access_token',
+	{
+		id: text('id').primaryKey(),
+		token: text('token').unique(),
+		clientId: text('client_id')
+			.notNull()
+			.references(() => oauthClient.clientId, { onDelete: 'cascade' }),
+		sessionId: text('session_id').references(() => session.id, {
+			onDelete: 'set null',
+		}),
+		userId: text('user_id').references(() => user.id, { onDelete: 'cascade' }),
+		referenceId: text('reference_id'),
+		refreshId: text('refresh_id').references(() => oauthRefreshToken.id, {
+			onDelete: 'cascade',
+		}),
+		expiresAt: timestamp('expires_at'),
+		createdAt: timestamp('created_at'),
+		scopes: text('scopes').array().notNull(),
+	},
+	(table) => [
+		index('oauthAccessToken_clientId_idx').on(table.clientId),
+		index('oauthAccessToken_sessionId_idx').on(table.sessionId),
+		index('oauthAccessToken_userId_idx').on(table.userId),
+		index('oauthAccessToken_refreshId_idx').on(table.refreshId),
+	],
 );
 
 export const oauthConsent = pgTable(
-  "oauth_consent",
-  {
-    id: text("id").primaryKey(),
-    clientId: text("client_id")
-      .notNull()
-      .references(() => oauthClient.clientId, { onDelete: "cascade" }),
-    userId: text("user_id").references(() => user.id, { onDelete: "cascade" }),
-    referenceId: text("reference_id"),
-    scopes: text("scopes").array().notNull(),
-    createdAt: timestamp("created_at"),
-    updatedAt: timestamp("updated_at"),
-  },
-  (table) => [
-    index("oauthConsent_clientId_idx").on(table.clientId),
-    index("oauthConsent_userId_idx").on(table.userId),
-  ],
+	'oauth_consent',
+	{
+		id: text('id').primaryKey(),
+		clientId: text('client_id')
+			.notNull()
+			.references(() => oauthClient.clientId, { onDelete: 'cascade' }),
+		userId: text('user_id').references(() => user.id, { onDelete: 'cascade' }),
+		referenceId: text('reference_id'),
+		scopes: text('scopes').array().notNull(),
+		createdAt: timestamp('created_at'),
+		updatedAt: timestamp('updated_at'),
+	},
+	(table) => [
+		index('oauthConsent_clientId_idx').on(table.clientId),
+		index('oauthConsent_userId_idx').on(table.userId),
+	],
 );
 
 export const passkey = pgTable(
-  "passkey",
-  {
-    id: text("id").primaryKey(),
-    name: text("name"),
-    publicKey: text("public_key").notNull(),
-    userId: text("user_id")
-      .notNull()
-      .references(() => user.id, { onDelete: "cascade" }),
-    credentialID: text("credential_id").notNull(),
-    counter: integer("counter").notNull(),
-    deviceType: text("device_type").notNull(),
-    backedUp: boolean("backed_up").notNull(),
-    transports: text("transports"),
-    createdAt: timestamp("created_at"),
-    aaguid: text("aaguid"),
-  },
-  (table) => [
-    index("passkey_userId_idx").on(table.userId),
-    index("passkey_credentialID_idx").on(table.credentialID),
-  ],
+	'passkey',
+	{
+		id: text('id').primaryKey(),
+		name: text('name'),
+		publicKey: text('public_key').notNull(),
+		userId: text('user_id')
+			.notNull()
+			.references(() => user.id, { onDelete: 'cascade' }),
+		credentialID: text('credential_id').notNull(),
+		counter: integer('counter').notNull(),
+		deviceType: text('device_type').notNull(),
+		backedUp: boolean('backed_up').notNull(),
+		transports: text('transports'),
+		createdAt: timestamp('created_at'),
+		aaguid: text('aaguid'),
+	},
+	(table) => [
+		index('passkey_userId_idx').on(table.userId),
+		index('passkey_credentialID_idx').on(table.credentialID),
+	],
 );
 
 export const userRelations = relations(user, ({ many }) => ({
-  sessions: many(session),
-  accounts: many(account),
-  oauthClients: many(oauthClient),
-  oauthRefreshTokens: many(oauthRefreshToken),
-  oauthAccessTokens: many(oauthAccessToken),
-  oauthConsents: many(oauthConsent),
-  passkeys: many(passkey),
+	sessions: many(session),
+	accounts: many(account),
+	oauthClients: many(oauthClient),
+	oauthRefreshTokens: many(oauthRefreshToken),
+	oauthAccessTokens: many(oauthAccessToken),
+	oauthConsents: many(oauthConsent),
+	passkeys: many(passkey),
 }));
 
 export const sessionRelations = relations(session, ({ one, many }) => ({
-  user: one(user, {
-    fields: [session.userId],
-    references: [user.id],
-  }),
-  oauthRefreshTokens: many(oauthRefreshToken),
-  oauthAccessTokens: many(oauthAccessToken),
+	user: one(user, {
+		fields: [session.userId],
+		references: [user.id],
+	}),
+	oauthRefreshTokens: many(oauthRefreshToken),
+	oauthAccessTokens: many(oauthAccessToken),
 }));
 
 export const accountRelations = relations(account, ({ one }) => ({
-  user: one(user, {
-    fields: [account.userId],
-    references: [user.id],
-  }),
+	user: one(user, {
+		fields: [account.userId],
+		references: [user.id],
+	}),
 }));
 
 export const oauthClientRelations = relations(oauthClient, ({ one, many }) => ({
-  user: one(user, {
-    fields: [oauthClient.userId],
-    references: [user.id],
-  }),
-  oauthRefreshTokens: many(oauthRefreshToken),
-  oauthAccessTokens: many(oauthAccessToken),
-  oauthConsents: many(oauthConsent),
+	user: one(user, {
+		fields: [oauthClient.userId],
+		references: [user.id],
+	}),
+	oauthRefreshTokens: many(oauthRefreshToken),
+	oauthAccessTokens: many(oauthAccessToken),
+	oauthConsents: many(oauthConsent),
 }));
 
 export const oauthRefreshTokenRelations = relations(
-  oauthRefreshToken,
-  ({ one, many }) => ({
-    oauthClient: one(oauthClient, {
-      fields: [oauthRefreshToken.clientId],
-      references: [oauthClient.clientId],
-    }),
-    session: one(session, {
-      fields: [oauthRefreshToken.sessionId],
-      references: [session.id],
-    }),
-    user: one(user, {
-      fields: [oauthRefreshToken.userId],
-      references: [user.id],
-    }),
-    oauthAccessTokens: many(oauthAccessToken),
-  }),
+	oauthRefreshToken,
+	({ one, many }) => ({
+		oauthClient: one(oauthClient, {
+			fields: [oauthRefreshToken.clientId],
+			references: [oauthClient.clientId],
+		}),
+		session: one(session, {
+			fields: [oauthRefreshToken.sessionId],
+			references: [session.id],
+		}),
+		user: one(user, {
+			fields: [oauthRefreshToken.userId],
+			references: [user.id],
+		}),
+		oauthAccessTokens: many(oauthAccessToken),
+	}),
 );
 
 export const oauthAccessTokenRelations = relations(
-  oauthAccessToken,
-  ({ one }) => ({
-    oauthClient: one(oauthClient, {
-      fields: [oauthAccessToken.clientId],
-      references: [oauthClient.clientId],
-    }),
-    session: one(session, {
-      fields: [oauthAccessToken.sessionId],
-      references: [session.id],
-    }),
-    user: one(user, {
-      fields: [oauthAccessToken.userId],
-      references: [user.id],
-    }),
-    oauthRefreshToken: one(oauthRefreshToken, {
-      fields: [oauthAccessToken.refreshId],
-      references: [oauthRefreshToken.id],
-    }),
-  }),
+	oauthAccessToken,
+	({ one }) => ({
+		oauthClient: one(oauthClient, {
+			fields: [oauthAccessToken.clientId],
+			references: [oauthClient.clientId],
+		}),
+		session: one(session, {
+			fields: [oauthAccessToken.sessionId],
+			references: [session.id],
+		}),
+		user: one(user, {
+			fields: [oauthAccessToken.userId],
+			references: [user.id],
+		}),
+		oauthRefreshToken: one(oauthRefreshToken, {
+			fields: [oauthAccessToken.refreshId],
+			references: [oauthRefreshToken.id],
+		}),
+	}),
 );
 
 export const oauthConsentRelations = relations(oauthConsent, ({ one }) => ({
-  oauthClient: one(oauthClient, {
-    fields: [oauthConsent.clientId],
-    references: [oauthClient.clientId],
-  }),
-  user: one(user, {
-    fields: [oauthConsent.userId],
-    references: [user.id],
-  }),
+	oauthClient: one(oauthClient, {
+		fields: [oauthConsent.clientId],
+		references: [oauthClient.clientId],
+	}),
+	user: one(user, {
+		fields: [oauthConsent.userId],
+		references: [user.id],
+	}),
 }));
 
 export const passkeyRelations = relations(passkey, ({ one }) => ({
-  user: one(user, {
-    fields: [passkey.userId],
-    references: [user.id],
-  }),
+	user: one(user, {
+		fields: [passkey.userId],
+		references: [user.id],
+	}),
 }));

--- a/packages/server/src/db/schema/auth.ts
+++ b/packages/server/src/db/schema/auth.ts
@@ -1,288 +1,320 @@
-import { relations } from 'drizzle-orm';
+import { relations } from "drizzle-orm";
 import {
-	boolean,
-	index,
-	jsonb,
-	pgTable,
-	text,
-	timestamp,
-} from 'drizzle-orm/pg-core';
+  pgTable,
+  text,
+  timestamp,
+  boolean,
+  integer,
+  jsonb,
+  index,
+} from "drizzle-orm/pg-core";
 
-export const user = pgTable('user', {
-	id: text('id').primaryKey(),
-	name: text('name').notNull(),
-	email: text('email').notNull().unique(),
-	emailVerified: boolean('email_verified').default(false).notNull(),
-	image: text('image'),
-	createdAt: timestamp('created_at').defaultNow().notNull(),
-	updatedAt: timestamp('updated_at')
-		.defaultNow()
-		.$onUpdate(() => /* @__PURE__ */ new Date())
-		.notNull(),
+export const user = pgTable("user", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  email: text("email").notNull().unique(),
+  emailVerified: boolean("email_verified").default(false).notNull(),
+  image: text("image"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .defaultNow()
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
 });
 
 export const session = pgTable(
-	'session',
-	{
-		id: text('id').primaryKey(),
-		expiresAt: timestamp('expires_at').notNull(),
-		token: text('token').notNull().unique(),
-		createdAt: timestamp('created_at').defaultNow().notNull(),
-		updatedAt: timestamp('updated_at')
-			.$onUpdate(() => /* @__PURE__ */ new Date())
-			.notNull(),
-		ipAddress: text('ip_address'),
-		userAgent: text('user_agent'),
-		userId: text('user_id')
-			.notNull()
-			.references(() => user.id, { onDelete: 'cascade' }),
-	},
-	(table) => [index('session_userId_idx').on(table.userId)],
+  "session",
+  {
+    id: text("id").primaryKey(),
+    expiresAt: timestamp("expires_at").notNull(),
+    token: text("token").notNull().unique(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+    ipAddress: text("ip_address"),
+    userAgent: text("user_agent"),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+  },
+  (table) => [index("session_userId_idx").on(table.userId)],
 );
 
 export const account = pgTable(
-	'account',
-	{
-		id: text('id').primaryKey(),
-		accountId: text('account_id').notNull(),
-		providerId: text('provider_id').notNull(),
-		userId: text('user_id')
-			.notNull()
-			.references(() => user.id, { onDelete: 'cascade' }),
-		accessToken: text('access_token'),
-		refreshToken: text('refresh_token'),
-		idToken: text('id_token'),
-		accessTokenExpiresAt: timestamp('access_token_expires_at'),
-		refreshTokenExpiresAt: timestamp('refresh_token_expires_at'),
-		scope: text('scope'),
-		password: text('password'),
-		createdAt: timestamp('created_at').defaultNow().notNull(),
-		updatedAt: timestamp('updated_at')
-			.$onUpdate(() => /* @__PURE__ */ new Date())
-			.notNull(),
-	},
-	(table) => [index('account_userId_idx').on(table.userId)],
+  "account",
+  {
+    id: text("id").primaryKey(),
+    accountId: text("account_id").notNull(),
+    providerId: text("provider_id").notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    accessToken: text("access_token"),
+    refreshToken: text("refresh_token"),
+    idToken: text("id_token"),
+    accessTokenExpiresAt: timestamp("access_token_expires_at"),
+    refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+    scope: text("scope"),
+    password: text("password"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("account_userId_idx").on(table.userId)],
 );
 
 export const verification = pgTable(
-	'verification',
-	{
-		id: text('id').primaryKey(),
-		identifier: text('identifier').notNull(),
-		value: text('value').notNull(),
-		expiresAt: timestamp('expires_at').notNull(),
-		createdAt: timestamp('created_at').defaultNow().notNull(),
-		updatedAt: timestamp('updated_at')
-			.defaultNow()
-			.$onUpdate(() => /* @__PURE__ */ new Date())
-			.notNull(),
-	},
-	(table) => [index('verification_identifier_idx').on(table.identifier)],
+  "verification",
+  {
+    id: text("id").primaryKey(),
+    identifier: text("identifier").notNull(),
+    value: text("value").notNull(),
+    expiresAt: timestamp("expires_at").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("verification_identifier_idx").on(table.identifier)],
 );
 
-export const jwks = pgTable('jwks', {
-	id: text('id').primaryKey(),
-	publicKey: text('public_key').notNull(),
-	privateKey: text('private_key').notNull(),
-	createdAt: timestamp('created_at').notNull(),
-	expiresAt: timestamp('expires_at'),
+export const jwks = pgTable("jwks", {
+  id: text("id").primaryKey(),
+  publicKey: text("public_key").notNull(),
+  privateKey: text("private_key").notNull(),
+  createdAt: timestamp("created_at").notNull(),
+  expiresAt: timestamp("expires_at"),
 });
 
 export const oauthClient = pgTable(
-	'oauth_client',
-	{
-		id: text('id').primaryKey(),
-		clientId: text('client_id').notNull().unique(),
-		clientSecret: text('client_secret'),
-		disabled: boolean('disabled').default(false),
-		skipConsent: boolean('skip_consent'),
-		enableEndSession: boolean('enable_end_session'),
-		subjectType: text('subject_type'),
-		scopes: text('scopes').array(),
-		userId: text('user_id').references(() => user.id, { onDelete: 'cascade' }),
-		createdAt: timestamp('created_at'),
-		updatedAt: timestamp('updated_at'),
-		name: text('name'),
-		uri: text('uri'),
-		icon: text('icon'),
-		contacts: text('contacts').array(),
-		tos: text('tos'),
-		policy: text('policy'),
-		softwareId: text('software_id'),
-		softwareVersion: text('software_version'),
-		softwareStatement: text('software_statement'),
-		redirectUris: text('redirect_uris').array().notNull(),
-		postLogoutRedirectUris: text('post_logout_redirect_uris').array(),
-		tokenEndpointAuthMethod: text('token_endpoint_auth_method'),
-		grantTypes: text('grant_types').array(),
-		responseTypes: text('response_types').array(),
-		public: boolean('public'),
-		type: text('type'),
-		requirePKCE: boolean('require_pkce'),
-		referenceId: text('reference_id'),
-		metadata: jsonb('metadata'),
-	},
-	(table) => [index('oauthClient_userId_idx').on(table.userId)],
+  "oauth_client",
+  {
+    id: text("id").primaryKey(),
+    clientId: text("client_id").notNull().unique(),
+    clientSecret: text("client_secret"),
+    disabled: boolean("disabled").default(false),
+    skipConsent: boolean("skip_consent"),
+    enableEndSession: boolean("enable_end_session"),
+    subjectType: text("subject_type"),
+    scopes: text("scopes").array(),
+    userId: text("user_id").references(() => user.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at"),
+    updatedAt: timestamp("updated_at"),
+    name: text("name"),
+    uri: text("uri"),
+    icon: text("icon"),
+    contacts: text("contacts").array(),
+    tos: text("tos"),
+    policy: text("policy"),
+    softwareId: text("software_id"),
+    softwareVersion: text("software_version"),
+    softwareStatement: text("software_statement"),
+    redirectUris: text("redirect_uris").array().notNull(),
+    postLogoutRedirectUris: text("post_logout_redirect_uris").array(),
+    tokenEndpointAuthMethod: text("token_endpoint_auth_method"),
+    grantTypes: text("grant_types").array(),
+    responseTypes: text("response_types").array(),
+    public: boolean("public"),
+    type: text("type"),
+    requirePKCE: boolean("require_pkce"),
+    referenceId: text("reference_id"),
+    metadata: jsonb("metadata"),
+  },
+  (table) => [index("oauthClient_userId_idx").on(table.userId)],
 );
 
 export const oauthRefreshToken = pgTable(
-	'oauth_refresh_token',
-	{
-		id: text('id').primaryKey(),
-		token: text('token').notNull().unique(),
-		clientId: text('client_id')
-			.notNull()
-			.references(() => oauthClient.clientId, { onDelete: 'cascade' }),
-		sessionId: text('session_id').references(() => session.id, {
-			onDelete: 'set null',
-		}),
-		userId: text('user_id')
-			.notNull()
-			.references(() => user.id, { onDelete: 'cascade' }),
-		referenceId: text('reference_id'),
-		expiresAt: timestamp('expires_at'),
-		createdAt: timestamp('created_at'),
-		revoked: timestamp('revoked'),
-		authTime: timestamp('auth_time'),
-		scopes: text('scopes').array().notNull(),
-	},
-	(table) => [
-		index('oauthRefreshToken_clientId_idx').on(table.clientId),
-		index('oauthRefreshToken_sessionId_idx').on(table.sessionId),
-		index('oauthRefreshToken_userId_idx').on(table.userId),
-	],
+  "oauth_refresh_token",
+  {
+    id: text("id").primaryKey(),
+    token: text("token").notNull().unique(),
+    clientId: text("client_id")
+      .notNull()
+      .references(() => oauthClient.clientId, { onDelete: "cascade" }),
+    sessionId: text("session_id").references(() => session.id, {
+      onDelete: "set null",
+    }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    referenceId: text("reference_id"),
+    expiresAt: timestamp("expires_at"),
+    createdAt: timestamp("created_at"),
+    revoked: timestamp("revoked"),
+    authTime: timestamp("auth_time"),
+    scopes: text("scopes").array().notNull(),
+  },
+  (table) => [
+    index("oauthRefreshToken_clientId_idx").on(table.clientId),
+    index("oauthRefreshToken_sessionId_idx").on(table.sessionId),
+    index("oauthRefreshToken_userId_idx").on(table.userId),
+  ],
 );
 
 export const oauthAccessToken = pgTable(
-	'oauth_access_token',
-	{
-		id: text('id').primaryKey(),
-		token: text('token').unique(),
-		clientId: text('client_id')
-			.notNull()
-			.references(() => oauthClient.clientId, { onDelete: 'cascade' }),
-		sessionId: text('session_id').references(() => session.id, {
-			onDelete: 'set null',
-		}),
-		userId: text('user_id').references(() => user.id, { onDelete: 'cascade' }),
-		referenceId: text('reference_id'),
-		refreshId: text('refresh_id').references(() => oauthRefreshToken.id, {
-			onDelete: 'cascade',
-		}),
-		expiresAt: timestamp('expires_at'),
-		createdAt: timestamp('created_at'),
-		scopes: text('scopes').array().notNull(),
-	},
-	(table) => [
-		index('oauthAccessToken_clientId_idx').on(table.clientId),
-		index('oauthAccessToken_sessionId_idx').on(table.sessionId),
-		index('oauthAccessToken_userId_idx').on(table.userId),
-		index('oauthAccessToken_refreshId_idx').on(table.refreshId),
-	],
+  "oauth_access_token",
+  {
+    id: text("id").primaryKey(),
+    token: text("token").unique(),
+    clientId: text("client_id")
+      .notNull()
+      .references(() => oauthClient.clientId, { onDelete: "cascade" }),
+    sessionId: text("session_id").references(() => session.id, {
+      onDelete: "set null",
+    }),
+    userId: text("user_id").references(() => user.id, { onDelete: "cascade" }),
+    referenceId: text("reference_id"),
+    refreshId: text("refresh_id").references(() => oauthRefreshToken.id, {
+      onDelete: "cascade",
+    }),
+    expiresAt: timestamp("expires_at"),
+    createdAt: timestamp("created_at"),
+    scopes: text("scopes").array().notNull(),
+  },
+  (table) => [
+    index("oauthAccessToken_clientId_idx").on(table.clientId),
+    index("oauthAccessToken_sessionId_idx").on(table.sessionId),
+    index("oauthAccessToken_userId_idx").on(table.userId),
+    index("oauthAccessToken_refreshId_idx").on(table.refreshId),
+  ],
 );
 
 export const oauthConsent = pgTable(
-	'oauth_consent',
-	{
-		id: text('id').primaryKey(),
-		clientId: text('client_id')
-			.notNull()
-			.references(() => oauthClient.clientId, { onDelete: 'cascade' }),
-		userId: text('user_id').references(() => user.id, { onDelete: 'cascade' }),
-		referenceId: text('reference_id'),
-		scopes: text('scopes').array().notNull(),
-		createdAt: timestamp('created_at'),
-		updatedAt: timestamp('updated_at'),
-	},
-	(table) => [
-		index('oauthConsent_clientId_idx').on(table.clientId),
-		index('oauthConsent_userId_idx').on(table.userId),
-	],
+  "oauth_consent",
+  {
+    id: text("id").primaryKey(),
+    clientId: text("client_id")
+      .notNull()
+      .references(() => oauthClient.clientId, { onDelete: "cascade" }),
+    userId: text("user_id").references(() => user.id, { onDelete: "cascade" }),
+    referenceId: text("reference_id"),
+    scopes: text("scopes").array().notNull(),
+    createdAt: timestamp("created_at"),
+    updatedAt: timestamp("updated_at"),
+  },
+  (table) => [
+    index("oauthConsent_clientId_idx").on(table.clientId),
+    index("oauthConsent_userId_idx").on(table.userId),
+  ],
+);
+
+export const passkey = pgTable(
+  "passkey",
+  {
+    id: text("id").primaryKey(),
+    name: text("name"),
+    publicKey: text("public_key").notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    credentialID: text("credential_id").notNull(),
+    counter: integer("counter").notNull(),
+    deviceType: text("device_type").notNull(),
+    backedUp: boolean("backed_up").notNull(),
+    transports: text("transports"),
+    createdAt: timestamp("created_at"),
+    aaguid: text("aaguid"),
+  },
+  (table) => [
+    index("passkey_userId_idx").on(table.userId),
+    index("passkey_credentialID_idx").on(table.credentialID),
+  ],
 );
 
 export const userRelations = relations(user, ({ many }) => ({
-	sessions: many(session),
-	accounts: many(account),
-	oauthClients: many(oauthClient),
-	oauthRefreshTokens: many(oauthRefreshToken),
-	oauthAccessTokens: many(oauthAccessToken),
-	oauthConsents: many(oauthConsent),
+  sessions: many(session),
+  accounts: many(account),
+  oauthClients: many(oauthClient),
+  oauthRefreshTokens: many(oauthRefreshToken),
+  oauthAccessTokens: many(oauthAccessToken),
+  oauthConsents: many(oauthConsent),
+  passkeys: many(passkey),
 }));
 
 export const sessionRelations = relations(session, ({ one, many }) => ({
-	user: one(user, {
-		fields: [session.userId],
-		references: [user.id],
-	}),
-	oauthRefreshTokens: many(oauthRefreshToken),
-	oauthAccessTokens: many(oauthAccessToken),
+  user: one(user, {
+    fields: [session.userId],
+    references: [user.id],
+  }),
+  oauthRefreshTokens: many(oauthRefreshToken),
+  oauthAccessTokens: many(oauthAccessToken),
 }));
 
 export const accountRelations = relations(account, ({ one }) => ({
-	user: one(user, {
-		fields: [account.userId],
-		references: [user.id],
-	}),
+  user: one(user, {
+    fields: [account.userId],
+    references: [user.id],
+  }),
 }));
 
 export const oauthClientRelations = relations(oauthClient, ({ one, many }) => ({
-	user: one(user, {
-		fields: [oauthClient.userId],
-		references: [user.id],
-	}),
-	oauthRefreshTokens: many(oauthRefreshToken),
-	oauthAccessTokens: many(oauthAccessToken),
-	oauthConsents: many(oauthConsent),
+  user: one(user, {
+    fields: [oauthClient.userId],
+    references: [user.id],
+  }),
+  oauthRefreshTokens: many(oauthRefreshToken),
+  oauthAccessTokens: many(oauthAccessToken),
+  oauthConsents: many(oauthConsent),
 }));
 
 export const oauthRefreshTokenRelations = relations(
-	oauthRefreshToken,
-	({ one, many }) => ({
-		oauthClient: one(oauthClient, {
-			fields: [oauthRefreshToken.clientId],
-			references: [oauthClient.clientId],
-		}),
-		session: one(session, {
-			fields: [oauthRefreshToken.sessionId],
-			references: [session.id],
-		}),
-		user: one(user, {
-			fields: [oauthRefreshToken.userId],
-			references: [user.id],
-		}),
-		oauthAccessTokens: many(oauthAccessToken),
-	}),
+  oauthRefreshToken,
+  ({ one, many }) => ({
+    oauthClient: one(oauthClient, {
+      fields: [oauthRefreshToken.clientId],
+      references: [oauthClient.clientId],
+    }),
+    session: one(session, {
+      fields: [oauthRefreshToken.sessionId],
+      references: [session.id],
+    }),
+    user: one(user, {
+      fields: [oauthRefreshToken.userId],
+      references: [user.id],
+    }),
+    oauthAccessTokens: many(oauthAccessToken),
+  }),
 );
 
 export const oauthAccessTokenRelations = relations(
-	oauthAccessToken,
-	({ one }) => ({
-		oauthClient: one(oauthClient, {
-			fields: [oauthAccessToken.clientId],
-			references: [oauthClient.clientId],
-		}),
-		session: one(session, {
-			fields: [oauthAccessToken.sessionId],
-			references: [session.id],
-		}),
-		user: one(user, {
-			fields: [oauthAccessToken.userId],
-			references: [user.id],
-		}),
-		oauthRefreshToken: one(oauthRefreshToken, {
-			fields: [oauthAccessToken.refreshId],
-			references: [oauthRefreshToken.id],
-		}),
-	}),
+  oauthAccessToken,
+  ({ one }) => ({
+    oauthClient: one(oauthClient, {
+      fields: [oauthAccessToken.clientId],
+      references: [oauthClient.clientId],
+    }),
+    session: one(session, {
+      fields: [oauthAccessToken.sessionId],
+      references: [session.id],
+    }),
+    user: one(user, {
+      fields: [oauthAccessToken.userId],
+      references: [user.id],
+    }),
+    oauthRefreshToken: one(oauthRefreshToken, {
+      fields: [oauthAccessToken.refreshId],
+      references: [oauthRefreshToken.id],
+    }),
+  }),
 );
 
 export const oauthConsentRelations = relations(oauthConsent, ({ one }) => ({
-	oauthClient: one(oauthClient, {
-		fields: [oauthConsent.clientId],
-		references: [oauthClient.clientId],
-	}),
-	user: one(user, {
-		fields: [oauthConsent.userId],
-		references: [user.id],
-	}),
+  oauthClient: one(oauthClient, {
+    fields: [oauthConsent.clientId],
+    references: [oauthClient.clientId],
+  }),
+  user: one(user, {
+    fields: [oauthConsent.userId],
+    references: [user.id],
+  }),
+}));
+
+export const passkeyRelations = relations(passkey, ({ one }) => ({
+  user: one(user, {
+    fields: [passkey.userId],
+    references: [user.id],
+  }),
 }));

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -27,6 +27,7 @@ import { type } from 'arktype';
 import { Hono } from 'hono';
 import { secureHeaders } from 'hono/secure-headers';
 import { describeRoute } from 'hono-openapi';
+import { configuredProviders } from '../auth/create-auth.js';
 import {
 	createOAuthIssuerURL,
 	OAUTH_AUTHORIZATION_SERVER_METADATA_PATH,
@@ -70,22 +71,14 @@ export const authApp = new Hono<CloudEnv>()
 				}),
 			);
 		}
+		// Buttons come from the same presence value that registers providers in
+		// createAuth, so the page can never offer a provider the server refuses.
+		const providers = configuredProviders(c.var.authSecrets);
 		return c.html(
 			renderSignInPage({
-				githubEnabled: Boolean(
-					c.var.authSecrets.GITHUB_CLIENT_ID &&
-						c.var.authSecrets.GITHUB_CLIENT_SECRET,
-				),
-				microsoftEnabled: Boolean(
-					c.var.authSecrets.MICROSOFT_CLIENT_ID &&
-						c.var.authSecrets.MICROSOFT_CLIENT_SECRET,
-				),
-				appleEnabled: Boolean(
-					c.var.authSecrets.APPLE_CLIENT_ID &&
-						c.var.authSecrets.APPLE_TEAM_ID &&
-						c.var.authSecrets.APPLE_KEY_ID &&
-						c.var.authSecrets.APPLE_PRIVATE_KEY,
-				),
+				githubEnabled: Boolean(providers.github),
+				microsoftEnabled: Boolean(providers.microsoft),
+				appleEnabled: Boolean(providers.apple),
 			}),
 		);
 	})


### PR DESCRIPTION
This stacks passkey sign-in on top of the Better Auth schema catch-up in #2375. The passkey table is now the only migration in this PR, so the WebAuthn feature can review and revert independently from the existing OAuth schema catch-up.

The auth pages stay bundler-free. The inline script drives the Better Auth passkey REST endpoints directly, and `packages/server/src/auth/plugins.test.ts` pins the contract the page depends on: authenticate options can be minted without a session, register options require a session, and a fresh session returns a base64url challenge with the expected RP/user shape.

Passkey registration still requires a fresh session. If Better Auth returns `401` or `403` while starting registration, the page now tells the user to sign in again before adding a passkey instead of asking whether they are signed in.

This also keeps provider visibility register-when-present through a shared `configuredProviders(env)` helper, so `createAuth` and the sign-in page read the same provider-presence owner.

Draft until #2375 lands and the browser WebAuthn matrix passes: Chrome, Safari/iCloud Keychain, register from the signed-in page, sign out, authenticate from `/sign-in`, OAuth re-entry with `?sig=`, cancel-path recovery, and the aged-session registration refusal.

## Changelog

- Add passkey registration for signed-in hosted users.
- Add passkey sign-in from the hosted `/sign-in` page.
- Show stale-session passkey setup failures as a sign-in-again prompt.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785885375&installation_id=128463665&pr_number=2377&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2377&signature=99daa5098abe3d10477a0212ecad4f16894ffe1bda96336f9111c0217d1fe923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->