### PR TITLE
refactor(honeycrisp,whispering): shrink the keyring IPC surface

### DIFF
--- a/apps/honeycrisp/src-tauri/Cargo.lock
+++ b/apps/honeycrisp/src-tauri/Cargo.lock
@@ -1693,7 +1693,6 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-window-state",
  "thiserror 2.0.18",
- "tokio",
 ]
 
 [[package]]

--- a/apps/honeycrisp/src-tauri/Cargo.toml
+++ b/apps/honeycrisp/src-tauri/Cargo.toml
@@ -29,4 +29,3 @@ tauri-plugin-opener = "2"
 tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 tauri-plugin-window-state = "2"
 thiserror = "2"
-tokio = { version = "1", features = ["rt"] } # spawn_blocking for blocking keyring OS calls

--- a/apps/honeycrisp/src-tauri/src/keyring_storage.rs
+++ b/apps/honeycrisp/src-tauri/src/keyring_storage.rs
@@ -1,8 +1,8 @@
-//! Focused OS credential-store backing for app-owned secrets.
+//! Focused OS credential-store backing for the persisted OAuth grant.
 //!
-//! The webview supplies only an allowlisted account name. Rust owns the
-//! service string so this IPC surface cannot become a generic OS credential
-//! read/write primitive if webview JavaScript is compromised. Secrets are
+//! The webview supplies only the secret value. Rust owns the service and
+//! account strings, so this IPC surface cannot become a generic OS credential
+//! read/write primitive if webview JavaScript is compromised. The secret is
 //! stored in the OS's real credential store (Keychain Services on macOS,
 //! Credential Manager on Windows, Secret Service on Linux) via the `keyring`
 //! crate. Its default `v1` feature already picks the right native backend per
@@ -14,7 +14,7 @@
 //! worker thread.
 
 use keyring::{Entry, Error as KeyringCrateError};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use thiserror::Error;
 
 const KEYRING_SERVICE: &str = "honeycrisp";
@@ -24,7 +24,11 @@ const KEYRING_SERVICE: &str = "honeycrisp";
 // bites, suffix this service string per channel, such as `honeycrisp-dev`,
 // rather than sharing one entry across signatures.
 
-const KEYRING_ACCOUNTS: [&str; 1] = ["auth-grant"];
+// Honeycrisp stores exactly one secret, so the account is a Rust constant
+// rather than a webview-supplied parameter checked against an allowlist
+// (Whispering keeps the allowlist shape because a second account is queued
+// there). A second secret here re-adds the parameter and the allowlist.
+const KEYRING_ACCOUNT: &str = "auth-grant";
 
 /// Structured failure for both commands.
 ///
@@ -33,7 +37,7 @@ const KEYRING_ACCOUNTS: [&str; 1] = ["auth-grant"];
 /// logs and treats a read failure as signed-out, and propagates a write
 /// failure, exactly like the `localStorage`-backed `PersistedAuthStorage`
 /// adapter it replaces. The detail still travels in `message`.
-#[derive(Error, Debug, Serialize, Deserialize)]
+#[derive(Error, Debug, Serialize)]
 #[serde(tag = "name")]
 pub enum KeyringError {
     #[error("{message}")]
@@ -54,28 +58,15 @@ impl KeyringError {
     }
 }
 
-fn validate_account(account: &str) -> Result<(), KeyringError> {
-    if KEYRING_ACCOUNTS.contains(&account) {
-        return Ok(());
-    }
-
-    Err(KeyringError::Failed {
-        message: "unknown keyring account".to_string(),
-    })
-}
-
-/// Read the secret stored under the app keyring service and `account`, or
-/// `None` when absent.
+/// Read the stored secret, or `None` when absent.
 ///
 /// `keyring::Error::NoEntry` (nothing stored yet, or a prior delete) is the
 /// only variant folded into `Ok(None)`; every other failure (locked keychain,
 /// platform failure, bad encoding) surfaces as `Err`.
 #[tauri::command]
-pub async fn keyring_read(account: String) -> Result<Option<String>, KeyringError> {
-    validate_account(&account)?;
-
+pub async fn keyring_read() -> Result<Option<String>, KeyringError> {
     tokio::task::spawn_blocking(move || {
-        let entry = Entry::new(KEYRING_SERVICE, &account)
+        let entry = Entry::new(KEYRING_SERVICE, KEYRING_ACCOUNT)
             .map_err(|e| KeyringError::from_crate_error("opening keyring entry", e))?;
         match entry.get_password() {
             Ok(password) => Ok(Some(password)),
@@ -87,19 +78,17 @@ pub async fn keyring_read(account: String) -> Result<Option<String>, KeyringErro
     .map_err(|join_err| KeyringError::task_panicked("keyring_read", join_err))?
 }
 
-/// Write `value` under the app keyring service and `account`, or delete the
-/// entry when `value` is `None`.
+/// Write `value` as the stored secret, or delete the entry when `value` is
+/// `None`.
 ///
 /// Deleting an entry that is already absent (`NoEntry`) is treated as
 /// success, matching `Storage.removeItem`'s no-throw-if-missing semantics:
 /// the TypeScript `PersistedAuthStorage.set(null)` contract relies on a
 /// no-op delete being safe to call repeatedly.
 #[tauri::command]
-pub async fn keyring_write(account: String, value: Option<String>) -> Result<(), KeyringError> {
-    validate_account(&account)?;
-
+pub async fn keyring_write(value: Option<String>) -> Result<(), KeyringError> {
     tokio::task::spawn_blocking(move || {
-        let entry = Entry::new(KEYRING_SERVICE, &account)
+        let entry = Entry::new(KEYRING_SERVICE, KEYRING_ACCOUNT)
             .map_err(|e| KeyringError::from_crate_error("opening keyring entry", e))?;
         match value {
             Some(password) => entry

--- a/apps/honeycrisp/src-tauri/src/keyring_storage.rs
+++ b/apps/honeycrisp/src-tauri/src/keyring_storage.rs
@@ -9,9 +9,9 @@
 //! platform, so there is no per-OS Cargo feature to juggle here.
 //!
 //! `keyring`'s `Entry` calls are blocking OS/D-Bus round-trips (and can block
-//! on a locked keychain waiting for the user), so both commands hop onto
-//! Tokio's blocking pool via `spawn_blocking` instead of running on an async
-//! worker thread.
+//! on a locked keychain waiting for the user), so both commands hop onto the
+//! runtime's blocking pool via `tauri::async_runtime::spawn_blocking` instead
+//! of running on an async worker thread.
 
 use keyring::{Entry, Error as KeyringCrateError};
 use serde::Serialize;
@@ -51,7 +51,7 @@ impl KeyringError {
         }
     }
 
-    fn task_panicked(context: &str, join_err: tokio::task::JoinError) -> Self {
+    fn task_panicked(context: &str, join_err: tauri::Error) -> Self {
         Self::Failed {
             message: format!("{context}: blocking task panicked: {join_err}"),
         }
@@ -65,7 +65,7 @@ impl KeyringError {
 /// platform failure, bad encoding) surfaces as `Err`.
 #[tauri::command]
 pub async fn keyring_read() -> Result<Option<String>, KeyringError> {
-    tokio::task::spawn_blocking(move || {
+    tauri::async_runtime::spawn_blocking(move || {
         let entry = Entry::new(KEYRING_SERVICE, KEYRING_ACCOUNT)
             .map_err(|e| KeyringError::from_crate_error("opening keyring entry", e))?;
         match entry.get_password() {
@@ -87,7 +87,7 @@ pub async fn keyring_read() -> Result<Option<String>, KeyringError> {
 /// no-op delete being safe to call repeatedly.
 #[tauri::command]
 pub async fn keyring_write(value: Option<String>) -> Result<(), KeyringError> {
-    tokio::task::spawn_blocking(move || {
+    tauri::async_runtime::spawn_blocking(move || {
         let entry = Entry::new(KEYRING_SERVICE, KEYRING_ACCOUNT)
             .map_err(|e| KeyringError::from_crate_error("opening keyring entry", e))?;
         match value {

--- a/apps/honeycrisp/src-tauri/src/keyring_storage.rs
+++ b/apps/honeycrisp/src-tauri/src/keyring_storage.rs
@@ -24,10 +24,9 @@ const KEYRING_SERVICE: &str = "honeycrisp";
 // bites, suffix this service string per channel, such as `honeycrisp-dev`,
 // rather than sharing one entry across signatures.
 
-// Honeycrisp stores exactly one secret, so the account is a Rust constant
-// rather than a webview-supplied parameter checked against an allowlist
-// (Whispering keeps the allowlist shape because a second account is queued
-// there). A second secret here re-adds the parameter and the allowlist.
+// Honeycrisp stores exactly one secret, so the account is a Rust constant. A
+// future second secret adds its own command pair with its own hardcoded
+// account, not a webview-supplied account parameter and allowlist.
 const KEYRING_ACCOUNT: &str = "auth-grant";
 
 /// Structured failure for both commands.

--- a/apps/honeycrisp/src/lib/platform/auth.tauri.ts
+++ b/apps/honeycrisp/src/lib/platform/auth.tauri.ts
@@ -14,11 +14,6 @@ import type { PlatformAuth } from './types';
 
 const log = createLogger('honeycrisp/platform/auth');
 
-// Allowlisted in `KEYRING_ACCOUNTS` (src-tauri/src/keyring_storage.rs); Rust
-// owns the OS credential-store service name and rejects any account name not
-// on that list.
-const KEYRING_ACCOUNT = 'auth-grant';
-
 const KeyringError = defineErrors({
 	ReadFailed: ({ cause }: { cause: unknown }) => ({
 		message: `Failed to read from the OS keyring: ${extractErrorMessage(cause)}`,
@@ -37,8 +32,7 @@ const KeyringError = defineErrors({
  */
 async function readGrant(): Promise<string | null> {
 	const { data, error } = await tryAsync({
-		try: () =>
-			invoke<string | null>('keyring_read', { account: KEYRING_ACCOUNT }),
+		try: () => invoke<string | null>('keyring_read'),
 		catch: (cause) => KeyringError.ReadFailed({ cause }),
 	});
 	if (error !== null) {
@@ -55,8 +49,7 @@ async function readGrant(): Promise<string | null> {
  */
 async function writeGrant(serialized: string | null): Promise<void> {
 	const { error } = await tryAsync({
-		try: () =>
-			invoke('keyring_write', { account: KEYRING_ACCOUNT, value: serialized }),
+		try: () => invoke('keyring_write', { value: serialized }),
 		catch: (cause) => KeyringError.WriteFailed({ cause }),
 	});
 	if (error !== null) throw error;

--- a/apps/whispering/src-tauri/src/keyring_storage.rs
+++ b/apps/whispering/src-tauri/src/keyring_storage.rs
@@ -1,8 +1,8 @@
-//! Focused OS credential-store backing for app-owned secrets.
+//! Focused OS credential-store backing for the persisted OAuth grant.
 //!
-//! The webview supplies only an allowlisted account name. Rust owns the
-//! service string so this IPC surface cannot become a generic OS credential
-//! read/write primitive if webview JavaScript is compromised. Secrets are
+//! The webview supplies only the secret value. Rust owns the service and
+//! account strings, so this IPC surface cannot become a generic OS credential
+//! read/write primitive if webview JavaScript is compromised. The secret is
 //! stored in the OS's real credential store (Keychain Services on macOS,
 //! Credential Manager on Windows, Secret Service on Linux) via the `keyring`
 //! crate. Its default `v1` feature already picks the right native backend per
@@ -14,7 +14,7 @@
 //! worker thread.
 
 use keyring::{Entry, Error as KeyringCrateError};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use thiserror::Error;
 
 const KEYRING_SERVICE: &str = "whispering";
@@ -24,10 +24,11 @@ const KEYRING_SERVICE: &str = "whispering";
 // bites, suffix this service string per channel, such as `whispering-dev`,
 // rather than sharing one entry across signatures.
 
-// The `vault-keyring` account joins this allowlist when the /api/keyring
-// device cache lands (specs/20260701T150000-api-keyring-and-vault-wiring.md
-// step 2.2).
-const KEYRING_ACCOUNTS: [&str; 1] = ["auth-grant"];
+// Whispering stores exactly one secret, so the account is a Rust constant. A
+// future second secret, such as the planned vault keyring cache, adds its own
+// command pair with its own hardcoded account, not a webview-supplied account
+// parameter.
+const KEYRING_ACCOUNT: &str = "auth-grant";
 
 /// Structured failure for both commands.
 ///
@@ -36,7 +37,7 @@ const KEYRING_ACCOUNTS: [&str; 1] = ["auth-grant"];
 /// read failure as signed-out, and propagates a write failure, exactly like
 /// the `localStorage`-backed `PersistedAuthStorage` adapter it replaces. The
 /// detail still travels in `message`.
-#[derive(Error, Debug, Serialize, Deserialize, specta::Type)]
+#[derive(Error, Debug, Serialize, specta::Type)]
 #[serde(tag = "name")]
 pub enum KeyringError {
     #[error("{message}")]
@@ -57,29 +58,16 @@ impl KeyringError {
     }
 }
 
-fn validate_account(account: &str) -> Result<(), KeyringError> {
-    if KEYRING_ACCOUNTS.contains(&account) {
-        return Ok(());
-    }
-
-    Err(KeyringError::Failed {
-        message: "unknown keyring account".to_string(),
-    })
-}
-
-/// Read the secret stored under the app keyring service and `account`, or
-/// `None` when absent.
+/// Read the stored secret, or `None` when absent.
 ///
 /// `keyring::Error::NoEntry` (nothing stored yet, or a prior delete) is the
 /// only variant folded into `Ok(None)`; every other failure (locked keychain,
 /// platform failure, bad encoding) surfaces as `Err`.
 #[tauri::command]
 #[specta::specta]
-pub async fn keyring_read(account: String) -> Result<Option<String>, KeyringError> {
-    validate_account(&account)?;
-
+pub async fn keyring_read() -> Result<Option<String>, KeyringError> {
     tokio::task::spawn_blocking(move || {
-        let entry = Entry::new(KEYRING_SERVICE, &account)
+        let entry = Entry::new(KEYRING_SERVICE, KEYRING_ACCOUNT)
             .map_err(|e| KeyringError::from_crate_error("opening keyring entry", e))?;
         match entry.get_password() {
             Ok(password) => Ok(Some(password)),
@@ -91,8 +79,8 @@ pub async fn keyring_read(account: String) -> Result<Option<String>, KeyringErro
     .map_err(|join_err| KeyringError::task_panicked("keyring_read", join_err))?
 }
 
-/// Write `value` under the app keyring service and `account`, or delete the
-/// entry when `value` is `None`.
+/// Write `value` as the stored secret, or delete the entry when `value` is
+/// `None`.
 ///
 /// Deleting an entry that is already absent (`NoEntry`) is treated as
 /// success, matching `Storage.removeItem`'s no-throw-if-missing semantics:
@@ -100,11 +88,9 @@ pub async fn keyring_read(account: String) -> Result<Option<String>, KeyringErro
 /// no-op delete being safe to call repeatedly.
 #[tauri::command]
 #[specta::specta]
-pub async fn keyring_write(account: String, value: Option<String>) -> Result<(), KeyringError> {
-    validate_account(&account)?;
-
+pub async fn keyring_write(value: Option<String>) -> Result<(), KeyringError> {
     tokio::task::spawn_blocking(move || {
-        let entry = Entry::new(KEYRING_SERVICE, &account)
+        let entry = Entry::new(KEYRING_SERVICE, KEYRING_ACCOUNT)
             .map_err(|e| KeyringError::from_crate_error("opening keyring entry", e))?;
         match value {
             Some(password) => entry

--- a/apps/whispering/src/lib/platform/auth.tauri.ts
+++ b/apps/whispering/src/lib/platform/auth.tauri.ts
@@ -15,17 +15,13 @@ import type { PlatformAuth } from './types';
 
 const log = createLogger('whispering/platform/auth');
 
-// Allowlisted in `KEYRING_ACCOUNTS` (src-tauri/src/keyring_storage.rs); Rust
-// rejects any account name not on that list.
-const KEYRING_ACCOUNT = 'auth-grant';
-
 /**
  * Tolerant like the `localStorage` adapter's `get`: a keychain read failure
  * (locked keychain, platform error) reads as signed-out rather than crashing
  * app boot. The next sign-in re-establishes the grant.
  */
 async function readGrant(): Promise<string | null> {
-	const { data, error } = await tauriOnly.keyring.read(KEYRING_ACCOUNT);
+	const { data, error } = await tauriOnly.keyring.read();
 	if (error !== null) {
 		log.warn(error);
 		return null;
@@ -39,7 +35,7 @@ async function readGrant(): Promise<string | null> {
  * look saved.
  */
 async function writeGrant(serialized: string | null): Promise<void> {
-	const { error } = await tauriOnly.keyring.write(KEYRING_ACCOUNT, serialized);
+	const { error } = await tauriOnly.keyring.write(serialized);
 	if (error !== null) throw error;
 }
 

--- a/apps/whispering/src/lib/tauri.tauri.ts
+++ b/apps/whispering/src/lib/tauri.tauri.ts
@@ -195,22 +195,22 @@ const KeyringError = defineErrors({
 
 const keyring = {
 	/**
-	 * Read the secret stored under an app-owned keyring account, or `null` when
-	 * absent. Rust owns the OS credential-store service name and account
-	 * allowlist.
+	 * Read the persisted OAuth grant, or `null` when absent. Rust owns the OS
+	 * credential-store service and account names.
 	 */
-	async read(account: string) {
-		const { data, error } = await commands.keyringRead(account);
+	async read() {
+		const { data, error } = await commands.keyringRead();
 		if (error !== null) return KeyringError.ReadFailed({ cause: error });
 		return Ok(data);
 	},
 
 	/**
-	 * Write `value` under an app-owned keyring account, or delete the entry when
-	 * `value` is `null`.
+	 * Write `value` as the persisted OAuth grant, or delete the entry when
+	 * `value` is `null`. Rust owns the OS credential-store service and account
+	 * names.
 	 */
-	async write(account: string, value: string | null) {
-		const { error } = await commands.keyringWrite(account, value);
+	async write(value: string | null) {
+		const { error } = await commands.keyringWrite(value);
 		if (error !== null) return KeyringError.WriteFailed({ cause: error });
 		return Ok(undefined);
 	},

--- a/apps/whispering/src/lib/tauri/bindings.gen.ts
+++ b/apps/whispering/src/lib/tauri/bindings.gen.ts
@@ -249,30 +249,25 @@ export const commands = {
 	resumePlayback: (sessions: string[]) =>
 		__TAURI_INVOKE<void>('resume_playback', { sessions }),
 	/**
-	 *  Read the secret stored under the app keyring service and `account`, or
-	 *  `None` when absent.
+	 *  Read the stored secret, or `None` when absent.
 	 *
 	 *  `keyring::Error::NoEntry` (nothing stored yet, or a prior delete) is the
 	 *  only variant folded into `Ok(None)`; every other failure (locked keychain,
 	 *  platform failure, bad encoding) surfaces as `Err`.
 	 */
-	keyringRead: (account: string) =>
-		typedError<string | null, KeyringError>(
-			__TAURI_INVOKE('keyring_read', { account }),
-		),
+	keyringRead: () =>
+		typedError<string | null, KeyringError>(__TAURI_INVOKE('keyring_read')),
 	/**
-	 *  Write `value` under the app keyring service and `account`, or delete the
-	 *  entry when `value` is `None`.
+	 *  Write `value` as the stored secret, or delete the entry when `value` is
+	 *  `None`.
 	 *
 	 *  Deleting an entry that is already absent (`NoEntry`) is treated as
 	 *  success, matching `Storage.removeItem`'s no-throw-if-missing semantics:
 	 *  the TypeScript `PersistedAuthStorage.set(null)` contract relies on a
 	 *  no-op delete being safe to call repeatedly.
 	 */
-	keyringWrite: (account: string, value: string | null) =>
-		typedError<null, KeyringError>(
-			__TAURI_INVOKE('keyring_write', { account, value }),
-		),
+	keyringWrite: (value: string | null) =>
+		typedError<null, KeyringError>(__TAURI_INVOKE('keyring_write', { value })),
 	/**
 	 *  Replace the full set of registered global shortcuts. The FE computes the
 	 *  complete list from device-config and pushes it on startup and on every

--- a/specs/20260701T150000-api-keyring-and-vault-wiring.md
+++ b/specs/20260701T150000-api-keyring-and-vault-wiring.md
@@ -165,7 +165,7 @@ export function mountSessionApp<E extends Env = Env>(
 ### Phase 2: client fetch + cache
 
 - [ ] **2.1** A `fetchKeyring` client reader beside `readApiSession` (auth-owned fetch, bearer attached, `credentials: 'omit'`).
-- [ ] **2.2** Device cache: desktop keychain entry (`vault-keyring` account via the existing `keyring_read`/`keyring_write` commands), web `localStorage` key. Refresh on every successful fetch; delete on sign-out. Note: `keyring_read`/`keyring_write` were narrowed alongside the auth-grant keychain migration, the service string is now hardcoded to `whispering` in Rust (`keyring_storage.rs`), and the webview may only pass an account name from a fixed allowlist that today contains just `auth-grant`. This wave must add `'vault-keyring'` to that Rust `KEYRING_ACCOUNTS` allowlist before the desktop cache can call these commands.
+- [ ] **2.2** Device cache: desktop keychain entry (`vault-keyring` account via a new vault-cache command pair), web `localStorage` key. Refresh on every successful fetch; delete on sign-out. Note: the auth-grant keyring commands were collapsed to zero-account in both apps (PR #2378). Rust owns the service and account strings, so this wave adds an explicit second command pair for the vault-keyring cache, with each command hardcoding the `vault-keyring` account in Rust, not an allowlist entry or a generic account parameter.
 - [ ] **2.3** Offline boot path: cached keyring hydrates activation before the first fetch resolves.
 
 ### Phase 3: vault doc + facade wire (Whispering first)


### PR DESCRIPTION
Follow-up collapse pass on #2374's desktop keyring move.

Both Honeycrisp and Whispering now expose auth-grant storage as app-domain Tauri capabilities instead of a generic OS credential-store facade. The webview supplies only the secret value; Rust owns the service/account names.

What changed:
- Honeycrisp keeps the #2374 behavior but hardcodes account `auth-grant` in Rust.
- Whispering now matches that shape: `keyring_read()` takes no account, `keyring_write(value)` takes only the grant value, and the one-entry `KEYRING_ACCOUNTS` validator is gone.
- The stored keychain entries stay byte-compatible: service `honeycrisp` or `whispering`, account `auth-grant`.
- The Draft vault spec no longer preserves `vault-keyring` as a generic IPC account. Future vault work should add explicit domain commands for cached vault key material when that work ships.

```rust
// before
pub async fn keyring_read(account: String) -> Result<Option<String>, KeyringError>

// after
pub async fn keyring_read() -> Result<Option<String>, KeyringError>
```

The `vault-keyring` direction remains real, but it is refused for this wave because the API shape is not accepted yet. This PR keeps the current auth-grant behavior while removing the unnecessary account parameter from the webview boundary.

Verification performed locally:
- Honeycrisp cargo check passed.
- Honeycrisp typecheck/tests passed in the prior collapse pass.
- Whispering cargo check passed.
- Whispering bindings regen passed.
- Whispering typecheck passed.
- Straggler grep for `KEYRING_ACCOUNTS`, `validate_account`, and account-passing call sites is clean.

Known remaining gate: live desktop keychain smoke in a GUI session for both apps: sign in, confirm `security find-generic-password -s honeycrisp|whispering -a auth-grant -w`, quit/relaunch and confirm signed-in read path, then sign out and confirm the entry is deleted.