### PR TITLE
docs: scope Codex guidance to the model-invocable surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,54 +2,21 @@
 
 # Claude-specific orchestration
 
-Claude owns the mission, context selection, ambiguity resolution, tradeoffs,
-ownership calls, implementation direction, and final synthesis.
+Claude decides mission, context selection, ambiguity resolution, tradeoffs,
+ownership, product direction, taste calls, and final synthesis. Codex supplies
+evidence, focused edits, verification, and first-pass analysis. Treat Codex
+output as evidence, not the decision.
 
-Assume the Codex plugin for Claude Code is available:
-`openai/codex-plugin-cc`.
+The Codex plugin (`openai/codex-plugin-cc`) is installed. Delegate bounded
+execution work through `/codex:rescue`: search, grep, broad file inspection,
+exact file reading, diff inspection, command execution, tests, typechecks,
+browser checks, local tools, and focused edits. Send one job per prompt with
+exact inputs, clear constraints, and one deliverable that names the evidence
+wanted (file references, command output, diffs, risks, a short
+recommendation).
 
-## Claude to Codex
-
-Use the plugin commands for bounded execution work:
-
-- `/codex:review`: normal read-only review of current work or a branch diff.
-  Use `--wait` for foreground review and `--background` for async review.
-- `/codex:adversarial-review`: steerable challenge review for design,
-  ownership, lifecycle, API, or regression risks.
-  Use `--wait` for foreground review and `--background` for async review.
-- `/codex:rescue`: investigation, bug fixing, focused implementation,
-  verification, cleanup, and first-pass synthesis.
-  Use `--fresh` for a new task and `--resume` to continue an existing Codex
-  thread. Use `--wait` for foreground work and `--background` for async work.
-- `/codex:transfer`: move the current Claude context into a persistent Codex
-  thread when Codex should continue directly.
-- `/codex:status`, `/codex:result`, and `/codex:cancel`: inspect, retrieve,
-  or stop background Codex jobs.
-- `/codex:setup`: verify Codex installation, authentication, and plugin
-  readiness.
-
-Send Codex bounded prompts: one job, exact inputs, clear constraints, and one
-deliverable. Use Codex for search, grep, broad file inspection, exact file
-reading, diff inspection, command execution, tests, typechecks, browser checks,
-local tools, and focused edits.
-
-## Consuming Codex Results
-
-Treat Codex output as evidence, not the decision.
-
-For background jobs, use `/codex:status` to find the job and
-`/codex:result` to retrieve the full output before making the call.
-
-Prefer Codex results that include:
-
-- file references and relevant snippets
-- command output and verification results
-- diffs or patch summaries
-- risks and open questions
-- short recommendations
-
-## Decision Boundary
-
-Claude decides mission, tradeoffs, ownership, product direction, taste calls,
-and final synthesis. Codex supplies evidence, focused edits, verification, and
-first-pass analysis.
+The review and job commands (`/codex:review`, `/codex:adversarial-review`,
+`/codex:transfer`, `/codex:status`, `/codex:result`, `/codex:cancel`) are
+user-invoked; Claude cannot call them directly. Suggest one when a second
+review pass or a Codex handoff would help, and relay the returned output
+faithfully before making the call.


### PR DESCRIPTION
Tightens the Claude/Codex orchestration section in root `CLAUDE.md` after verifying every command against the installed plugin (`codex@openai-codex` 1.0.5, marketplace repo `openai/codex-plugin-cc`) and DeepWiki.

Two problems with the previous text:

- Six of the eight commands (`review`, `adversarial-review`, `transfer`, `status`, `result`, `cancel`) carry `disable-model-invocation: true`, so Claude cannot invoke them. The section told Claude to use `/codex:status` and `/codex:result` to retrieve background results, an instruction the always-on reader can never follow. The only model-invocable delegation surface is `/codex:rescue` (plus `/codex:setup`).
- The per-command flag catalog (`--wait`, `--background`, `--fresh`, `--resume`) duplicated the plugin's own argument-hints and drifts per plugin version; `/codex:transfer` did not exist in 1.0.4.

What stays, because it is always-on Claude behavior the plugin cannot teach: the decision boundary (Claude decides, Codex supplies evidence), the plugin identifier, the bounded-prompt rule, and the evidence-not-decision framing, which matches the plugin's own verbatim-relay design. The user-invoked commands are now framed as suggestions Claude can surface rather than commands it runs.

Placement follows `AGENTS.md`: `CLAUDE.md` stays a shim (`@AGENTS.md`) plus a short Claude-specific note; the full handoff workflow stays in the `handoff` skill.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785888695&installation_id=128463665&pr_number=2379&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2379&signature=8096686146b9463d34dfa66921689b7536469e8240d6f671d1327fa86aa261c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->