### PR TITLE
refactor(workspace): collapse unused action helpers

### DIFF
--- a/apps/tab-manager/README.md
+++ b/apps/tab-manager/README.md
@@ -18,7 +18,7 @@ Part of the [Epicenter](https://github.com/EpicenterHQ/epicenter) monorepo. AGPL
 │  state       │  bookmarks, chat, tool trust)     │
 │  (ephemeral) │  @epicenter/workspace + sync      │
 ├──────────────┴───────────────────────────────────┤
-│  @epicenter/workspace actionsToAiTools (bridge)  │
+│  @epicenter/workspace/agent tool catalog         │
 └──────────────────────────────────────────────────┘
 ```
 
@@ -65,7 +65,7 @@ Conversation messages live in the per-row `conversations.messages` child doc, no
 
 ## AI chat
 
-The `AiDrawer` component supports multiple conversations. Chat inference needs a signed-in remote connection, but the drawer and its local conversation metadata do not gate the extension shell. Workspace actions are converted to AI tools via `@epicenter/workspace`'s `actionsToAiTools`, so the AI can read and write workspace data directly.
+The `AiDrawer` component supports multiple conversations. Chat inference needs a signed-in remote connection, but the drawer and its local conversation metadata do not gate the extension shell. Workspace actions are exposed to AI through `createLocalToolCatalog` from `@epicenter/workspace/agent`, so the AI can read and write workspace data directly.
 
 Destructive tool calls require inline approval before they execute. Each tool can also be set to "always allow," and that preference is stored in the `toolTrust` table, so it syncs across all your devices like any other workspace data.
 
@@ -119,7 +119,7 @@ Auth uses Google OAuth via `browser.identity`. The workspace always mounts: sign
 - [virtua](https://github.com/inokawa/virtua): virtualized tab list
 - [Tailwind CSS](https://tailwindcss.com): styling
 - `@epicenter/workspace`: CRDT-backed tables, sync, persistence
-- `@epicenter/workspace` `actionsToAiTools` - workspace-to-LLM tool bridge
+- `@epicenter/workspace/agent` `createLocalToolCatalog` - workspace-to-agent tool bridge
 - `@epicenter/svelte`: auth integration
 - `@epicenter/ui`: shadcn-svelte component library
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ The dependency shape runs bottom to top. Apps depend on middleware; middleware d
 | @epicenter/svelte      (packages/svelte-utils)                             |
 | @epicenter/filesystem                                                      |
 | @epicenter/skills                                                          |
-| @epicenter/workspace/ai                                                    |
+| @epicenter/workspace/agent                                                 |
 +----------------------------------------------------------------------------+
                                       |
                                       v
@@ -35,7 +35,7 @@ The dependency shape runs bottom to top. Apps depend on middleware; middleware d
 `@epicenter/sync` is the wire format, not the app model. It exports protocol primitives like `encodeSyncStep1`, `encodeSyncUpdate`, `decodeSyncMessage` so server and client can speak the same binary language without duplicating protocol logic.
 `@epicenter/constants` is the routing glue. It gives apps one source of truth for URLs, ports, and versioning so sync endpoints, auth URLs, and cross-app links do not drift.
 `@epicenter/ui` is the shared presentation layer. It knows Svelte components, not Yjs semantics.
-The middleware layer is where workspace data starts feeling like an application. `@epicenter/svelte` turns workspace helpers into reactive Svelte state, `@epicenter/filesystem` turns workspace rows and documents into a POSIX-style filesystem, `@epicenter/skills` proves that whole workspaces can be packaged and embedded as data products, and `@epicenter/workspace/ai` bridges workspace actions into LLM-callable tools.
+The middleware layer is where workspace data starts feeling like an application. `@epicenter/svelte` turns workspace helpers into reactive Svelte state, `@epicenter/filesystem` turns workspace rows and documents into a POSIX-style filesystem, `@epicenter/skills` proves that whole workspaces can be packaged and embedded as data products, and `@epicenter/workspace/agent` projects workspace actions into local agent tool catalogs.
 The apps are thin by comparison. Each app owns a shared `create<App>()` model, then runtime openers attach browser, daemon, or Tauri concerns on top.
 
 ## The lifecycle: define, create, open, attach
@@ -238,7 +238,7 @@ export function openOpensidianBrowser() {
 }
 ```
 
-That bundle then feeds other middleware packages. `attachYjsFileSystem(workspace.ydoc, workspace.tables.files, fileContent)` turns the files table plus content docs into a real virtual filesystem, and its `fs.index` is the single owner of path validity that the sqlite mirror converges to; `actionsToAiTools(workspace)` from `@epicenter/workspace/ai` turns workspace actions into chat tools; per-row content docs use sub-doc primitives like `attachRichText`; `createAppAuthClient()` and `createSameOriginCookieAuth()` from `@epicenter/svelte/auth` coordinate identity, fetch, and WebSocket auth, while `toConnection(auth, nodeId)` supplies the boot-time connection (the signed-in principal and WebSocket transport, or `null` signed out) to the workspace boot call.
+That bundle then feeds other middleware packages. `attachYjsFileSystem(workspace.ydoc, workspace.tables.files, fileContent)` turns the files table plus content docs into a real virtual filesystem, and its `fs.index` is the single owner of path validity that the sqlite mirror converges to; `createLocalToolCatalog(workspace.actions)` from `@epicenter/workspace/agent` exposes the same action handlers to the chat loop; per-row content docs use sub-doc primitives like `attachRichText`; `createAppAuthClient()` and `createSameOriginCookieAuth()` from `@epicenter/svelte/auth` coordinate identity, fetch, and WebSocket auth, while `toConnection(auth, nodeId)` supplies the boot-time connection (the signed-in principal and WebSocket transport, or `null` signed out) to the workspace boot call.
 
 ```text
 createOpensidian()
@@ -249,8 +249,8 @@ createOpensidian()
     |
     +-- attachYjsFileSystem(...)              -> editor + terminal + file tree
     +-- createSqliteIndex({ index: fs.index })-> SQL mirror, paths owned by fs.index
-    +-- actionsToAiTools(...).tools           -> local AI tool execution
-    +-- actionsToAiTools(...).definitions     -> wire payload for chat requests
+    +-- createLocalToolCatalog(actions)       -> local agent tool definitions + resolution
+    +-- agent loop approval policy            -> queries auto, mutations gated
     +-- attachRichText(childYdoc) per file    -> per-row content docs
     +-- fromTable / fromKv / auth             -> reactive Svelte app state
 ```

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -1412,7 +1412,6 @@ What the package does give you is the raw material a server adapter needs:
 - action metadata fields (`type`, `title`, `description`, and `input`) for
   adapters that need a discovery surface
 - iterate with `Object.entries(actions)`
-- action metadata (`type`, `title`, `input`, `description`)
 - direct access to `bundle.tables`, `bundle.kv`, `bundle.collaboration.peers`, and per-row content factories
 
 If you want HTTP, CLI, or MCP on top, build or import an adapter around those primitives.
@@ -1596,7 +1595,7 @@ The core package does not export an MCP server or own every adapter. What it doe
 
 That is enough to expose workspace actions over HTTP, CLI, TanStack AI, or MCP without coupling the core package to one transport.
 
-For AI editing, expose workspace mutations as tools. `createLocalToolCatalog(...)` does not teach the model to patch the materialized Markdown folder. It wires tool calls to the same action handlers the UI and CLI use. Query tools can read data; mutation tools write Yjs.
+For AI editing, expose workspace mutations as tools. `createLocalToolCatalog(...)` does not teach the model to patch the materialized Markdown folder. It wires tool calls to the same action handlers the UI and CLI use. Query tools can read data; mutation tools write Yjs. The agent loop runs queries unattended by default, asks before mutations, and denies gated mutations when no approval prompt is wired.
 
 ### Setup
 

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -22,7 +22,7 @@ Write path:
     -> SQLite mirror and Markdown export refresh
 ```
 
-Agents can still edit ordinary project files. They should not patch generated `.md` files to mutate app data. Give them actions instead: browser chat uses `actionsToAiTools`, scripts use `connectDaemonActions`, and humans or automation can call `epicenter run <action>`. The action writes the Yjs datastore; the materializers write the files back out.
+Agents can still edit ordinary project files. They should not patch generated `.md` files to mutate app data. Give them actions instead: browser chat uses `createLocalToolCatalog`, scripts use `connectDaemonActions`, and humans or automation can call `epicenter run <action>`. The action writes the Yjs datastore; the materializers write the files back out.
 
 The current center is small:
 
@@ -945,7 +945,7 @@ Ordering is just lexical: `collaboration` reads `idb.whenLoaded` as `waitFor` be
 
 Markdown comes from one seam, `attachMarkdownExport` (in `@epicenter/workspace/document/materializer/markdown`): a continuous, one-way Yjs to disk projection with free serialization (custom `filename`, `toMarkdown`, per-table `dir`). It exposes a single `markdown_rebuild` mutation for a destructive full re-export (orphan cleanup after a filename or layout change); there is no import path.
 
-The projection is read-only on purpose. The materialized `.md` is never read back into Yjs, so it carries no round-trip obligation and can shape the output however a human-readable export or a published site wants. App data mutates through validated actions (`epicenter run <action>`, `connectDaemonActions`, or TanStack AI tools created by `actionsToAiTools`), never by editing the materialized files. If an app needs Markdown as the authoring format, that parser/editor belongs in an app action or UI surface that writes Yjs. This export is not that path. The SQLite materializer is the read-only sibling for a relational projection.
+The projection is read-only on purpose. The materialized `.md` is never read back into Yjs, so it carries no round-trip obligation and can shape the output however a human-readable export or a published site wants. App data mutates through validated actions (`epicenter run <action>`, `connectDaemonActions`, or agent tools created by `createLocalToolCatalog`), never by editing the materialized files. If an app needs Markdown as the authoring format, that parser/editor belongs in an app action or UI surface that writes Yjs. This export is not that path. The SQLite materializer is the read-only sibling for a relational projection.
 
 ```typescript
 import { field } from '@epicenter/field';
@@ -1251,7 +1251,7 @@ Every action exposes:
 
 And the action itself is callable. There is no separate `.handler` property on the returned object.
 
-### Type guards and iteration
+### Action iteration
 
 ```typescript
 import Type from 'typebox';
@@ -1259,7 +1259,6 @@ import {
 	defineActions,
 	defineMutation,
 	defineQuery,
-	isAction,
 } from '@epicenter/workspace';
 
 const actions = defineActions({
@@ -1271,9 +1270,7 @@ const actions = defineActions({
 });
 
 for (const [key, action] of Object.entries(actions)) {
-	if (isAction(action)) {
-		console.log(key, action.type);
-	}
+	console.log(key, action.type);
 }
 
 const listAction = actions.posts_list;
@@ -1412,7 +1409,8 @@ What the package does give you is the raw material a server adapter needs:
 
 - `bundle.actions` (the typed `ActionRegistry` owned by the workspace bundle)
 - `defineActions(actions)` to author a flat snake_case registry
-- `toActionMeta(action)` to project an action to its wire-safe metadata
+- action metadata fields (`type`, `title`, `description`, and `input`) for
+  adapters that need a discovery surface
 - iterate with `Object.entries(actions)`
 - action metadata (`type`, `title`, `input`, `description`)
 - direct access to `bundle.tables`, `bundle.kv`, `bundle.collaboration.peers`, and per-row content factories
@@ -1492,8 +1490,6 @@ import {
 	defineActions,
 	defineMutation,
 	defineQuery,
-	isAction,
-	toActionMeta,
 	type Action,
 	type ActionRegistry,
 } from '@epicenter/workspace';
@@ -1562,14 +1558,7 @@ import {
 
 ### Introspection
 
-```typescript
-import {
-	isAction,
-	toActionMeta,
-} from '@epicenter/workspace';
-```
-
-`Object.entries(actions)` lets you iterate the flat registry. Combined with each action's `type`, `title`, `description`, and `input` schema, that is enough to build HTTP, CLI, or MCP adapters without coupling the core package to a transport. `toActionMeta(action)` projects a single action to its wire-safe metadata if you need to ship it across a transport.
+`Object.entries(actions)` lets you iterate the flat registry. Combined with each action's `type`, `title`, `description`, and `input` schema, that is enough to build HTTP, CLI, or MCP adapters without coupling the core package to a transport.
 
 ### IDs and dates
 
@@ -1603,13 +1592,11 @@ The core package does not export an MCP server or own every adapter. What it doe
 
 - actions with `type`, `title`, `description`, and `input`
 - `Object.entries(actions)` to iterate the flat registry
-- `isAction` type guard; narrow on `action.type === 'query' | 'mutation'` for the variant
-- `toActionMeta(action)` to project an action to its wire-safe shape
-- `@epicenter/workspace`: `actionsToAiTools(...)` for TanStack AI tool bindings
+- `@epicenter/workspace/agent`: `createLocalToolCatalog(...)` for local action tools
 
 That is enough to expose workspace actions over HTTP, CLI, TanStack AI, or MCP without coupling the core package to one transport.
 
-For AI editing, expose workspace mutations as tools. `actionsToAiTools(...)` does not teach the model to patch the materialized Markdown folder. It wires tool calls to the same action handlers the UI and CLI use. Query tools can read data; mutation tools write Yjs and are marked `needsApproval: true` by default.
+For AI editing, expose workspace mutations as tools. `createLocalToolCatalog(...)` does not teach the model to patch the materialized Markdown folder. It wires tool calls to the same action handlers the UI and CLI use. Query tools can read data; mutation tools write Yjs.
 
 ### Setup
 

--- a/packages/workspace/src/document/materializer/sqlite/core.test.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.test.ts
@@ -24,7 +24,6 @@ import {
 	defineTable,
 	type Tables,
 } from '../../../index.js';
-import { isAction, isMutation, isQuery } from '../../../shared/actions.js';
 import { nullable } from '../../nullable.js';
 import { attachSqliteMaterializerCore } from './core.js';
 
@@ -714,24 +713,24 @@ describe('attachSqliteMaterializerCore', () => {
 	});
 
 	// ============================================================================
-	// ACTION BRAND Tests
+	// Materializer action tests
 	// ============================================================================
 
-	describe('action brand', () => {
-		test('sqlite_rebuild is detectable via isAction()', async () => {
+	describe('actions', () => {
+		test('sqlite_rebuild is exposed as a mutation action', async () => {
 			const testSetup = setup();
 
 			try {
 				const { sqlite } = testSetup.workspace;
-				expect(isAction(sqlite.actions.sqlite_rebuild)).toBe(true);
-				expect(isMutation(sqlite.actions.sqlite_rebuild)).toBe(true);
+				expect(typeof sqlite.actions.sqlite_rebuild).toBe('function');
+				expect(sqlite.actions.sqlite_rebuild.type).toBe('mutation');
 			} finally {
 				await disposeAndYieldForClose(testSetup);
 			}
 		});
 
 		if (hasFts5) {
-			test('sqlite_search is detectable via isAction() when configured', async () => {
+			test('sqlite_search is exposed as a query action when configured', async () => {
 				const testSetup = setup({
 					build: (t) => ({
 						tables: { posts: t.posts },
@@ -742,10 +741,10 @@ describe('attachSqliteMaterializerCore', () => {
 				try {
 					await testSetup.workspace.sqlite.whenFlushed;
 					const sqliteWithFts = testSetup.workspace.sqlite as unknown as {
-						actions: { sqlite_search: unknown };
+						actions: { sqlite_search: { type?: unknown } };
 					};
-					expect(isAction(sqliteWithFts.actions.sqlite_search)).toBe(true);
-					expect(isQuery(sqliteWithFts.actions.sqlite_search)).toBe(true);
+					expect(typeof sqliteWithFts.actions.sqlite_search).toBe('function');
+					expect(sqliteWithFts.actions.sqlite_search.type).toBe('query');
 				} finally {
 					await disposeAndYieldForClose(testSetup);
 				}

--- a/packages/workspace/src/shared/actions.test.ts
+++ b/packages/workspace/src/shared/actions.test.ts
@@ -3,8 +3,8 @@
  *
  * `invokeAction` is the in-process invoker: raw return values get Ok-wrapped,
  * existing `Result`s pass through, thrown errors become `Err(cause)` with the
- * raw thrown value preserved. The RPC wire boundary lives in
- * `document/rpc.ts` and has its own coverage.
+ * raw thrown value preserved. Daemon and tool-boundary coverage lives with
+ * those adapters.
  */
 
 import { describe, expect, test } from 'bun:test';

--- a/packages/workspace/src/shared/actions.ts
+++ b/packages/workspace/src/shared/actions.ts
@@ -22,15 +22,13 @@
  * resolver: `Object.entries(actions)` is the iterator, `actions[key]` is
  * the lookup.
  *
- * Callers use `invokeAction`, which Ok-wraps raw values, preserves existing
- * Results, and catches throws as `Err(cause)`. A cross-device MCP route that
- * projects these actions (e.g. `apps/local-books mcp`) maps that `Err` to an
- * `isError` tool result before it crosses the wire.
+ * Boundary callers use `invokeAction`, which Ok-wraps raw values, preserves
+ * existing Results, and catches throws as `Err(cause)`.
  *
  * @module
  */
 
-import Type, { type Static, type TSchema } from 'typebox';
+import type { Static, TSchema } from 'typebox';
 import { Value } from 'typebox/value';
 import {
 	type AnyTaggedError,
@@ -122,25 +120,6 @@ export type ActionMeta<
 };
 
 /**
- * Schema for {@link ActionMeta}. Defines the single source of truth for the
- * metadata-only projection used by daemon `/list` and AI tool catalog
- * conversion. The `input` field is `Type.Object()` with additional properties
- * allowed because the node's local input schema is itself a TypeBox/JSON Schema
- * object; the validator only confirms shape, not the inner schema's semantics.
- *
- * `Static<typeof ActionMetaSchema>` collapses the parameterized in-process
- * {@link ActionMeta} to its metadata form (`input?: object`).
- */
-export const ActionMetaSchema = Type.Object({
-	type: Type.Enum(['query', 'mutation']),
-	title: Type.Optional(Type.String()),
-	description: Type.Optional(Type.String()),
-	input: Type.Optional(
-		Type.Object({}, { additionalProperties: Type.Unknown() }),
-	),
-});
-
-/**
  * Flat snake_case key to `ActionMeta` map. The metadata-only projection of an
  * `ActionRegistry`, suitable for surfaces that cannot carry callable handlers,
  * such as the daemon `/list` route.
@@ -152,8 +131,8 @@ export type ActionManifest = Record<string, ActionMeta>;
  * properties attached. Queries are idempotent reads; mutations write. The
  * `type` discriminant lives on the value, so the type stays a single union
  * rather than three named aliases. The local callable shape IS the handler's
- * signature (sync stays sync, raw stays raw); a cross-device MCP route that
- * projects the action normalizes the response before it crosses the wire.
+ * signature (sync stays sync, raw stays raw); boundary adapters normalize
+ * responses through {@link invokeAction}.
  */
 export type Action<
 	TInput extends TSchema | undefined = TSchema | undefined,
@@ -243,8 +222,8 @@ type InvalidActionKey<S extends string> =
 
 /**
  * Regex enforcing `^[a-z][a-z0-9_]{0,63}$` at runtime. Used by
- * `defineActions` for the authoring boundary check. Exported so tests and
- * future external validators can share the single source of truth.
+ * `defineActions` for the authoring boundary check and by tests that pin the
+ * runtime grammar.
  */
 export const ACTION_KEY_PATTERN = /^[a-z][a-z0-9_]{0,63}$/;
 
@@ -291,8 +270,8 @@ export function defineActions<T extends ActionRegistry>(
  *
  * Returns the handler with metadata attached. The action callable IS the
  * handler. Local callers see whatever the handler returns (sync if sync,
- * raw if raw, `Result` if explicit). A cross-device MCP route that projects
- * the action normalizes the response before it crosses the wire.
+ * raw if raw, `Result` if explicit). Boundary callers can normalize the
+ * response with {@link invokeAction}.
  */
 /** No input. `TInput` is explicitly `undefined`. */
 export function defineQuery<R>(
@@ -328,38 +307,6 @@ export function defineMutation({ handler, ...rest }: any): Action {
 }
 
 /**
- * Type guard to check if a value is an action definition.
- *
- * Structural check: anything callable with a `type` of `'query'` or
- * `'mutation'` is an action.
- */
-export function isAction(value: unknown): value is Action {
-	return (
-		typeof value === 'function' &&
-		'type' in value &&
-		(value.type === 'query' || value.type === 'mutation')
-	);
-}
-
-/**
- * Type guard to check if a value is a query action definition.
- */
-export function isQuery(
-	value: unknown,
-): value is Action<TSchema | undefined, unknown, 'query'> {
-	return isAction(value) && value.type === 'query';
-}
-
-/**
- * Type guard to check if a value is a mutation action definition.
- */
-export function isMutation(
-	value: unknown,
-): value is Action<TSchema | undefined, unknown, 'mutation'> {
-	return isAction(value) && value.type === 'mutation';
-}
-
-/**
  * Project a callable action onto its wire-form metadata. Functions drop;
  * live schemas, titles, and descriptions are kept. Used at the daemon
  * `/list` route and any other surface that needs metadata without handlers.
@@ -382,8 +329,7 @@ export function toActionMeta({
  * declared `input` schema. This is the one place the schema is enforced at
  * runtime: a value that reaches a handler has already matched the contract the
  * action published. The daemon maps it to a usage error (bad input, not a
- * handler crash); a cross-device MCP route that projects the action surfaces it
- * as an `isError` tool result.
+ * handler crash).
  */
 export const ActionInputError = defineErrors({
 	InvalidInput: ({
@@ -427,8 +373,7 @@ export function isActionInputError(error: unknown): error is ActionInputError {
  *
  * Otherwise: raw values get `Ok`-wrapped, existing `Result`s pass through, and
  * thrown errors become `Err(cause)` with the raw thrown value under `.error`.
- * A cross-device MCP route that projects these actions maps that `Err` to an
- * `isError` tool result before it crosses the wire; callers in-process see
+ * Boundary adapters decide how to present that `Err`; callers in-process see
  * whatever the handler actually threw or returned.
  *
  * @example


### PR DESCRIPTION
This collapses the workspace action helper surface around the contract apps actually use: an app authors a flat `snake_case` registry, local code can call actions directly, and daemon, CLI, and agent boundaries run them through `invokeAction` with schema validation.

`ActionMetaSchema` and the `isAction` / `isQuery` / `isMutation` guards were no longer part of the root public API and had no current source callers. Removing them leaves the durable concepts in place: `Action`, `ActionRegistry`, `ActionManifest`, `toActionMeta`, and `invokeAction`. The sqlite materializer tests now assert the public facts adapters rely on, namely that generated actions are callable and tagged as queries or mutations.

The current docs now match that shape. They point agent integrations at `createLocalToolCatalog` from `@epicenter/workspace/agent`, keep the direct-call versus boundary-invocation split explicit, and preserve the approval rule: queries run unattended by default, while mutations are gated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785895819&installation_id=128463665&pr_number=2382&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2382&signature=18620043d9dcb5b960d2353fedf0c5767ad47332eb90e0bd63270eaded269626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->