### PR TITLE
refactor(honeycrisp): render note cards with Item.Root

### DIFF
--- a/apps/honeycrisp/src/routes/components/NoteCard.svelte
+++ b/apps/honeycrisp/src/routes/components/NoteCard.svelte
@@ -3,6 +3,7 @@
 	import * as AlertDialog from '@epicenter/ui/alert-dialog';
 	import { Button } from '@epicenter/ui/button';
 	import * as ContextMenu from '@epicenter/ui/context-menu';
+	import * as Item from '@epicenter/ui/item';
 	import { DateTimeString } from '@epicenter/workspace';
 	import ArchiveRestoreIcon from '@lucide/svelte/icons/archive-restore';
 	import FileTextIcon from '@lucide/svelte/icons/file-text';
@@ -30,10 +31,9 @@
 
 <ContextMenu.Root>
 	<ContextMenu.Trigger>
-		<!-- svelte-ignore a11y_click_events_have_key_events -->
-		<!-- svelte-ignore a11y_no_static_element_interactions -->
-		<div
-			class="group relative flex cursor-pointer flex-col gap-0.5 rounded-lg px-3 py-2 text-sm transition-colors hover:bg-accent/30 {isSelected
+		<Item.Root
+			size="sm"
+			class="cursor-pointer flex-col items-stretch gap-0.5 rounded-lg py-2 hover:bg-accent/30 {isSelected
 				? 'bg-accent'
 				: ''}"
 			onclick={onSelect}
@@ -49,13 +49,13 @@
 					{format(new Date(note.updatedAt), 'h:mm a')}
 				</span>
 			</div>
-			<p class="line-clamp-2 text-xs text-muted-foreground">
+			<Item.Description class="text-xs">
 				{note.preview || 'No content'}
-			</p>
+			</Item.Description>
 
 			{#if isDeleted}
 				<div
-					class="absolute bottom-1 right-2 hidden items-center gap-0.5 group-hover:flex {isSelected
+					class="absolute bottom-1 right-2 hidden items-center gap-0.5 group-hover/item:flex {isSelected
 						? 'flex'
 						: ''}"
 				>
@@ -84,7 +84,7 @@
 				</div>
 			{:else}
 				<div
-					class="absolute bottom-1 right-2 hidden items-center gap-0.5 group-hover:flex {isSelected
+					class="absolute bottom-1 right-2 hidden items-center gap-0.5 group-hover/item:flex {isSelected
 						? 'flex'
 						: ''}"
 				>
@@ -112,7 +112,7 @@
 					</Button>
 				</div>
 			{/if}
-		</div>
+		</Item.Root>
 	</ContextMenu.Trigger>
 
 	<ContextMenu.Content class="w-48">


### PR DESCRIPTION
The note list row was a hand-rolled selectable div carrying its own group, relative, flex, padding, and text classes. It now renders as Item.Root, which supplies those wrapper classes plus a focus-visible ring, and the preview paragraph becomes Item.Description, which owns the line clamp and muted color. The hover action clusters key off Item.Root's built-in group/item scope instead of a bespoke group class, and the a11y suppression comments go away because the click handler now lands on the primitive.

Item.Button is deliberately not used here: the card contains nested pin, delete, and restore buttons, and a row that contains buttons cannot itself be a button. This matches the LocalModelSelector shape (Item.Root with actions inside) rather than the TabItem shape (whole-row button).

Selection styling and the accent hover stay explicit at the call site. Item's built-in hover is anchor-only, and the canonical selected-row treatment is a separately gated design decision, so this PR keeps the existing isSelected ternary and hover class untouched. ContextMenu.Trigger keeps rendering its own wrapper element, so context menu, selection, and hover behavior are unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785897767&installation_id=128463665&pr_number=2384&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2384&signature=ccde7b5b32808cae08e302160caf4cdeaa3bebbdec87f2fc291fb8ecc42fc219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->