### PR TITLE
feat: commit plain workspace edits at semantic boundaries

### DIFF
--- a/.agents/skills/svelte/references/mutations-and-workspace-inputs.md
+++ b/.agents/skills/svelte/references/mutations-and-workspace-inputs.md
@@ -225,6 +225,8 @@ Render `FlushEditsOnHide` from `@epicenter/svelte` once in the root layout
 
 When the page is being hidden (tab close, Cmd+W, tab switch, window minimize, iOS app-switch, bfcache), the component force-blurs the focused element; `.blur()` synchronously dispatches its blur event, which synchronously runs your commit handler, which synchronously updates the Y.Doc: all before the page tears down. One line in one place, and every `<input onblur>` in the app inherits the resilience.
 
+The guarantee is only as synchronous as the handler. A blur handler that defers its write (`requestAnimationFrame`, `setTimeout`, an `await` before the write) escapes the net: rAF callbacks never run while the document is hidden, and teardown outruns timers. If a handler needs a deferred path for a visible-page focus dance (the tree rename inputs wait one frame so a closing context menu does not cancel the edit), branch on `document.visibilityState === 'hidden'` and commit synchronously in that branch.
+
 Do not hand-roll the two listeners per app: `visibilitychange` is a document event and `pagehide` is a window event, and putting either on the wrong special element typechecks loosely and never fires. The component owns that split (see `packages/svelte-utils/src/flush-edits-on-hide.svelte`).
 
 ## The default for new apps

--- a/.agents/skills/svelte/references/mutations-and-workspace-inputs.md
+++ b/.agents/skills/svelte/references/mutations-and-workspace-inputs.md
@@ -212,29 +212,24 @@ The compare-then-write guard avoids a no-op Yjs transaction when focus passes th
 
 ## The safety net (app-wide, in `+layout.svelte`)
 
+Render `FlushEditsOnHide` from `@epicenter/svelte` once in the root layout
+(ADR-0110):
+
 ```svelte
 <script lang="ts">
-  function flushPendingEdits() {
-    if (
-      document.visibilityState === 'hidden' &&
-      document.activeElement instanceof HTMLElement
-    ) {
-      document.activeElement.blur();
-    }
-  }
+  import { FlushEditsOnHide } from '@epicenter/svelte';
 </script>
 
-<svelte:document onvisibilitychange={flushPendingEdits} />
-<svelte:window onpagehide={flushPendingEdits} />
+<FlushEditsOnHide />
 ```
 
-When the page is being hidden (tab close, Cmd+W, tab switch, window minimize, iOS app-switch, bfcache), `.blur()` on the focused element synchronously dispatches its blur event, which synchronously runs your commit handler, which synchronously updates the Y.Doc: all before the page tears down. Six lines, one place, every `<input onblur>` in the app inherits the resilience.
+When the page is being hidden (tab close, Cmd+W, tab switch, window minimize, iOS app-switch, bfcache), the component force-blurs the focused element; `.blur()` synchronously dispatches its blur event, which synchronously runs your commit handler, which synchronously updates the Y.Doc: all before the page tears down. One line in one place, and every `<input onblur>` in the app inherits the resilience.
 
-`visibilitychange` is a document event, `pagehide` is a window event. Per Svelte's `packages/svelte/elements.d.ts`, `onvisibilitychange` lives on `SvelteDocumentAttributes` and `onpagehide` lives on `SvelteWindowAttributes`: keep them on the right element. Listen to both: visibilitychange is more reliable on iOS Safari, pagehide catches bfcache navigations.
+Do not hand-roll the two listeners per app: `visibilitychange` is a document event and `pagehide` is a window event, and putting either on the wrong special element typechecks loosely and never fires. The component owns that split (see `packages/svelte-utils/src/flush-edits-on-hide.svelte`).
 
 ## The default for new apps
 
-Every new app under `apps/*` should ship the safety net in `+layout.svelte` as part of scaffolding. Treat it like `<Toaster />` or `<ModeWatcher />`: a layout-level concern that's free once installed. See `workspace-app-composition` for where this fits in the `+layout.svelte` checklist.
+Every app under `apps/*` ships `<FlushEditsOnHide />` in `+layout.svelte` as part of scaffolding. Treat it like `<Toaster />` or `<ModeWatcher />`: a layout-level concern that's free once installed. See `workspace-app-composition` for where this fits in the `+layout.svelte` checklist.
 
 ## When NOT to use commit-on-blur
 

--- a/.agents/skills/svelte/references/mutations-and-workspace-inputs.md
+++ b/.agents/skills/svelte/references/mutations-and-workspace-inputs.md
@@ -231,7 +231,7 @@ Do not hand-roll the two listeners per app: `visibilitychange` is a document eve
 
 ## The default for new apps
 
-Every app under `apps/*` ships `<FlushEditsOnHide />` in `+layout.svelte` as part of scaffolding. Treat it like `<Toaster />` or `<ModeWatcher />`: a layout-level concern that's free once installed. See `workspace-app-composition` for where this fits in the `+layout.svelte` checklist.
+An app ships `<FlushEditsOnHide />` in `+layout.svelte` as soon as it has its first commit-on-blur durable field; an app with none (Todos today) skips it. Once installed it is free, like `<Toaster />` or `<ModeWatcher />`: a layout-level concern with nothing to configure. See `workspace-app-composition` for where this fits in the `+layout.svelte` checklist.
 
 ## When NOT to use commit-on-blur
 

--- a/apps/honeycrisp/src/routes/+layout.svelte
+++ b/apps/honeycrisp/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { SignInMigrationDialog } from '@epicenter/app-shell/sign-in-migration';
 	import { WorkspaceGate } from '@epicenter/app-shell/workspace-gate';
+	import { FlushEditsOnHide } from '@epicenter/svelte';
 	import { reloadOnPrincipalChange } from '@epicenter/svelte/auth';
 	import { ConfirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { Toaster } from '@epicenter/ui/sonner';
@@ -41,3 +42,4 @@
 <ConfirmationDialog />
 <SignInMigrationDialog migration={signInMigration} />
 <ModeWatcher defaultMode="dark" track={false} />
+<FlushEditsOnHide />

--- a/apps/matter/src/routes/+layout.svelte
+++ b/apps/matter/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import '@epicenter/ui/app.css';
+	import { FlushEditsOnHide } from '@epicenter/svelte';
 	import * as Tooltip from '@epicenter/ui/tooltip';
 	import { ModeWatcher } from 'mode-watcher';
 
@@ -11,3 +12,4 @@
 <Tooltip.Provider>{@render children?.()}</Tooltip.Provider>
 
 <ModeWatcher defaultMode="dark" track={false} />
+<FlushEditsOnHide />

--- a/apps/opensidian/src/lib/components/tree/InlineNameInput.svelte
+++ b/apps/opensidian/src/lib/components/tree/InlineNameInput.svelte
@@ -77,6 +77,13 @@
 			e.stopPropagation();
 		}}
 		onblur={() => {
+			// FlushEditsOnHide force-blurs on page hide, and rAF never runs
+			// while the document is hidden: commit synchronously there or the
+			// rename is lost.
+			if (document.visibilityState === 'hidden') {
+				confirm();
+				return;
+			}
 			// Defer to next frame so transient focus shifts settle. Without
 			// this, context menu close restores focus to the trigger element,
 			// which blurs the input and cancels it before the user can type.

--- a/apps/opensidian/src/routes/+layout.svelte
+++ b/apps/opensidian/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { SignInMigrationDialog } from '@epicenter/app-shell/sign-in-migration';
 	import { WorkspaceGate } from '@epicenter/app-shell/workspace-gate';
+	import { FlushEditsOnHide } from '@epicenter/svelte';
 	import { reloadOnPrincipalChange } from '@epicenter/svelte/auth';
 	import { ConfirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { Toaster } from '@epicenter/ui/sonner';
@@ -41,3 +42,4 @@
 <Toaster />
 <SignInMigrationDialog migration={signInMigration} />
 <ModeWatcher defaultMode="dark" track={false} />
+<FlushEditsOnHide />

--- a/apps/skills/src/lib/components/tree/InlineNameInput.svelte
+++ b/apps/skills/src/lib/components/tree/InlineNameInput.svelte
@@ -61,6 +61,15 @@
 			e.stopPropagation();
 		}}
 		onblur={() => {
+			// FlushEditsOnHide force-blurs on page hide, and rAF never runs
+			// while the document is hidden: commit synchronously there or the
+			// rename is lost. The deferred path exists only for transient
+			// focus shifts while the page is visible (the closing context
+			// menu restoring focus must not cancel the edit).
+			if (document.visibilityState === 'hidden') {
+				confirm();
+				return;
+			}
 			requestAnimationFrame(() => {
 				if (inputEl && document.activeElement !== inputEl) {
 					confirm();

--- a/apps/skills/src/routes/+layout.svelte
+++ b/apps/skills/src/routes/+layout.svelte
@@ -1,42 +1,15 @@
 <script lang="ts">
 	import '../app.css';
+	import { FlushEditsOnHide } from '@epicenter/svelte';
 	import { ConfirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { Toaster } from '@epicenter/ui/sonner';
 	import { ModeWatcher } from 'mode-watcher';
 
 	let { children } = $props();
-
-	/**
-	 * Force-fire onblur on the currently-focused element when the page is
-	 * being hidden. This catches the "user typed in a field, hits Cmd+W"
-	 * case: `.blur()` synchronously dispatches the blur event, so any
-	 * commit-on-blur handler runs and updates the Y.Doc before the page is
-	 * destroyed. See docs/articles/commit-on-blur-survives-tab-close.md.
-	 */
-	function flushPendingEdits() {
-		if (
-			document.visibilityState === 'hidden' &&
-			document.activeElement instanceof HTMLElement
-		) {
-			document.activeElement.blur();
-		}
-	}
 </script>
-
-<!--
-	Tab-close safety net: when the page is being hidden (Cmd+W, tab switch,
-	window minimize, mobile app-switch, bfcache), force-blur the focused
-	element so any input wired to commit on `onblur` gets its handler fired
-	synchronously, updating the Y.Doc before the page is torn down.
-	Listening to both visibilitychange (document) and pagehide (window) for
-	cross-browser coverage: visibilitychange is more reliable on iOS Safari,
-	pagehide catches bfcache navigations. Per Svelte's elements.d.ts,
-	pagehide is a window event, visibilitychange is a document event.
--->
-<svelte:document onvisibilitychange={flushPendingEdits} />
-<svelte:window onpagehide={flushPendingEdits} />
 
 <ConfirmationDialog />
 <Toaster />
 <ModeWatcher />
+<FlushEditsOnHide />
 {@render children()}

--- a/apps/vocab/src/routes/+layout.svelte
+++ b/apps/vocab/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { SignInMigrationDialog } from '@epicenter/app-shell/sign-in-migration';
 	import { WorkspaceGate } from '@epicenter/app-shell/workspace-gate';
+	import { FlushEditsOnHide } from '@epicenter/svelte';
 	import { reloadOnPrincipalChange } from '@epicenter/svelte/auth';
 	import { ConfirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { Toaster } from '@epicenter/ui/sonner';
@@ -41,3 +42,4 @@
 <ConfirmationDialog />
 <SignInMigrationDialog migration={signInMigration} />
 <ModeWatcher />
+<FlushEditsOnHide />

--- a/apps/whispering/src/lib/components/settings/CompletionRuntimeConfig.svelte
+++ b/apps/whispering/src/lib/components/settings/CompletionRuntimeConfig.svelte
@@ -120,8 +120,12 @@
 				id="completion-model"
 				placeholder="e.g. llama3.1"
 				autocomplete="off"
-				bind:value={() => settings.get('completion.model'),
-					(value) => settings.set('completion.model', value)}
+				value={settings.get('completion.model')}
+				onblur={(e) => {
+					const next = e.currentTarget.value;
+					if (next !== settings.get('completion.model'))
+						settings.set('completion.model', next);
+				}}
 			/>
 			<Field.Description>
 				The model id your endpoint serves.

--- a/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
+++ b/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
@@ -527,10 +527,12 @@
 			id="transcription-prompt"
 			placeholder="e.g., This is an academic lecture about quantum physics with technical terms like 'eigenvalue' and 'Schrödinger'"
 			disabled={!currentServiceCapabilities.supportsPrompt}
-			bind:value={
-				() => settings.get('transcription.prompt'),
-				(value) => settings.set('transcription.prompt', value)
-			}
+			value={settings.get('transcription.prompt')}
+			onblur={(e) => {
+				const next = e.currentTarget.value;
+				if (next !== settings.get('transcription.prompt'))
+					settings.set('transcription.prompt', next);
+			}}
 		/>
 		<Field.Description>
 			{currentServiceCapabilities.supportsPrompt

--- a/apps/whispering/src/routes/(app)/(config)/settings/dictation/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/dictation/+page.svelte
@@ -86,10 +86,12 @@
 							<Textarea
 								id="polish-instructions"
 								placeholder={settings.getDefault('polish.instructions')}
-								bind:value={
-									() => settings.get('polish.instructions'),
-									(value) => settings.set('polish.instructions', value)
-								}
+								value={settings.get('polish.instructions')}
+								onblur={(e) => {
+									const next = e.currentTarget.value;
+									if (next !== settings.get('polish.instructions'))
+										settings.set('polish.instructions', next);
+								}}
 							/>
 							<Field.Description>
 								What Polish does to every transcript. Keep it

--- a/apps/whispering/src/routes/+layout.svelte
+++ b/apps/whispering/src/routes/+layout.svelte
@@ -5,6 +5,7 @@
 	import { onMount } from 'svelte';
 	import { auth } from '#platform/auth';
 	import { onNavigate } from '$app/navigation';
+	import { FlushEditsOnHide } from '@epicenter/svelte';
 	import { reloadOnPrincipalChange } from '@epicenter/svelte/auth';
 	import { queryClient } from '$lib/rpc/client';
 	import '@epicenter/ui/app.css';
@@ -58,6 +59,7 @@
 	}}
 />
 <ModeWatcher defaultMode="dark" track={false} />
+<FlushEditsOnHide />
 
 <style>
 	/* The default UA view-transition runs 0.25s, which is abrupt for the

--- a/docs/adr/0110-edit-write-timing-follows-the-value-owner-there-is-no-debounce-tier.md
+++ b/docs/adr/0110-edit-write-timing-follows-the-value-owner-there-is-no-debounce-tier.md
@@ -58,6 +58,15 @@ Two enforcement mechanisms make the middle tier real:
 - A debounced middle tier is refused. Debounce has every failure mode of blur
   (still needs the hide net) plus timers, flush-on-unmount bookkeeping, and
   writes that land mid-typing. Blur is strictly simpler and maps to intent.
+- The net is only as synchronous as the blur handler. `.blur()` dispatches the
+  blur event synchronously, but a handler that defers its write
+  (`requestAnimationFrame`, `setTimeout`, an `await` before the write) escapes
+  the guarantee: rAF callbacks do not run while the document is hidden, and
+  teardown outruns timers. Blur handlers on durable fields write synchronously;
+  a handler that needs a deferred path for a visible-page focus dance (the tree
+  rename inputs wait one frame so a closing context menu does not cancel the
+  edit) branches on `document.visibilityState === 'hidden'` and commits
+  immediately there.
 - Skipped no-op updates mean a caller can no longer "touch" a row to refresh
   its LWW timestamp by rewriting equal values. No current caller does this
   deliberately; if one ever needs touch semantics, that is an explicit new

--- a/docs/adr/0110-edit-write-timing-follows-the-value-owner-there-is-no-debounce-tier.md
+++ b/docs/adr/0110-edit-write-timing-follows-the-value-owner-there-is-no-debounce-tier.md
@@ -1,0 +1,86 @@
+# 0110. Edit write timing follows the value owner; there is no debounce tier
+
+- **Status:** Accepted
+- **Date:** 2026-07-05
+
+## Context
+
+Epicenter apps now carry five kinds of editable surface: CRDT-bound rich bodies
+(Honeycrisp's ProseMirror over a `Y.XmlFragment`, Opensidian's CodeMirror over a
+`Y.Text`), plain workspace fields (titles, folder names, term notes), search and
+filter inputs, local form drafts, and device-local settings. The sync path under
+them is deliberately immediate end to end: a Yjs transaction synchronously
+reaches y-indexeddb, sibling tabs over BroadcastChannel, and an open WebSocket,
+and the server appends and fans out in the same listener. The only debounce
+anywhere in the stack is the server's 300ms presence rebroadcast grace and
+y-indexeddb's internal compaction timer; neither is a save mechanism. Without a
+written standard, apps drifted: one app installed the commit-on-blur safety net
+in its layout while five apps with blur-committed fields did not, one app writes
+derived row metadata on every keystroke, and individual inputs choose `oninput`
+or `onblur` ad hoc.
+
+## Decision
+
+Write timing is a property of the value's owner, and there are exactly three
+timings. No surface gets a debounce.
+
+| Owner of the value | Write timing | Why |
+|---|---|---|
+| `Y.Text` / `Y.XmlFragment` behind an editor binding (y-prosemirror, y-codemirror.next) | Every editor transaction, immediately | Character-level CRDT merge is the product behavior; the binding is the document |
+| Workspace table row field or KV entry edited through a text input | Commit at a semantic boundary: blur, Enter, or explicit submit, with a compare-then-write guard | One typing session becomes one row write instead of N; the boundary is user intent, not a timer |
+| Discrete controls (selects, toggles, checkboxes, pickers) writing to any store | Immediately on change | Already one event per intent |
+| Local UI state (search, filter, in-flight form drafts) | Never persisted; local `$state` or URL params only | Transient by definition |
+| Device-local persisted settings (`createPersistedState` over localStorage) | Either timing is acceptable; per-input writes are fine | localStorage is synchronous and local; there is no transaction, sync message, or tombstone to amortize |
+
+Two enforcement mechanisms make the middle tier real:
+
+1. **The page-hide blur net is owned by `@epicenter/svelte`** as a
+   `FlushEditsOnHide` component and rendered by every app's root
+   `+layout.svelte`, exactly like `Toaster` and `ModeWatcher`. It force-blurs
+   `document.activeElement` on `visibilitychange`-to-hidden and `pagehide`, so
+   every commit-on-blur handler runs synchronously before teardown. Per-app
+   copies of the six-line handler are deleted; the copy-paste standard
+   demonstrably did not propagate (one app in six had it).
+2. **A no-op `table.update()` emits nothing.** When the merged row is
+   value-equal to the stored row, the write is skipped: no Yjs transaction, no
+   IndexedDB append, no sync frame, no LWW timestamp refresh. Derived-metadata
+   writers (Honeycrisp's title/preview/wordCount extraction on every editor
+   transaction) then cost nothing on the keystrokes that change nothing, while
+   keystrokes that do change the note list update it live, which is the named
+   product behavior.
+
+## Consequences
+
+- Rich editors stay per-keystroke everywhere. Moving them to blur or a debounce
+  would defeat character-level merge; a debounced CRDT write would also require
+  forking the editor bindings, whose model is that the shared type *is* the
+  document.
+- A debounced middle tier is refused. Debounce has every failure mode of blur
+  (still needs the hide net) plus timers, flush-on-unmount bookkeeping, and
+  writes that land mid-typing. Blur is strictly simpler and maps to intent.
+- Skipped no-op updates mean a caller can no longer "touch" a row to refresh
+  its LWW timestamp by rewriting equal values. No current caller does this
+  deliberately; if one ever needs touch semantics, that is an explicit new
+  method, not a side effect of `update()`.
+- The DOM net is a browser guarantee only. Tauri window close is not guaranteed
+  to fire page-lifecycle events; if a Tauri app grows workspace-backed
+  commit-on-blur fields whose loss is observed, the seam is a `CloseRequested`
+  handler that blurs before allowing close. Deferred until a real loss shows up.
+- Transport-level batching of Yjs updates (merging updates within a frame
+  before the WebSocket send) stays unbuilt. It is an infrastructure seam in the
+  sync supervisor, not an app pattern, and nothing has measured a need for it.
+
+## Considered alternatives
+
+- **`WorkspaceGate` owns the net.** Lost: only three of the six workspace-backed
+  apps render it, and a readiness gate acquiring document-global listeners as a
+  side effect is the wrong owner even where it is rendered.
+- **`@epicenter/app-shell` owns the net.** Lost: it is the branded, full-stack
+  chrome package; apps like Skills and Todos need the net without wanting that
+  dependency edge.
+- **Per-app six-line copies (status quo ante).** Lost empirically: documented in
+  the svelte skill, installed in one app out of six.
+- **A shared commit-on-blur input component.** Lost for now: the handler is
+  three lines and the sites are heterogeneous (rename inputs with Enter/Escape,
+  settings fields, textareas). Revisit if the defensive local-buffer-plus-focus-
+  flag variant appears a third time.

--- a/docs/adr/0110-edit-write-timing-follows-the-value-owner-there-is-no-debounce-tier.md
+++ b/docs/adr/0110-edit-write-timing-follows-the-value-owner-there-is-no-debounce-tier.md
@@ -35,8 +35,9 @@ timings. No surface gets a debounce.
 Two enforcement mechanisms make the middle tier real:
 
 1. **The page-hide blur net is owned by `@epicenter/svelte`** as a
-   `FlushEditsOnHide` component and rendered by every app's root
-   `+layout.svelte`, exactly like `Toaster` and `ModeWatcher`. It force-blurs
+   `FlushEditsOnHide` component, rendered once in the root `+layout.svelte`
+   of every app with blur-committed durable fields (six today; Todos has no
+   such field and renders nothing). It force-blurs
    `document.activeElement` on `visibilitychange`-to-hidden and `pagehide`, so
    every commit-on-blur handler runs synchronously before teardown. Per-app
    copies of the six-line handler are deleted; the copy-paste standard

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -185,5 +185,6 @@ Each option and the one reason it lost. Terse. This is not the spec.
 | [0106](0106-a-child-doc-body-owns-one-layout-the-polymorphic-timeline-is-refused-until-a-product-earns-it.md) | A child-doc body owns one layout; the polymorphic timeline is refused until a product earns it | Accepted |
 | [0107](0107-a-child-doc-text-body-is-a-plain-y-text-the-timeline-array-is-deleted.md) | A child-doc text body is a plain `Y.Text`; the timeline array is deleted | Accepted |
 | [0108](0108-provider-credentials-are-selected-by-target-environment-encoded-in-the-secret-name.md) | Third-party provider credentials are selected by the app's target provider-environment, encoded in the secret name and resolved by one injected helper | Accepted |
+| [0110](0110-edit-write-timing-follows-the-value-owner-there-is-no-debounce-tier.md) | Edit write timing follows the value owner; there is no debounce tier | Accepted |
 
 When you add an ADR, add its row here.

--- a/packages/svelte-utils/src/flush-edits-on-hide.svelte
+++ b/packages/svelte-utils/src/flush-edits-on-hide.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	/**
+	 * Force-blur the focused element when the page is being hidden (tab close,
+	 * Cmd+W, tab switch, window minimize, mobile app-switch, bfcache
+	 * navigation). `.blur()` synchronously dispatches the blur event, so every
+	 * commit-on-blur input handler runs and writes its store before the page
+	 * is torn down.
+	 *
+	 * Render once in the root `+layout.svelte`, like `Toaster` or
+	 * `ModeWatcher`. See ADR-0110 and
+	 * docs/articles/commit-on-blur-survives-tab-close.md.
+	 */
+	function flushPendingEdits() {
+		if (
+			document.visibilityState === 'hidden' &&
+			document.activeElement instanceof HTMLElement
+		) {
+			document.activeElement.blur();
+		}
+	}
+</script>
+
+<!--
+	visibilitychange is a document event and pagehide is a window event (per
+	Svelte's elements.d.ts); keep each on the right special element or it will
+	typecheck loosely and never fire. Listen to both: visibilitychange is more
+	reliable on iOS Safari, pagehide catches bfcache navigations.
+-->
+<svelte:document onvisibilitychange={flushPendingEdits} />
+<svelte:window onpagehide={flushPendingEdits} />

--- a/packages/svelte-utils/src/index.ts
+++ b/packages/svelte-utils/src/index.ts
@@ -2,6 +2,7 @@ export {
 	type BoundAgentConversation,
 	bindAgentConversation,
 } from './agent-conversation.svelte.js';
+export { default as FlushEditsOnHide } from './flush-edits-on-hide.svelte';
 export { fromDisposableCache } from './from-disposable-cache.svelte.js';
 export { fromKv } from './from-kv.svelte.js';
 export {

--- a/packages/workspace/src/document/create-table.test.ts
+++ b/packages/workspace/src/document/create-table.test.ts
@@ -261,6 +261,64 @@ describe('createTable', () => {
 			expect(saved).toEqual({ id: '1', name: 'Alice', age: 30 });
 		});
 
+		test('update with a value-equal merge emits no Yjs update', () => {
+			const { ydoc, ykv } = setup();
+			const definition = defineTable({
+				id: field.string(),
+				name: field.string(),
+				age: field.number(),
+			});
+			const helper = createTable(ykv, definition, 'test');
+			helper.set({ id: '1', name: 'Alice', age: 25 });
+
+			let updates = 0;
+			ydoc.on('update', () => {
+				updates += 1;
+			});
+			const data = expectOk(helper.update('1', { name: 'Alice', age: 25 }));
+
+			expect(data).toEqual({ id: '1', name: 'Alice', age: 25 });
+			expect(updates).toBe(0);
+
+			// A real change still writes.
+			expectOk(helper.update('1', { age: 26 }));
+			expect(updates).toBeGreaterThan(0);
+		});
+
+		test('update over an older-version row persists its migration even when value-equal', () => {
+			const { ykv, yarray } = setup();
+			const definition = defineTable(
+				{
+					id: field.string(),
+					name: field.string(),
+				},
+				{
+					id: field.string(),
+					name: field.string(),
+					age: field.number(),
+				},
+			).migrate(({ value, version }) => {
+				switch (version) {
+					case 1:
+						return { ...value, age: 0 };
+					case 2:
+						return value;
+				}
+			});
+			const helper = createTable(ykv, definition, 'test');
+			// Insert v1 data directly (raw yarray.push needs `_v` for routing).
+			yarray.push([
+				{ key: '1', val: { id: '1', name: 'Alice', _v: 1 }, ts: 0 },
+			]);
+
+			// The merge equals the migrated read, but the stored row is still v1:
+			// the no-op guard must not skip, so the write re-stamps at v2.
+			const data = expectOk(helper.update('1', { age: 0 }));
+
+			expect(data).toEqual({ id: '1', name: 'Alice', age: 0 });
+			expect(ykv.get('1')).toEqual({ id: '1', name: 'Alice', age: 0, _v: 2 });
+		});
+
 		test('update returns null data for missing rows', () => {
 			const { ykv } = setup();
 			const definition = defineTable({

--- a/packages/workspace/src/document/table.ts
+++ b/packages/workspace/src/document/table.ts
@@ -1043,6 +1043,22 @@ export function createTable<
 			// latest shape. Validate against the latest schema directly: no
 			// need to stamp _v, route, and re-migrate just to write back.
 			const merged = { ...current, ...partial, id } as TRow;
+			// A value-equal merge is a no-op: emit nothing (no Yjs transaction,
+			// no IndexedDB append, no sync frame, no LWW timestamp refresh), so
+			// callers that re-derive fields on every source change (Honeycrisp's
+			// title/preview/wordCount extraction per editor transaction) cost
+			// nothing when the derived values did not move (ADR-0110). Guarded to
+			// rows already stamped at the latest version so an update over an
+			// older-version row still persists its migration. Touch semantics
+			// (rewriting equal values to refresh the LWW timestamp) are not a
+			// thing `update()` provides; a caller that needs them writes a real
+			// change.
+			const stored = ykv.get(id);
+			const storedAtLatest =
+				typeof stored === 'object' &&
+				stored !== null &&
+				(stored as Record<string, unknown>)._v === latestVersion;
+			if (storedAtLatest && Value.Equal(current, merged)) return Ok(merged);
 			if (!Value.Check(definition.schema, merged)) {
 				const errors = [...Value.Errors(definition.schema, merged)].map(
 					(e) => ({


### PR DESCRIPTION
Plain durable workspace fields now commit at semantic boundaries instead of every keystroke. Rich CRDT document bodies remain live per transaction. Local UI drafts stay local. There is no debounce-save tier.

This PR records the rule in ADR-0110 and applies it where the current apps were still crossing that boundary. It adds a shared page-hide blur safety net, skips value-equal table updates at the latest schema version, fixes tree rename inputs so page-hide blur commits synchronously, moves Whispering synced free-text settings to blur commit, and renders the hide net only in apps with durable blur-committed edits.

Deliberately out of scope:

- rich editor timing
- persisted schema or wire-format changes
- adding the hide net to apps without durable blur commits
- a shared commit-on-blur input abstraction
- proving async daemon transport durability during teardown

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785898145&installation_id=128463665&pr_number=2385&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2385&signature=83aa3a4a5917e22a2c3b2c6ca3ed16e295b6726c6961f85789790229035a8766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->