### PR TITLE
refactor(matter): collapse surface switcher pills

### DIFF
--- a/apps/matter/src/routes/(vaults)/vault/[id]/SurfacePill.svelte
+++ b/apps/matter/src/routes/(vaults)/vault/[id]/SurfacePill.svelte
@@ -1,0 +1,31 @@
+<!--
+@component
+One route-backed surface pill. The URL owns the selected surface (see routes.ts);
+this button renders one navigation choice and navigates with the shared switch
+options, so active state is always derived from the route, never held locally.
+-->
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { SWITCH_NAV } from '$lib/routes';
+
+	let {
+		active,
+		to,
+		children,
+	}: { active: boolean; to: string; children: Snippet } = $props();
+</script>
+
+<button
+	type="button"
+	aria-current={active ? 'true' : undefined}
+	onclick={() => goto(to, SWITCH_NAV)}
+	class={[
+		'flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1 text-sm transition',
+		active
+			? 'bg-muted font-medium text-foreground'
+			: 'text-muted-foreground hover:bg-muted/50',
+	]}
+>
+	{@render children()}
+</button>

--- a/apps/matter/src/routes/(vaults)/vault/[id]/TablePane.svelte
+++ b/apps/matter/src/routes/(vaults)/vault/[id]/TablePane.svelte
@@ -6,13 +6,13 @@
 	import Grid2x2Icon from '@lucide/svelte/icons/grid-2x2';
 	import KanbanIcon from '@lucide/svelte/icons/kanban';
 	import type { ViewSpec } from '@epicenter/matter-core';
-	import { goto } from '$app/navigation';
-	import { routes, SWITCH_NAV } from '$lib/routes';
+	import { routes } from '$lib/routes';
 	import BoardView from '$lib/components/BoardView.svelte';
 	import TableGrid from '$lib/components/TableGrid.svelte';
 	import type { TableHandle } from '$lib/table.svelte';
 	import { createTableQuery } from '$lib/table-query.svelte';
 	import type { VaultHandle } from '$lib/vault.svelte';
+	import SurfacePill from './SurfacePill.svelte';
 
 	// One table of the active vault. The Vault constructs and disposes the table (it owns the
 	// watcher lifetime) and owns the shared `.matter` mirror the query reads; this pane just
@@ -57,35 +57,21 @@
 		{/if}
 		{#if table.read.view.mode === 'typed' && table.read.view.contract.views.length}
 			<div class="flex min-h-10 items-center gap-1 overflow-x-auto border-b px-3 py-1">
-				<button
-					type="button"
-					aria-current={projection === undefined ? 'true' : undefined}
-					onclick={() => goto(routes.table(table.folderName), SWITCH_NAV)}
-					class={[
-						'flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1 text-sm transition',
-						projection === undefined
-							? 'bg-muted font-medium text-foreground'
-							: 'text-muted-foreground hover:bg-muted/50',
-					]}
+				<SurfacePill
+					active={projection === undefined}
+					to={routes.table(table.folderName)}
 				>
 					<Grid2x2Icon class="size-4" />
 					Grid
-				</button>
+				</SurfacePill>
 				{#each table.read.view.contract.views as view (view.id)}
-					<button
-						type="button"
-						aria-current={projection?.id === view.id ? 'true' : undefined}
-						onclick={() => goto(routes.projection(table.folderName, view.id), SWITCH_NAV)}
-						class={[
-							'flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1 text-sm transition',
-							projection?.id === view.id
-								? 'bg-muted font-medium text-foreground'
-								: 'text-muted-foreground hover:bg-muted/50',
-						]}
+					<SurfacePill
+						active={projection?.id === view.id}
+						to={routes.projection(table.folderName, view.id)}
 					>
 						<KanbanIcon class="size-4" />
 						{view.title ?? view.id}
-					</button>
+					</SurfacePill>
 				{/each}
 			</div>
 		{/if}

--- a/apps/matter/src/routes/(vaults)/vault/[id]/VaultShell.svelte
+++ b/apps/matter/src/routes/(vaults)/vault/[id]/VaultShell.svelte
@@ -6,12 +6,10 @@
 	import FolderOpenIcon from '@lucide/svelte/icons/folder-open';
 	import LayersIcon from '@lucide/svelte/icons/layers';
 	import TerminalIcon from '@lucide/svelte/icons/terminal';
-	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import {
 		resolveVaultSurface,
 		routes,
-		SWITCH_NAV,
 		TABLE_PARAM,
 		type VaultPanel,
 	} from '$lib/routes';
@@ -19,6 +17,7 @@
 	import DatabaseTab from './DatabaseTab.svelte';
 	import IntegrityPanel from './IntegrityPanel.svelte';
 	import SqlConsole from './SqlConsole.svelte';
+	import SurfacePill from './SurfacePill.svelte';
 	import TablePane from './TablePane.svelte';
 
 	let { root }: { root: string } = $props();
@@ -104,61 +103,34 @@
 			<div class="flex min-h-10 items-center gap-1 border-b px-2 py-1">
 				<div class="flex flex-1 items-center gap-1 overflow-x-auto">
 					{#each vault.tables as table (table.folderName)}
-						{@const active =
-							activeSurface.kind !== 'panel' &&
-							activeTable?.folderName === table.folderName}
-						<button
-							type="button"
-							aria-current={active ? 'true' : undefined}
-							onclick={() => goto(routes.table(table.folderName), SWITCH_NAV)}
-							class={[
-								'shrink-0 rounded-md px-2.5 py-1 text-sm transition',
-								active
-									? 'bg-muted font-medium text-foreground'
-									: 'text-muted-foreground hover:bg-muted/50',
-							]}
+						<SurfacePill
+							active={activeSurface.kind !== 'panel' &&
+								activeTable?.folderName === table.folderName}
+							to={routes.table(table.folderName)}
 						>
 							{table.folderName}
-						</button>
+						</SurfacePill>
 					{/each}
 				</div>
 				<!-- The two vault-wide views, set off from the per-table tabs: SQL is the query face, the
 				     Database panel is the "this is a SQLite database" face. -->
 				<div class="flex shrink-0 items-center gap-1 border-l pl-1">
-					<button
-						type="button"
-						aria-current={activeSurface.kind === 'panel' &&
-						activeSurface.panel === 'sql'
-							? 'true'
-							: undefined}
-						onclick={() => goto(panelHref('sql'), SWITCH_NAV)}
-						class={[
-							'flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1 text-sm transition',
-							activeSurface.kind === 'panel' && activeSurface.panel === 'sql'
-								? 'bg-muted font-medium text-foreground'
-								: 'text-muted-foreground hover:bg-muted/50',
-						]}
+					<SurfacePill
+						active={activeSurface.kind === 'panel' &&
+							activeSurface.panel === 'sql'}
+						to={panelHref('sql')}
 					>
 						<TerminalIcon class="size-4" />
 						SQL
-					</button>
-					<button
-						type="button"
-						aria-current={activeSurface.kind === 'panel' &&
-						activeSurface.panel === 'db'
-							? 'true'
-							: undefined}
-						onclick={() => goto(panelHref('db'), SWITCH_NAV)}
-						class={[
-							'flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1 text-sm transition',
-							activeSurface.kind === 'panel' && activeSurface.panel === 'db'
-								? 'bg-muted font-medium text-foreground'
-								: 'text-muted-foreground hover:bg-muted/50',
-						]}
+					</SurfacePill>
+					<SurfacePill
+						active={activeSurface.kind === 'panel' &&
+							activeSurface.panel === 'db'}
+						to={panelHref('db')}
 					>
 						<DatabaseIcon class="size-4" />
 						Database
-					</button>
+					</SurfacePill>
 				</div>
 			</div>
 			{#if activeSurface.kind === 'panel' && activeSurface.panel === 'sql'}


### PR DESCRIPTION
Matter's surface switchers (table tabs, the SQL and Database panel pills, and the grid/projection pills) were five near-identical hand-rolled buttons across VaultShell and TablePane. This PR collapses them into one local route-backed component, `SurfacePill.svelte`, colocated with its two consumers.

@epicenter/ui Tabs was considered and refused. The vault strip is not one tab set: it is a scrollable table group plus a fixed panel group with distinct active predicates, so one `Tabs.Root` would need a synthetic composite value namespace (`table:<name>` / `panel:sql`) and an `onValueChange` parser to decode strings back into routes. bits-ui Tabs also installs roving-tabindex keyboard semantics with automatic activation, which would fire navigation on arrow-key focus, and `role="tab"` without tab panels is dishonest ARIA next to the current `aria-current` navigation semantics. Finally, the wrapper's bindable `value` keeps a shadow selected state that flips ahead of the URL; here the URL is the owner, full stop. Overriding the primitive's active styling on the list and every trigger would also have been more code than the buttons it replaced.

The local component keeps route ownership visible: `SurfacePill` takes `active` and `to`, renders one navigation choice, and navigates with the shared `SWITCH_NAV` options. Go-to-definition from any pill lands on twenty lines that show `goto(to, SWITCH_NAV)`. The `goto`/`SWITCH_NAV` imports disappear from both consumers because the pill is now the only place that navigates between surfaces.

Behavior is unchanged: same query params, same `replaceState`/`keepFocus`/`noScroll` navigation, same active/hover/icon/label classes, same `overflow-x-auto` scrolling with `shrink-0` pills. The one cosmetic unification is that text-only table pills now carry the same `flex items-center gap-1.5` classes as the icon pills, which renders identically for text-only children.

The repeated full-bleed Alert class string in TableGrid (3 occurrences) was deliberately left out: it is an alert-styling concern, not surface navigation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785899437&installation_id=128463665&pr_number=2386&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2386&signature=36f384db1ce458528d2135526b36a4cee3c1c04e1bcc39faae6ca41c4df9ea0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->