### PR TITLE
fix(honeycrisp): focus editor when selecting notes

### DIFF
--- a/apps/honeycrisp/src/lib/editor/Editor.svelte
+++ b/apps/honeycrisp/src/lib/editor/Editor.svelte
@@ -46,7 +46,7 @@
 		splitListItem,
 		wrapInList,
 	} from 'prosemirror-schema-list';
-	import { EditorState, Plugin } from 'prosemirror-state';
+	import { EditorState, Plugin, TextSelection } from 'prosemirror-state';
 	import { Decoration, DecorationSet, EditorView } from 'prosemirror-view';
 	import 'prosemirror-view/style/prosemirror.css';
 	import {
@@ -219,9 +219,11 @@
 
 	let {
 		yxmlfragment,
+		focusRequest,
 		onContentChange,
 	}: {
 		yxmlfragment: Y.XmlFragment;
+		focusRequest: number;
 		onContentChange: (content: NoteMetadata) => void;
 	} = $props();
 
@@ -379,6 +381,17 @@
 			currentView.destroy();
 			view = undefined;
 		};
+	});
+
+	$effect(() => {
+		if (!view) return;
+		focusRequest;
+		view.dispatch(
+			view.state.tr
+				.setSelection(TextSelection.atEnd(view.state.doc))
+				.scrollIntoView(),
+		);
+		view.focus();
 	});
 </script>
 

--- a/apps/honeycrisp/src/routes/+page.svelte
+++ b/apps/honeycrisp/src/routes/+page.svelte
@@ -36,7 +36,10 @@
 			<Resizable.Pane defaultSize={65} minSize={30} class="flex flex-col">
 				{#if honeycrisp.state.view.selectedNote && honeycrisp.state.view.selectedNoteId}
 					{#key honeycrisp.state.view.selectedNoteId}
-						<NoteBodyPane noteId={honeycrisp.state.view.selectedNoteId} />
+						<NoteBodyPane
+							noteId={honeycrisp.state.view.selectedNoteId}
+							focusRequest={honeycrisp.state.view.editorFocusRequest}
+						/>
 					{/key}
 				{:else}
 					<div class="flex h-full flex-col items-center justify-center gap-2">

--- a/apps/honeycrisp/src/routes/components/NoteBodyPane.svelte
+++ b/apps/honeycrisp/src/routes/components/NoteBodyPane.svelte
@@ -5,7 +5,8 @@
 	import HoneycripEditor from '$lib/editor/Editor.svelte';
 	import { honeycrisp } from '$lib/honeycrisp';
 
-	let { noteId }: { noteId: NoteId } = $props();
+	let { noteId, focusRequest }: { noteId: NoteId; focusRequest: number } =
+		$props();
 
 	const doc = fromDisposableCache(honeycrisp.tables.notes.docs.body, () => noteId);
 </script>
@@ -15,6 +16,7 @@
 {:then}
 	<HoneycripEditor
 		yxmlfragment={doc.current.binding}
+		{focusRequest}
 		onContentChange={(change) => honeycrisp.state.notes.updateContent(noteId, change)}
 	/>
 {/await}

--- a/apps/honeycrisp/src/routes/state/view.svelte.ts
+++ b/apps/honeycrisp/src/routes/state/view.svelte.ts
@@ -6,9 +6,10 @@
  * the user see right now" question (`currentNotes` plus its title and
  * empty-state messaging).
  *
- * State lives in the URL so it's bookmarkable, shareable, and works with
- * browser back/forward. Default values are elided from the URL to keep it
- * clean: `/` means all defaults (all notes, sorted by date edited, no search).
+ * Navigation state lives in the URL so it's bookmarkable, shareable, and
+ * works with browser back/forward. Default values are elided from the URL to
+ * keep it clean: `/` means all defaults (all notes, sorted by date edited, no
+ * search). Transient editor focus requests stay in memory.
  *
  * @example
  * ```svelte
@@ -35,6 +36,8 @@ export function createView({
 	folders: ReturnType<typeof createFolders>;
 	notes: ReturnType<typeof createNotes>;
 }) {
+	let editorFocusRequest = $state(0);
+
 	// ─── Derived State ───────────────────────────────────────────────────
 
 	/** Notes filtered by selected folder and search query, then sorted. */
@@ -83,6 +86,9 @@ export function createView({
 		},
 		get selectedNote() {
 			return selectedNote;
+		},
+		get editorFocusRequest() {
+			return editorFocusRequest;
 		},
 		get searchQuery() {
 			return searchParams.q;
@@ -159,6 +165,7 @@ export function createView({
 		 * ```
 		 */
 		selectNote(noteId: NoteId) {
+			editorFocusRequest += 1;
 			searchParams.update({ note: noteId });
 		},
 


### PR DESCRIPTION
Selecting a Honeycrisp note should put the user directly in the writing surface. Before this, creating or choosing a note opened the editor but left focus on the note list or command that triggered selection, so typing did not start editing the note.

This keeps the selected note in the URL and adds a transient in-memory focus request to the Honeycrisp view state. Every `selectNote()` call increments that request, and the mounted ProseMirror editor responds by moving the caret to the end of the note and focusing the editor. Reselecting the same note works too because focus intent is separate from durable selection.

## Changelog
- Fix Honeycrisp note selection so the editor receives focus and the caret moves to the end of the selected note

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785922002&installation_id=128463665&pr_number=2387&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2387&signature=326fe25231eb03793e645c4ad31a0d7cae50355c73753839b5b2129d7f6b1b96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->