### PR TITLE
refactor(server): collapse false server seams

### DIFF
--- a/apps/api/worker/billing/policies.ts
+++ b/apps/api/worker/billing/policies.ts
@@ -35,8 +35,10 @@
  *
  * The content-addressed blob store is unmetered in v1 (no storage policy here):
  * Autumn `check()` denies by default with no plan attached, so deferred quota
- * means not calling it. A `syncBlobStorageWithAutumn` policy slots in when blob
- * storage is billed (deleted spec 20260623T220000 decision 10, recoverable via git history; kernel is ADR-0089).
+ * means not calling it. When blob storage is billed (deleted spec
+ * 20260623T220000 decision 10, recoverable via git history; kernel is
+ * ADR-0089), a `syncBlobStorageWithAutumn` policy lands here together with the
+ * `policies` seam `mountBlobsApp` will need to carry it.
  *
  * The library remains billing-agnostic; everything here is cloud-only.
  */

--- a/apps/api/worker/index.ts
+++ b/apps/api/worker/index.ts
@@ -112,8 +112,9 @@ mountSessionApp(app, { auth: cookieOrBearer });
 mountRoomsApp(app, { resolveBearerPrincipal: resolveRequestOAuthPrincipal });
 // Content-addressed blob store (supersedes the retired assets surface). v1 is
 // unmetered (no Autumn policy): Autumn's check() denies by default with no plan
-// attached, so deferred quota means not calling it. A `syncBlobStorageWithAutumn`
-// policy slots in here when storage is billed.
+// attached, so deferred quota means not calling it. When storage is billed, a
+// `syncBlobStorageWithAutumn` policy and the `policies` seam it needs land on
+// `mountBlobsApp` together.
 mountBlobsApp(app, { auth: cookieOrBearer });
 mountInferenceApp(app, {
 	auth: bearer,

--- a/docs/guides/billing-autumn-boundary.md
+++ b/docs/guides/billing-autumn-boundary.md
@@ -156,8 +156,10 @@ own index, so an occasional `ListObjectsV2` SUM over `principals/<principalId>/b
 drives one absolute `autumn.balances.update({ usage })`. That is self-correcting
 (a missed update is overwritten by the next sweep) and needs no second ledger,
 which is exactly why the retired asset path also synced an absolute total rather
-than upload/delete deltas. A `syncBlobStorageWithAutumn` policy is the slot for
-it (`apps/api/worker/index.ts`, beside `chargeOpenAiCreditsWithAutumn`).
+than upload/delete deltas. A `syncBlobStorageWithAutumn` policy will carry it
+(`apps/api/worker/index.ts`, beside `chargeOpenAiCreditsWithAutumn`);
+`mountBlobsApp` takes no `policies` today, so that change adds the seam and the
+policy together.
 
 ## Errors: opaque on the wire, fat in the logs
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,7 +6,6 @@
 	"description": "Shared Hono server for Epicenter cloud and the self-hosted single-partition instance.",
 	"exports": {
 		".": "./src/index.ts",
-		"./schema": "./src/db/schema/index.ts",
 		"./bun": "./src/bun.ts"
 	},
 	"scripts": {

--- a/packages/server/src/bun.ts
+++ b/packages/server/src/bun.ts
@@ -30,7 +30,7 @@ export { createEnvTokenResolver } from './auth/instance-token.js';
 // gets it without importing the main barrel, which would drag in the `Room`
 // Durable Object and its `cloudflare:workers` import.
 export { OAuthError } from './auth/oauth-errors.js';
-export { createDb, type Db } from './db/create-db.js';
+export { createDb } from './db/create-db.js';
 // An opt-in burn-rate cap for the inference `policies` seam (ADR-0076).
 export { rateLimit } from './middleware/rate-limit.js';
 export {
@@ -45,7 +45,6 @@ export {
 // merged into the cloud Bun host's boot validation.
 export { CloudAuthBindings, mountCloudAuth } from './mount-cloud-auth.js';
 export { mountCloudDb } from './mount-cloud-db.js';
-export { doName } from './principal.js';
 // The Bun room backend: an in-process Rooms map + bun:sqlite update log,
 // plus the Bun `websocket` handler and `bindServer` the entry wires. Its `.rooms`
 // is what a Bun entry passes as `createServerApp`'s `resolveRooms`.
@@ -55,7 +54,7 @@ export { mountInferenceApp } from './routes/inference.js';
 export { mountRoomsApp } from './routes/rooms.js';
 export { mountSessionApp } from './routes/session.js';
 export { mountTranscriptionApp } from './routes/transcription.js';
-export { createServerApp, type Identity } from './server-app.js';
+export { createServerApp } from './server-app.js';
 // The portable env contract as both arktype schema (value) and inferred type;
 // the Bun entry validates `process.env` against it at boot (merging its own
 // process config and any secrets it re-requires).

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -29,7 +29,7 @@ export { connectHyperdriveDb } from './db/backends/cloudflare.js';
 // client/pool in drizzle with the auth schema; a cloud entry hands the result to
 // `mountCloudDb`. The Cloudflare per-request `pg.Client` over Hyperdrive comes from
 // `connectHyperdriveDb`; a Bun host builds its own `pg.Pool` inline.
-export { createDb, type Db } from './db/create-db.js';
+export { createDb } from './db/create-db.js';
 // An opt-in burn-rate cap for the inference `policies` seam: caps requests per
 // principal partition so a shared house key cannot be run up unbounded (ADR-0076).
 export { rateLimit } from './middleware/rate-limit.js';
@@ -59,9 +59,6 @@ export {
 // its own boot validation and resolves through `resolveAuthSecrets` (ADR-0076).
 export { CloudAuthBindings, mountCloudAuth } from './mount-cloud-auth.js';
 export { mountCloudDb } from './mount-cloud-db.js';
-// `doName` builds a room's principal-scoped DO name, deployment-agnostic and
-// exported for composing apps.
-export { doName } from './principal.js';
 // Re-export the Cloudflare Durable Object class so each deployment's
 // wrangler.jsonc can resolve `class_name: "Room"` against this entrypoint.
 export { Room } from './room/backends/cloudflare/durable-object.js';
@@ -85,7 +82,7 @@ export { mountTranscriptionApp } from './routes/transcription.js';
 // takes `resolveRooms` (the one runtime-specific portable concern) and an
 // `Identity` (who this deployment is on the web). The cloud's db + Better Auth are
 // NOT here; the cloud adds them via `mountCloudDb` + `mountCloudAuth`.
-export { createServerApp, type Identity } from './server-app.js';
+export { createServerApp } from './server-app.js';
 
 // Binding contract: the portable env the library reads from `c.env`, as both
 // the arktype schema (value) and its inferred type (same name). Each deployment

--- a/packages/server/src/routes/blobs.ts
+++ b/packages/server/src/routes/blobs.ts
@@ -259,28 +259,23 @@ async function listPrincipalBlobs(
  * uniformly gated by the same chain: the deployment's auth (the cloud passes
  * `requireCookieOrBearerPrincipal`), then {@link requireBlobStore}
  * (which 503s a deployment with no object storage and otherwise stamps
- * `c.var.blobStore`), then any deployment policies. Cloud passes no policies in v1
- * (storage is unmetered until Autumn is wired); a future `syncBlobStorageWithAutumn`
- * would slot into `policies`.
+ * `c.var.blobStore`). Unlike inference and transcription, blobs takes no
+ * `policies`: no deployment gates storage today (the cloud is unmetered until
+ * Autumn is wired, and a self-host's bucket is the operator's own, so there is
+ * no house key to cap). The first real storage policy adds the seam back in
+ * the same change that adds the policy.
  */
 export function mountBlobsApp<E extends Env = Env>(
 	app: Hono<E>,
-	opts: {
-		auth: MiddlewareHandler<E>;
-		/** Extra middleware after auth on every blob route. */
-		policies?: MiddlewareHandler<E>[];
-	},
+	opts: { auth: MiddlewareHandler<E> },
 ): void {
-	// Every blob route runs the same chain: authenticate, ensure object storage is
-	// configured, then any deployment policies. The chain is typed as a non-empty tuple so its leading fixed
-	// handler satisfies `app.on`'s overload (a bare `MiddlewareHandler[]` spread
-	// would be read as the path argument). It is bare-typed because it mixes the
+	// Every blob route runs the same chain: authenticate, then ensure object
+	// storage is configured. The chain is bare-typed because it mixes the
 	// deployment's `E`-typed auth with the blob-local `BlobEnv` middleware
 	// (`requireBlobStore` stamps `c.var.blobStore`); both run on the same app.
-	const chain: [MiddlewareHandler, ...MiddlewareHandler[]] = [
+	const chain: [MiddlewareHandler, MiddlewareHandler] = [
 		opts.auth,
 		requireBlobStore,
-		...(opts.policies ?? []),
 	];
 
 	app.use(API_ROUTES.blobs.list.pattern, ...chain);


### PR DESCRIPTION
`@epicenter/server` had a couple of seams that described future work as if it existed today. Blob routes accepted `policies?` even though every caller passed only auth, and the server package exported schema and helper types no deployable consumed.

This PR removes that false surface. `mountBlobsApp` now accepts only the auth middleware:

```ts
mountBlobsApp(app, { auth: cookieOrBearer });
```

Inference and transcription keep `policies` because cloud and self-host pass live billing or rate-limit middleware there. Blob storage gets its policy seam back in the same change that adds real storage billing.

The package barrel also stops exporting `@epicenter/server/schema`, `doName`, `Db`, and `Identity`. The implementations and types stay where internal code still needs them; they just stop advertising as deployable composition contracts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785955640&installation_id=128463665&pr_number=2389&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2389&signature=2dcfcd998584d179520dc001df9d67287c8bb72b3e05f710f66567ec5050088a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->