### PR TITLE
docs: clarify personal Infisical app configs

### DIFF
--- a/apps/local-books/README.md
+++ b/apps/local-books/README.md
@@ -148,13 +148,16 @@ Intuit production rejects `http://localhost` redirect URIs, so the one-time `aut
 
 The Intuit keys live in your personal Infisical project at `/apps/local-books`
 under their environment-qualified names (`QB_SANDBOX_*` and
-`QB_PRODUCTION_*`, ADR-0108). Because the name carries the QuickBooks target,
-both keysets sit in `prod` for a single injection. The app-local
-`.infisical.json` points at the personal project; copy
+`QB_PRODUCTION_*`, ADR-0108). This is per-person bring-your-own provider
+configuration, not Epicenter-hosted infrastructure. Because the name carries the
+QuickBooks target, both keysets sit in `prod` for a single injection. The
+app-local `.infisical.json` points at the personal project; copy
 `.infisical.json.example` to `.infisical.json` and keep the real file local.
-The monorepo root has no Infisical config. `--qb-env` alone picks the keyset.
-Instead of exporting keys by hand, wrap a command with Infisical from this app
-directory:
+That file is ignored because each operator has a different personal Infisical
+project. The committed `apps/api` and `ops` configs point at Epicenter's hosted
+project instead. The monorepo root has no Infisical config. `--qb-env` alone
+picks the keyset. Instead of exporting keys by hand, wrap a command with
+Infisical from this app directory:
 
 ```sh
 infisical run --path=/apps/local-books -- bun run src/bin.ts auth --qb-env sandbox

--- a/apps/local-mail/README.md
+++ b/apps/local-mail/README.md
@@ -39,10 +39,13 @@ infisical run --path=/apps/local-mail -- \
 
 The name carries the provider target. The app-local Infisical config should
 point at your personal secrets project, where both keysets sit under
-`prod /apps/local-mail` for a single injection. Copy
+`prod /apps/local-mail` for a single injection. This is per-person
+bring-your-own provider configuration, not Epicenter-hosted infrastructure. Copy
 `.infisical.json.example` to `.infisical.json` and keep the real file local.
-See [`.env.example`](.env.example) for the canonical names. The old
-unqualified `GMAIL_CLIENT_ID` / `GMAIL_CLIENT_SECRET` are retired.
+That file is ignored because each operator has a different personal Infisical
+project. The committed `apps/api` and `ops` configs point at Epicenter's hosted
+project instead. See [`.env.example`](.env.example) for the canonical names. The
+old unqualified `GMAIL_CLIENT_ID` / `GMAIL_CLIENT_SECRET` are retired.
 
 Local Mail requests `gmail.modify` so write-through label changes can round-trip
 through Gmail. Although Google grants send at the same OAuth layer, Local Mail

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -66,7 +66,9 @@ shapes, see `docs/adr/`.
 - **Infisical project**: the owner and access-control boundary. Each secret-using
   runnable surface owns its own `.infisical.json`: `apps/api` and `ops` point
   at Epicenter's hosted/operator project, and personal local apps use ignored
-  app-local configs that point at the operator's personal project.
+  app-local configs that point at the operator's personal project. The ignored
+  configs are per-person bring-your-own provider setup; the committed configs
+  are shared Epicenter infrastructure.
 - **Infisical environment**: a value-stakes tier inside a project, not an
   owner. In the Epicenter project, `dev` holds substitute values that can hurt
   nothing (the local `wrangler dev` bindings) and `prod` holds hosted


### PR DESCRIPTION
Clarifies the split between committed Epicenter Infisical configs and ignored per-person local app configs.

`apps/api` and `ops` point at shared hosted/operator infrastructure. `apps/local-books` and `apps/local-mail` use ignored app-local `.infisical.json` files because each operator points them at their own personal Infisical project for bring-your-own provider credentials.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785966386&installation_id=128463665&pr_number=2391&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2391&signature=6c295c8f61beec27d2fe4814a3cbc868c13058ae1c004d4d800b8ff7753ff5e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->