### PR TITLE
refactor(super-chat): share tool approval gate

### DIFF
--- a/apps/super-chat/src/server.test.ts
+++ b/apps/super-chat/src/server.test.ts
@@ -24,7 +24,11 @@ import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { AgentEngine, EngineChunk } from '@epicenter/workspace/agent';
+import type {
+	AgentEngine,
+	AgentToolDefinition,
+	EngineChunk,
+} from '@epicenter/workspace/agent';
 import {
 	createSuperChatHost,
 	type SuperChatHost,
@@ -124,10 +128,14 @@ describe('createSuperChatServer', () => {
 			});
 			expect(session.status).toBe(200);
 			const body = (await session.json()) as {
-				tools: Array<{ name: string; kind: string }>;
+				tools: AgentToolDefinition[];
 				snapshot: { messages: unknown[] };
 			};
-			expect(body.tools.map((t) => t.name)).toContain('todos__todos_create');
+			const createTodos = body.tools.find(
+				(t) => t.name === 'todos__todos_create',
+			);
+			expect(createTodos).toBeDefined();
+			expect(createTodos?.inputSchema).toBeDefined();
 			expect(body.snapshot.messages).toEqual([]);
 
 			const oldTools = await fetch(`${server.url.origin}/api/tools`, {

--- a/apps/super-chat/src/server.ts
+++ b/apps/super-chat/src/server.ts
@@ -16,8 +16,8 @@
 
 import { createHash, timingSafeEqual } from 'node:crypto';
 import type {
+	AgentToolDefinition,
 	ConversationSnapshot,
-	ToolCatalog,
 } from '@epicenter/workspace/agent';
 import { Hono } from 'hono';
 import { createBunWebSocket } from 'hono/bun';
@@ -34,12 +34,7 @@ export type ClientCommand =
 export type ServerEvent = { type: 'snapshot'; snapshot: ConversationSnapshot };
 
 export type SessionResponse = {
-	tools: Array<{
-		name: string;
-		kind: string;
-		title?: string;
-		description?: string;
-	}>;
+	tools: AgentToolDefinition[];
 	snapshot: ConversationSnapshot;
 };
 
@@ -94,7 +89,7 @@ export function createSuperChatServer({
 
 	app.get(SESSION_ROUTE.pattern, (c) =>
 		c.json({
-			tools: listTools(host.tools),
+			tools: host.tools.definitions(),
 			snapshot: host.conversation.snapshot(),
 		} satisfies SessionResponse),
 	);
@@ -148,15 +143,6 @@ function tokensMatch(candidate: string, expected: string): boolean {
 	const a = createHash('sha256').update(candidate).digest();
 	const b = createHash('sha256').update(expected).digest();
 	return timingSafeEqual(a, b);
-}
-
-function listTools(tools: ToolCatalog): SessionResponse['tools'] {
-	return tools.definitions().map(({ name, kind, title, description }) => ({
-		name,
-		kind,
-		...(title !== undefined && { title }),
-		...(description !== undefined && { description }),
-	}));
 }
 
 function parseCommand(data: unknown): ClientCommand | undefined {

--- a/docs/adr/0009-the-cli-dispatches-through-a-mandatory-daemon.md
+++ b/docs/adr/0009-the-cli-dispatches-through-a-mandatory-daemon.md
@@ -20,6 +20,7 @@ startup state enum).
 
 `run`, `list`, and `peers` require a live local daemon and have no `loadConfig`
 cold-path fallback. They dispatch over the Unix socket via `getDaemon(root)`
+<!-- doc-path-check: ignore-next-line -->
 (`packages/workspace/src/daemon/client.ts`), which pings the socket and returns
 `DaemonError.Required` when nothing answers; the command prints the hint and
 exits non-zero. The daemon is started by `epicenter daemon up` and is a long-lived

--- a/docs/adr/0112-the-cli-watcher-is-not-a-callable-action-server.md
+++ b/docs/adr/0112-the-cli-watcher-is-not-a-callable-action-server.md
@@ -12,8 +12,10 @@ The CLI daemon was introduced as a mandatory local process for `epicenter run`,
 framing the daemon as a callable peer in a device mesh: a device was either
 online and callable, or it was offline. That rationale no longer matches the
 system. The mesh peer, `run --peer`, in-room action dispatch, and relay action
-channel were deleted. `packages/workspace/src/daemon/action-handler.ts` now says
-cross-device runs are not a `/run` concern.
+channel were deleted.
+<!-- doc-path-check: ignore-next-line -->
+`packages/workspace/src/daemon/action-handler.ts` now says cross-device runs are
+not a `/run` concern.
 
 The useful product need that remains is different: a user can run Epicenter
 headlessly for one folder so the workspace stays synchronized and materialized.

--- a/packages/workspace/src/agent/index.ts
+++ b/packages/workspace/src/agent/index.ts
@@ -43,5 +43,6 @@ export {
 	type ApprovalDecision,
 	defaultApprovalDecision,
 	NO_TOOLS,
+	resolveApprovedToolCall,
 	type ToolCatalog,
 } from './tools.js';

--- a/packages/workspace/src/agent/loop.ts
+++ b/packages/workspace/src/agent/loop.ts
@@ -30,6 +30,7 @@ import {
 	type Approval,
 	defaultApprovalDecision,
 	NO_TOOLS,
+	resolveApprovedToolCall,
 	type ToolCatalog,
 } from './tools.js';
 
@@ -268,36 +269,14 @@ export function createConversation(
 		calls: AgentToolCall[],
 		signal: AbortSignal,
 	): Promise<void> {
-		const definitions = new Map(
-			tools.definitions().map((definition) => [definition.name, definition]),
-		);
 		for (const call of calls) {
 			if (signal.aborted) return;
-			const definition = definitions.get(call.toolName);
-			const decision = definition ? approval.decide(call, definition) : 'auto';
-
-			if (decision === 'deny') {
-				appendToolResult(assistant, call, 'Denied by policy.', undefined, true);
-				notify();
-				continue;
-			}
-			if (decision === 'ask' && definition) {
-				const approved = await approval.request(call, definition);
-				if (signal.aborted) return;
-				if (!approved) {
-					appendToolResult(
-						assistant,
-						call,
-						'Denied by the user.',
-						undefined,
-						true,
-					);
-					notify();
-					continue;
-				}
-			}
-
-			const outcome = await tools.resolve(call, signal);
+			const outcome = await resolveApprovedToolCall({
+				tools,
+				approval,
+				call,
+				signal,
+			});
 			if (signal.aborted) return;
 			appendToolResult(
 				assistant,

--- a/packages/workspace/src/agent/tools.test.ts
+++ b/packages/workspace/src/agent/tools.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Agent Tool Approval Tests
+ *
+ * Verifies the shared approval gate that sits between tool callers and the
+ * catalog resolver. Chat turns and direct invocations use this helper so query,
+ * mutation, deny, and user-decline behavior cannot drift by caller.
+ *
+ * Key behaviors:
+ * - Denied calls return an error without resolving the tool
+ * - Declined ask-level calls return an error without resolving the tool
+ * - Approved calls resolve through the catalog
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+	type AgentToolCall,
+	type Approval,
+	resolveApprovedToolCall,
+	type ToolCatalog,
+} from './tools.js';
+
+const CALL: AgentToolCall = {
+	toolCallId: 't1',
+	toolName: 'write_note',
+	input: {},
+};
+
+function catalog({
+	kind = 'mutation',
+}: {
+	kind?: 'query' | 'mutation';
+} = {}): ToolCatalog & { resolved: AgentToolCall[] } {
+	const resolved: AgentToolCall[] = [];
+	return {
+		resolved,
+		definitions: () => [{ name: CALL.toolName, kind }],
+		resolve: async (call) => {
+			resolved.push(call);
+			return { content: 'ran', isError: false };
+		},
+	};
+}
+
+function approval(decision: ReturnType<Approval['decide']>, approved = true) {
+	return {
+		decide: () => decision,
+		request: async () => approved,
+	} satisfies Approval;
+}
+
+describe('resolveApprovedToolCall', () => {
+	test('denies by policy without resolving the tool', async () => {
+		const tools = catalog();
+
+		const outcome = await resolveApprovedToolCall({
+			tools,
+			approval: approval('deny'),
+			call: CALL,
+			signal: new AbortController().signal,
+		});
+
+		expect(outcome).toEqual({ content: 'Denied by policy.', isError: true });
+		expect(tools.resolved).toEqual([]);
+	});
+
+	test('returns a user denial when an asked call is declined', async () => {
+		const tools = catalog();
+
+		const outcome = await resolveApprovedToolCall({
+			tools,
+			approval: approval('ask', false),
+			call: CALL,
+			signal: new AbortController().signal,
+		});
+
+		expect(outcome).toEqual({ content: 'Denied by the user.', isError: true });
+		expect(tools.resolved).toEqual([]);
+	});
+
+	test('a stop during a pending approval wins over a late approval', async () => {
+		const tools = catalog();
+		const controller = new AbortController();
+		const approval: Approval = {
+			decide: () => 'ask',
+			request: async () => {
+				controller.abort();
+				return true;
+			},
+		};
+
+		const outcome = await resolveApprovedToolCall({
+			tools,
+			approval,
+			call: CALL,
+			signal: controller.signal,
+		});
+
+		expect(outcome.isError).toBe(true);
+		expect(tools.resolved).toEqual([]);
+	});
+
+	test('fails closed when the call names no cataloged tool', async () => {
+		const tools = catalog();
+
+		const outcome = await resolveApprovedToolCall({
+			tools,
+			approval: approval('auto'),
+			call: { ...CALL, toolName: 'not_in_catalog' },
+			signal: new AbortController().signal,
+		});
+
+		expect(outcome).toEqual({
+			content: 'No tool named not_in_catalog is available.',
+			isError: true,
+		});
+		expect(tools.resolved).toEqual([]);
+	});
+
+	test('resolves an approved tool call', async () => {
+		const tools = catalog();
+
+		const outcome = await resolveApprovedToolCall({
+			tools,
+			approval: approval('ask', true),
+			call: CALL,
+			signal: new AbortController().signal,
+		});
+
+		expect(outcome).toEqual({ content: 'ran', isError: false });
+		expect(tools.resolved).toEqual([CALL]);
+	});
+});

--- a/packages/workspace/src/agent/tools.ts
+++ b/packages/workspace/src/agent/tools.ts
@@ -48,6 +48,52 @@ export type ToolCatalog = {
 	resolve(call: AgentToolCall, signal: AbortSignal): Promise<AgentToolOutcome>;
 };
 
+/**
+ * Run one tool call through the shared approval gate. Chat turns and direct
+ * invocations must share this path so mutation policy cannot drift by caller.
+ */
+export async function resolveApprovedToolCall({
+	tools,
+	approval,
+	call,
+	signal,
+}: {
+	tools: ToolCatalog;
+	approval: Approval;
+	call: AgentToolCall;
+	signal: AbortSignal;
+}): Promise<AgentToolOutcome> {
+	const definition = tools
+		.definitions()
+		.find((candidate) => candidate.name === call.toolName);
+	// Fail closed on an unlisted name: catalog resolvers are not required to
+	// police their own listings (the stdio MCP resolver forwards any name to
+	// the subprocess), so reaching `resolve` without a definition would run an
+	// unlisted tool with no approval decision at all.
+	if (!definition) {
+		return {
+			content: `No tool named ${call.toolName} is available.`,
+			isError: true,
+		};
+	}
+	const decision = approval.decide(call, definition);
+
+	if (decision === 'deny') {
+		return { content: 'Denied by policy.', isError: true };
+	}
+	if (decision === 'ask') {
+		const approved = await approval.request(call, definition);
+		// The approval prompt is the one await before execution; a stop that
+		// landed while it was pending must win over a late approval.
+		if (signal.aborted) {
+			return { content: 'Stopped before the tool ran.', isError: true };
+		}
+		if (!approved) return { content: 'Denied by the user.', isError: true };
+	}
+
+	return tools.resolve(call, signal);
+}
+
 /** The empty catalog: a capability-free agent offers and runs no tools. */
 export const NO_TOOLS: ToolCatalog = {
 	definitions: () => [],

--- a/specs/20260706T220000-cross-device-coordination-vision.md
+++ b/specs/20260706T220000-cross-device-coordination-vision.md
@@ -1,0 +1,639 @@
+# Cross-device coordination: replicate, materialize, observe, attach
+
+State: Draft
+
+A greenfield vision memo for Epicenter cross-device synchronization, command
+execution, and machine-specific capabilities. Existing ADRs were treated as
+evidence, not constraints. Stops at vision; nothing here is implemented.
+
+## 1. Product vision in one sentence
+
+A person's data replicates to every device as local-first state; capabilities
+that live on one machine are driven by durable work records that machine
+observes; and exactly one live channel exists (attaching to the desktop host
+session over the user's own overlay), so Epicenter operates one transport (CRDT
+sync) and routes zero capability calls. Put pithily: sync is the coordination
+layer; execution stays where the capability lives.
+
+## 2. Historical context: what we built, deleted, and learned
+
+The repo has already run this experiment three times.
+
+```txt
+BUILD-UP
+#1707  2026-04-28  typed peer RPC; flags "action manifest on awareness is too heavy"
+#1754  2026-05-14  RPC + presence moved onto Yjs state (lasted five days)
+#1778  2026-05-19  live device dispatch over the relay
+#2077  2026-06-18  always-on actors over synced docs (doc-as-wire proof)
+#2236  2026-06-30  relay floor: per-user relay carries blind MCP channels; iroh deleted
+
+TEAR-DOWN
+#2237  2026-06-30  in-room dispatch deleted; run --peer refused
+#2238  2026-06-30  presence action manifest decommissioned
+#2277  2026-07-02  entire relay channel layer deleted (~3,400 lines)
+```
+
+Three lessons survived every teardown, and they are the spine of this memo:
+
+1. Doc-as-wire works. The one pattern that shipped and stayed is ADR-0025: a
+   durable record in a synced doc is the queue, an observing worker on the
+   capable machine reconciles it, existence of the keyed result is the claim,
+   cancel is a durable field, dispatch is at most a doorbell. The V0 observing
+   worker is live code today (`packages/workspace/src/document/child-doc-worker.ts`,
+   proven over a real synced room in `worker-over-room-sync.test.ts`).
+2. Live capability transport dies of no consumers. Peer RPC, in-room dispatch,
+   and the relay floor each shipped speculative reach and were deleted with
+   zero end-to-end users. ADR-0086's bar is the durable rule: no spend on
+   network-reachable capability until a real, named consumer exists.
+3. Presence cannot carry capability. The action-manifest-on-presence idea was
+   flagged in #1707, orphaned in #2237, and deleted in #2238. Presence today is
+   `nodeId` / `connectedAt` / `agentId`, and the schema rejects route-shaped
+   fields at the validation boundary. That is correct and final.
+
+One more historical fact matters: the deleted things were all synchronous.
+`dispatch.ts` required a live peer; the relay floor carried live MCP calls. The
+durable variant (ADR-0025, PR #2077) was never deleted. The failure mode was
+liveness, not the sync plane.
+
+## 3. The gradient, tested
+
+The candidate was a four-level gradient: synced app data, synced derived/index
+data, synced command/job outbox, direct/live connection. Verdict: the shape is
+right, two of the levels are wrong as stated.
+
+Level 1 (synced app data) is proven and shipped (Whispering, Honeycrisp,
+Todos). Keep.
+
+Level 2 (synced derived/index data) dissolves. Grounding it against the real
+apps shows it is not a sync level at all. Gmail's mobile story is each device
+holding its own mirror against Gmail directly (Google allows 100 concurrent
+grants, ADR-0081); no Epicenter transport is involved. The syncable parts of a
+mail app (annotations, rules, saved views, triage state) are ordinary Level 1
+app data. And the one true "replicated index" case (a bounded books hot-cache
+for a phone) was already designed cold in the seam-2 spec as box-to-device
+fan-out over the capability plane, deliberately not hosted sync, because ledger
+rows are exactly what the operator must not read. There is nothing left for a
+distinct level to own.
+
+Level 3 (synced command/job outbox) survives, but demoted and renamed. As a
+platform primitive (a generic job table any app writes into) it repeats four
+recorded mistakes at once: ADR-0025 explicitly foreclosed a `generation_requests`
+table and a CRDT claim field; a generic schema invites N status enums and
+fragments audit (the ADR-0021 disease); an enqueue is not an authorization; and
+"job" payloads have no exemption from the sync plane's trust model. What
+survives is the ADR-0025 kernel as a per-app pattern: a domain row with a named
+executor, observed by that machine's worker. Section 7 pins the semantics.
+
+Level 4 (direct/live connection) narrows to exactly one shape: attaching to
+the desktop host session as a thin client, end-to-end over the user's own
+overlay (ADR-0080). Not per-app endpoints, not a per-tool channel, not an
+Epicenter-routed relay.
+
+The replacement model has four verbs and one Epicenter-operated transport:
+
+```txt
+replicate    durable user data syncs as local-first CRDT state
+             (the sync plane; the paid product; the only Epicenter transport)
+
+materialize  provider-owned data builds per device from the upstream's own API
+             when the upstream's OAuth concurrency allows it (Gmail yes,
+             QuickBooks no; ADR-0081). No Epicenter transport involved.
+
+observe      machine-specific work is a durable domain row bound to one
+             executor agent; the capable machine's worker observes it, runs
+             it, writes results back. Rides the same sync plane; inherits its
+             trust model and gates (section 7).
+
+attach       live interaction with a specific machine is remote access to the
+             one desktop host session, E2E over the user's overlay
+             (ADR-0080). The only live cross-device channel.
+```
+
+A phone is a full citizen for replicate and materialize, a requester for
+observe, and a thin client for attach. It is never a remote control for a
+desktop's apps.
+
+## 4. Use-case matrix
+
+```txt
+use case          replicate                     materialize          observe                          attach
+Whispering        recordings meta, transcripts,  no                   not needed today; batch          no
+                  recipes, synced settings                            transcription is a future
+                  (audio = local blob refs)                           candidate if ever named
+
+Todos/Honeycrisp  everything                     no                   no                               no
+
+Local Mail        annotations, rules, saved      mailbox per device   no: mail materializes per        via Super Chat
+                  views, triage state            direct from Gmail    device first                     session if wanted
+
+Local Books       nothing (off the mesh)         forbidden (Intuit    hosted: not offered in v1;       yes: the default
+                                                 one-connection)      self-host/attach if needed       phone story
+                                                                      hot-cache stays deferred
+
+iMessage          n/a                            n/a                  hosted: not offered in v1;      n/a
+                                                                      self-host: query/summarize;
+                                                                      send only under section 7 rules
+
+Coding agent/Pi   run rows, transcripts,         no                   YES: the named first consumer    escalation path
+                  progress, results (blob refs)                       (section 13)                     for live terminal
+
+Super Chat        host-local replicas; its own   no                   consumes run rows like any       the one attach
+                  transcript stays ephemeral                          client; never the executor        target (ADR-0080)
+                  for now                                             registry
+```
+
+Three of these deserve a sentence beyond the table.
+
+iMessage is not a hosted-sync feature in v1. On hosted, message bodies would
+be trusted-cloud data, and the product does not need to make that promise now.
+On self-host, the operator is the user, so query and summarize jobs become
+viable: Apple syncs the Messages app to the user's devices, but it does not give
+an agent query access to `chat.db`. Sending is admissible only under the
+section-7 safety rules: exact-payload approval, short expiry, executor-local
+send ledger, no auto-retry after unknown outcome, claim before send, and
+cancel-until-intent. Money-shaped verbs remain refused outright.
+
+The coding agent is the opposite: the best consumer the mailbox pattern will
+ever get. The work is minutes-to-hours scale, nobody awaits it synchronously,
+progress is naturally a streamed log, results are naturally blob references (a
+diff, a test report), and the human who must approve a step is by definition on
+a different device than the executor. The durable job log is the primary model;
+live terminal control is the attach escalation, not the default.
+
+Local Mail's phone story is the cleanest proof that materialize beats remote
+control: a mobile mail app authorizes Gmail itself and holds its own mirror. Do
+not let Super Chat become the mobile mail client; ADR-0080 already refused that
+("reading email on a phone is the email app on the phone").
+
+## 5. Positive target architecture
+
+```txt
+synced docs/tables      workspace CRDT state, one per-user hibernatable anchor,
+                        operator-readable by design (ADR-0004). Owns: app data,
+                        run/job domain rows, approval records, durable config.
+
+derived/index data      per-device projections (SQLite materializers, markdown)
+                        built locally from synced state or from the upstream
+                        API. Never synced themselves; rebuildable.
+
+command/job rows        per-app domain tables (a runs table, not a jobs table),
+                        each row bound to one executor AgentId at creation.
+                        Child doc per row for progress/transcript; blob refs
+                        for bulk payloads and results; row deletion tears the
+                        child doc down.
+
+worker observation      the shipped V0 loop: a daemon holds a live replica,
+                        filters rows to the agent it answers as, reconciles
+                        unanswered work, streams progress into Y.Text, writes
+                        a write-once finish. Workers dial OUT to the sync
+                        anchor only; a capable machine exposes no inbound
+                        surface at all.
+
+presence/liveness       nodeId, connectedAt, agentId. Decorates the UI
+                        ("Mac Studio: offline, will run when it wakes").
+                        Never routing truth, never capability.
+
+approvals               durable records in the job's child doc, resolvable
+                        from any device, scoped to the exact visible payload
+                        (the consent rule from specs/super-chat-direct-command-forms.md).
+                        Never ambient, never carried across calls.
+
+result/audit log        the domain rows ARE the audit log: requester-minted id,
+                        executor identity, write-once finish/error, approval
+                        records, all in one place per app. No parallel audit
+                        table to reconcile.
+
+direct/live             exactly one: the ADR-0080 session remote, E2E over the
+                        user's overlay. Earned today by bring-your-own-
+                        Tailscale; a hosted variant exists only as a future
+                        content-blind E2E relay (ADR-0080's trigger).
+```
+
+The security consequence of "workers dial out only" is worth naming: the
+biggest deleted liability (a daemon HTTP surface with CORS and a load-bearing
+public bearer, the verified `/mcp` cross-origin write vector) cannot return,
+because there is no inbound listener to attack. NAT and CGNAT also stop
+mattering; the box only ever makes outbound connections.
+
+## 6. Presence and discoverability
+
+Presence owns one fact: which peers are connected right now, as
+`{nodeId, connectedAt, agentId}`. It exists so a requester can set expectations
+("queued; desktop offline") and so a worker picker can decorate a configured
+list with live/offline badges.
+
+Durable config owns addressing. The AgentId catalog (which agents exist, which
+machine answers as which) is configuration on synced state, exactly as ADR-0025
+put it: "a configured offline daemon can still be the correct binding because
+the conversation doc is the durable mailbox it will read when it wakes."
+
+Jobs own the work: payload, target, lifecycle, results, approvals, audit.
+
+What must never ride presence: action manifests, tool catalogs, route tables,
+endpoint URLs, capability advertisements of any kind. This was built and
+deleted three separate times. The presence schema's current rejection of
+route-shaped fields is a permanent invariant, not a cleanup artifact.
+
+Discoverability of what a machine can do is a durable question with a durable
+answer: the apps installed on that machine and the agent catalog, both synced
+state. "What can my Mac do" is read from config; "is my Mac awake" is read from
+presence; the two never merge.
+
+## 7. Command/job semantics (the mailbox kernel)
+
+The pattern, pinned field by field. Every choice below is ADR-0025's shipped
+mechanics generalized from conversations to work, with the rejected
+alternatives kept rejected.
+
+```txt
+job id          requester-minted at creation. It is simultaneously the
+                idempotency key and the claim key.
+
+job type        the domain table is the type. A coding run is a row in a runs
+                table with run-shaped columns. There is no generic jobs table
+                and no type enum. (Forecloses N status vocabularies and keeps
+                each app's audit self-contained.)
+
+payload         domain columns; anything bulky is a content-addressed blob
+                reference, never inline CRDT bytes.
+
+target          one immutable executor AgentId, set at creation, never
+                reassigned. Retargeting is creating a new row. (The ADR-0025
+                binding, and the reason contention is rare by construction.)
+
+requester       implied by the partition (one person). Within the partition,
+                writers are indistinguishable, so an enqueue is NEVER an
+                authorization. Anything requiring consent gates at the
+                executor via the approval record.
+
+status          no shared status enum and no claim field. Disjoint
+                single-writer regions: the requester owns cancelRequested and
+                expiry; the executor owns started/progress/finish. The claim
+                is the existence of the executor's started record keyed to the
+                job id; whoever appends first wins, every other observer
+                reconciles the same predicate and stops.
+
+idempotency     the executor must be idempotent per job id, or the verb must
+                be approval-gated. A verb that is neither (send a message,
+                move money) does not ride the mailbox at all.
+
+result          executor-owned, write-once, blob refs for bulk. The job row
+                plus child doc is deletable as a unit, so history does not
+                grow forever.
+
+error           executor-owned write-once error record beside finish.
+
+approvals       a durable record in the job's child doc that any of the
+                person's devices resolves; scoped to the exact visible
+                payload; never ambient. This is ADR-0025's approval returning
+                in a smaller form: it gates side effects on a headless
+                executor, not reasoning (which stays re-askable, ADR-0047).
+
+cancellation    requester-owned advisory flag, honored before the point of no
+                return; plus a requester-set expiry the executor checks at
+                claim time, so a job enqueued against a sleeping machine
+                refuses to fire stale.
+
+claim pools     deferred, exactly as ADR-0025 forecloses: no lease machinery
+                until N interchangeable workers per agent actually exist, and
+                then via a compare-and-set action, never a raw field.
+```
+
+The gates, stated once: a verb may ride the mailbox only if it is (a)
+non-urgent (a late run is still a good run), (b) idempotent per job id or
+approval-gated, and (c) permitted on the deployment's sync plane. On hosted,
+that means ordinary trusted-cloud data only. On self-host, sensitive observe
+jobs become viable because the operator is the user. A coding run is the first
+fit; a self-hosted iMessage query can fit later.
+
+One honest limit: within a single-user partition, a compromised bearer or an
+XSS in any synced surface can write a job and its approval. Sync write access
+already meant total data compromise; the mailbox escalates it toward execution.
+That is why gate (b) exists at the executor. Money-shaped verbs stay refused
+outright; send-message jobs are admissible only with exact-payload approval,
+short expiry, a crash-surviving executor-local send ledger, no auto-retry after
+unknown outcome, claim before send, and cancellation until the ledger records
+intent-to-send.
+
+## 8. Privacy model
+
+The sync plane is operator-readable by decision, not accident (ADR-0004; the
+anchor deliberately holds plaintext). Job payloads and results get no
+exemption; "it's just a job" is the exact move ADR-0080 already rejected when
+it refused "just sync the chat over the sync plane."
+
+The product rule is deliberately shorter than a class ladder:
+
+```txt
+hosted      trusted managed sync. Epicenter can read synced payloads.
+self-host   the user runs the operator. Epicenter is not in the data path.
+```
+
+There is no third "hosted but Epicenter cannot read" mode for v1, and no
+per-dataset privacy opt-in dial. If a payload rides hosted sync, the product
+treats it as trusted-cloud data. If that is not acceptable, the answer is
+self-host. This keeps privacy a deployment decision, not a feature setting, and
+prevents the UI from implying that some hosted synced data has a different
+reader set than the rest.
+
+Server-derived encryption does not change the rule. A key Epicenter can derive
+changes the storage format and may reduce breach surface, but it does not
+remove Epicenter from the reader set. Application-layer encryption at rest may
+return later only as unmarketed hygiene for a concrete compliance need, never
+as a mode, a class, a lock icon, or a reason to put sensitive content on hosted
+sync.
+
+This means sensitive observe jobs are deployment-scoped. Hosted can run observe
+for ordinary trusted-cloud data, such as coding runs over repos a user is
+comfortable syncing. Self-host can run observe over mail bodies, message
+bodies, or other sensitive content because the operator is the user. Product
+promises can still be stricter than the deployment allows: if "the books never
+leave the box" remains the Local Books promise, books stay box/attach even on
+hosted and are not softened by a setting.
+
+## 9. Super Chat's place
+
+Super Chat is an app, not a runtime and not a transport. It is the desktop
+orchestration surface: one host process composing local action registries
+(Honeycrisp, Todos) and local stdio facades (Local Books), per ADR-0080/0111.
+
+Its cross-device story is exactly one thing: attach. A phone is a thin client
+to the one host session over the user's overlay. Super Chat does not become
+the mobile mail client (materialize owns that), does not become the executor
+registry (each app's worker owns its own rows), and does not grow per-app
+network endpoints. As a requester it is unprivileged: creating a coding run
+from Super Chat writes the same domain row any other surface would write.
+
+Its transcript stays ephemeral until there is a reason to sync it. If it ever
+syncs on hosted, it is trusted-cloud data, so tool results that the product is
+not willing to expose to Epicenter Cloud must stay out of the synced transcript.
+That is a real constraint, and it is another reason attach (not transcript
+sync) is Super Chat's remote story.
+
+## 10. What stays deleted
+
+- The relay channel layer: 4-frame protocol, channel router, relay acceptor,
+  account room, route table (#2277).
+- In-room dispatch and `run --peer` (#2237); typed peer RPC, peer-wait, the
+  peer error taxonomy (#1707/#1778 lineage).
+- Presence action manifests and `exposedRoutes` (#2238); presence stays
+  liveness-only forever.
+- The MCP gateway catalog and MCP-over-relay; per-app network `/mcp`
+  endpoints; `epicenter tools` / `call` / `--relay-expose`.
+- iroh and any Epicenter-owned reachability broker (returns only behind the
+  turnkey trigger, as ADR-0079 already gates it).
+- The content-readable hosted session broker (rejected in ADR-0080, stays
+  rejected).
+- Generic job/queue/`generation_requests` tables and CRDT claim fields
+  (foreclosed by ADR-0025, reaffirmed here).
+
+One deleted idea returns smaller: durable doc-mediated approval (built for
+ADR-0042/0044, deleted by ADR-0047 when the loop moved into the client). What
+changed: it no longer gates reasoning in a chat loop where the human is
+present; it gates side effects on a headless executor where the human is by
+definition elsewhere. It lives in the job's child doc, is scoped to the exact
+payload, and is never ambient. ADR-0047's own escape clause ("if a scheduled
+or autonomous agent becomes a real need it reopens the daemon loop explicitly")
+names this exact reopening; the coding worker is its consumer.
+
+## 11. ADR and spec impact
+
+```txt
+ADR-0025   promote Proposed -> Accepted. It is the platform's mailbox kernel;
+           this memo generalizes it from conversations to work rows.
+ADR-0047   amend, not replace. Client loop stays the default for human-driven
+           chat. The async-job tier gains the section-7 semantics, and the
+           "autonomous agent reopens the daemon loop" clause is exercised for
+           the coding worker: an executor may run its own loop (pi in-process)
+           over a run row, as an explicit, named reopening.
+ADR-0079   leave standing; amend the status note: the capability plane is
+           empty by construction (0086), and the "capabilities directory"
+           sketch in its Decision 3 is dead until a named consumer (it was
+           never built). The two-plane split survives as sync + attach.
+ADR-0080   leave alone. It is the attach shape and the seam-2 constraint.
+ADR-0081   flip Proposed -> Accepted; it is load-bearing for materialize.
+ADR-0086   leave alone; its "real, named consumer" bar is the governing rule.
+ADR-0111   leave alone.
+ADR-0043   stays superseded; do not resurrect answer-where-capability-lives
+           as a general rule. The coding worker is a scoped exception recorded
+           via the 0047 amendment, not a return to per-agent loop placement.
+new ADR    record this model: cross-device coordination is replicate,
+           materialize, observe, attach; one Epicenter transport; presence is
+           liveness-only; hosted is trusted sync; self-host is the privacy
+           answer; no third mode; no per-dataset privacy dial; and the
+           mailbox gates (non-urgent, idempotent-or-approved, permitted on
+           this deployment's sync plane). Supersedes this spec once accepted,
+           and this spec is then deleted per hygiene.
+seam-2     keep; its open founder question is Q1 below and gates the deferred
+spec       books/mail hot-cache design.
+```
+
+## 12. Sharpest asymmetric wins, as product refusals
+
+1. Epicenter never routes a capability call. This one sentence keeps roughly
+   ten code families dead: channel protocols, route tables, acceptors, peer
+   RPC, gateway catalogs, per-app endpoints, CORS hardening, public bearers,
+   reachability brokers, reconnect taxonomies.
+2. A capable machine exposes no inbound surface. Workers dial out to sync;
+   the entire remote-attack class (the `/mcp` CORS write vector) becomes
+   unbuildable rather than mitigated, and NAT stops being a design input.
+3. Presence carries liveness only. Learned three times; now an invariant.
+4. There is no jobs table. An app that wants async work publishes its own
+   domain rows and passes the three gates. This refusal is what keeps audit
+   whole and status vocabularies from multiplying.
+5. If it matters when it runs, it does not ride the mailbox. No urgent verbs
+   over sync; urgency is what attach is for.
+6. Epicenter does not build a hosted iMessage feature in v1. A self-hosted
+   assistant may observe Messages on the user's own deployment, and send only
+   under the section-7 safety rules.
+7. The phone reads mail from Gmail, not from your desktop. Materialize beats
+   remote control whenever the upstream allows it.
+8. Job payloads get no privacy exemption. Hosted sync is trusted-cloud sync;
+   self-host is the privacy answer. There is no per-dataset privacy dial.
+9. Super Chat is reachable as exactly one session. It never becomes the
+   universal cross-device runtime.
+
+## 13. Exact next experiment
+
+Build workers V1 with the coding run as the named consumer, entirely on the
+existing sync plane. Smallest honest slice:
+
+1. A `runs` table plus per-row child doc in a dev workspace: requester-minted
+   id, immutable executor `agent`, a read-only verb first ("run the test suite
+   on branch X"), `cancelRequested`, expiry.
+2. The desktop daemon extends the shipped V0 observe loop: filter runs bound
+   to its agent, claim by writing the started record keyed to the run id,
+   stream progress into `Y.Text`, write a write-once finish whose bulk output
+   is a blob reference.
+3. A second device (a browser is enough; a phone browser is better) creates
+   the run, watches presence-decorated status ("desktop offline, will run when
+   it wakes"), and exercises durable cancel.
+4. One approval-gated second verb (apply the produced patch to the branch) to
+   prove the durable approval record round-trips from the non-executor device.
+
+This proves or falsifies every load-bearing claim (existence-claim under a
+real second writer, disjoint regions, liveness UX, durable approval, blob-ref
+results) while resurrecting zero transport: no new routes, no inbound daemon
+surface, no relay machinery. If this slice feels bad in the hand, the vision
+is wrong somewhere that matters.
+
+## 14. Open product-owner questions
+
+1. Is offline reading of owned sensitive data (mail on a plane, books with no
+   box reachable) a committed product goal? Mail should materialize per device
+   where the upstream allows it; books would need the deferred hot-cache design
+   or self-host. (This is the seam-2 spec's standing question.)
+2. For hosted-sync users, is repo content in coding runs acceptable
+   trusted-cloud data, or is the coding agent a self-host/overlay-only feature?
+3. Is turnkey mobile remote (no Tailscale) worth building E2E session crypto,
+   or does bring-your-own-overlay remain the answer? (ADR-0080's trigger,
+   restated; everything in this memo works without deciding it.)
+4. Does Whispering ever want cross-device transcription (phone records,
+   desktop GPU transcribes via a run row), or is per-device transcription
+   final? Nothing should be built ahead of a yes.
+5. When Super Chat's replicas converge with app UIs (ADR-0096 slice), does its
+   transcript sync too, given tool results can carry sensitive trusted-cloud
+   data on hosted, or does it stay ephemeral by design?
+
+## 15. What would falsify this vision
+
+- The experiment in section 13 shows doc-mediated approval is too slow or
+  clumsy for real coding-agent workflows; attach becomes the primary model and
+  the mailbox demotes to fire-and-forget only.
+- Users demonstrably need urgent phone-initiated side effects on a specific
+  machine (not served by the mailbox, too heavy for attach); that is the one
+  product pressure that would genuinely reopen live capability transport, and
+  it should be resisted until a named consumer passes the ADR-0086 bar.
+- Hosted-sync users reject operator-readable run payloads (Q2 answered
+  self-host/overlay-only); the mailbox then only serves self-hosters for coding
+  work, which weakens the claim that one transport serves the whole product.
+- A real third-party integration needs a per-app network endpoint and cannot
+  be served as a built-in, a stdio facade, or a run row; the capability plane
+  returns with a consumer for the first time.
+- The always-on premise fails in practice: if most users never leave a machine
+  awake, "observe" starves and the product truth becomes phone-plus-cloud,
+  which is a different architecture (hosted executors) this memo deliberately
+  does not design.
+
+---
+
+## Appendix: greenfield findings for the major decisions
+
+### F1. The mailbox is a per-app pattern, not a platform outbox
+
+Product sentence: an app that needs machine-specific async work publishes its
+own domain rows bound to one executor agent; the workspace owns sync and the
+observe loop; no shared job infrastructure exists.
+
+Drift: "synced command outbox" drifts toward a generic jobs table with status
+enums, retries, and claim fields, which is hidden RPC plus audit fragmentation.
+
+Value owners: durable state = the app's rows; liveness = presence; side
+effects = the executor's worker; audit = the rows themselves; consent = the
+durable approval record; execution = the machine bound at creation.
+
+Code family created if we drift: a jobs schema, a status vocabulary, a retry
+policy engine, a claim/lease module, a cross-app audit UI, migration paths for
+every app that outgrows the generic shape.
+
+Greenfield vision: ADR-0025's kernel per app, three gates (non-urgent,
+idempotent-or-approved, permitted on this deployment's sync plane), claim pools
+deferred until N interchangeable workers exist.
+
+User loss: no universal "all my jobs" screen in v1; each app lists its own
+runs. Acceptable; a read-only aggregation view can be earned later without a
+shared write schema.
+
+Decision: refuse the platform outbox; keep the per-app mailbox pattern.
+
+### F2. Live per-app capability transport stays deleted
+
+Product sentence: Epicenter syncs state and never routes a capability call.
+
+Drift: every "phone reaches a tool on my Mac, live" story pulls the ten
+families back (section 10).
+
+Value owners: reachability = the user's overlay; the only live surface = the
+one host session (attach).
+
+Code family created if revived: the entire #2277/#2237 ledger plus token
+bootstrap hardening and a reconnect/timeout error taxonomy.
+
+Greenfield vision: observe for async, attach for live, nothing in between.
+
+User loss: no zero-install browser reach to a NAT'd box (already accepted in
+ADR-0079); no per-tool remote invocation without a session.
+
+Decision: refuse; ADR-0086's named-consumer bar governs any reopening.
+
+### F3. Materialize replaces "synced derived data"
+
+Product sentence: provider-owned data builds per device from the provider,
+gated only by the provider's own OAuth concurrency.
+
+Drift: treating "mobile access to mail" as a sync or remote-control problem
+when Google already offers every device its own grant.
+
+Value owners: the upstream owns the source of truth; each device owns its
+mirror; synced state owns only the human-authored layer (annotations, rules,
+views).
+
+Code family created if we drift: box-to-phone replication channels, partial-
+mirror protocols, staleness reconciliation, all to tunnel data the phone could
+fetch first-hand.
+
+Greenfield vision: per-device mirrors where allowed (Gmail); box-owned mirror
+plus attach where forbidden (QuickBooks); the deferred hot-cache design only
+behind Q1.
+
+User loss: none for mail; for books, no offline phone reading until Q1 is
+answered yes.
+
+Decision: keep (this is ADR-0081, promoted to a pillar).
+
+### F4. Attach is the only live channel
+
+Product sentence: exactly one thing is remotely reachable, the desktop host
+session, end-to-end over the user's own overlay.
+
+Drift: every new live need (terminal streaming, approval latency, "watch the
+agent think") tempts a second channel.
+
+Value owners: the desktop host owns the session; the overlay owns transport
+and authorization; Epicenter owns nothing in the path.
+
+Code family created if we drift: a second remote protocol, its auth, its
+reconnect logic, its privacy review.
+
+Greenfield vision: ADR-0080 unchanged; a hosted variant only ever as a
+content-blind E2E relay behind its trigger.
+
+User loss: non-overlay users have no live remote today; they keep replicate,
+materialize, and observe.
+
+Decision: keep.
+
+### F5. Durable approval returns, scoped
+
+Product sentence: a side-effecting run on a headless executor pauses on a
+durable approval record any of the person's devices resolves.
+
+Drift: either ambient approval (enqueue = consent, which within-partition
+forgery breaks) or resurrecting full doc-mediated chat approval that ADR-0047
+deleted for good reasons.
+
+Value owners: the executor owns enforcement (nothing runs unapproved); the
+requester's human owns the decision; the job child doc owns the record.
+
+Code family created: one approval record shape, one executor-side wait, one
+resolve UI; deliberately no policy engine in v1 beyond per-verb
+deny/ask/auto.
+
+Greenfield vision: approval gates side effects, never reasoning; scoped to the
+exact visible payload; irreversible external verbs stay refused rather than
+approval-gated.
+
+User loss: dangerous verbs (money, messages) are simply unavailable via the
+mailbox, by design.
+
+Decision: keep, scoped exactly this far.

--- a/specs/20260706T233000-encrypted-job-envelope-strategy.md
+++ b/specs/20260706T233000-encrypted-job-envelope-strategy.md
@@ -1,0 +1,572 @@
+# Encrypted job envelopes: strategy review of the class-b refusal
+
+State: Draft
+
+A privacy strategy memo, not a design. It answers one question: is the
+cross-device vision memo (`specs/20260706T220000-cross-device-coordination-vision.md`)
+too strict when it says class-b payloads never ride hosted sync, or would a
+narrow server-derived encrypted envelope for command/job payloads and results
+(the ADR-0074 vault posture, applied to work rows) earn a place between
+plaintext hosted sync and self-host? Existing ADRs were treated as evidence,
+not constraints. Stops at strategy; nothing here is implemented.
+
+## 1. Verdict
+
+Keep the current class model. Reject the encrypted-envelope class.
+
+The one-sentence reason: Epicenter's privacy classes are defined by who can
+read, and a server-derived envelope does not change who can read; it changes
+what a partial storage breach exposes. That is hygiene inside class a, not a
+new class between a and b. The only mechanism that creates an honest middle
+class is a client-held key the server never sees, and that is the
+zero-knowledge design ADR-0004 rejected with its full cost intact: keyring
+lifecycle, unreadable states, recovery cliffs, and the loss of server-side
+reads. A job wrapper does not make that math smaller; it makes it per-app.
+
+Two refinements come with the verdict:
+
+1. The vision memo's section 8 asserts "encryption posture: unchanged" without
+   saying why an envelope cannot help. It should state the reader-set argument
+   in one paragraph, so the next person who asks this question (this memo is
+   proof someone will) finds the reasoning foreclosed rather than assumed.
+2. The honest strictness dial is deployment, not cryptography. Hosted sync is
+   trusted-cloud sync; self-host relocates the operator to the user. If a
+   payload is not acceptable on hosted under that sentence, the answer is
+   self-host or do not build the hosted feature, never an envelope that implies
+   more than it delivers.
+
+## 2. What PR #2023 actually removed, and why
+
+PR #2023 (merged 2026-06-15) removed exactly the candidate under review, at
+workspace scale. The layer was:
+
+```txt
+ENCRYPTION_SECRETS            root keyring, on Epicenter's server
+  -> owner key                auth server derives it (HKDF)
+    -> workspace key          client derives it (HKDF)
+      -> XChaCha20-Poly1305   encrypt the value, then into the Y.Doc
+```
+
+Server-derived keys, ciphertext at rest on the relay, keyring delivered on the
+authenticated session. The PR body names the tell: "encrypting at rest still
+trusts the server. The root key lived on our infrastructure, so server code
+could read your data, a bug could log it, an operator could inspect it. You
+were never server-blind; you were trusting the application." Once the relay is
+trusted anyway, "the per-owner workspace key buys nothing but a key-recovery
+tax and a class of 'unreadable cell' failures."
+
+What the removal cost, concretely: the `unreadable` read state existed only
+for encrypted rows (ADR-0002, superseded by ADR-0003); the keyring threaded
+through auth, session, and every workspace factory; `/api/session` served key
+material; and the KV read contract was a tri-state every consumer branched on.
+Deleting the layer collapsed reads to `value | undefined` and dropped the
+keyring parameter from six app factories.
+
+ADR-0004 then recorded the decision twice over: it rejected zero-knowledge,
+and in its considered alternatives it separately rejected "per-workspace
+encryption at rest, server holds keys" as "complexity of an encryption layer
+with none of the server-blindness benefit." That second rejection is the
+candidate model of this memo, verbatim. The candidate is not a new idea; it is
+the deleted idea at smaller scope.
+
+One state-of-the-tree note: the primitives survived the wiring. On main today,
+`@epicenter/encryption` (MIT) still exports a tested, versioned AEAD envelope
+(`encryptBytes`/`decryptBytes`, XChaCha20-Poly1305, key-version header, AAD
+binding) and per-principal derivation (`parseRootKeyring` + `deriveKeyring`,
+info label `principal:{id}`), and `createEncryptedYkvLww` sits dormant in
+`packages/workspace`. Zero production callers. Feasibility was never the
+question; a narrow envelope is buildable in days. The question is whether it
+buys anything.
+
+## 3. What ADR-0074 proves, and what it does not
+
+ADR-0074 (the secret vault) is the one accepted narrow exception, and it is
+the strongest evidence for the envelope, so it deserves an exact reading.
+
+What it proves: the server-derived posture is livable when scoped. No
+passphrase, no unlock ceremony, no `locked` state; the keyring arrives with
+the authenticated session, so a present value is always decryptable and the
+read contract stays two-state (`available | missing`). The relay and its
+backups hold ciphertext while the keyring lives in the auth service, so a
+relay or backup leak alone exposes nothing. And the ADR is honest about what
+that is: "defense in depth, not a privacy claim. On hosted the operator can
+read a stored key, and that is the accepted point."
+
+What it does not prove:
+
+1. It is not yet livable in production. The wiring spec
+   (`specs/20260701T150000-api-keyring-and-vault-wiring.md`) is Draft, branch
+   not started; `deriveKeyring` has no caller; Whispering's secrets facade is
+   device-local plaintext today. ADR-0074 proves the policy is acceptable, not
+   that the plumbing is proven.
+2. Its justification does not transfer to content. The vault holds brought
+   credentials: small, dense, long-lived, and directly exploitable. A leaked
+   Groq key is a working credential for a third-party account; encrypting it
+   at rest defends against a real, specific blast radius. A job payload is
+   content. Content leaking from a storage snapshot is bad, but the user's
+   actual question about content ("can Epicenter read my mail query?") has the
+   same answer with or without the envelope. Citing ADR-0074 as precedent for
+   content envelopes reads the exception wider than its own rationale.
+3. It defended one store, once. Jobs are deliberately not one store. The
+   vision memo's refusal #4 (no generic jobs table; every app publishes its
+   own domain rows) means there is no single integration point to encrypt.
+   An envelope would either be re-implemented per app table, or it would
+   pressure the generic jobs table back into existence to have one place to
+   bolt itself on. The envelope is structurally in tension with a refusal the
+   memo fought three teardowns to earn.
+
+There is one more piece of settled evidence: ADR-0090 already decided that the
+blob layer stays plaintext and "confidentiality belongs to the encrypting
+consumer," who encrypts before `blobs.add` and owns key management. So the
+seam for a consumer-owned envelope over bulk payloads exists, sanctioned, and
+requires no new decision. If the trigger in section 9 ever fires, that seam is
+where the work lands; nothing needs to be pre-built to keep it open.
+
+## 4. The reader-set argument (why no honest middle class exists)
+
+```txt
+Question:
+  does encrypting a job payload under a server-derived key move it
+  between privacy classes?
+
+Model:
+  class    = the set of parties who can read the payload
+  class a  = {user's devices, Epicenter operator}     (hosted plaintext)
+  class c  = {user's devices, user-as-operator}       (self-host)
+  envelope = same reader set as class a; smaller breach surface
+
+Rule:
+  encryption moves a payload between classes only when it removes a
+  reader. A key the operator derives removes no reader. Therefore the
+  envelope cannot admit class-b data to hosted sync; it can only make
+  class-a data cheaper to hold safely.
+```
+
+Class b exists because of promises about readers: "the books never leave the
+box" is a claim about who can read ledger rows, and ADR-0080's seam-2
+constraint bars class-b tool results from "any operator-readable channel,"
+naming "just sync it over the sync plane" as the exact costume to refuse. An
+envelope whose key sits in Epicenter's auth service leaves the channel
+operator-readable. The promise breaks identically; the machinery just makes
+the break harder to see, which is worse. ADR-0068 has a name for a
+configuration that implies privacy it does not deliver: a false privacy claim.
+
+The infra baseline also matters here. Cloudflare already encrypts Durable
+Object storage at rest below the application. The envelope's real marginal
+protection over that baseline is application-layer exposure: server logs,
+backups readable by app code, an operator inspecting the DB, a leaked storage
+export. Real, but thin, and identical in kind to what every hosted SaaS means
+by "encrypted at rest." It is a hygiene property, not a product tier.
+
+## 5. Revised privacy class table
+
+This table records the original memo's intermediate framing. The addendum below
+supersedes it with the final owner decision: hosted is trusted managed sync,
+self-host is the privacy answer, and there is no per-dataset privacy dial. The
+useful part that survives is the reader-set argument, not the class vocabulary.
+
+```txt
+class a   may ride hosted sync. Reader set: user + operator. Data the
+          user already trusts to the plane: notes, todos, transcripts,
+          mail annotations, run rows for opted-in repos.
+
+          (hygiene option inside class a, not a class: a consumer MAY
+          encrypt its bulk payload blobs before blobs.add under the
+          vault keyring, per ADR-0090. Reader set unchanged; breach
+          surface smaller. Built only behind the section-9 trigger.)
+
+class b   never rides hosted sync, in any costume, including inside a
+          server-derived envelope: ledger rows, mail bodies, message
+          bodies. The class is defined by a reader-set promise no
+          operator-held key can satisfy. Cross-device class-b is
+          attach (E2E session) or nothing.
+
+class c   self-host relocates the operator and dissolves class b for
+          that deployment. Unchanged.
+```
+
+The honest ladder of "who can read," for completeness: class a and the
+envelope share a rung; the next rung up is E2E artifacts (the ADR-0080
+content-blind session relay, a client-held-key store), and the top is class c.
+The envelope is not a rung.
+
+## 6. Use-case matrix
+
+The mission's four use cases, tested against the envelope. The pattern across
+the matrix: in no case is operator-readability the binding constraint that
+encryption would relieve. Each case fails or succeeds for reasons the envelope
+cannot touch.
+
+```txt
+use case            envelope changes verdict?   binding constraint            verdict
+iMessage summary/   no                          urgency (a summary is wanted  stays refused
+query                                           now); phantom need (Apple
+                                                already syncs Messages to
+                                                the user's devices); result
+                                                bodies still operator-
+                                                readable either way
+
+iMessage send       no                          no upstream idempotency key;  stays refused
+                                                maximally urgent; irrevers-
+                                                ible external side effect
+                                                (refused outright, not
+                                                approval-gated). Encryption
+                                                is orthogonal to all three.
+
+Local Mail body     no                          materialize already gives     stays materialize;
+queries                                         every device its own Gmail    no job exists to
+                                                mirror (100 grants, ADR-      encrypt
+                                                0081). A desktop-query job
+                                                solves a problem the phone
+                                                solves better first-hand.
+
+Local Books         no                          the promise is a reader-set   stays attach /
+queries                                         claim ("never leaves the      self-host; hot-
+                                                box"); an operator-derivable  cache stays behind
+                                                key leaves the operator a     seam-2 Q1
+                                                reader. Only self-host or
+                                                the E2E hot-cache honors it.
+
+coding-agent runs   marginally (at-rest         (1) the class question is     stays trusted-cloud
+                    hygiene on payload/result   Q2, and the envelope does     data if hosted,
+                    blobs), but under-covers    not change its honest         or self-host;
+                                                answer; (2) the sensitive     revisit on the
+                                                content also flows through    section-9 trigger
+                                                the child doc's Y.Text
+                                                progress stream, which an
+                                                envelope cannot cover
+                                                without reviving encrypted-
+                                                CRDT machinery (PR #2023's
+                                                deleted layer)
+```
+
+The coding agent deserves the extra sentence because it is the only real
+candidate. Its transcript stream is the trap: a coding run's sensitive content
+is the streamed diff and log, not just the enqueued payload and final result
+blob. An envelope over the blobs with a plaintext Y.Text transcript protects
+the part nobody was worried about and leaks the part they were. Covering the
+stream means per-update CRDT encryption, which is `createEncryptedYkvLww`
+generalized to Y.Text: the exact layer PR #2023 deleted, with compaction and
+tri-state reads back in tow. So the envelope either under-covers (dishonest)
+or grows back into the thing it promised to stay smaller than.
+
+## 7. Honest product copy
+
+The copy test is the cheapest way to see the verdict. Write the sentence each
+tier can honestly say:
+
+```txt
+class a today       "Synced through Epicenter Cloud. Epicenter can
+                    read it, like your notes."
+
+with envelope       "Encrypted in sync storage. Epicenter's service
+                    can still decrypt it on hosted."
+
+E2E / class c       "Epicenter cannot read this."
+```
+
+The envelope sentence is the problem. Written honestly, it promises nothing
+the class-a sentence did not already cover; no user upgrades their trust
+because of it. Written shorter ("encrypted," "private," a lock icon), it
+implies the third sentence while delivering the first, which is the false
+privacy claim ADR-0068 forecloses. There is no wording between honest-and-
+worthless and dishonest, because the underlying property has no user-visible
+edge. The vault survives this test only because its copy never mentions
+encryption at all ("Synced to your devices" vs "Saved only on this device");
+the encryption is an operational detail, not a promise. Job payloads have no
+equivalent promise-free framing that would make the envelope worth stating.
+
+## 8. Code families the envelope reintroduces
+
+Counted against PR #2023's deletion ledger. "Narrow" shrinks N; it does not
+delete the family.
+
+```txt
+family                        avoided by narrowing?
+server keyring plumbing       shared with the vault wiring (coming anyway
+                              if the vault ships), so marginal cost is low;
+                              but the envelope makes it load-bearing for
+                              every job-emitting app, not one store
+key rotation / version        no. Root rotation means every surviving blob's
+retention                     key version must stay derivable forever;
+                              dropping a version is silent data loss
+unreadable states             shrunk, not avoided. A device whose keyring
+                              fetch failed (offline boot, auth hiccup) holds
+                              ciphertext rows; every job list, approval
+                              screen, and audit view grows a third state.
+                              This is ADR-0003's collapse reversing.
+approval over ciphertext      new, and consent-critical. The memo's rule is
+                              approval "scoped to the exact visible payload";
+                              decrypt-before-display becomes part of the
+                              consent path, and a decrypt failure is now an
+                              approval-blocking error class
+boot ordering                 new dependency: keyring before job UI, per app
+per-app integration           multiplied by design: no generic jobs table
+                              means each app's runs table re-pays encrypt/
+                              decrypt/error wiring
+migration + dual-read         once per adopting table
+server-side blindness         the plane's whole reason for plaintext (ADR-
+                              0004): any future server-side run search,
+                              hosted dashboard, or server materialization
+                              over jobs goes blind on payloads
+UI copy / trust lines         once per job-creating surface, and per section
+                              7 there is no good sentence to put there
+```
+
+Verdict on the packet-4 question (does a narrow envelope avoid these or hide
+them): it hides them. Blob-only scope genuinely avoids the CRDT-encryption and
+compaction families, but rotation, unreadable states, approval-over-
+ciphertext, and boot ordering return at reduced N, and the per-app structure
+of the mailbox multiplies them back up.
+
+## 9. Smallest next experiment, and the trigger to revisit
+
+No encryption experiment now. The experiments that actually gate this space:
+
+1. Workers V1 (vision memo section 13), unchanged. It tests the mailbox on
+   class-a payloads and needs no envelope.
+2. Ship the vault keyring wiring
+   (`specs/20260701T150000-api-keyring-and-vault-wiring.md`). It is the shared
+   prerequisite for any future envelope, it is already specified, and it has
+   its own consumer. If the envelope is ever earned, its keys come from there
+   and the marginal server work is near zero.
+3. Put Q2 in front of real hosted users as a copy test, not a crypto test:
+   "run payloads and transcripts are readable by Epicenter, like your notes."
+   If that sentence loses the segment, the remedy on the table is self-host
+   reachability or E2E, and knowing that early is cheaper than building the
+   middle thing nobody asked for.
+
+The trigger that reopens this memo, stated so it is checkable: a real, named,
+paying segment says it would run hosted coding agents if run content were
+encrypted at rest, while explicitly accepting the "Epicenter can decrypt"
+sentence (this is ADR-0068's deferred segment becoming real, applied to runs);
+or a compliance requirement from a committed customer demands application-
+layer encryption at rest. If either fires, the build is the narrow shape from
+the feasibility evidence: consumer-side `encryptBytes` before `blobs.add`
+(the ADR-0090 seam), keys from the vault keyring endpoint, plaintext rows,
+blob-only scope, one consuming app; plus a solved design for the transcript
+stream (for example: the Y.Text stream carries operational plaintext only,
+status and progress, while all content chunks ride encrypted blobs). Without
+the stream design, the envelope under-covers and should not ship.
+
+What would falsify the reject beyond those triggers: nothing else. In
+particular, "it would be easy" is not a trigger; section 2 shows it was always
+easy, and easy was never the question.
+
+## 10. ADR and spec impact
+
+```txt
+vision memo    amend section 8 with the reader-set paragraph (section 4
+               here) and the class-a hygiene annotation (section 5 here).
+               The class model itself is unchanged and correct.
+
+new ADR        when the memo's cross-device ADR is written (its section 11),
+               include one line: "server-derived encryption of job payloads
+               is refused; it shrinks breach surface, not the reader set,
+               and cannot move a payload between classes." That forecloses
+               the re-litigation this memo answers.
+
+ADR-0004       no amendment. Its considered-alternatives already rejected
+               this memo's candidate by name.
+
+ADR-0068       no amendment. Its deferred "encrypted hosted mode" trigger is
+               restated, checkably, in section 9 here.
+
+ADR-0074       no amendment, one caution: do not cite it as precedent for
+               content envelopes. Its rationale is credential density; the
+               exception does not widen to content.
+
+ADR-0090       no amendment. It is the sanctioned seam if the trigger fires.
+
+this spec      deleted once the vision memo's section 8 is amended and the
+               cross-device ADR carries the one-line refusal; git keeps the
+               body recoverable.
+```
+
+## 11. Open product-owner questions
+
+1. Q2, restated under the addendum and still the real question: for hosted-sync users, is repo
+   content acceptable trusted-cloud data, or is the coding agent a self-host/
+   overlay feature? The envelope does not change the honest answer; only the
+   user's trust in the operator does.
+2. If a compliance-driven segment appears ("encrypted at rest" as a
+   procurement checkbox), do we serve it with the narrow blob envelope, or
+   route it to self-host on principle? The checkbox is satisfiable honestly;
+   the question is whether Epicenter wants to sell a property with no
+   user-visible edge.
+3. Does the vault stay the only server-derived-keyring consumer until a
+   section-9 trigger fires? Recommendation: yes, and the vault wiring should
+   ship on its own merits regardless.
+4. Mail-query results: if product ever wants them on hosted sync, are they
+   acceptable trusted-cloud data? Moot while materialize covers the phone
+   story, but worth answering once so nobody reaches for the envelope as a
+   compromise.
+
+---
+
+## Addendum: no third mode, no opt-in dial (2026-07-06, founder direction)
+
+Product rule, stated by the owner after the verdict above:
+
+```txt
+Hosted Epicenter is trusted managed sync. Epicenter can read synced payloads.
+Self-hosted Epicenter relocates the operator to the user.
+There is no third "hosted but Epicenter cannot read" mode for v1.
+There is also no per-dataset privacy opt-in dial in v1.
+```
+
+This addendum supersedes the earlier deployment-plus-opt-in framing. The
+collapse goes one step further: privacy is chosen at deployment time, not per
+feature, per dataset, or per command. If a payload rides hosted sync, the
+product treats it as trusted-cloud data. If that is not acceptable, the answer
+is self-host.
+
+### A1. Does this simplify the privacy model?
+
+Yes. The model is now two deployments and zero privacy dials:
+
+```txt
+hosted      operator = Epicenter. Epicenter can read synced payloads.
+self-host   operator = the user. Epicenter is not in the data path.
+```
+
+This is the shortest honest rule and it aligns directly with ADR-0068:
+privacy is the choice of which computer runs the program, not a toggle inside
+the app. A per-dataset "Epicenter can read this" dial sounds precise, but it
+reintroduces a privacy settings surface and implies other hosted data may have
+a different reader set. It does not. Hosted sync is trusted sync.
+
+The rule governs the sync plane only. Attach (ADR-0080) stays a live session
+over the user's own overlay, and a future content-blind relay remains a
+transport question, not a hosted-sync privacy mode. Server-derived encryption
+also stays outside the product model: it may be used later as unmarketed
+storage hygiene for a concrete compliance need, but never as a mode, a class,
+a lock icon, or a reason to move sensitive data onto hosted sync.
+
+### A2. Does the iMessage verdict change?
+
+Yes, but only by deployment.
+
+```txt
+hosted      no iMessage feature in v1. Hosted sync is readable by Epicenter,
+            and message bodies are too sensitive to make a default hosted
+            product promise around them.
+
+self-host   query and summarize jobs are viable because the operator is the
+            user. Send jobs are admissible only under A4.
+```
+
+The original refusal stacked four arguments: bodies on the hosted anchor, no
+send idempotency, urgency, and phantom product need. Self-host dissolves the
+hosted-reader problem. The phantom-need argument also narrows: Apple syncs the
+Messages app to the user's devices, but it does not give an agent query
+access. "What did Mom say about Thursday?" asked from a phone to a self-hosted
+assistant whose Mac holds `chat.db` is a real agentic need Apple does not
+serve.
+
+Send remains the hard case. Money stays refused. A duplicate or late text is
+apology-recoverable, so send can be admitted on self-host, but only with every
+rule in A4; missing any one of them, it reverts to refused.
+
+### A3. The observe/job model for a self-hosted iMessage assistant
+
+The section-7 kernel, applied. No new platform machinery.
+
+```txt
+tables       the Messages app owns its own domain tables: queries and sends.
+             There is no generic jobs table.
+
+executor     one immutable AgentId: the Mac running the daemon with access to
+             chat.db for reads and Messages automation for sends. Set at row
+             creation, never reassigned.
+
+query row    question/filters as columns; executor claims by writing the
+             started record keyed to the job id; streams progress into the
+             child doc; writes a write-once result with bodies as blob refs.
+             Results land on the self-hosted plane, whose operator is the
+             user.
+
+send row     recipient + exact literal text (+ attachment hashes) as the
+             payload; durable approval record in the child doc scoped to
+             exactly that content; short expiry; outcome write-once.
+
+presence     decoration only: "Mac asleep; will answer when it wakes."
+
+hosted       not offered in v1. There is no opt-in dial to convert iMessage
+             payloads into a hosted feature.
+```
+
+The same observe structure still works on hosted for ordinary trusted-cloud
+features. The distinction is product permission, not a different mechanism.
+The coordination layer remains sync in both deployments.
+
+### A4. Mandatory safety rules for send-message jobs
+
+All seven, conjunctive; any missing rule reverts send to refused.
+
+1. Exact-payload approval: the durable approval record binds recipient and
+   the full literal text (and attachment hashes) by content hash to the job
+   id. Any edit invalidates the approval. Approval policy for send verbs is
+   always ask; there is no per-verb auto for sends, ever.
+2. Short expiry, set at creation (minutes, not hours). The executor checks
+   it at claim time and again immediately before the send call, so a job
+   enqueued against a sleeping Mac expires cleanly instead of firing stale.
+3. Requester-minted job id as the idempotency key, enforced by a durable
+   executor-local send ledger: the executor records intent-to-send in the
+   ledger before invoking the send, and consults it on every claim. iMessage
+   offers no upstream idempotency; this ledger is the substitute, and it
+   must survive crash and restart.
+4. No auto-retry after unknown outcome: a crash between intent-to-send and
+   the outcome record terminates the job in a write-once `unknown` state
+   surfaced to the human. Retry is a new row with a new approval.
+5. Claim before send: the started record keyed to the job id is written
+   before any side effect, so a second observer reconciles and stops.
+6. Cancellation honored up to the point of no return, which is defined as
+   the moment intent-to-send hits the local ledger.
+7. Money-shaped verbs stay refused outright. The message/money split in A2
+   is a floor, not a precedent for other irreversible verbs.
+
+### A5. Exact edits to the two specs
+
+`specs/20260706T220000-cross-device-coordination-vision.md`:
+
+1. Section 8: replace the three-class table with the two-deployment model:
+   hosted means trusted managed sync; self-host relocates the operator to the
+   user; no third mode and no per-dataset privacy dial in v1. Keep the
+   reader-set paragraph from this memo.
+2. Section 7, the gates: gate (c) becomes "permitted on this deployment's
+   sync plane." On hosted, that means ordinary trusted-cloud data only. On
+   self-host, sensitive observe jobs become viable because the operator is the
+   user. Money remains refused; send-message is admissible only under A4.
+3. Section 4, iMessage row and prose: from "refused (fails every gate)" to
+   "hosted: not offered in v1; self-host: query/summarize via observe, send
+   only under the safety ruleset." The old counterexample paragraph is
+   rescoped to hosted.
+4. Section 12, refusal #6: reword to "Epicenter does not build a hosted
+   iMessage feature; a self-hosted assistant may observe Messages on the
+   user's own deployment."
+5. Section 14: remove the hosted opt-in wording. Keep the concrete product
+   question: is repo content acceptable trusted-cloud data, or is the coding
+   agent self-host/overlay-only?
+
+This memo (`20260706T233000-encrypted-job-envelope-strategy.md`):
+
+6. Section 5's table is now transitional. The final model is deployment-based,
+   not class-based: hosted trusted sync vs self-host.
+7. Section 9's compliance trigger is subordinated to the no-third-mode rule:
+   unmarketed storage hygiene only, never a mode.
+8. Section 11 Q4 is answered: there is no opt-in dial for mail-query results
+   in v1. If mail bodies are not acceptable trusted-cloud data, they do not
+   ride hosted sync.
+
+### A6. Which ADR records this
+
+The new cross-device coordination ADR, not an ADR-0068 amendment. ADR-0068
+already says the load-bearing sentence: privacy is the choice of which
+computer runs the program, not a toggle inside the app. The new ADR should
+carry this concrete application of that rule: replicate/materialize/observe/
+attach; hosted as trusted sync; self-host as the privacy answer; no third mode;
+no per-dataset privacy dial; the one-line envelope refusal; the reworded
+mailbox gates; and the A4 send ruleset. It cites ADR-0004, ADR-0068, ADR-0074,
+ADR-0080, and ADR-0090 as evidence. Both this spec and the vision memo are
+then deleted per hygiene once the ADR lands.

--- a/specs/super-chat-direct-command-forms.md
+++ b/specs/super-chat-direct-command-forms.md
@@ -1,0 +1,66 @@
+# Super Chat direct command forms
+
+State: Draft
+
+## Product sentence
+
+Super Chat is a local command surface for Epicenter apps. Chat can call Epicenter-native actions and external MCP tools with the right approval policy; the direct command palette is narrower and only gives first-class forms to Epicenter-native actions with field-shaped inputs.
+
+## Decision
+
+Do not build a universal JSON Schema form generator for v1.
+
+A Super Chat direct command form uses an Epicenter-native form contract:
+
+- the input schema is a flat object
+- every object property is an `@epicenter/field`-recognized leaf schema
+- nested objects are not formable in v1
+- unions are not formable in v1, including nullable unions
+- arrays are formable only when they are part of the field vocabulary, such as `tags` or `multiSelect`
+
+The wire format is still JSON Schema. The app authors the schema with TypeBox and `field.*`; the future direct-command listing will classify the serialized schema with `recognize(...)` from `@epicenter/field` when it has a real caller.
+
+## Tool surfaces
+
+```text
+Epicenter-native action
+  chat: yes
+  direct command palette: yes, when input is formable
+  generated UI: Epicenter field form
+
+External MCP tool
+  chat: yes
+  direct command palette: not in v1
+  generated UI: none in v1
+  later escape hatch: whole-body JSON editor validated against inputSchema
+```
+
+External MCP tools can still be powerful in chat. They should not force the native command palette to become a generic API console.
+
+## Consent boundary
+
+Direct submit means consent only for the exact visible payload.
+
+For generated Epicenter forms, every submitted property must be visible as a field in the form. No hidden schema branches, no server-side enrichment, and no ambient approval that carries to another call.
+
+If a future advanced JSON runner exists, the whole JSON body is the visible payload. That is a separate surface from the polished direct command form path.
+
+## Future implementation hook
+
+The first direct-command listing or palette slice should introduce a small Super Chat-local classifier:
+
+```text
+recognizeFormableActionInput(schema)
+  -> FormableActionInput when the schema is a flat object of field leaves
+  -> null when the schema is chat-callable but not direct-formable
+```
+
+That classifier should live with Super Chat, not `@epicenter/field` or `@epicenter/workspace`: field owns leaf recognition, workspace owns tool execution, and Super Chat owns the product policy that only flat field-shaped inputs get direct forms. Add the classifier in the same slice as its first production caller so it does not exist only for tests.
+
+The renderer should consume the classified shape instead of re-deciding formability in Svelte components. The route or client model that lists direct commands should hide or mark non-formable tools before the palette renders them.
+
+## Asymmetric win
+
+Refusing universal generated forms deletes a large code family: nested object rendering, arbitrary arrays, JSON Schema composition keywords, schema refs, MCP metadata quirks, default injection rules, and consent ambiguity around hidden payloads.
+
+The product loss is small for v1. External tools remain available through chat, and a raw JSON runner can be added later without changing the polished Epicenter-native form contract.


### PR DESCRIPTION
Super Chat is moving toward one catalog with two callers: chat turns and future direct commands. This PR makes the shared execution seam real without building the command palette or endpoint yet.

The agent loop now runs tool calls through `resolveApprovedToolCall`, so approval policy, user denial, stop-after-approval handling, and unknown-tool failure all live in one path. That gives the future direct-command surface a safe primitive to reuse instead of re-implementing mutation approval beside chat. Super Chat also returns full `AgentToolDefinition` values from `/api/session`, including `inputSchema`, so the UI can inspect the same catalog the model sees.

The docs record the product boundary we settled while reviewing the next steps:

```text
sync is the coordination layer; execution stays where the capability lives
```

Direct command forms are intentionally Epicenter-native in v1: no universal JSON Schema form generator, no generated forms for external MCP tools, and no premature `@epicenter/field` classifier until the palette has a real caller. The cross-device vision drafts the broader direction: replicate data, materialize provider-owned data per device where possible, observe durable work rows for machine-specific async work, and attach only to the one desktop host session for live interaction.

The privacy stance stays simple: hosted sync is trusted sync, self-host is the privacy answer, and there is no third hosted-but-private mode or per-dataset privacy dial in v1. Server-derived encryption may still be useful as unmarketed storage hygiene later, but it does not change who can read synced payloads and should not be used to move sensitive content onto hosted sync.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785996683&installation_id=128463665&pr_number=2393&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2393&signature=238d8fb45c2b15b633b9b9ec8c333967f06495e38ed7646aff8f7176efab22fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->