### PR TITLE
refactor(local-mail): collapse Gmail credentials to BYO keyset

### DIFF
--- a/apps/local-mail/.env.example
+++ b/apps/local-mail/.env.example
@@ -1,21 +1,12 @@
-# local-mail provider credentials (ADR-0108).
+# local-mail provider credentials.
 #
-# Local Mail has two distinct Google Desktop OAuth clients: a dev/unverified one
-# and a prod/verified one. The name carries the environment, so `--gmail-env dev`
-# reads the GMAIL_DEV_* keyset and `--gmail-env prod` reads GMAIL_PROD_*. Set only
-# the environments you run. --gmail-env is required at connect only when both
-# keysets are present; with one present it is inferred.
+# Local Mail is BYO: set one Google OAuth Desktop client pair for the account
+# you want this local app to connect through. The stored token records the
+# concrete client id that minted it, so a later client-id change fails loudly and
+# asks you to reconnect instead of surfacing as Google's opaque invalid_grant.
 #
 # In the monorepo, keep these in your personal Infisical project at
 # prod /apps/local-mail and inject them with the app-local .infisical.json.
-# The account records which environment it was connected under; every later sync
-# asserts it. This file is the source of the canonical names; a drift test pins
-# it to GMAIL_SPEC (see src/env-example.test.ts).
 
-# GMAIL (set only the environments you run)
-# dev
-GMAIL_DEV_CLIENT_ID=
-GMAIL_DEV_CLIENT_SECRET=
-# prod
-GMAIL_PROD_CLIENT_ID=
-GMAIL_PROD_CLIENT_SECRET=
+GMAIL_CLIENT_ID=
+GMAIL_CLIENT_SECRET=

--- a/apps/local-mail/README.md
+++ b/apps/local-mail/README.md
@@ -26,26 +26,23 @@ Gmail, not a local-only table.
 
 ## Commands
 
-Connect once. `--gmail-env` picks the OAuth keyset: `dev` reads `GMAIL_DEV_*`
-(the unverified client), `prod` reads `GMAIL_PROD_*` (the verified one). It is
-required only when both keysets are present, and inferred when just one is. The
-account records the environment it was connected under, and every later sync
-asserts it (ADR-0108):
+Connect once. Local Mail is BYO: set one Google OAuth Desktop client pair as
+`GMAIL_CLIENT_ID` / `GMAIL_CLIENT_SECRET`, then run the connect flow. The stored
+token records the concrete client id that minted it, and later refreshes refuse
+if the configured client id changes:
 
 ```sh
 infisical run --path=/apps/local-mail -- \
-  bun run src/bin.ts connect --gmail-env dev
+  bun run src/bin.ts connect
 ```
 
-The name carries the provider target. The app-local Infisical config should
-point at your personal secrets project, where both keysets sit under
-`prod /apps/local-mail` for a single injection. This is per-person
+The app-local Infisical config should point at your personal secrets project,
+with those two secrets under `prod /apps/local-mail`. This is per-person
 bring-your-own provider configuration, not Epicenter-hosted infrastructure. Copy
 `.infisical.json.example` to `.infisical.json` and keep the real file local.
 That file is ignored because each operator has a different personal Infisical
 project. The committed `apps/api` and `ops` configs point at Epicenter's hosted
-project instead. See [`.env.example`](.env.example) for the canonical names. The
-old unqualified `GMAIL_CLIENT_ID` / `GMAIL_CLIENT_SECRET` are retired.
+project instead. See [`.env.example`](.env.example) for the canonical names.
 
 Local Mail requests `gmail.modify` so write-through label changes can round-trip
 through Gmail. Although Google grants send at the same OAuth layer, Local Mail
@@ -59,7 +56,7 @@ Gmail profile instead of being typed:
 
 ```sh
 infisical run --path=/apps/local-mail -- \
-  bun run src/bin.ts seed-token <refresh-token> --gmail-env dev
+  bun run src/bin.ts seed-token <refresh-token>
 ```
 
 Build or refresh the mirror:
@@ -150,10 +147,9 @@ Tools:
 
 ## Config
 
-- `GMAIL_DEV_CLIENT_ID` / `GMAIL_DEV_CLIENT_SECRET`, `GMAIL_PROD_CLIENT_ID` /
-  `GMAIL_PROD_CLIENT_SECRET`: the Google OAuth Desktop client keys, one keyset per
-  environment (ADR-0108). `--gmail-env` selects which the resolver reads, lazily at
-  connect/refresh; a missing keyset fails loudly naming the exact variables.
+- `GMAIL_CLIENT_ID` / `GMAIL_CLIENT_SECRET`: the BYO Google OAuth Desktop client
+  keys. The resolver reads them lazily at connect/refresh; missing credentials
+  fail loudly naming the exact variables.
 - `LOCAL_MAIL_ACCOUNT`: optional account override for `sync`, `query`, and
   `mcp`. Required only when more than one account is connected.
 - `LOCAL_MAIL_DIR`: data directory override.

--- a/apps/local-mail/package.json
+++ b/apps/local-mail/package.json
@@ -15,8 +15,7 @@
 		"./http/api": "./src/http/api.ts"
 	},
 	"scripts": {
-		"connect:dev": "infisical run --path=/apps/local-mail -- bun run src/bin.ts connect --gmail-env dev",
-		"connect:prod": "infisical run --path=/apps/local-mail -- bun run src/bin.ts connect --gmail-env prod",
+		"connect": "infisical run --path=/apps/local-mail -- bun run src/bin.ts connect",
 		"sync": "infisical run --path=/apps/local-mail -- bun run src/bin.ts sync",
 		"status": "infisical run --path=/apps/local-mail -- bun run src/bin.ts status",
 		"test": "bun test",

--- a/apps/local-mail/src/cli.test.ts
+++ b/apps/local-mail/src/cli.test.ts
@@ -130,7 +130,6 @@ test('label honors LOCAL_MAIL_READ_ONLY before resolving labels', async () => {
 	const token: TokenSet = {
 		accountEmail: 'you@example.com',
 		clientIdUsed: 'client-id',
-		environment: 'dev',
 		accessToken: 'access-token',
 		refreshToken: 'refresh-token',
 		accessTokenExpiresAt: new Date(Date.now() + 10 * 60_000).toISOString(),
@@ -174,7 +173,6 @@ test('status --json resolves the sole stored account and prints JSON', async () 
 	const token: TokenSet = {
 		accountEmail: 'you@example.com',
 		clientIdUsed: 'client-id',
-		environment: 'dev',
 		accessToken: 'access-token',
 		refreshToken: 'refresh-token',
 		accessTokenExpiresAt: new Date(Date.now() + 10 * 60_000).toISOString(),

--- a/apps/local-mail/src/cli.ts
+++ b/apps/local-mail/src/cli.ts
@@ -1,5 +1,4 @@
 import { loadConfig } from './config.ts';
-import { selectGmailEnvironment } from './gmail-credentials.ts';
 import {
 	type ModifyMessageLabelsOutcome,
 	resolveAndModifyMessageLabels,
@@ -10,7 +9,6 @@ import { openLocalMailRuntime, openSyncSession } from './runtime.ts';
 import { type MailStatus, readMailStatus } from './status.ts';
 import { runSyncLoop, type SyncOutcome, syncMailbox } from './sync.ts';
 import { createFileTokenStore } from './token-store.ts';
-import type { GmailEnvironment } from './tokens.ts';
 import { VERSION } from './version.ts';
 
 export type ParsedArgs = {
@@ -21,8 +19,6 @@ export type ParsedArgs = {
 	watchIntervalMs?: number;
 	noOpen: boolean;
 	port?: number;
-	/** The provider-environment chosen at connect/seed time (ADR-0108). */
-	gmailEnv?: GmailEnvironment;
 	addLabels: string[];
 	removeLabels: string[];
 	json: boolean;
@@ -35,8 +31,8 @@ const DEFAULT_WATCH_INTERVAL_MS = 30_000;
 const HELP = `local-mail: keep a private local copy of Gmail for local tools and agents.
 
 Usage:
-  local-mail connect [--gmail-env <dev|prod>]
-  local-mail seed-token <refreshToken> [--gmail-env <dev|prod>]
+  local-mail connect
+  local-mail seed-token <refreshToken>
   local-mail sync [--full] [--watch [intervalMs]] [--json]
   local-mail status [--json]
   local-mail query "<sql>"
@@ -62,8 +58,6 @@ Commands:
   mcp          Serve query/status/sync/modify_labels tools over stdio.
 
 Options:
-  --gmail-env <dev|prod>  Pick the OAuth keyset at connect/seed. Required only when
-                          both GMAIL_DEV_* and GMAIL_PROD_* are present.
   --full                Force a full pull on the first sync pass.
   --watch [intervalMs]  Keep syncing on a loop. Default: 30000.
   --add <label>         Add a Gmail label by exact name or id. Repeatable.
@@ -76,8 +70,7 @@ Options:
   -v, --version         Show version.
 
 Environment:
-  GMAIL_DEV_CLIENT_ID / GMAIL_DEV_CLIENT_SECRET     Dev (unverified) OAuth client keys.
-  GMAIL_PROD_CLIENT_ID / GMAIL_PROD_CLIENT_SECRET   Prod (verified) OAuth client keys.
+  GMAIL_CLIENT_ID / GMAIL_CLIENT_SECRET   Google OAuth Desktop client keys.
   LOCAL_MAIL_ACCOUNT                      Account override when multiple are connected.
   LOCAL_MAIL_DIR                          Where the local copy lives.
   LOCAL_MAIL_TOKEN_FILE                   Override the credentials file path.
@@ -147,16 +140,6 @@ export function parseArgs(argv: string[]): ParsedArgs {
 		};
 
 		switch (name) {
-			case '--gmail-env': {
-				const value = takeValue();
-				if (value !== 'dev' && value !== 'prod') {
-					throw new Error(
-						`--gmail-env must be "dev" or "prod", got "${value}"`,
-					);
-				}
-				args.gmailEnv = value;
-				break;
-			}
 			case '--full':
 				args.full = true;
 				break;
@@ -211,20 +194,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
 	return args;
 }
 
-async function runConnect(args: ParsedArgs): Promise<number> {
+async function runConnect(_args: ParsedArgs): Promise<number> {
 	const config = loadConfig();
-	// The environment is chosen here, at connect, and persisted on the token
-	// (ADR-0108 rule 4). --gmail-env is required only when both keysets are present.
-	const { data: environment, error: envError } = selectGmailEnvironment(
-		args.gmailEnv,
-	);
-	if (envError) {
-		console.error(envError.message);
-		return 1;
-	}
-
 	const { data: token, error } = await runAuthorizationFlow(config, {
-		environment,
 		now: () => Date.now(),
 		log: (message) => console.error(message),
 	});
@@ -235,7 +207,7 @@ async function runConnect(args: ParsedArgs): Promise<number> {
 
 	const store = createFileTokenStore(config.credentialsPath);
 	await store.set(token);
-	console.log(`Connected ${token.accountEmail} (${token.environment}).`);
+	console.log(`Connected ${token.accountEmail}.`);
 	console.log(`Tokens stored in ${config.credentialsPath}.`);
 	console.log(`Next: run "local-mail sync --full".`);
 	return 0;
@@ -250,17 +222,9 @@ async function runSeedToken(args: ParsedArgs): Promise<number> {
 		return 1;
 	}
 	const config = loadConfig();
-	const { data: environment, error: envError } = selectGmailEnvironment(
-		args.gmailEnv,
-	);
-	if (envError) {
-		console.error(envError.message);
-		return 1;
-	}
 	const { data: token, error } = await redeemRefreshToken(
 		config,
 		refreshToken,
-		environment,
 		() => Date.now(),
 	);
 	if (error) {
@@ -269,9 +233,7 @@ async function runSeedToken(args: ParsedArgs): Promise<number> {
 	}
 	const store = createFileTokenStore(config.credentialsPath);
 	await store.set(token);
-	console.log(
-		`Seeded ${token.accountEmail} (${token.environment}) at ${config.credentialsPath}.`,
-	);
+	console.log(`Seeded ${token.accountEmail} at ${config.credentialsPath}.`);
 	console.log(`Next: run "local-mail sync --full".`);
 	return 0;
 }
@@ -467,7 +429,6 @@ function renderStatus(status: MailStatus): string {
 		['data dir', status.dataDir],
 		['token file', status.tokenFile],
 		['connected', status.connected ? 'yes' : 'no'],
-		['environment', status.environment ?? 'none'],
 		['access token', accessToken],
 		['mirror', status.mirror],
 		['schema version', status.schemaVersion ?? 'none'],

--- a/apps/local-mail/src/config.ts
+++ b/apps/local-mail/src/config.ts
@@ -61,9 +61,7 @@ export function loadConfig(): AppConfig {
 	return {
 		dataDir,
 		// The Google OAuth client keys are NOT read here: they are resolved lazily
-		// at the connect/refresh site by their environment-qualified names
-		// (GMAIL_DEV_* / GMAIL_PROD_*, ADR-0108), selected by the account's
-		// persisted environment. See `resolveGmailCredentials` in gmail-credentials.ts.
+		// at the connect/refresh site from GMAIL_CLIENT_ID / GMAIL_CLIENT_SECRET.
 		// The env override exists for the MCP subprocess test, which cannot
 		// inject an AppConfig in-process. The OAuth endpoints have no such
 		// consumer: in-process tests override the AppConfig fields directly.

--- a/apps/local-mail/src/env-example.test.ts
+++ b/apps/local-mail/src/env-example.test.ts
@@ -1,15 +1,10 @@
 import { expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { specToEnvExampleLines } from '@epicenter/constants/provider-credentials';
-import { GMAIL_SPEC } from './gmail-credentials.ts';
 
 /**
- * Drift guard for `.env.example` (ADR-0108): the committed file must document
- * exactly the environment-qualified names `GMAIL_SPEC` resolves. `specToEnvExampleLines`
- * builds those names from the same name-builder the resolver reads through, so
- * this test fails the moment the file lists a stale name (the retired unqualified
- * `GMAIL_CLIENT_ID`) or omits a real one.
+ * Drift guard for `.env.example`: Local Mail's BYO path documents exactly the
+ * single Gmail OAuth Desktop client pair it reads at connect and refresh time.
  */
 
 /** Extract the `NAME=` variable names from `.env.example`-style lines. */
@@ -19,19 +14,12 @@ function envNames(lines: string[]): string[] {
 		.map((line) => line.slice(0, line.indexOf('=')));
 }
 
-test(".env.example lists exactly GMAIL_SPEC's qualified names", () => {
+test('.env.example lists exactly the BYO Gmail OAuth keyset', () => {
 	const file = readFileSync(
 		join(import.meta.dir, '..', '.env.example'),
 		'utf8',
 	);
 	const documented = envNames(file.split('\n'));
-	const expected = envNames(specToEnvExampleLines(GMAIL_SPEC));
 
-	expect(expected).toEqual([
-		'GMAIL_DEV_CLIENT_ID',
-		'GMAIL_DEV_CLIENT_SECRET',
-		'GMAIL_PROD_CLIENT_ID',
-		'GMAIL_PROD_CLIENT_SECRET',
-	]);
-	expect([...documented].sort()).toEqual([...expected].sort());
+	expect(documented).toEqual(['GMAIL_CLIENT_ID', 'GMAIL_CLIENT_SECRET']);
 });

--- a/apps/local-mail/src/gmail-credentials.test.ts
+++ b/apps/local-mail/src/gmail-credentials.test.ts
@@ -1,14 +1,10 @@
 import { expect, test } from 'bun:test';
-import {
-	availableGmailEnvironments,
-	resolveGmailCredentials,
-	selectGmailEnvironment,
-} from './gmail-credentials.ts';
+import { resolveGmailCredentials } from './gmail-credentials.ts';
 
 /**
- * The Gmail credential resolver and the connect-time environment chooser
- * (ADR-0108). Every case injects a `read` source instead of touching
- * `process.env`, so the tests are hermetic and order-independent.
+ * The Gmail credential resolver reads the single BYO Local Mail OAuth keyset.
+ * Every case injects a `read` source instead of touching `process.env`, so the
+ * tests are hermetic and order-independent.
  */
 
 /** Read from a fixed map instead of process.env. */
@@ -17,74 +13,25 @@ const readFrom =
 	(name: string): string | undefined =>
 		map[name];
 
-const DEV = {
-	GMAIL_DEV_CLIENT_ID: 'dev-id',
-	GMAIL_DEV_CLIENT_SECRET: 'dev-secret',
-};
-const PROD = {
-	GMAIL_PROD_CLIENT_ID: 'prod-id',
-	GMAIL_PROD_CLIENT_SECRET: 'prod-secret',
-};
-
-test('resolveGmailCredentials reads the environment-qualified keyset', () => {
-	expect(resolveGmailCredentials('dev', readFrom({ ...DEV, ...PROD }))).toEqual(
-		{
-			clientId: 'dev-id',
-			clientSecret: 'dev-secret',
-		},
-	);
+test('resolveGmailCredentials reads the BYO Gmail keyset', () => {
 	expect(
-		resolveGmailCredentials('prod', readFrom({ ...DEV, ...PROD })),
+		resolveGmailCredentials(
+			readFrom({
+				GMAIL_CLIENT_ID: 'client-id',
+				GMAIL_CLIENT_SECRET: 'client-secret',
+			}),
+		),
 	).toEqual({
-		clientId: 'prod-id',
-		clientSecret: 'prod-secret',
+		clientId: 'client-id',
+		clientSecret: 'client-secret',
 	});
 });
 
-test('availableGmailEnvironments reports only the fully-present keysets', () => {
-	expect(availableGmailEnvironments(readFrom(DEV))).toEqual(['dev']);
-	expect(availableGmailEnvironments(readFrom({ ...DEV, ...PROD }))).toEqual([
-		'dev',
-		'prod',
-	]);
-	// A half-present keyset (id but no secret) does not count as available.
-	expect(
-		availableGmailEnvironments(readFrom({ GMAIL_DEV_CLIENT_ID: 'dev-id' })),
-	).toEqual([]);
-});
-
-test('selectGmailEnvironment infers the sole present environment', () => {
-	const { data, error } = selectGmailEnvironment(undefined, readFrom(DEV));
-	expect(error).toBeNull();
-	expect(data).toBe('dev');
-});
-
-test('selectGmailEnvironment requires the flag when both keysets are present', () => {
-	const { data, error } = selectGmailEnvironment(
-		undefined,
-		readFrom({ ...DEV, ...PROD }),
+test('resolveGmailCredentials names missing variables', () => {
+	expect(() => resolveGmailCredentials(readFrom({}))).toThrow(
+		'GMAIL_CLIENT_ID and GMAIL_CLIENT_SECRET',
 	);
-	expect(data).toBeNull();
-	expect(error?.message).toContain('--gmail-env');
-});
-
-test('selectGmailEnvironment honors an explicit choice that is present', () => {
-	const { data, error } = selectGmailEnvironment(
-		'prod',
-		readFrom({ ...DEV, ...PROD }),
-	);
-	expect(error).toBeNull();
-	expect(data).toBe('prod');
-});
-
-test('selectGmailEnvironment names the missing vars for an absent explicit choice', () => {
-	const { data, error } = selectGmailEnvironment('prod', readFrom(DEV));
-	expect(data).toBeNull();
-	expect(error?.message).toContain('GMAIL_PROD_CLIENT_ID');
-});
-
-test('selectGmailEnvironment fails when no keyset is present', () => {
-	const { data, error } = selectGmailEnvironment(undefined, readFrom({}));
-	expect(data).toBeNull();
-	expect(error?.message).toContain('GMAIL_DEV_CLIENT_ID');
+	expect(() =>
+		resolveGmailCredentials(readFrom({ GMAIL_CLIENT_ID: 'client-id' })),
+	).toThrow('GMAIL_CLIENT_SECRET');
 });

--- a/apps/local-mail/src/gmail-credentials.ts
+++ b/apps/local-mail/src/gmail-credentials.ts
@@ -1,89 +1,25 @@
-import {
-	type CredentialSource,
-	type ProviderCredentialSpec,
-	resolveProviderCredentials,
-} from '@epicenter/constants/provider-credentials';
-import { Err, Ok, type Result } from 'wellcrafted/result';
-import type { GmailEnvironment } from './tokens.ts';
+type CredentialSource = (name: string) => string | undefined;
 
 /**
- * Gmail provider-credential spec (ADR-0108), app-owned. Local Mail has two Google
- * Desktop OAuth clients, a dev/unverified one and a prod/verified one, and they
- * are entirely distinct clients (different ids, secrets, and consent screens), so
- * both roles vary per environment and are environment-qualified:
- *
- *   GMAIL_DEV_CLIENT_ID   / GMAIL_DEV_CLIENT_SECRET    (unverified dev client)
- *   GMAIL_PROD_CLIENT_ID  / GMAIL_PROD_CLIENT_SECRET   (verified prod client)
- *
- * The old undifferentiated `GMAIL_CLIENT_ID` / `GMAIL_CLIENT_SECRET` are retired.
- * Which vault environment stores each qualified name is an orthogonal
- * access-control choice, not a selector: the name carries the environment.
- */
-export const GMAIL_SPEC = {
-	prefix: 'GMAIL',
-	environments: ['dev', 'prod'],
-	environmentRoles: ['CLIENT_ID', 'CLIENT_SECRET'],
-} as const satisfies ProviderCredentialSpec<GmailEnvironment>;
-
-/**
- * Resolve the Google OAuth client keyset for a target environment. Throws a
- * `ProviderCredentialError` naming the exact missing qualified variables when the
- * environment's keys are absent, so a wrong-keyset run fails loudly at resolution
- * time instead of dying later as an opaque Google `invalid_client`.
+ * Resolve the single Google OAuth Desktop client used by BYO Local Mail.
+ * Local Mail is a local app: the operator supplies one client id/secret pair,
+ * and the stored token records the concrete client id that minted it so refresh
+ * can fail loudly if the configured client changes later.
  */
 export function resolveGmailCredentials(
-	environment: GmailEnvironment,
-	read?: CredentialSource,
+	read: CredentialSource = (name) => process.env[name],
 ): { clientId: string; clientSecret: string } {
-	const credentials = resolveProviderCredentials(GMAIL_SPEC, environment, read);
-	return {
-		clientId: credentials.CLIENT_ID,
-		clientSecret: credentials.CLIENT_SECRET,
-	};
-}
-
-/** The environments whose full keyset is present in the injected source. */
-export function availableGmailEnvironments(
-	read?: CredentialSource,
-): GmailEnvironment[] {
-	return GMAIL_SPEC.environments.filter((environment) => {
-		try {
-			resolveGmailCredentials(environment, read);
-			return true;
-		} catch {
-			return false;
-		}
-	});
-}
-
-/**
- * Pick the provider-environment to connect an account under (ADR-0108 rule 4).
- * The `--gmail-env` flag is the chooser and the disambiguator: it is required
- * only when more than one environment's credentials are present. With a single
- * keyset present it is inferred; with none present the failure names both
- * keysets so the operator knows what to set.
- */
-export function selectGmailEnvironment(
-	explicit: GmailEnvironment | undefined,
-	read?: CredentialSource,
-): Result<GmailEnvironment, { message: string }> {
-	const available = availableGmailEnvironments(read);
-	if (explicit) {
-		if (available.includes(explicit)) return Ok(explicit);
-		const upper = explicit.toUpperCase();
-		return Err({
-			message: `No Gmail ${explicit} credentials found. Set GMAIL_${upper}_CLIENT_ID and GMAIL_${upper}_CLIENT_SECRET (see .env.example).`,
-		});
+	const clientId = read('GMAIL_CLIENT_ID');
+	const clientSecret = read('GMAIL_CLIENT_SECRET');
+	if (!clientId || !clientSecret) {
+		const missing = [
+			clientId ? null : 'GMAIL_CLIENT_ID',
+			clientSecret ? null : 'GMAIL_CLIENT_SECRET',
+		].filter((name): name is string => name !== null);
+		throw new Error(
+			`Missing Gmail OAuth credentials: set ${missing.join(' and ')} (see .env.example).`,
+		);
 	}
-	if (available.length === 1) return Ok(available[0] as GmailEnvironment);
-	if (available.length === 0) {
-		return Err({
-			message:
-				'No Gmail OAuth credentials found. Set GMAIL_DEV_CLIENT_ID / GMAIL_DEV_CLIENT_SECRET or GMAIL_PROD_CLIENT_ID / GMAIL_PROD_CLIENT_SECRET (see .env.example).',
-		});
-	}
-	return Err({
-		message:
-			'Both dev and prod Gmail credentials are present; choose one with --gmail-env dev|prod.',
-	});
+
+	return { clientId, clientSecret };
 }

--- a/apps/local-mail/src/mcp-server.test.ts
+++ b/apps/local-mail/src/mcp-server.test.ts
@@ -75,7 +75,6 @@ async function seedToken(dir: string): Promise<void> {
 	const token: TokenSet = {
 		accountEmail: ACCOUNT,
 		clientIdUsed: 'client-id',
-		environment: 'dev',
 		accessToken: 'access-token',
 		refreshToken: 'refresh-token',
 		accessTokenExpiresAt: new Date(Date.now() + 10 * 60_000).toISOString(),

--- a/apps/local-mail/src/oauth.test.ts
+++ b/apps/local-mail/src/oauth.test.ts
@@ -20,12 +20,12 @@ import {
 } from './oauth.ts';
 import type { TokenSet } from './tokens.ts';
 
-// The credential resolver (ADR-0108) reads the Google OAuth keyset from the
-// environment by qualified name. These tests exercise the dev keyset and assert
-// the resolved client id against `clientIdUsed`, so seed it unconditionally to a
-// known value rather than inheriting whatever the ambient environment holds.
-process.env.GMAIL_DEV_CLIENT_ID = 'client-id-123';
-process.env.GMAIL_DEV_CLIENT_SECRET = 'client-secret-456';
+// The credential resolver reads the BYO Google OAuth keyset from the
+// environment. These tests assert the resolved client id against `clientIdUsed`,
+// so seed it unconditionally to a known value rather than inheriting whatever
+// the ambient environment holds.
+process.env.GMAIL_CLIENT_ID = 'client-id-123';
+process.env.GMAIL_CLIENT_SECRET = 'client-secret-456';
 
 function config(overrides: Partial<AppConfig>): AppConfig {
 	return {
@@ -95,7 +95,6 @@ test('runAuthorizationFlow exchanges a PKCE callback and stores the connected Gm
 			tokenUrl: `http://127.0.0.1:${tokenServer.port}/token`,
 		}),
 		{
-			environment: 'dev',
 			now: () => Date.parse('2026-07-01T00:00:00.000Z'),
 			openBrowser: (url) => {
 				authorizeUrl = url;
@@ -164,7 +163,6 @@ test('runAuthorizationFlow reports OAuth error details from the token endpoint',
 			tokenUrl: `http://127.0.0.1:${tokenServer.port}/token`,
 		}),
 		{
-			environment: 'dev',
 			now: () => Date.parse('2026-07-01T00:00:00.000Z'),
 			openBrowser: (url) => {
 				authorizeUrl = url;
@@ -212,7 +210,6 @@ test('refreshAccessToken uses a newly returned refresh token when Google rotates
 		{
 			accountEmail: 'you@example.com',
 			clientIdUsed: 'client-id-123',
-			environment: 'dev',
 			accessToken: 'stale',
 			accessTokenExpiresAt: new Date(0).toISOString(),
 			refreshToken: 'old-refresh-token',
@@ -243,7 +240,6 @@ test('refreshAccessToken maps invalid_grant to ReauthRequired', async () => {
 		{
 			accountEmail: 'you@example.com',
 			clientIdUsed: 'client-id-123',
-			environment: 'dev',
 			accessToken: 'stale',
 			accessTokenExpiresAt: new Date(0).toISOString(),
 			refreshToken: 'dead-refresh-token',
@@ -294,7 +290,6 @@ test('redeemRefreshToken performs the grant now and reads the account email from
 			tokenUrl: `http://127.0.0.1:${tokenServer.port}/token`,
 		}),
 		'seed-refresh-token',
-		'dev',
 		() => Date.parse('2026-07-01T00:00:00.000Z'),
 	);
 
@@ -313,7 +308,6 @@ test('refreshAccessToken refuses a token minted by a different OAuth client, bef
 	const token: TokenSet = {
 		accountEmail: 'you@example.com',
 		clientIdUsed: 'the-original-client',
-		environment: 'dev',
 		accessToken: 'stale',
 		accessTokenExpiresAt: new Date(0).toISOString(),
 		refreshToken: 'a-refresh-token',
@@ -332,19 +326,17 @@ test('refreshAccessToken refuses a token minted by a different OAuth client, bef
 	expect(error?.message).toContain('client-id-123');
 });
 
-test('refreshAccessToken fails loudly when the token environment has no keyset', async () => {
-	// A token minted under prod resolves to a MissingCredentials error naming the
-	// exact prod variables (ADR-0108), before any network call. Clear the prod
-	// keyset so the test holds regardless of the ambient environment.
-	const savedId = process.env.GMAIL_PROD_CLIENT_ID;
-	const savedSecret = process.env.GMAIL_PROD_CLIENT_SECRET;
-	delete process.env.GMAIL_PROD_CLIENT_ID;
-	delete process.env.GMAIL_PROD_CLIENT_SECRET;
+test('refreshAccessToken fails loudly when the Gmail keyset is missing', async () => {
+	// Missing credentials fail before any network call. Clear the keyset so the
+	// test holds regardless of the ambient environment.
+	const savedId = process.env.GMAIL_CLIENT_ID;
+	const savedSecret = process.env.GMAIL_CLIENT_SECRET;
+	delete process.env.GMAIL_CLIENT_ID;
+	delete process.env.GMAIL_CLIENT_SECRET;
 	try {
 		const token: TokenSet = {
 			accountEmail: 'you@example.com',
 			clientIdUsed: 'prod-client',
-			environment: 'prod',
 			accessToken: 'stale',
 			accessTokenExpiresAt: new Date(0).toISOString(),
 			refreshToken: 'a-refresh-token',
@@ -355,11 +347,11 @@ test('refreshAccessToken fails loudly when the token environment has no keyset',
 		);
 		expect(data).toBeNull();
 		expect(error?.name).toBe('MissingCredentials');
-		expect(error?.message).toContain('GMAIL_PROD_CLIENT_ID');
+		expect(error?.message).toContain('GMAIL_CLIENT_ID');
 	} finally {
-		if (savedId === undefined) delete process.env.GMAIL_PROD_CLIENT_ID;
-		else process.env.GMAIL_PROD_CLIENT_ID = savedId;
-		if (savedSecret === undefined) delete process.env.GMAIL_PROD_CLIENT_SECRET;
-		else process.env.GMAIL_PROD_CLIENT_SECRET = savedSecret;
+		if (savedId === undefined) delete process.env.GMAIL_CLIENT_ID;
+		else process.env.GMAIL_CLIENT_ID = savedId;
+		if (savedSecret === undefined) delete process.env.GMAIL_CLIENT_SECRET;
+		else process.env.GMAIL_CLIENT_SECRET = savedSecret;
 	}
 });

--- a/apps/local-mail/src/oauth.ts
+++ b/apps/local-mail/src/oauth.ts
@@ -9,7 +9,6 @@ import type { AppConfig } from './config.ts';
 import { createGmailClient } from './gmail-client.ts';
 import { resolveGmailCredentials } from './gmail-credentials.ts';
 import {
-	type GmailEnvironment,
 	type TokenGrantError,
 	type TokenSet,
 	tokenSetFromGrant,
@@ -24,8 +23,6 @@ import {
 
 export const OAuthError = defineErrors({
 	MissingCredentials: ({ reason }: { reason: string }) => ({
-		// `reason` is the resolver's message, which names the exact missing
-		// environment-qualified variables (ADR-0108).
 		message: reason,
 		reason,
 	}),
@@ -69,18 +66,15 @@ export const OAuthError = defineErrors({
 	ClientIdMismatch: ({
 		stored,
 		configured,
-		environment,
 	}: {
 		stored: string;
 		configured: string;
-		environment: GmailEnvironment;
 	}) => ({
 		message:
-			`The stored token was minted by OAuth client ${stored}, but GMAIL_${environment.toUpperCase()}_CLIENT_ID is now ${configured}. ` +
+			`The stored token was minted by OAuth client ${stored}, but GMAIL_CLIENT_ID is now ${configured}. ` +
 			'Refreshing through a different client fails as invalid_grant; restore the original client id or run "local-mail connect" again.',
 		stored,
 		configured,
-		environment,
 	}),
 });
 export type OAuthError = InferErrors<typeof OAuthError>;
@@ -88,8 +82,6 @@ export type OAuthError = InferErrors<typeof OAuthError>;
 type GrantResult = Promise<Result<TokenSet, OAuthError | TokenGrantError>>;
 
 type AuthorizationFlowOptions = {
-	/** The provider-environment to connect under (ADR-0108); tags the minted token. */
-	environment: GmailEnvironment;
 	now: () => number;
 	openBrowser?: (url: string) => void;
 	log?: (message: string) => void;
@@ -120,17 +112,15 @@ function httpOptions(config: AppConfig) {
 }
 
 /**
- * Resolve the Google OAuth client keyset for a provider-environment (ADR-0108),
- * lazily, at the connect/refresh site rather than eagerly in `loadConfig`, so a
- * credential-free verb never reads keys it does not use. The resolver throws when
- * the qualified names are absent; convert that into the {@link OAuthError} Result
- * channel so the loud "Missing GMAIL_<ENV>_CLIENT_ID" message reaches the caller.
+ * Resolve the BYO Gmail OAuth client lazily at the connect/refresh site rather
+ * than eagerly in `loadConfig`, so credential-free verbs never read secrets.
  */
-function loadGmailCredentials(
-	environment: GmailEnvironment,
-): Result<{ clientId: string; clientSecret: string }, OAuthError> {
+function loadGmailCredentials(): Result<
+	{ clientId: string; clientSecret: string },
+	OAuthError
+> {
 	try {
-		return Ok(resolveGmailCredentials(environment));
+		return Ok(resolveGmailCredentials());
 	} catch (cause) {
 		return OAuthError.MissingCredentials({
 			reason: extractErrorMessage(cause),
@@ -206,11 +196,9 @@ export async function runAuthorizationFlow(
 	config: AppConfig,
 	options: AuthorizationFlowOptions,
 ): GrantResult {
-	// Resolve the chosen environment's keyset lazily; this is the connect path's
-	// ONLY credentials read. Destructured so the narrowing survives the awaits.
-	const { data: credentials, error: credentialsError } = loadGmailCredentials(
-		options.environment,
-	);
+	// Resolve the BYO OAuth keyset lazily; this is the connect path's only
+	// credentials read. Destructured so the narrowing survives the awaits.
+	const { data: credentials, error: credentialsError } = loadGmailCredentials();
 	if (credentialsError) return { data: null, error: credentialsError };
 	const { clientId, clientSecret } = credentials;
 
@@ -280,7 +268,6 @@ export async function runAuthorizationFlow(
 		return tokenSetFromGrant(grant, {
 			accountEmail,
 			clientIdUsed: clientId,
-			environment: options.environment,
 			now: options.now(),
 		});
 	} catch (cause) {
@@ -336,12 +323,7 @@ export async function refreshAccessToken(
 	token: TokenSet,
 	now: () => number,
 ): GrantResult {
-	// Resolve the keyset for the environment this token was minted under
-	// (ADR-0108 rule 3): the tag selects the qualified names, and a missing keyset
-	// fails loudly here naming GMAIL_<ENV>_*.
-	const { data: credentials, error: credentialsError } = loadGmailCredentials(
-		token.environment,
-	);
+	const { data: credentials, error: credentialsError } = loadGmailCredentials();
 	if (credentialsError) return { data: null, error: credentialsError };
 	// A refresh token is bound to the client that minted it; refreshing through a
 	// different client id (the environment's key was rotated) dies as a bare
@@ -351,7 +333,6 @@ export async function refreshAccessToken(
 		return OAuthError.ClientIdMismatch({
 			stored: token.clientIdUsed,
 			configured: credentials.clientId,
-			environment: token.environment,
 		});
 	}
 	const { data: grant, error } = await requestRefreshGrant({
@@ -361,12 +342,10 @@ export async function refreshAccessToken(
 		refreshToken: token.refreshToken,
 	});
 	if (error) return { data: null, error };
-	// Rotation: Google may omit refresh_token when the old one stays valid. The
-	// minted token carries the same environment, asserted by the token manager.
+	// Rotation: Google may omit refresh_token when the old one stays valid.
 	return tokenSetFromGrant(grant, {
 		accountEmail: token.accountEmail,
 		clientIdUsed: token.clientIdUsed,
-		environment: token.environment,
 		now: now(),
 		fallbackRefreshToken: token.refreshToken,
 	});
@@ -383,11 +362,9 @@ export async function refreshAccessToken(
 export async function redeemRefreshToken(
 	config: AppConfig,
 	refreshToken: string,
-	environment: GmailEnvironment,
 	now: () => number,
 ): GrantResult {
-	const { data: credentials, error: credentialsError } =
-		loadGmailCredentials(environment);
+	const { data: credentials, error: credentialsError } = loadGmailCredentials();
 	if (credentialsError) return { data: null, error: credentialsError };
 	const { data: grant, error } = await requestRefreshGrant({
 		config,
@@ -404,7 +381,6 @@ export async function redeemRefreshToken(
 	return tokenSetFromGrant(grant, {
 		accountEmail,
 		clientIdUsed: credentials.clientId,
-		environment,
 		now: now(),
 		fallbackRefreshToken: refreshToken,
 	});

--- a/apps/local-mail/src/status.ts
+++ b/apps/local-mail/src/status.ts
@@ -1,15 +1,13 @@
 import { existsSync } from 'node:fs';
 import { mailDbPath, openMailDbReadonly } from './db.ts';
 import type { LocalMailRuntime } from './runtime.ts';
-import { type GmailEnvironment, isAccessTokenExpired } from './tokens.ts';
+import { isAccessTokenExpired } from './tokens.ts';
 
 export type MailStatus = {
 	accountEmail: string;
 	dataDir: string;
 	tokenFile: string;
 	connected: boolean;
-	/** The provider-environment the account was connected under (ADR-0108); null when not connected. */
-	environment: GmailEnvironment | null;
 	accessToken: { valid: boolean; expiresAt: string } | null;
 	mirror: 'empty' | 'building' | 'ready';
 	schemaVersion: string | null;
@@ -30,7 +28,6 @@ export async function readMailStatus({
 		dataDir: config.dataDir,
 		tokenFile: config.credentialsPath,
 		connected: token !== null,
-		environment: token?.environment ?? null,
 		accessToken: token
 			? {
 					valid: !isAccessTokenExpired(token, Date.now(), 0),

--- a/apps/local-mail/src/token-manager.test.ts
+++ b/apps/local-mail/src/token-manager.test.ts
@@ -17,11 +17,11 @@ import { createTokenManager } from './token-manager.ts';
 import type { TokenStore } from './token-store.ts';
 import type { TokenSet } from './tokens.ts';
 
-// The credential resolver (ADR-0108) reads the Google OAuth keyset from the
-// environment by qualified name; seed the dev keyset these tokens were minted by,
-// unconditionally, so the resolved client id matches `clientIdUsed` exactly.
-process.env.GMAIL_DEV_CLIENT_ID = 'client-id-123';
-process.env.GMAIL_DEV_CLIENT_SECRET = 'client-secret-456';
+// The credential resolver reads the BYO Google OAuth keyset from the
+// environment; seed it unconditionally so the resolved client id matches
+// `clientIdUsed` exactly.
+process.env.GMAIL_CLIENT_ID = 'client-id-123';
+process.env.GMAIL_CLIENT_SECRET = 'client-secret-456';
 
 function config(overrides: Partial<AppConfig>): AppConfig {
 	return {
@@ -43,7 +43,6 @@ function token(overrides: Partial<TokenSet> = {}): TokenSet {
 	return {
 		accountEmail: 'you@example.com',
 		clientIdUsed: 'client-id-123',
-		environment: 'dev',
 		accessToken: 'old-access-token',
 		accessTokenExpiresAt: new Date(0).toISOString(),
 		refreshToken: 'old-refresh-token',

--- a/apps/local-mail/src/token-manager.ts
+++ b/apps/local-mail/src/token-manager.ts
@@ -49,16 +49,6 @@ export function createTokenManager({
 			now,
 		);
 		if (error) return { data: null, error };
-		// ADR-0108 rule 3: the minted token carries the provider environment it was
-		// minted for, and every use asserts it. A refresh must never change the
-		// environment (it is threaded from the stored token); a mismatch is an
-		// invariant violation, not a user error, so fail loudly before persisting.
-		if (refreshed.environment !== current.environment) {
-			throw new Error(
-				`Refreshed token environment "${refreshed.environment}" does not match ` +
-					`the stored "${current.environment}" for ${current.accountEmail}.`,
-			);
-		}
 		current = refreshed;
 		await store.set(refreshed);
 		return Ok(refreshed.accessToken);

--- a/apps/local-mail/src/token-store.test.ts
+++ b/apps/local-mail/src/token-store.test.ts
@@ -31,7 +31,6 @@ function token(accountEmail: string): TokenSet {
 	return {
 		accountEmail,
 		clientIdUsed: 'test-client',
-		environment: 'dev',
 		accessToken: 'access-token',
 		accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
 		refreshToken: 'refresh-token',
@@ -61,7 +60,6 @@ describe('token sets round-trip through the real store', () => {
 		const seeded: TokenSet = {
 			accountEmail: 'you@example.com',
 			clientIdUsed: 'test-client',
-			environment: 'dev',
 			accessToken: 'an-expired-access-token',
 			accessTokenExpiresAt: new Date(0).toISOString(),
 			refreshToken: 'a-real-refresh-token',
@@ -86,7 +84,6 @@ describe('token sets round-trip through the real store', () => {
 		await store.set({
 			accountEmail: 'you@example.com',
 			clientIdUsed: 'test-client',
-			environment: 'dev',
 			accessToken: '',
 			accessTokenExpiresAt: new Date(0).toISOString(),
 			refreshToken: 'a-real-refresh-token',

--- a/apps/local-mail/src/tokens.ts
+++ b/apps/local-mail/src/tokens.ts
@@ -1,4 +1,4 @@
-import { Type, type Static } from 'typebox';
+import { type Static, Type } from 'typebox';
 import { Value } from 'typebox/value';
 import { defineErrors, type InferErrors } from 'wellcrafted/error';
 import { Ok, type Result } from 'wellcrafted/result';

--- a/apps/local-mail/src/tokens.ts
+++ b/apps/local-mail/src/tokens.ts
@@ -1,21 +1,7 @@
-import { type Static, Type } from 'typebox';
+import { Type, type Static } from 'typebox';
 import { Value } from 'typebox/value';
 import { defineErrors, type InferErrors } from 'wellcrafted/error';
 import { Ok, type Result } from 'wellcrafted/result';
-
-/**
- * Which Google OAuth client (dev/unverified vs prod/verified) an account was
- * connected through. This is the provider-environment axis of ADR-0108: it
- * selects the keyset by name (`GMAIL_DEV_*` vs `GMAIL_PROD_*`), and every later
- * use of the token asserts it. `GmailEnvironment` derives from this schema, which
- * `TokenSetSchema` embeds; `GMAIL_SPEC` mirrors these literals under a `satisfies`
- * check (see `gmail-credentials.ts`).
- */
-export const GmailEnvironmentSchema = Type.Union([
-	Type.Literal('dev'),
-	Type.Literal('prod'),
-]);
-export type GmailEnvironment = Static<typeof GmailEnvironmentSchema>;
 
 /**
  * A persisted Google OAuth2 token set for one Gmail account, stored verbatim in
@@ -25,15 +11,13 @@ export type GmailEnvironment = Static<typeof GmailEnvironmentSchema>;
  * it was issued. This schema is the single source of truth: `TokenSet` derives
  * from it, and the file token store validates disk bytes against it on read.
  *
- * `clientIdUsed` and `environment` are the two provenance tags: the OAuth client
- * that minted the token and the provider-environment it was minted for (ADR-0108).
- * A token written before this field existed fails validation and reads as absent,
- * so the account is reconnected once through `local-mail connect --gmail-env`.
+ * `clientIdUsed` records the OAuth client that minted the refresh token. A token
+ * written by a different configured client id reads as a local mismatch during
+ * refresh instead of surfacing later as Google's opaque `invalid_grant`.
  */
 export const TokenSetSchema = Type.Object({
 	accountEmail: Type.String({ minLength: 1 }),
 	clientIdUsed: Type.String({ minLength: 1 }),
-	environment: GmailEnvironmentSchema,
 	accessToken: Type.String({ minLength: 1 }),
 	refreshToken: Type.String({ minLength: 1 }),
 	accessTokenExpiresAt: Type.String({ minLength: 1 }),
@@ -79,13 +63,11 @@ export function tokenSetFromGrant(
 	{
 		accountEmail,
 		clientIdUsed,
-		environment,
 		now,
 		fallbackRefreshToken,
 	}: {
 		accountEmail: string;
 		clientIdUsed: string;
-		environment: GmailEnvironment;
 		now: number;
 		fallbackRefreshToken?: string;
 	},
@@ -112,7 +94,6 @@ export function tokenSetFromGrant(
 	return Ok({
 		accountEmail,
 		clientIdUsed,
-		environment,
 		accessToken: payload.access_token,
 		refreshToken,
 		accessTokenExpiresAt: new Date(

--- a/docs/adr/0108-provider-credentials-are-selected-by-target-environment-encoded-in-the-secret-name.md
+++ b/docs/adr/0108-provider-credentials-are-selected-by-target-environment-encoded-in-the-secret-name.md
@@ -8,9 +8,7 @@
 
 Several Epicenter apps authenticate to a third-party provider that has both a
 non-production account and a production account: QuickBooks in `apps/local-books`
-(Intuit's Development vs Production keysets), Gmail in `apps/local-mail` (a
-dev/unverified and a prod/verified Google Desktop OAuth client; only the dev
-client is wired in code today), Plaid in the planned finance app
+(Intuit's Development vs Production keysets), Plaid in the planned finance app
 (sandbox / development / production), and more to come.
 Two orthogonal axes get conflated at the point where a credential is read:
 
@@ -62,8 +60,8 @@ A third-party provider credential is selected by exactly one knob, the app's
    variables. It lives in `@epicenter/constants` (AGPL, already a `local-books`
    dependency, zero runtime deps, `bun build --compile`-safe). The shared package
    owns only the mechanism (the resolver, the `ProviderCredentialSpec` type); each
-   app owns its own `spec` (`QB_SPEC` in `local-books`, `GMAIL_SPEC` in
-   `local-mail`). There is no central provider registry: a spec is app-local code,
+   app owns its own `spec` (`QB_SPEC` in `local-books`). There is no central
+   provider registry: a spec is app-local code,
    not shared config, so no package accretes knowledge of every app's providers.
 
 3. **The minted token carries and asserts its provider environment.** When an
@@ -79,10 +77,9 @@ A third-party provider credential is selected by exactly one knob, the app's
 4. **Provider environment is chosen once, at connect, and persisted, not passed
    per command.** The account/realm records its environment at connect/auth time
    (beside the client identity a token already records), and every later command
-   reads it from that record and asserts it. The selection flag (`--qb-env`,
-   `--gmail-env`) is the connect-time chooser and disambiguator (required only
-   when more than one environment's credentials are present), never a per-run
-   mode knob.
+   reads it from that record and asserts it. The selection flag (`--qb-env`) is
+   the connect-time chooser and disambiguator (required only when more than one
+   environment's credentials are present), never a per-run mode knob.
 
 The app's only portable interface to any secret backend is the flat
 `name -> value` map that Infisical, a `.env` file, Docker secrets, systemd,
@@ -170,7 +167,6 @@ tier surface (ADR-0068).
 - **Drop the single-environment exemption** (force qualified names even for a
   provider with one account). Kept the exemption instead, because a genuinely
   single-account provider gains nothing from an env segment. Note this is a
-  narrow case: `local-mail` has two Google OAuth clients (an unverified dev
-  client and a verified prod client), so it is a two-environment provider and
-  qualifies now (`GMAIL_DEV_*` / `GMAIL_PROD_*`), same as `local-books`. The
-  exemption exists only for a provider that really has one account.
+  narrow case: `local-mail` now uses one BYO Google OAuth Desktop client
+  (`GMAIL_CLIENT_ID` / `GMAIL_CLIENT_SECRET`), so it falls under this exemption.
+  `local-books` remains a two-environment provider and keeps qualified names.

--- a/packages/constants/src/provider-credentials.test.ts
+++ b/packages/constants/src/provider-credentials.test.ts
@@ -2,7 +2,7 @@
  * Provider credential resolution mechanism (ADR-0105).
  *
  * Fixtures are declared inline: the shared package owns only the mechanism, so
- * the app specs (`QB_SPEC`, `GMAIL_SPEC`) live in their apps, not here. These
+ * app specs such as `QB_SPEC` live in their apps, not here. These
  * fixtures mirror their real shapes to pin the naming convention: a role that
  * varies per account is env-qualified, a shared role is not, a single-environment
  * provider drops the env segment, and a missing name throws by exact name.
@@ -16,7 +16,7 @@ import {
 	specToEnvExampleLines,
 } from './provider-credentials.ts';
 
-// Two accounts, both roles differ per keyset (QuickBooks / Gmail shape).
+// Two accounts, both roles differ per keyset (QuickBooks shape).
 const TWO_ENV_SPEC = {
 	prefix: 'QB',
 	environments: ['sandbox', 'production'],

--- a/packages/constants/src/provider-credentials.ts
+++ b/packages/constants/src/provider-credentials.ts
@@ -2,8 +2,8 @@
  * Third-party provider credential resolution (ADR-0105).
  *
  * The mechanism only: one pure resolver plus the `ProviderCredentialSpec` type
- * and an `.env.example` formatter. Each app owns its own `spec` (`QB_SPEC` in
- * local-books, `GMAIL_SPEC` in local-mail); there is no central provider
+ * and an `.env.example` formatter. Each multi-environment app owns its own
+ * `spec` (`QB_SPEC` in local-books); there is no central provider
  * registry here, so no package accretes knowledge of every app's providers.
  *
  * A provider credential is selected by exactly one knob, the app's target
@@ -29,7 +29,7 @@ export type CredentialRole = string;
  *  - `sharedRoles`      value is the same across accounts -> `${PREFIX}_${ROLE}`
  *                       (Plaid's client_id: one id, a secret per environment)
  *  - `environmentRoles` value differs per account -> `${PREFIX}_${ENV}_${ROLE}`
- *                       (QB / Gmail: a whole distinct OAuth client per account)
+ *                       (QB: a whole distinct OAuth client per account)
  */
 export type ProviderCredentialSpec<
 	Env extends string = string,


### PR DESCRIPTION
Local Mail is a bring-your-own Gmail app, not a hosted provider-environment selector. This removes the dev/prod Gmail keyset split and the `--gmail-env` flag so an operator configures one Google OAuth Desktop client with `GMAIL_CLIENT_ID` and `GMAIL_CLIENT_SECRET`.

The token still records the concrete client id that minted it. If the configured client changes later, refresh refuses before making a confusing Google request and asks the operator to reconnect.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785999381&installation_id=128463665&pr_number=2396&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2396&signature=d0834d9d5c1043f103030d05440fcce2b0853520d9bdd3de868352d2b8c7e319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->