### PR TITLE
docs(handoff): simplify Claude Code handoff skill

### DIFF
--- a/.agents/skills/handoff/SKILL.md
+++ b/.agents/skills/handoff/SKILL.md
@@ -1,95 +1,152 @@
 ---
 name: handoff
-description: 'Draft a compact, cold-start prompt to paste into Claude Code, with Claude as orchestrator and the Codex plugin available through /codex:rescue for bounded evidence, commands, verification, and focused edits. Use when the user says "hand this off", "wrap up for the next session", "resume this later", "continue in a new chat", "write a continuation prompt", "make a prompt I can copy-paste", "create a delegation brief", "prompt for an orchestrator", or invokes /handoff. Not for /goal lines (use agent-goal) or prompts that ship inside product code.'
+description: 'Draft a compact, cold-start prompt to paste into Claude Code, with Claude as orchestrator and Codex available through /codex:rescue for bounded evidence gathering, focused implementation, commands, verification, cleanup, and creative support. Use when the user says "hand this off", "wrap up for the next session", "resume this later", "continue in a new chat", "write a continuation prompt", "make a prompt I can copy-paste", "create a delegation brief", "prompt for an orchestrator", or invokes /handoff. Not for /goal lines (use agent-goal) or prompts that ship inside product code.'
 argument-hint: "What should the next agent accomplish?"
 metadata:
   author: epicenter
-  version: '4.2'
+  version: '5.0'
 ---
 
 # Claude Code Handoff
 
-Write one copy-paste prompt for Claude Code. It must be cold-start: Claude Code can continue the work without this thread and can use the Codex plugin for bounded execution work.
+Write one copy-paste prompt for Claude Code. It must be cold-start: Claude can continue without this thread.
 
-Return only the prompt. Do not launch, supervise, or automate the recipient.
+Default output: return only the prompt. If the user is designing or reviewing the handoff itself, a short note before the prompt is allowed.
 
-## Operating Model
+## One Sentence
 
-State this as fact, not a choice:
+A handoff prompt gives Claude context, starting points, proof targets, and a strong bias to use Codex creatively, while leaving Claude free to rethink the plan and choose the delegation shape.
 
-- Address the prompt to Claude Code as the continuing agent.
-- Claude owns orchestration: mission, context selection, ambiguity, tradeoffs, ownership calls, implementation direction, taste calls, and final synthesis.
-- The Codex plugin supports bounded execution through `/codex:rescue`: search, grep, broad file inspection, exact file reading, diff inspection, command execution, tests, typechecks, browser checks, local tools, focused edits, verification, cleanup, and first-pass analysis.
-- Codex returns evidence packets: file references, command output, diffs, risks, short summaries, and recommendations. Claude consumes the evidence, makes the calls, and writes the final answer.
+## Mental Model
 
-Use Codex for mechanical excavation and focused execution. Keep judgment, ownership, product direction, and final synthesis with Claude.
+Claude is the continuing agent:
 
-## Required Content
+```txt
+Claude owns:
+  orchestration
+  context selection
+  ambiguity and tradeoffs
+  implementation direction
+  Codex delegation choices
+  final synthesis
 
-Include only live context. A small handoff should fit in 12 to 20 lines; a large continuation may need short sections.
+Codex can help with:
+  broad search and grep
+  diff excavation
+  exact file reads
+  focused edits
+  command execution
+  tests and typechecks
+  browser checks
+  cleanup
+  adversarial checks
+  small prototypes
+```
 
-Cover:
+Do not pre-orchestrate the session. Prime Claude to use Codex, suggest seams when they are obvious, and explicitly allow Claude to revise, split, skip, or invent Codex calls after reading live context.
 
-1. Mission: one outcome and the exact artifact wanted.
-2. State: branch, dirty versus committed work, checks run, and what remains open.
-3. Reading list: exact paths, commands, or snippets to inspect first, with why each matters.
-4. Decisions: settled facts, recommendations, open questions, and whose call they are.
-5. Boundaries: what may change, what must not change, and what is out of scope.
-6. `/codex:rescue` jobs: bounded tasks with one question, exact inputs, constraints, and one evidence packet.
-7. Proof and stop: verification commands, expected evidence in the final answer, and where to stop.
+## Ground Before Writing
 
-## Grounding Pass
+Gather the context the next agent should not have to rediscover.
 
-Before writing the prompt, gather the evidence a cold-start agent cannot infer:
+For coding handoffs, usually collect:
 
-- `git status --short`: dirty files, staged files, and unrelated user changes.
-- Relevant diffs or file excerpts: only the parts the next agent must trust.
-- Commands already run: include pass/fail status and the important output line.
-- Current decisions: what is settled, what is still a hypothesis, and what was
-  deliberately refused.
-- Exact source-of-truth paths: ADRs, specs, skills, package files, tests, or
-  docs the next agent should read first.
+```bash
+git status --short --branch
+git diff --name-status
+git diff -- <relevant paths>
+```
 
-Do not hand off vibes. If a claim matters, point at the file, command, or
-decision record that grounds it.
+Also read the key files, tests, specs, ADRs, PR notes, or logs that ground the prompt. Include commands already run and their pass/fail status when useful.
 
-## Rules
+For non-coding handoffs, gather the equivalent source material: docs, notes, links, current conclusions, open questions, and the artifact the next agent should produce.
 
-- Prefer dense bullets over prose. Use headings only when they make the prompt easier to scan.
-- Paste real code or command output when it is shorter than explaining it. Use real paths, never vague references.
-- Do not duplicate specs, plans, commits, or diffs. Link the stable path and summarize the decision it carries.
-- Use absolute dates. "Today", "yesterday", and "recently" rot.
-- Keep each `/codex:rescue` task bounded: one job, bounded sources, one deliverable.
-- Enumerate the useful Codex capability in the job when it matters: search, grep, broad file inspection, exact file reading, diff inspection, command execution, tests, typechecks, browser checks, local tools, focused edits, verification, cleanup, or first-pass analysis.
-- Ask Codex for evidence packets: command output, file references, short summaries, diffs, risks, and verification results.
-- Avoid chatty delegation loops. Codex compresses aggressively; Claude should not receive a second transcript.
-- Bound the phase. If the recipient should not implement, say so. If implementation may follow, ask for a separate execution handoff.
-- Name the active skills or conventions only when they change behavior. Do not
-  list every skill loaded in this chat.
-- Preserve dirty-worktree ownership. If a file was already modified by the
-  user, say so and tell the next agent not to overwrite it casually.
-- Include enough refusal context that the next agent does not reopen settled
-  branches without new evidence.
+Skip heavy grounding only for obviously tiny handoffs or when the user asks for a fast conversational prompt.
 
-## Codex Plugin Commands
+## Prompt Contents
 
-Name `/codex:rescue` directly when the next Claude Code session should delegate execution work. Shape each rescue prompt as one job with exact inputs, clear constraints, and one evidence packet.
+Include only live context. A small handoff should fit in 12 to 20 dense lines; a large handoff may need short sections.
 
-Mention the user-invoked commands as suggestions for the human running Claude Code:
+Cover what helps Claude start:
 
-- `/codex:review`: second review pass.
-- `/codex:adversarial-review`: adversarial challenge pass.
-- `/codex:transfer`: hand work or context to Codex.
-- `/codex:status`: inspect job status.
-- `/codex:result`: retrieve job output.
-- `/codex:cancel`: cancel a job.
+```txt
+Mission:
+  One outcome and the artifact wanted.
 
-If the handoff suggests one of these commands, tell Claude Code to relay the returned output faithfully before making the final call.
+State:
+  Branch, dirty worktree, staged files, checks run, and what remains open.
 
-## Task Defaults
+Source paths:
+  Exact files, diffs, commands, PRs, specs, ADRs, or notes to inspect first.
 
-- Edits: Claude Code uses `/codex:rescue` in a disposable git worktree on its own branch, asks for commit-sized waves, then reviews the final diff.
-- Review: Claude Code uses `/codex:rescue` for one concrete evidence-gathering question, then reports findings, risks, and gaps.
-- Adversarial rework: Claude states what would falsify the current direction and names refusals with the value each gives up.
+Current read:
+  What seems true, recommendations so far, and why. Avoid calling these settled unless an ADR, code path, or explicit user decision makes them settled.
+
+Open questions:
+  What Claude should decide or re-check. Invite challenge when code, tests, ADRs, or product constraints contradict the current read.
+
+Watch-outs:
+  Only real hazards: dirty user work, destructive git, production or deploy actions, migrations, security, licensing/package boundaries, obsolete paths to avoid, or explicit user non-goals.
+
+Codex posture:
+  Tell Claude to look actively for Codex-shaped work. For substantial work, list candidate seams, but make them examples, not a queue.
+
+Proof and stop:
+  Likely verification commands or evidence targets, plus where to stop.
+```
+
+## Codex Posture
+
+Always prime Claude that Codex is available. For tiny handoffs, one sentence is enough:
+
+```txt
+Use Codex where it buys speed, breadth, focused execution, or independent verification.
+```
+
+For substantial coding, review, debugging, migration, or verification work, suggest candidate `/codex:rescue` seams. Shape them as options:
+
+```txt
+Candidate Codex seams:
+  - Diff excavation: inspect <range/paths>; return keep/rewrite/drop map with risks.
+  - Focused implementation: edit <bounded paths> for <one wave>; return changed files, diff summary, risks, and verification.
+  - Verification: run <commands>; return pass/fail output and likely next fix.
+```
+
+Rules for candidate Codex seams:
+
+- one job, bounded sources, one deliverable, clear stop condition
+- exact inputs when known
+- commit-sized waves for implementation
+- disposable worktree or clearly named branch when edits are non-trivial
+- result packets include changed files, diffs, command output, risks, and recommendations
+- Claude may revise, split, skip, or add jobs after reading live context
+
+## What To Avoid
+
+Do not turn the handoff into:
+
+```txt
+an execution script
+an unchallengeable decision record
+a mandatory Codex job queue
+a rigid constraints list
+a duplicate spec or pasted diff dump
+a transcript summary with no source paths
+```
+
+Prefer current read over settled decision. Prefer watch-out over prohibition. Prefer candidate seam over commandment.
+
+## Stop Condition
+
+The recipient should know what counts as done:
+
+```txt
+Stop after:
+  a review memo
+  a PR-ready diff
+  a clean implementation branch
+  a verified command output set
+  a blocker list with the smallest remaining decisions
+```
 
 For a `/goal` one-liner, use [agent-goal](../agent-goal/SKILL.md). For a human-facing progress summary, use [progress-summary](../progress-summary/SKILL.md).


### PR DESCRIPTION
Rewrites the handoff skill around a simpler cold-start model: ground Claude with live context, prime Codex as a bounded helper, and leave orchestration decisions with Claude.

The new shape keeps the prompt copy-pasteable while replacing rigid Codex job queues and settled-decision language with current reads, open questions, watch-outs, candidate Codex seams, and proof targets.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786002034&installation_id=128463665&pr_number=2398&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2398&signature=98c79fd00d9b4b7b2318f2b3e061ac9cfcb8e2c4d5b4d7b0ad2283c191ce96d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->