### PR TITLE
feat(account-popover): show sync as account presence

### DIFF
--- a/packages/app-shell/src/account-popover/account-popover.svelte
+++ b/packages/app-shell/src/account-popover/account-popover.svelte
@@ -6,12 +6,10 @@
 	import { toast, toastOnError } from '@epicenter/ui/sonner';
 	import { Spinner } from '@epicenter/ui/spinner';
 	import type { Collaboration, SyncStatus } from '@epicenter/workspace';
-	import Cloud from '@lucide/svelte/icons/cloud';
-	import CloudOff from '@lucide/svelte/icons/cloud-off';
+	import CircleUser from '@lucide/svelte/icons/circle-user';
 	import DatabaseZap from '@lucide/svelte/icons/database-zap';
 	import LogOut from '@lucide/svelte/icons/log-out';
 	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
-	import User from '@lucide/svelte/icons/user';
 	import {
 		createMutation,
 		createQuery,
@@ -208,27 +206,39 @@
 		return unsubscribe;
 	});
 
-	// The sync phase copy is decided once here: the popover line shows the
-	// label, the trigger tooltip adds the action hint. (The trigger icon still
-	// branches on the raw status; it mixes in auth and pending states.)
+	// The sync phase copy and dot tone are decided once here: the popover's
+	// sync line renders the dot beside its label (the legend), the trigger
+	// reuses the same dot, and the tooltip adds the action hint. Dot tones
+	// are theme tokens (success connected, warning pulse in flight, muted
+	// offline, destructive failed).
 	const sync = $derived.by(() => {
 		if (!syncStatus) return undefined;
 		switch (syncStatus.phase) {
 			case 'connected':
-				return { label: 'Connected', tooltip: 'Connected' };
+				return {
+					label: 'Connected',
+					dot: 'bg-success',
+					tooltip: 'Connected',
+				};
 			case 'connecting':
 				return {
 					label: 'Connecting…',
+					dot: 'bg-warning animate-pulse',
 					tooltip:
 						syncStatus.retries > 0
 							? `Reconnecting (retry ${syncStatus.retries})…`
 							: 'Connecting…',
 				};
 			case 'offline':
-				return { label: 'Offline', tooltip: 'Offline. Click to reconnect' };
+				return {
+					label: 'Offline',
+					dot: 'bg-muted-foreground',
+					tooltip: 'Offline. Click to reconnect',
+				};
 			case 'failed':
 				return {
 					label: 'Failed',
+					dot: 'bg-destructive',
 					tooltip: 'Authentication failed. Click to reconnect',
 				};
 		}
@@ -237,7 +247,15 @@
 	const tooltip = $derived.by(() => {
 		if (disabledReason) return disabledReason;
 		if (!isSignedIn) return sync ? 'Sign in to sync across devices' : 'Sign in';
-		return sync?.tooltip ?? 'Account';
+		return sync ? `Account · ${sync.tooltip}` : 'Account';
+	});
+	// The dot is presence for sync: it appears only when a signed-in account
+	// has a sync surface attached. Signed out renders a dimmed glyph instead
+	// of a nudge dot; local-only is a valid resting state, not a notification.
+	const triggerDot = $derived.by(() => {
+		if (!isSignedIn) return undefined;
+		if (signOut.isPending) return 'bg-warning animate-pulse';
+		return sync?.dot;
 	});
 
 	function openInstanceModal() {
@@ -273,25 +291,20 @@
 <Popover.Root bind:open={popoverOpen}>
 	<Popover.Trigger>
 		{#snippet child({ props })}
-			<Button {...props} variant="ghost" size="icon-sm" class="relative" {tooltip}>
-				{#if signOut.isPending}
-					<Spinner class="size-4" />
-				{:else if !isSignedIn}
-					<CloudOff class="size-4 text-muted-foreground" />
-				{:else if !syncStatus}
-					<User class="size-4" />
-				{:else if syncStatus.phase === 'connected'}
-					<Cloud class="size-4" />
-				{:else if syncStatus.phase === 'connecting'}
-					<Spinner class="size-4" />
-				{:else}
-					<CloudOff class="size-4 text-destructive" />
-				{/if}
-				{#if !isSignedIn}
-					<span
-						class="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-primary"
-					></span>
-				{/if}
+			<Button {...props} variant="ghost" size="icon-sm" {tooltip}>
+				<!-- Identity glyph stays fixed; the sync dot sits at its
+				     bottom-right like a presence badge (top-right would read
+				     as a notification). -->
+				<span class="relative">
+					<CircleUser
+						class="size-4 {isSignedIn ? '' : 'text-muted-foreground'}"
+					/>
+					{#if triggerDot}
+						<span
+							class="absolute -right-0.5 -bottom-0.5 size-2 rounded-full {triggerDot}"
+						></span>
+					{/if}
+				</span>
 			</Button>
 		{/snippet}
 	</Popover.Trigger>
@@ -328,8 +341,13 @@
 					<p class="text-xs text-muted-foreground">{disabledReason}</p>
 				{/if}
 				{#if collaboration && sync}
-					<div class="border-t pt-3 space-y-1">
-						<p class="text-xs text-muted-foreground">Sync: {sync.label}</p>
+					<!-- Same dot as the trigger, beside its meaning: this line is
+					     the legend for the trigger's presence badge. -->
+					<div
+						class="border-t pt-3 flex items-center gap-1.5 text-xs text-muted-foreground"
+					>
+						<span class="size-2 shrink-0 rounded-full {sync.dot}"></span>
+						<span>Sync: {sync.label}</span>
 					</div>
 				{/if}
 				<div class="border-t pt-3 flex gap-2">

--- a/packages/app-shell/src/account-popover/sign-in-panel.svelte
+++ b/packages/app-shell/src/account-popover/sign-in-panel.svelte
@@ -108,12 +108,12 @@
 <div class="flex flex-col gap-3">
 	<div class="space-y-1">
 		<p class="text-sm font-medium">
-			{selfHosted ? `Connect to ${host}` : 'Sign in'}
+			{selfHosted ? `Connect to ${host}` : 'Sync across devices'}
 		</p>
-		<p class="text-xs text-muted-foreground">
+		<p class="text-xs leading-relaxed text-muted-foreground">
 			{selfHosted
 				? 'Sign in to your self-hosted instance.'
-				: `Sign in to sync your ${syncNoun} across devices.`}
+				: `Your ${syncNoun} live on this device. Sign in to sync them to your other devices.`}
 		</p>
 	</div>
 	{#if disabledReason}
@@ -138,14 +138,20 @@
 			Sign in with Epicenter
 		{/if}
 	</Button>
-	<!-- Self-host is a real mode, so it gets a real button; Cloud vs Server names the two modes. -->
-	<Button
-		variant="outline"
-		class="w-full"
-		disabled={accountLocked}
-		onclick={onConfigure}
-	>
-		<Server class="size-4" />
-		{selfHosted ? 'Change instance' : 'Connect to a self-hosted instance'}
-	</Button>
+	<!-- Self-host is a real mode (Cloud vs Server names the deployments), but
+	     hosted sign-in is the common path, so the instance action reads like
+	     the signed-in panel's utility rows instead of competing as a peer
+	     button. -->
+	<div class="border-t pt-3">
+		<Button
+			variant="ghost"
+			size="sm"
+			class="w-full justify-start text-muted-foreground hover:text-foreground"
+			disabled={accountLocked}
+			onclick={onConfigure}
+		>
+			<Server class="size-3.5" />
+			{selfHosted ? 'Change instance' : 'Use a self-hosted instance'}
+		</Button>
+	</div>
 </div>

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -17,6 +17,11 @@
 @import "./styles/epicenter-overlay.css" layer(base);
 
 @source "./**/*.{svelte,ts}";
+/* app-shell ships Svelte templates with no CSS entry of its own; apps get all
+   their Tailwind from this file. Without this line, a utility used only in an
+   app-shell component (status dots, credit tints) is never generated and
+   silently renders unstyled in every app. */
+@source "../../app-shell/src/**/*.{svelte,ts}";
 
 /*
   The default border color has changed to `currentcolor` in Tailwind CSS v4,

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -17,10 +17,8 @@
 @import "./styles/epicenter-overlay.css" layer(base);
 
 @source "./**/*.{svelte,ts}";
-/* app-shell ships Svelte templates with no CSS entry of its own; apps get all
-   their Tailwind from this file. Without this line, a utility used only in an
-   app-shell component (status dots, credit tints) is never generated and
-   silently renders unstyled in every app. */
+/* App-shell components are styled through this shared CSS entrypoint, so Tailwind
+   must scan app-shell sources or app-shell-only utilities will not be generated. */
 @source "../../app-shell/src/**/*.{svelte,ts}";
 
 /*


### PR DESCRIPTION
The account popover was using sync state as the whole trigger identity: cloud, cloud-off, spinner, or user depending on auth and connection state. That made the surface read like a sync button instead of an account menu.

This keeps the trigger anchored on identity with a stable account glyph, then shows sync as a small presence dot when a signed-in account has a sync surface attached. The popover uses the same dot beside the sync label, so the status has a legend instead of relying on icon swapping.

The signed-out panel now leads with local-first framing: your data lives on this device, and signing in syncs it to other devices. Self-hosting remains available, but as a secondary instance action rather than a peer primary button.

This also fixes Tailwind utility generation for app-shell components by adding app-shell to the shared UI CSS source scan. Without that, utilities used only inside app-shell could silently render unstyled in consuming apps.

## Changelog

- Show account sync state as a presence dot on the shared account popover trigger.
- Fix Tailwind utility generation for shared app-shell components.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786008224&installation_id=128463665&pr_number=2402&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2402&signature=e165c63553e7f689e3469b91b6ea5803c3514a95a8d7aefdfa61adc5da7493bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->