### PR TITLE
docs: clean up watcher IPC docs

### DIFF
--- a/docs/adr/0112-the-cli-watcher-is-not-a-callable-action-server.md
+++ b/docs/adr/0112-the-cli-watcher-is-not-a-callable-action-server.md
@@ -11,21 +11,19 @@ The CLI daemon was introduced as a mandatory local process for `epicenter run`,
 `epicenter list`, and `epicenter peers`. ADR-0009 justified that shape by
 framing the daemon as a callable peer in a device mesh: a device was either
 online and callable, or it was offline. That rationale no longer matches the
-system. The mesh peer, `run --peer`, in-room action dispatch, and relay action
-channel were deleted.
-<!-- doc-path-check: ignore-next-line -->
-`packages/workspace/src/daemon/action-handler.ts` now says cross-device runs are
-not a `/run` concern.
+system. The mesh peer, `run --peer`, in-room action dispatch, relay action channel,
+and the daemon action handler were deleted. Cross-device work is no longer a
+`/run` concern.
 
 The useful product need that remains is different: a user can run Epicenter
 headlessly for one folder so the workspace stays synchronized and materialized.
 That process owns the lease, node id, sync connection, materializers, logs, and
 metadata. It does not need to be an addressable local action server.
 
-The generic off-process action surface also has no live first-party consumer.
+The generic off-process action surface also had no live first-party consumer.
 Apps call workspace actions in-process through their own runtime or local tool
-catalogs. The documented script path, `connectDaemonActions`, is covered by its
-own tests but has no production caller in the repo.
+catalogs. The old documented script path, `connectDaemonActions`, had tests but
+no production caller in the repo.
 
 ## Decision
 
@@ -47,12 +45,10 @@ an import or capture command, instead of resurrecting a generic action bus.
 
 ## Consequences
 
-The first cleanup deletes the external IPC plane while preserving headless
-operation. `epicenter daemon up` still opens a mount, syncs, materializes, logs
-presence and sync status, and tears down. `daemon down`, `daemon ps`, and
-`daemon logs` continue to operate through metadata, pid liveness, and log files.
-A later wave promoted these lifecycle commands to top-level `epicenter up`,
-`down`, `status`, and `logs`, deleting the `daemon` namespace with no
+The cleanup deleted the external IPC plane while preserving headless operation.
+`epicenter up` opens a mount, syncs, materializes, logs presence and sync status,
+and tears down. `down`, `status`, and `logs` operate through metadata, pid
+liveness, and log files. The old `daemon` namespace was deleted with no
 compatibility aliases.
 
 The trade-off is explicit: users lose the generic shell escape hatch
@@ -82,9 +78,9 @@ keep a socket protocol alive.
 
 ## Considered alternatives
 
-Keep the current IPC plane and fix the docs: rejected. It preserves a socket,
-HTTP app, typed client, action manifest, JSON input parser, and three commands
-for a callable-peer story that no longer exists in code.
+Keep the then-current IPC plane and fix the docs: rejected. It would have
+preserved a socket, HTTP app, typed client, action manifest, JSON input parser,
+and three commands for a callable-peer story that no longer exists in code.
 
 Delete the resident process entirely: rejected. The resident process still owns
 real headless value: the single-writer lease, sync connection, materializer

--- a/specs/20260706T183000-cli-watcher-ipc-collapse.md
+++ b/specs/20260706T183000-cli-watcher-ipc-collapse.md
@@ -14,23 +14,22 @@ Keep Epicenter's headless watcher, but delete the external daemon IPC plane so a
 Read first:
 
 - One Sentence
-- Target shape
-- Wave 1
+- Current target shape
+- Remaining review focus
 - Success criteria
 
-Read when changing deeper architecture:
+Read historical sections when changing deeper architecture:
 
 - Design decisions
-- Runtime shape follow-up
-- Open questions
+- Implementation plan
 
 Historical only:
 
 - Earlier clean-break analysis named the broader radical-options pass; this spec is the narrower execution slice.
 
-## Current shape
+## Historical shape before the collapse
 
-The CLI has two products tangled together:
+The CLI used to have two products tangled together:
 
 ```txt
 Headless watcher:
@@ -52,35 +51,35 @@ Callable action server:
     -> action registry exposed by the mount runtime
 ```
 
-The first product is still useful. The second product is the collapse target.
+The first product was useful. The second product was the collapse target.
 
-## Target shape
+## Current target shape
 
-`epicenter daemon up` remains for the first implementation wave. It opens one app mount headlessly for one folder, keeps sync and materializers alive, writes logs and metadata, and shuts down cleanly. It does not bind a socket and nothing can call it.
+The shipped CLI exposes the headless watcher directly: `epicenter up`, `down`, `status`, and `logs`. `up` opens one app mount headlessly for one folder, keeps sync and materializers alive, writes logs and metadata, and shuts down cleanly. It does not bind a socket and nothing can call it.
 
 ```txt
-CLI after Wave 1:
-  daemon up      keep, no socket
-  daemon down    keep, metadata + pid signal
-  daemon ps      keep, metadata + pid liveness
-  daemon logs    keep, log file tail/read
-  auth           keep
-  init           keep
-  blobs          keep
-  matter         keep
+CLI after Waves 1-3:
+  up        keep, no socket
+  down      keep, metadata + pid signal
+  status    keep, metadata + pid liveness
+  logs      keep, log file tail/read
+  auth      keep
+  init      keep
+  blobs     keep
+  matter    keep
 
-  run            delete
-  list           delete
-  peers          delete
+  run       deleted
+  list      deleted
+  peers     deleted
 ```
 
-Workspace actions stay. Apps, local tools, tests, and future app-specific commands can call actions in-process. This spec deletes only the generic off-process daemon action bus.
+Workspace actions stay. Apps, local tools, tests, and future app-specific commands can call actions in-process. This spec deleted only the generic off-process daemon action bus.
 
 ## Motivation
 
-The current daemon IPC plane preserves an old story: the daemon as a callable peer. ADR-0009 says `run`, `list`, and `peers` require a daemon because the daemon represents an online callable device. That no longer matches the code. The mesh peer, `run --peer`, and relay action dispatch were deleted; `action-handler.ts` explicitly says cross-device runs are not a `/run` concern.
+The removed daemon IPC plane preserved an old story: the daemon as a callable peer. ADR-0009 said `run`, `list`, and `peers` required a daemon because the daemon represented an online callable device. That stopped matching the code before this collapse. The mesh peer, `run --peer`, relay action dispatch, and the daemon action handler are all gone.
 
-The current shape creates problems:
+That shape created problems:
 
 1. The watcher has to carry an action registry because the socket can serve it, even though the sync/materialization product does not need external calls.
 2. `connectDaemonActions` and the daemon client create a public-looking script surface with no production caller.
@@ -101,22 +100,20 @@ The desired state is smaller: a headless watcher plus explicit future verbs when
 
 ## Architecture
 
-Before:
+Removed path:
 
 ```txt
 epicenter run/list/peers
-  -> getDaemon(root)
-    -> socketPathFor(root)
-      -> daemonClient(socket)
-        -> Unix socket transport
-          -> Hono app
-            -> mount.runtime.actions / mount.runtime.collaboration.peers
+  -> daemon client
+    -> Unix socket transport
+      -> Hono app
+        -> mount.runtime.actions / mount.runtime.collaboration.peers
 ```
 
-After Wave 1:
+Current path:
 
 ```txt
-epicenter daemon up
+epicenter up
   -> claim lease
   -> openEpicenterRoot
     -> load epicenter.config.ts
@@ -176,92 +173,55 @@ Goal: make the CLI say what the product is.
 
 ### Wave 4: one-shot sync
 
-Goal: add `epicenter sync` only after the watcher runtime is smaller.
+Refused for now. `epicenter sync` is not needed without a concrete workflow, and its convergence contract would be easy to over-promise. Keep `epicenter up` as the lifecycle surface until a real user needs one-shot sync and can name what "done" means.
 
-Open design question: what proves convergence? Candidate signal: root doc `whenConnected`, child-doc sync completion for materialized rows, and materializer flush/drain. Do not add `sync` until this contract is explicit.
+## PR strategy history
 
-## PR strategy
+Wave 1 was reviewable on its own because the headless watcher remained while the callable action server disappeared. Wave 3 then renamed the lifecycle surface to top-level commands with no compatibility aliases.
 
-Open a PR after Wave 1 if the diff is reviewable and green. Wave 1 is already a coherent product change: the headless watcher remains, but the callable action server is gone. It should not wait for rename churn or `sync`.
-
-Recommended PR title:
+The durable PR summary was:
 
 ```txt
-Collapse daemon IPC into a headless watcher
-```
-
-Recommended PR body shape:
-
-```txt
-This keeps `epicenter daemon up` as the headless sync/materialization process, but removes the generic local action server around it.
-
 Before:
   run/list/peers -> daemon client -> Unix socket -> Hono app -> action registry
 
 After:
-  daemon up opens the mount, syncs, materializes, writes logs and metadata, and cannot be called.
+  up opens the mount, syncs, materializes, writes logs and metadata, and cannot be called.
 
 Workspace actions remain in-process for apps and local tools. Future write workflows should earn explicit app verbs instead of reviving a generic daemon action bus.
 ```
 
-## When to use a bigger orchestrator review
+## Remaining review focus
 
-Use a bigger orchestrator before Wave 2 or Wave 3, not before Wave 1, unless Wave 1 uncovers a real production caller for IPC.
-
-Wave 1 is evidence-backed and mechanically bounded. The risky design questions come next:
-
-- whether `DaemonRuntime.actions` disappears entirely;
-- whether materializer operations stay action-shaped;
-- whether lifecycle commands get clean-break renames without aliases;
-- what `sync` means and how it proves convergence.
-
-A good orchestrator prompt after Wave 1:
-
-```txt
-Review the Wave 1 diff for the CLI watcher IPC collapse. Challenge whether any remaining `daemon`, `actions`, socket, or RPC-shaped boundary still exists only because the old callable-server model leaked through. Do not propose compatibility aliases unless you can name a real contract. Focus on Wave 2: should `DaemonRuntime.actions` disappear, and should materializer rebuild/search remain action-shaped or become direct materializer methods?
-```
+Waves 1-3 are shipped. Wave 4 is refused for now: do not add `epicenter sync` without a concrete workflow and a crisp definition of "done."
 
 ## Edge cases
 
 ### Inactive mount
 
-`daemon up` may still return an inactive mount when a session-required app is signed out. It should report the reason, release the lease, and exit without metadata for a running watcher.
+`epicenter up` may still return an inactive mount when a session-required app is signed out. It should report the reason, release the lease, and exit without metadata for a running watcher.
 
 ### Mount with collaboration
 
-`daemon up` should still print initial peers and sync status from the in-process collaboration object. Deleting `epicenter peers` removes only the on-demand query path.
-
-### Existing socket files
-
-If runtime-file sweeping currently removes stale sockets, keep the cleanup if it also handles metadata/log hygiene. Delete socket-specific cleanup only when no caller or test depends on it.
+`epicenter up` should still print initial peers and sync status from the in-process collaboration object. Deleting `epicenter peers` removes only the on-demand query path.
 
 ### External package consumers
 
 `@epicenter/workspace` is published. Removing `connectDaemonActions` and daemon client exports is a clean break. Pause if we decide published compatibility matters for the current release; otherwise ADR-0112 is the decision record.
 
-## Open questions
+## Refused follow-up
 
-1. Should `daemon` vocabulary be renamed internally to `watcher`?
-   - Recommendation: not in Wave 1. Delete behavior first, rename once the shape is smaller.
-
-2. Should materializer rebuild/search remain workspace actions?
-   - Recommendation: defer to Wave 2. The answer is probably “direct materializer methods,” but collapsing the external IPC plane should not wait on it.
-
-3. Should `epicenter peers` be replaced by `status --peers`?
-   - Recommendation: no. Presence is visible in watcher logs or app UI until a real operator workflow needs an on-demand command.
-
-4. Should `run` return later as an app-specific command generator?
-   - Recommendation: no generic return. Add explicit verbs for real workflows, such as import, capture, or post.
+Do not add `epicenter sync` as speculative symmetry with `up`. A one-shot command only earns itself when a real workflow needs it and can define convergence across root-doc sync, child-doc sync, and materializer flush/drain.
 
 ## Success criteria
 
-- [x] `epicenter daemon up` starts a mount, syncs, materializes, writes metadata, logs status, and tears down.
+- [x] `epicenter up` starts a mount, syncs, materializes, writes metadata, logs status, and tears down.
 - [x] No Unix socket is bound by the watcher.
 - [x] `epicenter run`, `epicenter list`, and `epicenter peers` are gone from the CLI.
 - [x] No exported daemon client or `connectDaemonActions` surface remains without a non-test caller.
 - [x] Workspace actions still work in-process.
 - [x] Package tests and typechecks pass for `packages/cli` and `packages/workspace`.
-- [ ] ADR-0112 is accepted or left Proposed for PR review, and ADR-0009 is no longer the active decision after merge.
+- [x] ADR-0112 is accepted, and ADR-0009 is no longer the active decision after merge.
 
 ## References
 
@@ -270,7 +230,4 @@ If runtime-file sweeping currently removes stale sockets, keep the cleanup if it
 - `packages/cli/src/commands/up.ts` - watcher startup owner.
 - `packages/cli/src/cli.ts` - CLI command registration.
 - `packages/workspace/src/config/open-epicenter-root.ts` - config-to-mounted-runtime startup path.
-- `packages/workspace/src/daemon/types.ts` - runtime shape to trim after IPC deletion.
-- `packages/workspace/src/daemon/app.ts` - Hono IPC app to delete in Wave 1.
-- `packages/workspace/src/daemon/client.ts` - daemon client to delete in Wave 1.
-- `packages/workspace/src/client/connect-daemon-actions.ts` - documented script proxy to delete in Wave 1.
+- `packages/workspace/src/daemon/types.ts` - watcher runtime shape after IPC deletion.


### PR DESCRIPTION
Updates the watcher IPC decision docs to match the shipped CLI shape.

The docs now say the watcher lifecycle surface is `epicenter up`, `down`, `status`, and `logs`, with no socket, no callable daemon, and no generic `run` / `list` / `peers` revival.

This also marks `epicenter sync` as refused for now rather than leaving it as speculative follow-up. A one-shot sync command should only return if a real workflow can define what convergence means.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786047530&installation_id=128463665&pr_number=2404&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2404&signature=9089ad398089bf1f5f95e214f23d1254549d93a6a458f202852412bd14e4fa85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->