### PR TITLE
refactor(auth): move CLI callback out of /auth

### DIFF
--- a/.agents/skills/content-distribution/SKILL.md
+++ b/.agents/skills/content-distribution/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: content-distribution
-description: Turn one real idea, vault page, article, photo, screenshot, code diff, spec excerpt, or diagram into platform-native content for LinkedIn, X, Reddit, TikTok, Instagram Reels, YouTube Shorts, Medium, Substack, or a personal-site article. Use when creating or editing files in adaptations/ or publications/, choosing a channel or platform for a page, republishing or updating content that already shipped, or figuring out what's currently live for a given page.
+description: Turn one real idea, vault page, article, photo, screenshot, code diff, spec excerpt, or diagram into platform-native content for LinkedIn, X, Reddit, TikTok, Instagram Reels, YouTube Shorts, Medium, Substack, or a personal-site article. Use when creating or editing files in variants/, choosing a channel or platform for a page, republishing or updating content that already shipped, or figuring out what's currently live for a given page.
 ---
 
 # Content Distribution
@@ -18,8 +18,8 @@ Use one markdown source. Use real artifacts. AI adapts, packages, resizes, rewri
 ```txt
 real idea
   -> pages/<slug>.md (the private draft)
-  -> adaptations/<slug>-<channel>-<format>.md (platform-native rendering)
-  -> publications/<adaptation-stem>-<platform>.md (a shipped placement)
+  -> variants/<slug>-<channel>-<format>-<version>.md (the shaped artifact)
+       placements: [{platform, published_at, url, caption}] (shipped facts)
   -> performance notes
   -> next ideas from replies
 ```
@@ -111,26 +111,34 @@ Reddit:
 
 ## Source Of Truth
 
-`pages/<slug>.md` is the source. `channel` is the content identity (`bradencodes`, `braden-essays`, `epicenter`, ...). In the sibling vault repo, channel promises live at `../vault/specs/20260609T010000-channel-promise-approval-ledger.md`; read that file before picking a channel for a page for the first time because each channel's "what belongs" and "what does not belong" sections are normative. `format` is `short-video | thread | text | article`. `platform` is the distribution surface (`instagram`, `x`, `medium`, `personal-blog`, ...).
+`pages/<slug>.md` is the source. `channel` is the content identity (`bradencodes`, `braden-essays`, `epicenter`, ...). In the sibling vault repo, channel promises live at `../vault/specs/20260609T010000-channel-promise-approval-ledger.md`; read that file before picking a channel for a page for the first time because each channel's "what belongs" and "what does not belong" sections are normative. `format` is `article | social-post | short-video`. A `social-post` body is one or more short written segments separated by `---`: one segment is a one-shot post, several are a thread. `platform` is the distribution surface, and each format ships only to its platform class (the lint enforces this matrix):
+
+```txt
+article      → personal-blog | medium | substack | newsletter
+social-post  → x | linkedin | reddit
+short-video  → instagram | tiktok | youtube
+```
+
+A variant's filename is `<page>-<channel>-<format>-<version>` where `version` is the `YYYY-MM-DD` checkpoint the variant was cut from the page:
 
 ```txt
 pages/2026-06-15-my-page.md
-  -> adaptations/2026-06-15-my-page-bradencodes-thread.md
-       -> publications/2026-06-15-my-page-bradencodes-thread-x.md
-  -> adaptations/2026-06-15-my-page-braden-essays-article.md
-       -> publications/2026-06-15-my-page-braden-essays-article-personal-blog.md
+  -> variants/2026-06-15-my-page-bradencodes-social-post-2026-06-20.md
+       placements: [{platform: x, published_at, url}]
+  -> variants/2026-06-15-my-page-braden-essays-article-2026-06-20.md
+       placements: [{platform: personal-blog, published_at, url}]
 ```
 
-### Both layers are append-only
+### Freeze-on-supersede
 
-Never edit an existing adaptation or publication file's content in place. This is a ledger, not a mutable record.
+The **latest** variant for a `(page, channel, format)` lineage is living: edit it in place to track the page. Cutting a new version freezes its predecessor — never touch a superseded variant again; it is the curated record of what shipped.
 
-- Content changed (revised article, rewritten thread)? Create a **new adaptation** file, dated with its own creation date (not the page's date), so the filename doesn't collide with the original.
-- Shipping again, either an update to something already live or a genuine repost months later? Create a **new publication** row. Point it at the new adaptation if the content changed, or the same adaptation if it's an unchanged repost.
+- Content changed enough to preserve the old checkpoint? Cut a **new variant** with today's date as its `version`; the old one freezes.
+- Shipping the living variant somewhere (first ship, update, or repost)? Append a **placement** to its `placements[]` — one object per platform shipment.
 
-**What's currently live** is derived, not stored: for a given (page, channel, format, platform), the current publication is the one with the latest `published_at`. Older publication rows are history, not stale data to clean up.
+**What's currently live** is derived, not stored: for a given platform, the current placement is the one with the latest `published_at` on the latest variant that carries that platform. Older variants and placements are history, not stale data to clean up.
 
-Current vault schema: `pages/matter.json` requires `title`, `date`, `timezone`, and `status`; `adaptations/matter.json` requires `page`, `channel`, and `format`; `publications/matter.json` requires `adaptation` and `platform`, with optional `scheduled_for`, `published_at`, and `url`. Existing adaptation files may also carry `subtitle` as a channel-specific dek; the page's own `title` stays private and canonical. Leave `published_at` blank until content is actually live.
+Current vault schema: `pages/matter.json` requires `title`, `date`, `timezone`, and `status`; `variants/matter.json` requires `page`, `version`, `channel`, and `format`, with optional `subtitle` (a channel-specific dek; the page's own `title` stays private and canonical). `placements[]` is validated by `bun run publishing-lint`, not Matter: each object has `platform` plus optional `published_at`, `url`, and `caption`. Leave `published_at` off until content is actually live.
 
 ## Do Not
 

--- a/.agents/skills/content-distribution/references/platform-renderers.md
+++ b/.agents/skills/content-distribution/references/platform-renderers.md
@@ -164,10 +164,10 @@ Optimize for:
 Best default:
 
 ```txt
-publications/*.md record
+variants/*.md placements[]
   + destination wrappers
   + attempts
   + performance notes
 ```
 
-`publications/` should own distribution state, not the source idea. `pages/` owns finished writing. `publications/` owns where it went, what wrapper was used, and what happened next.
+A variant's `placements[]` should own distribution state, not the source idea. `pages/` owns finished writing. The variant owns the shaped artifact; its placements own where it went, what wrapper was used, and what happened next.

--- a/.agents/skills/handoff/SKILL.md
+++ b/.agents/skills/handoff/SKILL.md
@@ -15,7 +15,7 @@ Default output: return only the prompt. If the user is designing or reviewing th
 
 ## One Sentence
 
-A handoff prompt gives Claude context, starting points, proof targets, and a strong bias to use Codex creatively, while leaving Claude free to rethink the plan and choose the delegation shape.
+A handoff prompt gives Claude context, starting points, proof targets, and a strong bias to use `/codex:rescue` creatively, while leaving Claude free to rethink the plan and choose the delegation shape.
 
 ## Mental Model
 
@@ -27,7 +27,7 @@ Claude owns:
   context selection
   ambiguity and tradeoffs
   implementation direction
-  Codex delegation choices
+  `/codex:rescue` delegation choices
   final synthesis
 
 Codex can help with:
@@ -43,7 +43,7 @@ Codex can help with:
   small prototypes
 ```
 
-Do not pre-orchestrate the session. Prime Claude to use Codex, suggest seams when they are obvious, and explicitly allow Claude to revise, split, skip, or invent Codex calls after reading live context.
+Do not pre-orchestrate the session. Prime Claude to use the literal `/codex:rescue` command, suggest seams when they are obvious, and explicitly allow Claude to revise, split, skip, or invent Codex calls after reading live context.
 
 ## Ground Before Writing
 
@@ -89,7 +89,7 @@ Watch-outs:
   Only real hazards: dirty user work, destructive git, production or deploy actions, migrations, security, licensing/package boundaries, obsolete paths to avoid, or explicit user non-goals.
 
 Codex posture:
-  Tell Claude to look actively for Codex-shaped work. For substantial work, list candidate seams, but make them examples, not a queue.
+  Tell Claude to look actively for work worth delegating through `/codex:rescue`. For substantial work, list candidate seams, but make them examples, not a queue.
 
 Proof and stop:
   Likely verification commands or evidence targets, plus where to stop.
@@ -97,13 +97,13 @@ Proof and stop:
 
 ## Codex Posture
 
-Always prime Claude that Codex is available. For tiny handoffs, one sentence is enough:
+Always prime Claude that Codex is available through the literal `/codex:rescue` command. For tiny handoffs, one sentence is enough:
 
 ```txt
-Use Codex where it buys speed, breadth, focused execution, or independent verification.
+Use /codex:rescue where it buys speed, breadth, focused execution, or independent verification.
 ```
 
-For substantial coding, review, debugging, migration, or verification work, suggest candidate `/codex:rescue` seams. Shape them as options:
+For substantial coding, review, debugging, migration, or verification work, suggest candidate `/codex:rescue` seams. Name the command in the handoff so Claude does not have to infer it from “Codex.” Shape seams as options:
 
 ```txt
 Candidate Codex seams:

--- a/apps/api/scripts/dev.ts
+++ b/apps/api/scripts/dev.ts
@@ -9,7 +9,7 @@ const devVars = resolve(apiRoot, '.dev.vars');
 // The cloud UI SPA is built into apps/api/ui/build/ (SvelteKit
 // adapter-static, fallback.html shell). Wrangler errors if its assets
 // directory does not exist, and the auth surfaces (/sign-in, /consent,
-// /auth/cli-callback) are served from that build, so build it once when the
+// /cli-callback) are served from that build, so build it once when the
 // shell is missing. Subsequent boots skip the build to keep the edit loop
 // fast; rerun `bun run --cwd apps/api/ui build` after UI changes you want
 // visible through wrangler dev.

--- a/apps/api/ui/src/lib/auth/AuthCard.svelte
+++ b/apps/api/ui/src/lib/auth/AuthCard.svelte
@@ -12,7 +12,7 @@
 </script>
 
 <div class="flex min-h-dvh items-center justify-center p-6">
-	<Card.Root class="w-full max-w-sm">
+	<Card.Root class="w-full max-w-sm gap-5">
 		<div class="flex justify-center">
 			<EpicenterMark class="size-12 rounded-xl" />
 		</div>

--- a/apps/api/ui/src/lib/auth/AuthCard.svelte
+++ b/apps/api/ui/src/lib/auth/AuthCard.svelte
@@ -1,7 +1,7 @@
 <!--
-	Centered card shell shared by every auth surface (sign-in, consent,
-	CLI callback): Epicenter mark centered on top, page content composed by the
-	caller with Card.Header / Card.Content / Card.Footer.
+	Hosted auth card shell shared by sign-in, consent, and CLI callback.
+
+	Keep this surface plain and operational: see ADR-0113.
 -->
 <script lang="ts">
 	import type { Snippet } from 'svelte';

--- a/apps/api/ui/src/lib/auth/AuthHeader.svelte
+++ b/apps/api/ui/src/lib/auth/AuthHeader.svelte
@@ -1,0 +1,24 @@
+<!--
+	Centered header for the hosted auth surfaces. Owns the one auth title scale
+	and centering so routes stop re-deciding typography per page: the h1 gives
+	each surface a semantic heading, the description snippet carries any inline
+	markup (a client id, a code span).
+-->
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import * as Card from '@epicenter/ui/card';
+
+	let {
+		title,
+		description,
+	}: { title: string; description?: Snippet } = $props();
+</script>
+
+<Card.Header class="justify-items-center text-center">
+	<Card.Title>
+		<h1 class="text-xl font-semibold tracking-tight">{title}</h1>
+	</Card.Title>
+	{#if description}
+		<Card.Description>{@render description()}</Card.Description>
+	{/if}
+</Card.Header>

--- a/apps/api/ui/src/lib/auth/ProviderButton.svelte
+++ b/apps/api/ui/src/lib/auth/ProviderButton.svelte
@@ -22,7 +22,7 @@
 	} = $props();
 </script>
 
-<Button variant="outline" size="lg" class="w-full gap-2" {disabled} {onclick}>
+<Button variant="outline" size="lg" class="w-full" {disabled} {onclick}>
 	{#if provider === 'google'}
 		<svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
 			<path

--- a/apps/api/ui/src/lib/auth/ProviderButton.svelte
+++ b/apps/api/ui/src/lib/auth/ProviderButton.svelte
@@ -1,11 +1,8 @@
 <!--
-	One "Continue with <provider>" button. Owns the brand icon and label per
+	One "Continue with <provider>" action. Owns the brand icon and label per
 	provider id so the sign-in page can render enabled providers from a loop.
 	Brand icons stay inline SVG: Google and Microsoft use fixed brand colors,
 	GitHub and Apple inherit the button text color via currentColor.
-
-	The icon is absolutely positioned at a fixed left inset so stacked buttons
-	form an aligned icon rail while each label stays centered.
 -->
 <script lang="ts">
 	import { Button } from '@epicenter/ui/button';
@@ -25,62 +22,57 @@
 	} = $props();
 </script>
 
-<Button variant="outline" class="relative h-11 w-full" {disabled} {onclick}>
-	<span
-		class="absolute left-4 flex size-4 items-center justify-center"
-		aria-hidden="true"
-	>
-		{#if provider === 'google'}
-			<svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
-				<path
-					d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-					fill="#4285F4"
-				/>
-				<path
-					d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-					fill="#34A853"
-				/>
-				<path
-					d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-					fill="#FBBC05"
-				/>
-				<path
-					d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-					fill="#EA4335"
-				/>
-			</svg>
-		{:else if provider === 'github'}
-			<svg
-				width="16"
-				height="16"
-				viewBox="0 0 16 16"
-				aria-hidden="true"
-				fill="currentColor"
-			>
-				<path
-					d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"
-				/>
-			</svg>
-		{:else if provider === 'microsoft'}
-			<svg width="16" height="16" viewBox="0 0 23 23" aria-hidden="true">
-				<path fill="#F25022" d="M1 1h10v10H1z" />
-				<path fill="#7FBA00" d="M12 1h10v10H12z" />
-				<path fill="#00A4EF" d="M1 12h10v10H1z" />
-				<path fill="#FFB900" d="M12 12h10v10H12z" />
-			</svg>
-		{:else if provider === 'apple'}
-			<svg
-				width="16"
-				height="16"
-				viewBox="0 0 24 24"
-				aria-hidden="true"
-				fill="currentColor"
-			>
-				<path
-					d="M17.05 12.53c-.02-2.02 1.65-2.99 1.72-3.04-.94-1.37-2.4-1.56-2.92-1.58-1.24-.13-2.42.73-3.05.73-.63 0-1.6-.71-2.63-.69-1.35.02-2.6.79-3.3 2-1.4 2.44-.36 6.05 1 8.03.67.97 1.47 2.06 2.5 2.02 1-.04 1.38-.65 2.6-.65 1.2 0 1.55.65 2.6.63 1.08-.02 1.76-.99 2.42-1.96.76-1.12 1.07-2.2 1.09-2.26-.02-.01-2.09-.8-2.11-3.18zM15.1 6.3c.55-.67.92-1.6.82-2.53-.79.03-1.76.53-2.33 1.19-.51.59-.96 1.54-.84 2.44.88.07 1.79-.44 2.35-1.1z"
-				/>
-			</svg>
-		{/if}
-	</span>
+<Button variant="outline" size="lg" class="w-full gap-2" {disabled} {onclick}>
+	{#if provider === 'google'}
+		<svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+			<path
+				d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+				fill="#4285F4"
+			/>
+			<path
+				d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+				fill="#34A853"
+			/>
+			<path
+				d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+				fill="#FBBC05"
+			/>
+			<path
+				d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+				fill="#EA4335"
+			/>
+		</svg>
+	{:else if provider === 'github'}
+		<svg
+			width="16"
+			height="16"
+			viewBox="0 0 16 16"
+			aria-hidden="true"
+			fill="currentColor"
+		>
+			<path
+				d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"
+			/>
+		</svg>
+	{:else if provider === 'microsoft'}
+		<svg width="16" height="16" viewBox="0 0 23 23" aria-hidden="true">
+			<path fill="#F25022" d="M1 1h10v10H1z" />
+			<path fill="#7FBA00" d="M12 1h10v10H12z" />
+			<path fill="#00A4EF" d="M1 12h10v10H1z" />
+			<path fill="#FFB900" d="M12 12h10v10H12z" />
+		</svg>
+	{:else if provider === 'apple'}
+		<svg
+			width="16"
+			height="16"
+			viewBox="0 0 24 24"
+			aria-hidden="true"
+			fill="currentColor"
+		>
+			<path
+				d="M17.05 12.53c-.02-2.02 1.65-2.99 1.72-3.04-.94-1.37-2.4-1.56-2.92-1.58-1.24-.13-2.42.73-3.05.73-.63 0-1.6-.71-2.63-.69-1.35.02-2.6.79-3.3 2-1.4 2.44-.36 6.05 1 8.03.67.97 1.47 2.06 2.5 2.02 1-.04 1.38-.65 2.6-.65 1.2 0 1.55.65 2.6.63 1.08-.02 1.76-.99 2.42-1.96.76-1.12 1.07-2.2 1.09-2.26-.02-.01-2.09-.8-2.11-3.18zM15.1 6.3c.55-.67.92-1.6.82-2.53-.79.03-1.76.53-2.33 1.19-.51.59-.96 1.54-.84 2.44.88.07 1.79-.44 2.35-1.1z"
+			/>
+		</svg>
+	{/if}
 	Continue with {PROVIDER_LABELS[provider]}
 </Button>

--- a/apps/api/ui/src/routes/+layout.svelte
+++ b/apps/api/ui/src/routes/+layout.svelte
@@ -10,7 +10,7 @@
 
 	let { children } = $props();
 
-	const authSurfacePaths = ['/sign-in', '/consent', '/auth/cli-callback'];
+	const authSurfacePaths = ['/sign-in', '/consent', '/cli-callback'];
 	const showQueryDevtools = $derived(
 		dev && !authSurfacePaths.includes(page.url.pathname),
 	);

--- a/apps/api/ui/src/routes/+layout.svelte
+++ b/apps/api/ui/src/routes/+layout.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { dev } from '$app/environment';
+	import { page } from '$app/state';
 	import { Toaster } from '@epicenter/ui/sonner';
 	import { QueryClientProvider } from '@tanstack/svelte-query';
 	import { SvelteQueryDevtools } from '@tanstack/svelte-query-devtools';
@@ -7,6 +9,11 @@
 	import '../app.css';
 
 	let { children } = $props();
+
+	const authSurfacePaths = ['/sign-in', '/consent', '/auth/cli-callback'];
+	const showQueryDevtools = $derived(
+		dev && !authSurfacePaths.includes(page.url.pathname),
+	);
 </script>
 
 <QueryClientProvider client={queryClient}>
@@ -17,4 +24,6 @@
 
 <Toaster offset={16} closeButton />
 <ModeWatcher defaultMode="dark" track={false} />
-<SvelteQueryDevtools client={queryClient} buttonPosition="bottom-right" />
+{#if showQueryDevtools}
+	<SvelteQueryDevtools client={queryClient} buttonPosition="bottom-right" />
+{/if}

--- a/apps/api/ui/src/routes/auth/cli-callback/+page.svelte
+++ b/apps/api/ui/src/routes/auth/cli-callback/+page.svelte
@@ -30,7 +30,7 @@
 <AuthCard>
 	{#if oauthError}
 		<Card.Header class="justify-items-center text-center">
-			<Card.Title><h1 class="text-xl">Sign-in failed</h1></Card.Title>
+			<Card.Title><h1 class="text-xl font-semibold tracking-tight">Sign-in failed</h1></Card.Title>
 			<Card.Description>
 				The authorization server rejected the request.
 			</Card.Description>
@@ -50,7 +50,7 @@
 		</Card.Content>
 	{:else if !code}
 		<Card.Header class="justify-items-center text-center">
-			<Card.Title><h1 class="text-xl">Sign-in failed</h1></Card.Title>
+			<Card.Title><h1 class="text-xl font-semibold tracking-tight">Sign-in failed</h1></Card.Title>
 			<Card.Description>
 				This page expects an authorization code from the sign-in flow.
 			</Card.Description>
@@ -64,7 +64,7 @@
 		</Card.Content>
 	{:else}
 		<Card.Header class="justify-items-center text-center">
-			<Card.Title><h1 class="text-xl">Signed in to Epicenter CLI</h1></Card.Title>
+			<Card.Title><h1 class="text-xl font-semibold tracking-tight">Signed in to Epicenter CLI</h1></Card.Title>
 			<Card.Description>
 				Copy this code and paste it into the terminal where you ran
 				<code class="font-mono text-xs">epicenter auth login</code>.

--- a/apps/api/ui/src/routes/cli-callback/+page.svelte
+++ b/apps/api/ui/src/routes/cli-callback/+page.svelte
@@ -2,7 +2,7 @@
 	OAuth callback surface for the CLI's OOB authorization code flow.
 
 	The CLI launcher prints an /auth/oauth2/authorize URL; after the user signs
-	in, Better Auth redirects to /auth/cli-callback?code=...&state=.... This
+	in, Better Auth redirects to /cli-callback?code=...&state=.... This
 	page renders the code in a monospace block with a copy button so the user
 	can paste it into the terminal where `epicenter auth login` waits on stdin.
 

--- a/apps/api/ui/src/routes/cli-callback/+page.svelte
+++ b/apps/api/ui/src/routes/cli-callback/+page.svelte
@@ -17,6 +17,7 @@
 	import * as Card from '@epicenter/ui/card';
 	import { CopyButton } from '@epicenter/ui/copy-button';
 	import AuthCard from '$lib/auth/AuthCard.svelte';
+	import AuthHeader from '$lib/auth/AuthHeader.svelte';
 
 	const code = $derived(page.url.searchParams.get('code'));
 	const oauthError = $derived(page.url.searchParams.get('error'));
@@ -29,12 +30,9 @@
 
 <AuthCard>
 	{#if oauthError}
-		<Card.Header class="justify-items-center text-center">
-			<Card.Title><h1 class="text-xl font-semibold tracking-tight">Sign-in failed</h1></Card.Title>
-			<Card.Description>
-				The authorization server rejected the request.
-			</Card.Description>
-		</Card.Header>
+		<AuthHeader title="Sign-in failed">
+			{#snippet description()}The authorization server rejected the request.{/snippet}
+		</AuthHeader>
 		<Card.Content class="flex flex-col gap-2 text-sm">
 			<p>Error: <code class="font-mono text-xs">{oauthError}</code></p>
 			{#if oauthErrorDescription}
@@ -49,12 +47,10 @@
 			</p>
 		</Card.Content>
 	{:else if !code}
-		<Card.Header class="justify-items-center text-center">
-			<Card.Title><h1 class="text-xl font-semibold tracking-tight">Sign-in failed</h1></Card.Title>
-			<Card.Description>
-				This page expects an authorization code from the sign-in flow.
-			</Card.Description>
-		</Card.Header>
+		<AuthHeader title="Sign-in failed">
+			{#snippet description()}This page expects an authorization code from the sign-in
+				flow.{/snippet}
+		</AuthHeader>
 		<Card.Content class="flex flex-col gap-2 text-sm">
 			<p>Error: <code class="font-mono text-xs">missing_code</code></p>
 			<p class="text-muted-foreground">
@@ -63,13 +59,10 @@
 			</p>
 		</Card.Content>
 	{:else}
-		<Card.Header class="justify-items-center text-center">
-			<Card.Title><h1 class="text-xl font-semibold tracking-tight">Signed in to Epicenter CLI</h1></Card.Title>
-			<Card.Description>
-				Copy this code and paste it into the terminal where you ran
-				<code class="font-mono text-xs">epicenter auth login</code>.
-			</Card.Description>
-		</Card.Header>
+		<AuthHeader title="Signed in to Epicenter CLI">
+			{#snippet description()}Copy this code and paste it into the terminal where you
+				ran <code class="font-mono text-xs">epicenter auth login</code>.{/snippet}
+		</AuthHeader>
 		<Card.Content class="flex flex-col gap-3">
 			<pre
 				class="overflow-x-auto rounded-md border bg-muted/50 p-3 text-center font-mono text-sm break-all whitespace-pre-wrap"><code

--- a/apps/api/ui/src/routes/consent/+page.svelte
+++ b/apps/api/ui/src/routes/consent/+page.svelte
@@ -16,6 +16,7 @@
 	import CircleAlertIcon from '@lucide/svelte/icons/circle-alert';
 	import CircleCheckIcon from '@lucide/svelte/icons/circle-check';
 	import AuthCard from '$lib/auth/AuthCard.svelte';
+	import AuthHeader from '$lib/auth/AuthHeader.svelte';
 	import { getOAuthQuery } from '$lib/auth/oauth-query';
 
 	const clientId = $derived(page.url.searchParams.get('client_id'));
@@ -74,17 +75,14 @@
 <svelte:head><title>Authorize: Epicenter</title></svelte:head>
 
 <AuthCard>
-	<Card.Header class="justify-items-center text-center">
-		<Card.Title>
-			<h1 class="text-xl font-semibold tracking-tight">Authorize application</h1>
-		</Card.Title>
-		<Card.Description>
+	<AuthHeader title="Authorize application">
+		{#snippet description()}
 			<span class="font-medium text-foreground">
 				{clientId ?? 'An application'}
 			</span>
 			is requesting access to your Epicenter account.
-		</Card.Description>
-	</Card.Header>
+		{/snippet}
+	</AuthHeader>
 	<Card.Content class="flex flex-col gap-3">
 		{#if scopes.length > 0}
 			<p class="text-sm font-medium">Requested permissions</p>

--- a/apps/api/ui/src/routes/consent/+page.svelte
+++ b/apps/api/ui/src/routes/consent/+page.svelte
@@ -75,7 +75,9 @@
 
 <AuthCard>
 	<Card.Header class="justify-items-center text-center">
-		<Card.Title><h1 class="text-xl">Authorize application</h1></Card.Title>
+		<Card.Title>
+			<h1 class="text-xl font-semibold tracking-tight">Authorize application</h1>
+		</Card.Title>
 		<Card.Description>
 			<span class="font-medium text-foreground">
 				{clientId ?? 'An application'}

--- a/apps/api/ui/src/routes/sign-in/+page.svelte
+++ b/apps/api/ui/src/routes/sign-in/+page.svelte
@@ -224,7 +224,7 @@
 	{:else}
 		<Card.Header class="justify-items-center text-center">
 			<Card.Title>
-				<h1 class="text-2xl font-semibold tracking-tight">epicenter</h1>
+				<h1 class="text-xl font-semibold tracking-tight">epicenter</h1>
 			</Card.Title>
 			<Card.Description>Sign in to your account</Card.Description>
 		</Card.Header>
@@ -247,16 +247,12 @@
 				{#if passkeyAvailable}
 					<Button
 						variant="outline"
-						class="relative h-11 w-full"
+						size="lg"
+						class="w-full gap-2"
 						disabled={busy}
 						onclick={startPasskey}
 					>
-						<span
-							class="absolute left-4 flex size-4 items-center justify-center"
-							aria-hidden="true"
-						>
-							<FingerprintIcon class="size-4" />
-						</span>
+						<FingerprintIcon class="size-4" />
 						Continue with passkey
 					</Button>
 				{/if}

--- a/apps/api/ui/src/routes/sign-in/+page.svelte
+++ b/apps/api/ui/src/routes/sign-in/+page.svelte
@@ -29,6 +29,7 @@
 	import CircleAlertIcon from '@lucide/svelte/icons/circle-alert';
 	import FingerprintIcon from '@lucide/svelte/icons/fingerprint';
 	import AuthCard from '$lib/auth/AuthCard.svelte';
+	import AuthHeader from '$lib/auth/AuthHeader.svelte';
 	import ProviderButton from '$lib/auth/ProviderButton.svelte';
 	import { getOAuthQuery } from '$lib/auth/oauth-query';
 	import {
@@ -167,12 +168,9 @@
 
 <AuthCard>
 	{#if session}
-		<Card.Header class="justify-items-center text-center">
-			<Card.Title>
-				<h1 class="text-xl font-semibold tracking-tight">You're signed in</h1>
-			</Card.Title>
-			<Card.Description>This browser is ready for Epicenter.</Card.Description>
-		</Card.Header>
+		<AuthHeader title="You're signed in">
+			{#snippet description()}This browser is ready for Epicenter.{/snippet}
+		</AuthHeader>
 		<Card.Content class="flex flex-col gap-1 text-center">
 			{#if hasRealName}
 				<p class="text-sm font-medium">{session.name}</p>
@@ -222,12 +220,9 @@
 			</Button>
 		</Card.Footer>
 	{:else}
-		<Card.Header class="justify-items-center text-center">
-			<Card.Title>
-				<h1 class="text-xl font-semibold tracking-tight">epicenter</h1>
-			</Card.Title>
-			<Card.Description>Sign in to your account</Card.Description>
-		</Card.Header>
+		<AuthHeader title="epicenter">
+			{#snippet description()}Sign in to your account{/snippet}
+		</AuthHeader>
 		<Card.Content class="flex flex-col gap-3">
 			{#if enabledProviders.length === 0 && !passkeyAvailable}
 				<Alert.Root variant="destructive">
@@ -248,7 +243,7 @@
 					<Button
 						variant="outline"
 						size="lg"
-						class="w-full gap-2"
+						class="w-full"
 						disabled={busy}
 						onclick={startPasskey}
 					>

--- a/apps/api/ui/svelte.config.js
+++ b/apps/api/ui/svelte.config.js
@@ -5,7 +5,7 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 const config = {
 	kit: {
 		// The cloud UI is one root-based SPA covering every hosted browser
-		// surface (/dashboard, /sign-in, /consent, /auth/cli-callback). The
+		// surface (/dashboard, /sign-in, /consent, /cli-callback). The
 		// fallback shell is deliberately NOT index.html: Workers static assets
 		// auto-serve index.html for `/`, which would shadow the Worker's root
 		// health endpoint. Server routes decide which URLs get the shell.

--- a/apps/api/ui/vite.config.ts
+++ b/apps/api/ui/vite.config.ts
@@ -19,7 +19,11 @@ export default defineConfig({
 				target: `http://localhost:${APPS.API.port}`,
 				changeOrigin: true,
 			},
-			// Forward auth requests for session cookies
+			// Everything under /auth is a Better Auth API endpoint (sign-in/social,
+			// sign-out, oauth2/*, passkey/*, get-session, .well-known/*), so the whole
+			// prefix forwards to the Worker. The hosted auth UI pages (/sign-in,
+			// /consent, /cli-callback) live at root and are served by SvelteKit
+			// directly, so none of them collide with this proxy.
 			'/auth': {
 				target: `http://localhost:${APPS.API.port}`,
 				changeOrigin: true,

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -16,7 +16,7 @@
 	// --- Static assets: cloud UI SPA (built by SvelteKit adapter-static) ---
 	// SvelteKit writes hashed assets to ui/build/_app/* plus a fallback.html
 	// shell. The asset layer serves matching files (/_app/*, favicon) before the
-	// Worker runs; UI URLs (/dashboard, /sign-in, /consent, /auth/cli-callback)
+	// Worker runs; UI URLs (/dashboard, /sign-in, /consent, /cli-callback)
 	// match no file and fall through to Hono, which serves fallback.html for
 	// the routes it owns. The shell is deliberately not index.html so the asset
 	// layer never shadows the Worker's `/` route. `html_handling: none` keeps

--- a/bun.lock
+++ b/bun.lock
@@ -1008,6 +1008,8 @@
       "name": "@epicenter/ui",
       "version": "0.3.0",
       "dependencies": {
+        "@fontsource-variable/geist": "^5.2.9",
+        "@fontsource-variable/geist-mono": "^5.2.8",
         "@lucide/svelte": "^1.7.0",
         "@tanstack/svelte-table": "catalog:",
         "bits-ui": "^2.16.5",
@@ -1535,6 +1537,10 @@
     "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
+    "@fontsource-variable/geist": ["@fontsource-variable/geist@5.2.9", "", {}, "sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ=="],
+
+    "@fontsource-variable/geist-mono": ["@fontsource-variable/geist-mono@5.2.8", "", {}, "sha512-KI5bj+hkkRiHttYHmccotUZ80ZuZyai+RwI1d7UId0clkx/jXxlo8qYK8j54WzmpBjtMoEMPyllV7faDcj+6RA=="],
 
     "@hexagon/base64": ["@hexagon/base64@1.1.28", "", {}, "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="],
 

--- a/docs/adr/0113-hosted-auth-surfaces-are-plain-tool-logins-not-marketing-pages.md
+++ b/docs/adr/0113-hosted-auth-surfaces-are-plain-tool-logins-not-marketing-pages.md
@@ -1,0 +1,46 @@
+# 0113. Hosted auth surfaces are plain tool logins, not marketing pages
+
+- **Status:** Accepted
+- **Date:** 2026-07-07
+- **Relates:** [ADR-0076](0076-the-relational-auth-substrate-is-a-cloud-only-layer-the-instance-composes-neither.md), [ADR-0088](0088-sign-in-is-an-enhancement-never-a-door.md)
+
+## Context
+
+The hosted API exposes browser auth surfaces such as:
+
+- `https://api.epicenter.so/sign-in`
+
+These pages sit on the API origin, not the marketing site. They are part of the auth system: users land there to sign in, consent to a client, or complete a CLI/device flow. The page needs to feel trustworthy at the moment a user grants access, but it should not become a second product homepage.
+
+The visual direction for the hosted sign-in page was intentionally shaped by two references:
+
+- Claude Code artifact: `https://claude.ai/code/artifact/e258decd-92aa-4776-ac2c-666b80397bd6`
+- Tailscale login: `https://login.tailscale.com/login`
+
+The references matter for their shared traits: a compact centered card, low-noise hierarchy, provider-first action, little or no marketing copy, and a page that feels operational rather than promotional.
+
+This matches [ADR-0088](0088-sign-in-is-an-enhancement-never-a-door.md): sign-in adds hosted capabilities to a local-first app, but it is not the primary product surface.
+
+## Decision
+
+Hosted Epicenter auth surfaces should look like plain tool login pages, not marketing pages.
+
+The default shape is:
+
+- centered auth card
+- minimal chrome
+- quiet monochrome hierarchy
+- provider-first sign-in action
+- no feature pitch
+- no marketing navigation
+- copy that explains the immediate auth task
+
+The hosted auth shell may carry the Epicenter mark and enough brand continuity to reassure the user that they are on the right origin. It should not carry landing-page structure, product positioning, testimonials, screenshots, broad navigation, or conversion copy.
+
+## Consequences
+
+The sign-in page may look intentionally understated compared with `epicenter.so`. That is correct. The auth origin is a trust and task surface, not a conversion surface.
+
+Design changes to hosted auth pages should preserve the operational login feel unless a later ADR changes this direction.
+
+External reference URLs may change or disappear, so this ADR records the durable design traits in words rather than relying only on links.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -189,5 +189,6 @@ Each option and the one reason it lost. Terse. This is not the spec.
 | [0110](0110-edit-write-timing-follows-the-value-owner-there-is-no-debounce-tier.md) | Edit write timing follows the value owner; there is no debounce tier | Accepted |
 | [0111](0111-super-chat-v1-exposes-built-in-epicenter-apps-and-defers-extension-surfaces.md) | Super Chat v1 exposes built-in Epicenter apps and defers extension surfaces | Accepted |
 | [0112](0112-the-cli-watcher-is-not-a-callable-action-server.md) | The CLI watcher is not a callable action server | Accepted |
+| [0113](0113-hosted-auth-surfaces-are-plain-tool-logins-not-marketing-pages.md) | Hosted auth surfaces are plain tool logins, not marketing pages | Accepted |
 
 When you add an ADR, add its row here.

--- a/packages/auth/src/node/oob-launcher.test.ts
+++ b/packages/auth/src/node/oob-launcher.test.ts
@@ -120,9 +120,7 @@ test('happy path returns a 3-field OAuthTokenGrant', async () => {
 	expect(body.get('code')).toBe('CODE123');
 	expect(body.get('code_verifier')).toBeTruthy();
 	expect(body.get('client_id')).toBe('epicenter-cli');
-	expect(body.get('redirect_uri')).toBe(
-		'http://localhost:8787/cli-callback',
-	);
+	expect(body.get('redirect_uri')).toBe('http://localhost:8787/cli-callback');
 	expect(body.get('resource')).toBe('http://localhost:8787');
 	expect(printed[0]).toContain('/auth/oauth2/authorize');
 	expect(new URL(printed[0] ?? '').searchParams.get('scope')).toBe(

--- a/packages/auth/src/node/oob-launcher.test.ts
+++ b/packages/auth/src/node/oob-launcher.test.ts
@@ -121,7 +121,7 @@ test('happy path returns a 3-field OAuthTokenGrant', async () => {
 	expect(body.get('code_verifier')).toBeTruthy();
 	expect(body.get('client_id')).toBe('epicenter-cli');
 	expect(body.get('redirect_uri')).toBe(
-		'http://localhost:8787/auth/cli-callback',
+		'http://localhost:8787/cli-callback',
 	);
 	expect(body.get('resource')).toBe('http://localhost:8787');
 	expect(printed[0]).toContain('/auth/oauth2/authorize');

--- a/packages/auth/src/node/oob-launcher.ts
+++ b/packages/auth/src/node/oob-launcher.ts
@@ -3,7 +3,7 @@
  *
  * Prints an authorize URL, optionally opens it in the user's browser,
  * waits for the user to paste the one-time code from
- * `https://api.epicenter.so/auth/cli-callback`, then exchanges the code
+ * `https://api.epicenter.so/cli-callback`, then exchanges the code
  * at `/auth/oauth2/token` with PKCE. Returns a completed OAuth launch result
  * containing a 3-field `OAuthTokenGrant`.
  *

--- a/packages/constants/src/oauth-clients.ts
+++ b/packages/constants/src/oauth-clients.ts
@@ -16,7 +16,7 @@
  * The CLI uses an out-of-band (OOB) authorization-code + PKCE flow against
  * the same `/auth/oauth2/token` endpoint the browser uses. After sign-in
  * on the hosted portal, Better Auth redirects to the API origin's
- * `/auth/cli-callback`, which renders the one-time code; the user pastes
+ * `/cli-callback`, which renders the one-time code; the user pastes
  * it into the terminal. This identifies the CLI app type, not a user,
  * machine, install, or secret. Every CLI install uses the same value.
  */

--- a/packages/constants/src/oauth-routes.ts
+++ b/packages/constants/src/oauth-routes.ts
@@ -6,10 +6,14 @@
  * authorization-server endpoints Epicenter clients (CLI, Tauri, hosted
  * UI) hit during OAuth flows.
  *
- * URL values mirror Better Auth's default issuer path layout. Changing
- * them requires a coordinated Better Auth configuration change; this
- * module is the single place every caller imports from so the change
- * lands once.
+ * The `token`, `authorize`, and `revoke` values mirror Better Auth's default
+ * issuer path layout under `/auth/*`; changing them requires a coordinated
+ * Better Auth configuration change. `cliCallback` is the exception: it is a
+ * page Epicenter owns (the CLI's OOB redirect target), not a Better Auth
+ * endpoint, so it lives at root (`/cli-callback`) alongside the other hosted
+ * auth UI pages (`/sign-in`, `/consent`) instead of inside Better Auth's
+ * reserved `/auth/*` catch-all namespace. This module is the single place
+ * every caller imports from so the change lands once.
  *
  * @example
  * ```ts
@@ -23,8 +27,8 @@ const stripTrailing = (s: string) => s.replace(/\/+$/, '');
 
 export const OAUTH_ROUTES = {
 	cliCallback: {
-		pattern: '/auth/cli-callback',
-		url: (baseURL: string) => `${stripTrailing(baseURL)}/auth/cli-callback`,
+		pattern: '/cli-callback',
+		url: (baseURL: string) => `${stripTrailing(baseURL)}/cli-callback`,
 	},
 	token: {
 		pattern: '/auth/oauth2/token',

--- a/packages/server/src/auth/plugins.test.ts
+++ b/packages/server/src/auth/plugins.test.ts
@@ -186,7 +186,7 @@ test('buildTrustedOAuthClients gives the CLI a callback at each deployment baseU
 		'https://api.acme.example',
 	]) {
 		const cliClient = findCliClient(baseURL);
-		expect(cliClient.redirectUris).toEqual([`${baseURL}/auth/cli-callback`]);
+		expect(cliClient.redirectUris).toEqual([`${baseURL}/cli-callback`]);
 	}
 });
 

--- a/packages/server/src/routes/auth.test.ts
+++ b/packages/server/src/routes/auth.test.ts
@@ -131,10 +131,10 @@ test('GET /consent with a session serves the auth UI shell', async () => {
 	expect(await response.text()).toContain('Svelte auth shell');
 });
 
-test('GET /auth/cli-callback serves a no-store auth UI shell before /auth/*', async () => {
+test('GET /cli-callback serves a no-store auth UI shell', async () => {
 	const app = createAuthRouteApp();
 
-	const response = await app.request('/auth/cli-callback?code=abc');
+	const response = await app.request('/cli-callback?code=abc');
 
 	expect(response.status).toBe(200);
 	expect(response.headers.get('Cache-Control')).toBe('no-store, no-transform');

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -6,7 +6,7 @@
  *   /sign-in          hosted auth UI shell after redirect policy
  *   /sign-in/context  JSON bootstrap for the hosted sign-in UI
  *   /consent          hosted consent UI shell after session policy
- *   /auth/cli-callback CLI OOB landing page shell
+ *   /cli-callback     CLI OOB landing page shell
  *   /auth/.well-known/openid-configuration   OIDC discovery
  *   /auth/.well-known/oauth-authorization-server   OAuth metadata
  *   /.well-known/oauth-protected-resource   resource server metadata

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,6 +30,8 @@
 		"typecheck": "svelte-check --tsconfig ./tsconfig.json"
 	},
 	"dependencies": {
+		"@fontsource-variable/geist": "^5.2.9",
+		"@fontsource-variable/geist-mono": "^5.2.8",
 		"@lucide/svelte": "^1.7.0",
 		"@tanstack/svelte-table": "catalog:",
 		"bits-ui": "^2.16.5",

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -1,5 +1,8 @@
 @import "tailwindcss";
 
+@import "@fontsource-variable/geist/wght.css";
+@import "@fontsource-variable/geist-mono/wght.css";
+
 @import "tw-animate-css";
 
 @import "./prose.css";
@@ -42,12 +45,15 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-	/* One stack for both modes; dark must not redeclare a shorter one. A stack
-	   that bottoms out at bare sans-serif renders Helvetica on macOS, whose
-	   vertical metrics sit text ink ~2px high in a line box, so every icon
-	   beside a label reads as drooping. system-ui (SF Pro, Segoe UI) centers. */
+	/* One stack for both modes; dark must not redeclare a shorter one. Geist gives
+	   the UI the even, product-tool grotesk feel we wanted from Anthropic Sans
+	   without depending on a proprietary brand font. */
 	--font-sans:
-		system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+		"Geist Variable", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+		Roboto, sans-serif;
+	--font-mono:
+		"Geist Mono Variable", "SF Mono", ui-monospace, SFMono-Regular, Menlo,
+		Consolas, monospace;
 	--radius: 0.625rem;
 	/* Dark mode already separates --background from --card (0.129 vs 0.208); light mode
 	   collapsing both to pure white is the asymmetry. This barely-there warm-neutral tint
@@ -129,6 +135,7 @@
 
 @theme inline {
 	--font-sans: var(--font-sans);
+	--font-mono: var(--font-mono);
 	--radius-sm: calc(var(--radius) - 4px);
 	--radius-md: calc(var(--radius) - 2px);
 	--radius-lg: var(--radius);


### PR DESCRIPTION
The CLI callback page no longer lives inside Better Auth's `/auth/*` namespace. That prefix is now reserved for Better Auth API endpoints, while hosted auth UI pages stay at the root beside `/sign-in` and `/consent`.

```txt
Before: /auth/cli-callback?code=abc
After:  /cli-callback?code=abc
```

This removes the dev routing collision where Vite proxied the UI page to the Worker, received the built fallback shell, and then failed to serve the referenced `/_app/immutable/*` chunks. The Vite config can keep a plain `/auth` proxy because there is no longer an exception under that prefix.

## Breaking

The CLI OAuth redirect URI changed. Local and production OAuth client rows need to be re-seeded so `epicenter-cli` registers the new callback URL.

```sh
bun run --cwd apps/api oauth:seed:local
bun run --cwd apps/api oauth:seed:remote
```

Older installed CLIs that still send `/auth/cli-callback` will fail until updated or until a transitional dual-registration is added.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786054631&installation_id=128463665&pr_number=2405&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2405&signature=3fadfe5a3604428ffb638cb458caf5e10b914351d0d7c7fde97d6d0d63840d17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->