### PR TITLE
fix(local-mail): align mail navigation rows

### DIFF
--- a/apps/local-mail/ui/src/lib/components/LabelRail.svelte
+++ b/apps/local-mail/ui/src/lib/components/LabelRail.svelte
@@ -60,6 +60,12 @@
 	</Item.Button>
 {/snippet}
 
+{#snippet groupLabel(text: string)}
+	<p class="px-2 pb-1 pt-4 text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground">
+		{text}
+	</p>
+{/snippet}
+
 <nav class="flex w-56 shrink-0 flex-col border-r border-border bg-background">
 	<div class="border-b border-border p-2">
 		<div class="relative">
@@ -84,9 +90,7 @@
 		</ul>
 
 		{#if categories.length}
-			<p class="px-2 pb-1 pt-4 text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground">
-				Categories
-			</p>
+			{@render groupLabel('Categories')}
 			<ul class="space-y-0.5">
 				{#each categories as label (label.id)}
 					<li>
@@ -101,9 +105,7 @@
 		{/if}
 
 		{#if userLabels.length}
-			<p class="px-2 pb-1 pt-4 text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground">
-				Labels
-			</p>
+			{@render groupLabel('Labels')}
 			<ul class="space-y-0.5">
 				{#each userLabels as label (label.id)}
 					<li>

--- a/apps/local-mail/ui/src/lib/components/LabelRail.svelte
+++ b/apps/local-mail/ui/src/lib/components/LabelRail.svelte
@@ -44,7 +44,7 @@
 	<Item.Button
 		size="sm"
 		class={cn(
-			'w-full justify-start gap-2 rounded px-2 py-1.5 text-sm',
+			'w-full justify-start text-left',
 			selectedLabel === id
 				? 'bg-accent font-medium text-accent-foreground'
 				: 'text-foreground/80 hover:bg-accent/50',

--- a/apps/local-mail/ui/src/lib/components/LabelRail.svelte
+++ b/apps/local-mail/ui/src/lib/components/LabelRail.svelte
@@ -44,7 +44,7 @@
 	<Item.Button
 		size="sm"
 		class={cn(
-			'gap-2 rounded px-2 py-1.5 text-sm',
+			'w-full justify-start gap-2 rounded px-2 py-1.5 text-sm',
 			selectedLabel === id
 				? 'bg-accent font-medium text-accent-foreground'
 				: 'text-foreground/80 hover:bg-accent/50',

--- a/apps/local-mail/ui/src/lib/components/MessageList.svelte
+++ b/apps/local-mail/ui/src/lib/components/MessageList.svelte
@@ -99,7 +99,7 @@
 						size="sm"
 						data-message-id={message.id}
 						class={cn(
-							'items-start rounded-none text-left',
+							'w-full items-start rounded-none text-left',
 							selectedId === message.id
 								? 'bg-accent'
 								: 'hover:bg-accent/40',


### PR DESCRIPTION
The local mail UI had a few small row alignment issues across the message list and label rail. Selected message rows did not stretch cleanly, group labels repeated markup, and label buttons still carried local anatomy classes on top of `Item.Button`.

This keeps the UI behavior small and direct. Selected rows now fill the list, label groups render through one snippet, and label buttons only add placement and state classes on top of the shared item primitive.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786055504&installation_id=128463665&pr_number=2406&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2406&signature=aa5a30e9de6917a5fdb205cbcc6ce28d3a92aa153ece298d2e56119c6ae76c6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->