### PR TITLE
refactor(ui): standardize loading spinners

### DIFF
--- a/.agents/skills/epicenter-ui/SKILL.md
+++ b/.agents/skills/epicenter-ui/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # Epicenter UI
 
-Reach for a local `@epicenter/ui` component before writing one-off UI. Most state surfaces (loading, empty, pending, error, confirm, command, chat) already have a component that owns spacing, color, accessibility, and composition. This skill covers which local component to reach for and the conventions you cannot derive from upstream shadcn-svelte.
+Reach for a local `@epicenter/ui` component before writing one-off UI. Most state surfaces (loading, empty, pending, error, confirm, command, chat) already have a component that owns spacing, color, accessibility, and composition. This skill covers which local component to reach for and the conventions you cannot derive from upstream shadcn-svelte. Svelte decides which branch renders; this skill decides what the branch looks like.
 
 - Use `svelte` for branch mechanics: `{#if}`, `{#await}`, derived state, query state, lifecycle.
 - Use `styling` for Tailwind details, whether a wrapper element is needed, scroll traps, and disabled-state styling.
@@ -92,21 +92,13 @@ Before copying or forking component internals, escalate in order:
 
 For whether a wrapper element is needed at all, and for scroll-layout traps, defer to `styling`. Before pulling upstream component updates, commit local wrapper state, then reconcile upstream changes against local deltas instead of overwriting the wrapper.
 
-## Boundary With Svelte
-
-Svelte decides which branch renders (`{#if}`, `{#await}`, query status, derived state). Epicenter UI decides what the branch looks like (`Loading`, `Spinner`, `Skeleton`, `Progress`, `Empty`, `Command.Empty`, a `tooltip` prop, or chat typing state).
-
 ## Extras And Chat
 
-- Prefer existing local extras such as copy buttons, snippets, links, and chat components before one-off equivalents.
-- Chat list, bubble variants, typing state, copy actions, and auto-scroll live in local wrappers. Compose them; do not duplicate their internals.
-- Copy a small generic primitive into `packages/ui` when it is stable and visual; wrap instead when Epicenter adds domain behavior or persistent app state.
+Prefer existing local extras (copy buttons, snippets, links, chat) before one-off equivalents; chat list, bubble variants, typing, copy actions, and auto-scroll live in local wrappers, so compose them rather than duplicating their internals. Copy a small generic primitive into `packages/ui` only when it is stable and visual; wrap instead when Epicenter adds domain behavior or persistent app state.
 
 ## Avoid
 
-- Raw `animate-spin`, `LoaderCircleIcon`, or `Loader2Icon` in app code. Use `Spinner`.
-- Bare `Loading...` text with no affordance.
-- Raw `animate-pulse` content placeholders. Use `Skeleton`.
-- Hand-wrapped `Tooltip.*` around a `Button` or `Link` when the `tooltip` prop fits.
-- App imports from `packages/ui/src` or the stock `$lib/components/ui/*` path.
-- Duplicating shadcn-svelte or extras internals instead of importing the local wrapper.
+The positive rules above cover the common mistakes. Two structural traps are easy to fall into from generic shadcn-svelte habits and are worth naming on their own:
+
+- App imports from `packages/ui/src` or the stock `$lib/components/ui/*` path. Import through `@epicenter/ui/*`.
+- Copying shadcn-svelte or extras component internals into an app instead of importing the local wrapper, or forking past step 5 of the composition ladder.

--- a/.agents/skills/epicenter-ui/SKILL.md
+++ b/.agents/skills/epicenter-ui/SKILL.md
@@ -3,226 +3,110 @@ name: epicenter-ui
 description: Epicenter UI component selection and composition patterns for Svelte apps using @epicenter/ui. Use when choosing or reviewing local UI components, loading or empty states, skeletons, spinners, command empty states, action pending UI, table/list no-row states, button or link tooltips, modal/dialog/sheet/drawer surfaces, package import boundaries, wrapper minimization, or replacing ad hoc UI such as Loading... text, custom loading dots, raw animate-pulse placeholders, raw tooltip wrappers, or one-off centered status markup.
 metadata:
   author: epicenter
-  version: '1.1'
+  version: '2.0'
 ---
 
 # Epicenter UI
 
-Use the local `@epicenter/ui` package before writing one-off UI. Most state surfaces already have a component with spacing, color, accessibility, and composition handled.
+Reach for a local `@epicenter/ui` component before writing one-off UI. Most state surfaces (loading, empty, pending, error, confirm, command, chat) already have a component that owns spacing, color, accessibility, and composition. This skill covers which local component to reach for and the conventions you cannot derive from upstream shadcn-svelte.
 
-Related skills:
+- Use `svelte` for branch mechanics: `{#if}`, `{#await}`, derived state, query state, lifecycle.
+- Use `styling` for Tailwind details, whether a wrapper element is needed, scroll traps, and disabled-state styling.
 
-- Use `svelte` for branch mechanics: `{#if}`, `{#await}`, derived state, query state, and component lifecycle.
-- Use `styling` for Tailwind details, wrapper element decisions, scroll traps, and disabled-state styling.
-- Use this skill for local component choice and composition.
-
-Read `packages/ui/README.md` when changing `packages/ui` internals, public exports, style hooks, overlay CSS, or shadcn-svelte vendored code. It is the source of truth for the package import boundary, `style-vega` activation, `cn-*` style hooks, Epicenter overlay deltas, and the component update workflow.
+`packages/ui/README.md` is the source of truth for the package internals: import boundary, `style-vega` activation, `cn-*` style hooks, overlay deltas, and the vendored-component update workflow. Read it before changing anything inside `packages/ui`.
 
 ## Package Boundary
 
-App code imports through the public package API:
+App code imports the public API, such as `import { Button } from '@epicenter/ui/button'`. Never import from `packages/ui/src`, never add aliases that reach into it, and never use the stock `$lib/components/ui/*` path. Apps must set `class="style-vega"` on their root element or the scoped `cn-*` rules do not apply. `scripts/check-ui-boundary.ts` owns and enforces this boundary; run `bun run check:ui-boundary` if unsure.
 
-```svelte
-<script lang="ts">
-	import { Button } from '@epicenter/ui/button';
-	import { Loading } from '@epicenter/ui/loading';
-	import '@epicenter/ui/app.css';
-</script>
-```
-
-Files inside `packages/ui/src` import sibling UI files with relative paths, such as `../button/index.js` and `../utils.js`. Do not add app aliases or `kit.alias` entries that point at `packages/ui/src`.
-
-Apps need the preset active with `class="style-vega"` on their root element. Without that class, the scoped `cn-*` rules do not apply.
+Import compound components as namespaces (`import * as Dialog from '@epicenter/ui/dialog'`); import single components by name (`import { Button } from '@epicenter/ui/button'`).
 
 ## Reference Repositories
 
 - [shadcn-svelte](https://github.com/huntabyte/shadcn-svelte): component structure and Svelte composition patterns
 - [shadcn-svelte-extras](https://github.com/ieedan/shadcn-svelte-extras): chat components and extra UI patterns
 - [TanStack Table](https://github.com/TanStack/table): headless table state, not table empty UI
-- [Autumn](https://github.com/useautumn/autumn): billing and usage UI contexts where pending, progress, and empty states matter
+- [Autumn](https://github.com/useautumn/autumn): billing and usage UI where pending, progress, and empty states matter
 
 ## Upstream Grounding
 
-When local `@epicenter/ui` behavior depends on shadcn-svelte component structure, Bits UI composition, snippets, bindable props, or wrapper APIs, use source-backed grounding before relying on memory. If DeepWiki MCP is available, ask a narrow question against `huntabyte/shadcn-svelte`; for extras components, ask against `ieedan/shadcn-svelte-extras`; for table state behavior, ask against `TanStack/table`; for billing UI nouns or usage-state semantics, ask against `useautumn/autumn`. If DeepWiki is unavailable or the repo is not indexed, use upstream source or official docs directly. Treat DeepWiki as orientation, then verify decisive details against local wrappers, installed types, source, or official docs before changing code.
+When local `@epicenter/ui` behavior depends on shadcn-svelte component structure, Bits UI composition, snippets, bindable props, or wrapper APIs, use source-backed grounding before relying on memory. If DeepWiki MCP is available, ask a narrow question against `huntabyte/shadcn-svelte`; for extras components, ask against `ieedan/shadcn-svelte-extras`; for table state, ask against `TanStack/table`; for billing UI nouns, ask against `useautumn/autumn`. If DeepWiki is unavailable or the repo is not indexed, use upstream source or official docs directly. Treat DeepWiki as orientation, then verify decisive details against local wrappers, installed types, source, or official docs before changing code.
 
-Skip DeepWiki for local loading, empty, pending, and tooltip conventions already documented below.
+Upstream shadcn-svelte is the authority for component API and behavior, but `packages/ui` is a pinned 1.x Vega fork, so verify version-sensitive conventions against the local component source before applying them. For example, newer upstream buttons space icons with a `data-icon="inline-start"` attribute; the vendored button predates that and has no `data-icon`, so grep `packages/ui/src` before trusting a fresh upstream idiom. The fork also ships no standalone `Combobox` (compose `Command` in `Popover`; see `timezone-combobox`) or `InputOTP`, though upstream documents both.
 
-## Loading State Choice
+Skip DeepWiki for the local conventions documented below.
 
-Pick the component by what the user is waiting for:
+## Which Local Component
 
-- Generic full-surface pending with only a spinner and optional caption: use `Loading`.
-- Full-surface pending with a title, description, custom media, actions, or exact parity with nearby empty/error markup: compose `Empty.Root` with `Spinner`.
-- Known progress: use `Progress`, not a spinner.
-- Content shape is known: use `Skeleton`, not raw `animate-pulse` divs.
-- Button action pending: disable the `Button` and put a small `Spinner` inside it.
-- Chat assistant typing: use `Chat.BubbleMessage typing`. `LoadingDots` is only for chat bubbles.
-- Command search with no matches: use `Command.Empty`.
-- No rows, no files, no results, or failed surface: use `Empty.*`.
+Reach for the component whose contract matches the job. Several have no upstream equivalent and exist only here: `Loading`, `ConfirmationDialog`, `Modal`, `CommandPalette`, `Chat.*`, `Item`, `SectionHeader`, and `Sidebar.*`.
 
-Do not show plain text such as `Loading...` by itself. Pair status text with an affordance, usually `Spinner`, and choose text that says what is happening: `Checking session`, `Loading tabs`, `Downloading model`.
+Surfaces:
 
-## Composition And Wrappers
+- `Dialog` or `AlertDialog`: confirmations, yes/no prompts, display-only content.
+- `ConfirmationDialog`: reusable simple confirmation before hand-rolling alert-dialog markup.
+- `Modal`: forms, typing, dropdowns, multi-step input. Renders as a dialog on desktop and a drawer on mobile.
+- `Sheet` or `Drawer`: secondary panels and side surfaces.
+- `Command` or `CommandPalette`: command menus and filtered actions.
+- `Item`, `SectionHeader`, `ButtonGroup`, `InputGroup`, `CopyButton`, `Sidebar.*`: list rows, page sections, grouped controls, inline input actions, copy actions, app chrome.
 
-Collapse wrapper elements whenever a component can own the layout directly. `Loading` and `Empty.Root` both center content, lay out a column, set text alignment, and accept `class`, so full-surface pending, empty, and error states usually do not need an outer `div`.
+Dialog, Modal, Sheet, and Drawer need an accessible title. Use an `sr-only` title when the visual design already supplies equivalent context.
 
-```svelte
-<!-- Prefer this -->
-<Loading class="h-dvh" label="Checking session" />
+Waiting and absence states, chosen by what the user is waiting for:
 
-<!-- Avoid this -->
-<div class="flex h-dvh items-center justify-center">
-	<Empty.Root class="border-0">
-		<Empty.Title>Checking session</Empty.Title>
-	</Empty.Root>
-</div>
-```
+- Generic full-surface pending, spinner plus optional caption: `Loading` (it wraps `Empty.Root` plus `Spinner` and accepts sizing `class`, so it usually needs no outer `div`).
+- Full-surface pending that needs a title, description, media, or actions: compose `Empty.Root` with `Spinner`.
+- Known progress: `Progress`.
+- Known content shape: `Skeleton`.
+- Button action pending: disable the `Button` and put a `Spinner` inside it; keep the label when the action needs context.
+- Command search with no match: `Command.Empty`.
+- No rows, files, or results, or a failed surface: `Empty.*`, with different copy for truly-empty versus filter-empty. TanStack Table is headless, so render `Empty.*` yourself when `rows.length === 0`.
+- Chat assistant typing: `Chat.BubbleMessage typing` (`LoadingDots` is chat-only).
 
-Add a wrapper only when it owns a real layout boundary that the component should not own: scroll containment, pane sizing, table cell structure, sticky headers, or sibling spacing.
+## Never Hand-Roll A Spinner
 
-Use this boundary ladder before copying or forking component internals:
+Use `Spinner` for every spinning affordance. Do not put raw `animate-spin`, `LoaderCircleIcon`, or `Loader2Icon` in app code: the local `Spinner` owns the size, color token, and animation. This is the most common local UI violation. Do not print bare `Loading...` text either; pair status text with a `Spinner` and say what is happening (`Checking session`, `Downloading model`).
 
-1. Use an existing local `@epicenter/ui` component and variant.
-2. Pass a `class` or supported prop.
-3. Add a local variant to the wrapper component.
-4. Wrap the component for a real composition boundary.
-5. Copy upstream component code only when Epicenter needs to own behavior, tokens, persistence, shortcuts, or app state.
-
-Import compound components as namespaces, such as `import * as Dialog from '@epicenter/ui/dialog'`. Import single components by name, such as `import { Button } from '@epicenter/ui/button'`.
-
-Dialog, Modal, Sheet, and Drawer surfaces need accessible titles. Use an `sr-only` title when the visual design already supplies equivalent context. Form controls with validation state should expose `aria-invalid` or the local component equivalent.
-
-Before pulling upstream shadcn-svelte component updates, commit local wrapper state. Then reconcile upstream changes against local deltas instead of overwriting the wrapper.
-
-## Surface Choice
-
-Use the component whose interaction contract matches the job:
-
-- `Dialog` or `AlertDialog`: confirmations, simple yes/no prompts, display-only content, and simple action confirmations.
-- `ConfirmationDialog`: reusable simple confirmations before one-off alert dialog markup.
-- `Modal`: forms, typing, dropdowns, multi-step input, or any workflow that collects user data.
-- `Sheet` or `Drawer`: secondary panels, mobile-friendly drawers, and side surfaces.
-- `Command` or `CommandPalette`: command menus, filtered actions, and search empty states.
-- `Item`, `SectionHeader`, `ButtonGroup`, `InputGroup`, `CopyButton`, and `Sidebar.*`: repeated list rows, page sections, grouped controls, inline input actions, copy actions, and app chrome.
-
-## Empty States
-
-Use the `Empty.*` compound component for an absent or failed surface:
-
-```svelte
-<script lang="ts">
-	import * as Empty from '@epicenter/ui/empty';
-	import FolderOpenIcon from '@lucide/svelte/icons/folder-open';
-</script>
-
-<Empty.Root class="py-8">
-	<Empty.Media variant="icon">
-		<FolderOpenIcon class="size-5" />
-	</Empty.Media>
-	<Empty.Title>No recordings yet</Empty.Title>
-	<Empty.Description>Record audio to see transcripts here.</Empty.Description>
-</Empty.Root>
-```
-
-Use `Empty.Content` when the state has an action button. Keep the title short and let the description explain the next step.
-
-## Pending Surfaces
-
-When pending replaces a whole pane or page and only needs a spinner plus optional caption, use `Loading`. It wraps the standard `Empty.Root` plus `Spinner` structure and accepts sizing classes for the surrounding layout:
-
-```svelte
-<script lang="ts">
-	import { Loading } from '@epicenter/ui/loading';
-</script>
-
-<Loading class="h-dvh" label="Checking session" />
-```
-
-`Loading` renders its `label` as supporting caption text. Use `Empty.Root` plus `Spinner` directly when the loading branch needs a title, description, custom media, actions, or exact structural parity with an error or empty branch.
-
-For inline pending inside an existing surface, keep the wrapper small and only use it when no existing element can take the layout classes:
-
-```svelte
-<div class="flex h-full items-center justify-center">
-	<Spinner class="size-5 text-muted-foreground" />
-</div>
-```
-
-## Button Pending
-
-```svelte
-<script lang="ts">
-	import { Button } from '@epicenter/ui/button';
-	import { Spinner } from '@epicenter/ui/spinner';
-</script>
-
-<Button onclick={save} disabled={isSaving}>
-	{#if isSaving}
-		<Spinner class="size-3.5" />
-		<span>Saving</span>
-	{:else}
-		Save
-	{/if}
-</Button>
-```
-
-Keep the label when the action needs context. Icon-only pending is fine for compact row actions where the button tooltip or surrounding label already names the action.
+Do not drop raw `animate-pulse` content placeholders; use `Skeleton`. An intentional pulsing status dot is fine; a fake-content placeholder block is not.
 
 ## Tooltips
 
-`Button` and `Link` have built-in `tooltip` props. Use them before hand-wrapping with `Tooltip.Root`, `Tooltip.Trigger`, and `Tooltip.Content`.
+`Button` and `Link` take a `tooltip` prop. Use it instead of hand-wrapping `Tooltip.Root`, `Tooltip.Trigger`, and `Tooltip.Content`:
 
 ```svelte
-<Button
-	size="icon"
-	variant="ghost"
-	tooltip="Delete recording"
-	onclick={deleteRecording}
->
+<Button size="icon" variant="ghost" tooltip="Delete recording" onclick={deleteRecording}>
 	<TrashIcon />
 </Button>
 ```
 
-The built-in tooltip expects a parent `Tooltip.Provider` somewhere above the trigger. Hand-roll tooltip composition only when the trigger is not a `Button` or `Link`, the content needs custom markup, or the interaction is not a simple tooltip.
+The prop expects a `Tooltip.Provider` somewhere above the trigger. Hand-roll `Tooltip.*` only when the trigger is not a `Button` or `Link`, or the content is not a simple label.
 
-## Table and List Empty States
+## Composition Ladder
 
-TanStack Table is headless. It gives row state, sorting, filtering, and pagination, but it does not decide what empty UI should look like. When `table.getRowModel().rows.length === 0`, render `Empty.Root` in the table body or the surrounding list panel.
+Before copying or forking component internals, escalate in order:
 
-Use different copy for true empty data and filtered empty data:
+1. Use an existing local component and its variants.
+2. Pass a `class` or supported prop.
+3. Add a local variant to the wrapper component.
+4. Wrap the component for a real composition boundary (scroll containment, pane sizing, table cell structure, sticky header).
+5. Copy upstream component code only when Epicenter needs to own behavior, tokens, persistence, shortcuts, or app state.
 
-```svelte
-{#if rows.length === 0}
-	<Empty.Root class="min-h-64 border-0">
-		<Empty.Title>
-			{filter ? 'No results match your filters' : 'No recordings yet'}
-		</Empty.Title>
-		<Empty.Description>
-			{filter ? 'Try a different search term.' : 'Record audio to see transcripts here.'}
-		</Empty.Description>
-	</Empty.Root>
-{/if}
-```
-
-## Avoid
-
-- Plain `Loading...` text.
-- Hand-composed full-page `Empty.Root` plus `Spinner` when the standard `Loading` caption shell fits.
-- Raw `Loader2Icon`, `LoaderCircleIcon`, or custom `animate-spin` outside `packages/ui`. Use `Spinner`.
-- Raw `animate-pulse` placeholder blocks. Use `Skeleton`.
-- Loading dots outside chat messages.
-- Empty state copy inside an unstructured centered `div` when `Empty.*` would fit.
-- Tooltip wrappers around `Button` or `Link` when the `tooltip` prop is enough.
-- Extra wrapper `div`s around `Empty.Root` just to center or stack content.
-- Duplicating component internals from shadcn-svelte or extras instead of importing the local `@epicenter/ui` wrapper.
-- App imports from `packages/ui/src` or aliases that bypass `@epicenter/ui/*`.
+For whether a wrapper element is needed at all, and for scroll-layout traps, defer to `styling`. Before pulling upstream component updates, commit local wrapper state, then reconcile upstream changes against local deltas instead of overwriting the wrapper.
 
 ## Boundary With Svelte
 
-Svelte decides which branch renders: `{#if}`, `{#await}`, query status, or derived state. Epicenter UI decides what the branch looks like: `Loading`, `Spinner`, `Skeleton`, `Progress`, `Empty`, `Command.Empty`, `Button` or `Link` tooltip, or chat typing state.
+Svelte decides which branch renders (`{#if}`, `{#await}`, query status, derived state). Epicenter UI decides what the branch looks like (`Loading`, `Spinner`, `Skeleton`, `Progress`, `Empty`, `Command.Empty`, a `tooltip` prop, or chat typing state).
 
 ## Extras And Chat
 
-- Prefer existing local extras such as copy buttons, snippets, links, and chat components before adding one-off equivalents.
-- Chat list, message bubble variants, typing state, copy actions, and auto-scroll behavior belong in local wrappers. App code should compose them, not duplicate their internals.
-- Copy small generic primitives into `packages/ui` when the primitive is stable and visual. Wrap instead when Epicenter adds domain behavior or persistent app state.
+- Prefer existing local extras such as copy buttons, snippets, links, and chat components before one-off equivalents.
+- Chat list, bubble variants, typing state, copy actions, and auto-scroll live in local wrappers. Compose them; do not duplicate their internals.
+- Copy a small generic primitive into `packages/ui` when it is stable and visual; wrap instead when Epicenter adds domain behavior or persistent app state.
+
+## Avoid
+
+- Raw `animate-spin`, `LoaderCircleIcon`, or `Loader2Icon` in app code. Use `Spinner`.
+- Bare `Loading...` text with no affordance.
+- Raw `animate-pulse` content placeholders. Use `Skeleton`.
+- Hand-wrapped `Tooltip.*` around a `Button` or `Link` when the `tooltip` prop fits.
+- App imports from `packages/ui/src` or the stock `$lib/components/ui/*` path.
+- Duplicating shadcn-svelte or extras internals instead of importing the local wrapper.

--- a/.agents/skills/epicenter-ui/SKILL.md
+++ b/.agents/skills/epicenter-ui/SKILL.md
@@ -53,14 +53,28 @@ Dialog, Modal, Sheet, and Drawer need an accessible title. Use an `sr-only` titl
 
 Waiting and absence states, chosen by what the user is waiting for:
 
-- Generic full-surface pending, spinner plus optional caption: `Loading` (it wraps `Empty.Root` plus `Spinner` and accepts sizing `class`, so it usually needs no outer `div`).
+- Generic full-surface pending, spinner plus optional caption: `Loading` (it wraps `Empty.Root` plus `Spinner` and accepts a sizing `class` plus a `label` caption, so it usually needs no outer `div`).
 - Full-surface pending that needs a title, description, media, or actions: compose `Empty.Root` with `Spinner`.
 - Known progress: `Progress`.
 - Known content shape: `Skeleton`.
-- Button action pending: disable the `Button` and put a `Spinner` inside it; keep the label when the action needs context.
+- Button action pending: disable the `Button` and put a `Spinner` inside it; keep the label when the action needs context, though icon-only pending is fine for a compact row action the tooltip or a nearby label already names.
 - Command search with no match: `Command.Empty`.
 - No rows, files, or results, or a failed surface: `Empty.*`, with different copy for truly-empty versus filter-empty. TanStack Table is headless, so render `Empty.*` yourself when `rows.length === 0`.
 - Chat assistant typing: `Chat.BubbleMessage typing` (`LoadingDots` is chat-only).
+
+`Loading` is the common case: pass the surrounding layout as `class` and the caption as `label`.
+
+```svelte
+<Loading class="h-dvh" label="Checking session" />
+```
+
+For inline pending inside an existing surface, drop to a bare `Spinner` and add a wrapper only when no existing element can take the layout classes.
+
+```svelte
+<div class="flex h-full items-center justify-center">
+	<Spinner class="size-5 text-muted-foreground" />
+</div>
+```
 
 ## Never Hand-Roll A Spinner
 

--- a/apps/api/ui/src/routes/dashboard/+layout.svelte
+++ b/apps/api/ui/src/routes/dashboard/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Button } from '@epicenter/ui/button';
 	import * as Card from '@epicenter/ui/card';
-	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '@epicenter/ui/spinner';
 	import { createMutation } from '@tanstack/svelte-query';
 	import { mutationOptions } from 'wellcrafted/query';
 	import UserMenu from '$lib/components/UserMenu.svelte';
@@ -46,7 +46,7 @@
 					disabled={startSignIn.isPending}
 				>
 					{#if startSignIn.isPending}
-						<LoaderCircle class="size-4 animate-spin" />
+						<Spinner class="size-4" />
 						Signing in…
 					{:else}
 						Sign in with Epicenter

--- a/apps/vocab/src/routes/components/DictationButton.svelte
+++ b/apps/vocab/src/routes/components/DictationButton.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { Button } from '@epicenter/ui/button';
 	import { toast } from '@epicenter/ui/sonner';
+	import { Spinner } from '@epicenter/ui/spinner';
 	import CircleStopIcon from '@lucide/svelte/icons/circle-stop';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import MicIcon from '@lucide/svelte/icons/mic';
 	import { extractErrorMessage } from 'wellcrafted/error';
 	import { dictation } from '$lib/state/dictation.svelte';
@@ -69,7 +69,7 @@
 	{:else if dictation.status === 'listening'}
 		<CircleStopIcon />
 	{:else if dictation.isTranscribing}
-		<LoaderCircleIcon class="animate-spin" />
+		<Spinner />
 	{:else}
 		<MicIcon />
 	{/if}

--- a/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
+++ b/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
@@ -7,10 +7,10 @@
 	import { Input } from '@epicenter/ui/input';
 	import { Link } from '@epicenter/ui/link';
 	import * as Select from '@epicenter/ui/select';
+	import { Spinner } from '@epicenter/ui/spinner';
 	import { Textarea } from '@epicenter/ui/textarea';
 	import { cn } from '@epicenter/ui/utils';
 	import { createMutation } from '@tanstack/svelte-query';
-	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
 	import { mutationOptions } from 'wellcrafted/query';
 	import CopyablePre from '$lib/components/copyable/CopyablePre.svelte';
 	import {
@@ -212,7 +212,7 @@
 				disabled={startSignIn.isPending || accountLocked}
 			>
 				{#if startSignIn.isPending}
-					<LoaderCircle class="size-4 animate-spin" />
+					<Spinner class="size-4" />
 					Signing in...
 				{:else if auth.state.status === 'reauth-required'}
 					Reconnect

--- a/apps/whispering/src/routes/(app)/(config)/settings/account/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/account/+page.svelte
@@ -2,8 +2,8 @@
 	import { Button } from '@epicenter/ui/button';
 	import * as Field from '@epicenter/ui/field';
 	import { toastOnError } from '@epicenter/ui/sonner';
+	import { Spinner } from '@epicenter/ui/spinner';
 	import { createMutation } from '@tanstack/svelte-query';
-	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
 	import LogOut from '@lucide/svelte/icons/log-out';
 	import { mutationOptions } from 'wellcrafted/query';
 	import { auth } from '#platform/auth';
@@ -64,7 +64,7 @@
 					disabled={signOut.isPending || accountLocked}
 				>
 					{#if signOut.isPending}
-						<LoaderCircle class="size-4 animate-spin" />
+						<Spinner class="size-4" />
 					{:else}
 						<LogOut class="size-4" />
 					{/if}
@@ -84,7 +84,7 @@
 					disabled={startSignIn.isPending || accountLocked}
 				>
 					{#if startSignIn.isPending}
-						<LoaderCircle class="size-4 animate-spin" />
+						<Spinner class="size-4" />
 						Signing in...
 					{:else if auth.state.status === 'reauth-required'}
 						Reconnect

--- a/packages/app-shell/src/inference-picker/inference-picker.svelte
+++ b/packages/app-shell/src/inference-picker/inference-picker.svelte
@@ -21,6 +21,7 @@
 	import { Input } from '@epicenter/ui/input';
 	import { Label } from '@epicenter/ui/label';
 	import * as Popover from '@epicenter/ui/popover';
+	import { Spinner } from '@epicenter/ui/spinner';
 	import ArrowLeft from '@lucide/svelte/icons/arrow-left';
 	import Check from '@lucide/svelte/icons/check';
 	import ChevronsUpDown from '@lucide/svelte/icons/chevrons-up-down';
@@ -28,7 +29,6 @@
 	import Eye from '@lucide/svelte/icons/eye';
 	import EyeOff from '@lucide/svelte/icons/eye-off';
 	import HardDrive from '@lucide/svelte/icons/hard-drive';
-	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
 	import Plus from '@lucide/svelte/icons/plus';
 	import RefreshCw from '@lucide/svelte/icons/refresh-cw';
 	import Trash2 from '@lucide/svelte/icons/trash-2';
@@ -318,7 +318,7 @@
 								onSelect={() => refreshConnection(connection.baseUrl)}
 							>
 								{#if refreshingBaseUrls.has(connection.baseUrl)}
-									<LoaderCircle class="size-4 animate-spin" />
+									<Spinner class="size-4" />
 								{:else}
 									<RefreshCw class="size-4" />
 								{/if}
@@ -425,7 +425,7 @@
 						<Label class="text-xs">Model</Label>
 						{#if discovering}
 							<p class="flex items-center gap-2 text-xs text-muted-foreground">
-								<LoaderCircle class="size-3.5 animate-spin" /> Loading models...
+								<Spinner class="size-3.5" /> Loading models...
 							</p>
 						{:else if discovered && discovered.length > 0}
 							<p class="text-xs text-muted-foreground">

--- a/packages/app-shell/src/sign-in-migration/sign-in-migration-dialog.svelte
+++ b/packages/app-shell/src/sign-in-migration/sign-in-migration-dialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Button } from '@epicenter/ui/button';
 	import * as Dialog from '@epicenter/ui/dialog';
-	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '@epicenter/ui/spinner';
 	import type { SignInMigrationState } from './create-sign-in-migration.svelte';
 
 	/**
@@ -39,7 +39,7 @@
 					onclick={() => migration.deleteFromDevice()}
 				>
 					{#if migration.phase === 'deleting'}
-						<LoaderCircle class="size-4 animate-spin" />
+						<Spinner class="size-4" />
 					{/if}
 					Delete from device
 				</Button>
@@ -48,7 +48,7 @@
 					onclick={() => migration.addToAccount()}
 				>
 					{#if migration.phase === 'adding'}
-						<LoaderCircle class="size-4 animate-spin" />
+						<Spinner class="size-4" />
 					{/if}
 					Add to my account
 				</Button>

--- a/packages/app-shell/src/workspace-gate/workspace-gate.svelte
+++ b/packages/app-shell/src/workspace-gate/workspace-gate.svelte
@@ -31,8 +31,8 @@
 	import * as Empty from '@epicenter/ui/empty';
 	import { Loading } from '@epicenter/ui/loading';
 	import { toast } from '@epicenter/ui/sonner';
+	import { Spinner } from '@epicenter/ui/spinner';
 	import DatabaseZapIcon from '@lucide/svelte/icons/database-zap';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import LogOutIcon from '@lucide/svelte/icons/log-out';
 	import RefreshCwIcon from '@lucide/svelte/icons/refresh-cw';
 	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
@@ -134,7 +134,7 @@
 							disabled={forgettingDevice}
 						>
 							{#if forgettingDevice}
-								<LoaderCircleIcon class="size-4 animate-spin" />
+								<Spinner class="size-4" />
 							{:else}
 								<DatabaseZapIcon class="size-4" />
 							{/if}


### PR DESCRIPTION
Tightens the Epicenter UI skill around the real component-selection work it owns, then applies that guidance to ordinary app loading states.

The skill now focuses on local UI surface choices, live violator patterns, sibling routing, and the fork caveats that matter in this repo. The app cleanup replaces hand-rolled Lucide loader icons with the shared `Spinner` component in pending and reconnecting states, while leaving package internals and bespoke recording HUD icons out of scope.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786056465&installation_id=128463665&pr_number=2408&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2408&signature=31c178201571fd43355696169e339059998b22f065f25a23eee284360dcb9818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->