### PR TITLE
feat(local-mail): resolve Gmail credentials at machine tier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ bench-oneshot.ts
 !.env*.example
 .dev.vars
 apps/local-books/.infisical.json
-apps/local-mail/.infisical.json
 
 # Vercel
 .vercel

--- a/apps/local-mail/.env.example
+++ b/apps/local-mail/.env.example
@@ -5,8 +5,14 @@
 # concrete client id that minted it, so a later client-id change fails loudly and
 # asks you to reconnect instead of surfacing as Google's opaque invalid_grant.
 #
-# In the monorepo, keep these in your personal Infisical project at
-# prod /apps/local-mail and inject them with the app-local .infisical.json.
+# Provide these in your environment for the first connect or seed-token: an
+# export, a local .env, or a secrets manager such as
+# `infisical run --path=/apps/local-mail -- ...` if that is how you keep
+# secrets.
+#
+# After the first successful connect or refresh, Local Mail caches the pair to a
+# 0600 <data-dir>/provider.json. Later runs and other git worktrees on this
+# machine read it from there with no per-worktree config.
 
 GMAIL_CLIENT_ID=
 GMAIL_CLIENT_SECRET=

--- a/apps/local-mail/.infisical.json.example
+++ b/apps/local-mail/.infisical.json.example
@@ -1,5 +1,0 @@
-{
-	"workspaceId": "<your-personal-infisical-project-id>",
-	"defaultEnvironment": "prod",
-	"gitBranchToEnvironmentMapping": null
-}

--- a/apps/local-mail/README.md
+++ b/apps/local-mail/README.md
@@ -32,17 +32,18 @@ token records the concrete client id that minted it, and later refreshes refuse
 if the configured client id changes:
 
 ```sh
-infisical run --path=/apps/local-mail -- \
-  bun run src/bin.ts connect
+bun run src/bin.ts connect
 ```
 
-The app-local Infisical config should point at your personal secrets project,
-with those two secrets under `prod /apps/local-mail`. This is per-person
-bring-your-own provider configuration, not Epicenter-hosted infrastructure. Copy
-`.infisical.json.example` to `.infisical.json` and keep the real file local.
-That file is ignored because each operator has a different personal Infisical
-project. The committed `apps/api` and `ops` configs point at Epicenter's hosted
-project instead. See [`.env.example`](.env.example) for the canonical names.
+The client pair is machine-level bring-your-own configuration, not Epicenter
+infrastructure. Provide it however you keep local secrets for the first connect:
+an export, a local `.env`, or a secrets manager such as
+`infisical run --path=/apps/local-mail -- bun run src/bin.ts connect`. On the
+first successful connect or refresh, Local Mail caches the pair to a 0600
+`<data-dir>/provider.json` sibling to `credentials.json`. Every later run and
+every other git worktree on this machine reads it from there, so no per-worktree
+secrets config is needed. See [`.env.example`](.env.example) for the canonical
+names.
 
 Local Mail requests `gmail.modify` so write-through label changes can round-trip
 through Gmail. Although Google grants send at the same OAuth layer, Local Mail
@@ -55,18 +56,15 @@ here rather than on the first sync, and the account email comes from the
 Gmail profile instead of being typed:
 
 ```sh
-infisical run --path=/apps/local-mail -- \
-  bun run src/bin.ts seed-token <refresh-token>
+bun run src/bin.ts seed-token <refresh-token>
 ```
 
 Build or refresh the mirror:
 
 ```sh
-infisical run --path=/apps/local-mail -- \
-  bun run src/bin.ts sync --full
+bun run src/bin.ts sync --full
 
-infisical run --path=/apps/local-mail -- \
-  bun run src/bin.ts sync --watch
+bun run src/bin.ts sync --watch
 ```
 
 Check connection and mirror state:
@@ -148,8 +146,9 @@ Tools:
 ## Config
 
 - `GMAIL_CLIENT_ID` / `GMAIL_CLIENT_SECRET`: the BYO Google OAuth Desktop client
-  keys. The resolver reads them lazily at connect/refresh; missing credentials
-  fail loudly naming the exact variables.
+  keys. The resolver reads them at connect/refresh from the environment first,
+  then `<data-dir>/provider.json`, which is cached as `0600` on first connect.
+  Missing credentials fail loudly naming the exact variables.
 - `LOCAL_MAIL_ACCOUNT`: optional account override for `sync`, `query`, and
   `mcp`. Required only when more than one account is connected.
 - `LOCAL_MAIL_DIR`: data directory override.

--- a/apps/local-mail/package.json
+++ b/apps/local-mail/package.json
@@ -15,9 +15,9 @@
 		"./http/api": "./src/http/api.ts"
 	},
 	"scripts": {
-		"connect": "infisical run --path=/apps/local-mail -- bun run src/bin.ts connect",
-		"sync": "infisical run --path=/apps/local-mail -- bun run src/bin.ts sync",
-		"status": "infisical run --path=/apps/local-mail -- bun run src/bin.ts status",
+		"connect": "bun run src/bin.ts connect",
+		"sync": "bun run src/bin.ts sync",
+		"status": "bun run src/bin.ts status",
 		"test": "bun test",
 		"typecheck": "tsc --noEmit && tsc --noEmit -p test-support/tsconfig.json"
 	},

--- a/apps/local-mail/src/config.ts
+++ b/apps/local-mail/src/config.ts
@@ -2,9 +2,10 @@ import { credentialsFilePath, resolveDataDir } from './paths.ts';
 
 /**
  * Fully-resolved runtime configuration. Precedence is env > built-in defaults;
- * there is no `config.json` yet (local-books' file-config layer is not ported
- * until Phase 2's connect flow needs per-mode `clientId` selection). Base-URL
- * fields are overridable so tests can point the client at a mock Gmail server.
+ * BYO client credentials are resolved at the machine tier by
+ * `gmailCredentialSource` (env, then `<data-dir>/provider.json`), so no
+ * `config.json` is needed here. Base-URL fields are overridable so tests can
+ * point the client at a mock Gmail server.
  *
  * Unlike `apps/local-books`' `AppConfig.entities` (a configurable QuickBooks
  * entity list), Gmail's mirrored set is fixed: messages and labels. There is
@@ -61,7 +62,7 @@ export function loadConfig(): AppConfig {
 	return {
 		dataDir,
 		// The Google OAuth client keys are NOT read here: they are resolved lazily
-		// at the connect/refresh site from GMAIL_CLIENT_ID / GMAIL_CLIENT_SECRET.
+		// at the connect/refresh site by gmailCredentialSource.
 		// The env override exists for the MCP subprocess test, which cannot
 		// inject an AppConfig in-process. The OAuth endpoints have no such
 		// consumer: in-process tests override the AppConfig fields directly.

--- a/apps/local-mail/src/gmail-credentials.test.ts
+++ b/apps/local-mail/src/gmail-credentials.test.ts
@@ -29,7 +29,7 @@ test('resolveGmailCredentials reads the BYO Gmail keyset', () => {
 
 test('resolveGmailCredentials names missing variables', () => {
 	expect(() => resolveGmailCredentials(readFrom({}))).toThrow(
-		'GMAIL_CLIENT_ID and GMAIL_CLIENT_SECRET',
+		'GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET',
 	);
 	expect(() =>
 		resolveGmailCredentials(readFrom({ GMAIL_CLIENT_ID: 'client-id' })),

--- a/apps/local-mail/src/gmail-credentials.ts
+++ b/apps/local-mail/src/gmail-credentials.ts
@@ -4,7 +4,10 @@ import {
 	resolveProviderCredentials,
 } from '@epicenter/constants/provider-credentials';
 import { providerFilePath } from './paths.ts';
-import { readProviderFile, writeProviderFileIfAbsent } from './provider-store.ts';
+import {
+	readProviderFile,
+	writeProviderFileIfAbsent,
+} from './provider-store.ts';
 
 /**
  * The single BYO Google OAuth Desktop client Local Mail connects through
@@ -18,9 +21,10 @@ export const GMAIL_SPEC = {
 	environmentRoles: ['CLIENT_ID', 'CLIENT_SECRET'],
 } as const satisfies ProviderCredentialSpec<'default'>;
 
-export function resolveGmailCredentials(
-	read?: CredentialSource,
-): { clientId: string; clientSecret: string } {
+export function resolveGmailCredentials(read?: CredentialSource): {
+	clientId: string;
+	clientSecret: string;
+} {
 	const credentials = resolveProviderCredentials(GMAIL_SPEC, 'default', read);
 	return {
 		clientId: credentials.CLIENT_ID,
@@ -39,9 +43,7 @@ export function gmailCredentialSource(dataDir: string): CredentialSource {
 		const fromEnv = process.env[name];
 		if (fromEnv !== undefined && fromEnv.length > 0) return fromEnv;
 		const fromFile = file[name];
-		return fromFile !== undefined && fromFile.length > 0
-			? fromFile
-			: undefined;
+		return fromFile !== undefined && fromFile.length > 0 ? fromFile : undefined;
 	};
 }
 

--- a/apps/local-mail/src/gmail-credentials.ts
+++ b/apps/local-mail/src/gmail-credentials.ts
@@ -1,25 +1,57 @@
-type CredentialSource = (name: string) => string | undefined;
+import {
+	type CredentialSource,
+	type ProviderCredentialSpec,
+	resolveProviderCredentials,
+} from '@epicenter/constants/provider-credentials';
+import { providerFilePath } from './paths.ts';
+import { readProviderFile, writeProviderFileIfAbsent } from './provider-store.ts';
 
 /**
- * Resolve the single Google OAuth Desktop client used by BYO Local Mail.
- * Local Mail is a local app: the operator supplies one client id/secret pair,
- * and the stored token records the concrete client id that minted it so refresh
- * can fail loudly if the configured client changes later.
+ * The single BYO Google OAuth Desktop client Local Mail connects through
+ * (ADR-0108). Gmail issues one client, not a per-account keyset, so it is a
+ * single-environment provider: names stay unqualified GMAIL_CLIENT_ID /
+ * GMAIL_CLIENT_SECRET.
  */
-export function resolveGmailCredentials(
-	read: CredentialSource = (name) => process.env[name],
-): { clientId: string; clientSecret: string } {
-	const clientId = read('GMAIL_CLIENT_ID');
-	const clientSecret = read('GMAIL_CLIENT_SECRET');
-	if (!clientId || !clientSecret) {
-		const missing = [
-			clientId ? null : 'GMAIL_CLIENT_ID',
-			clientSecret ? null : 'GMAIL_CLIENT_SECRET',
-		].filter((name): name is string => name !== null);
-		throw new Error(
-			`Missing Gmail OAuth credentials: set ${missing.join(' and ')} (see .env.example).`,
-		);
-	}
+export const GMAIL_SPEC = {
+	prefix: 'GMAIL',
+	environments: ['default'],
+	environmentRoles: ['CLIENT_ID', 'CLIENT_SECRET'],
+} as const satisfies ProviderCredentialSpec<'default'>;
 
-	return { clientId, clientSecret };
+export function resolveGmailCredentials(
+	read?: CredentialSource,
+): { clientId: string; clientSecret: string } {
+	const credentials = resolveProviderCredentials(GMAIL_SPEC, 'default', read);
+	return {
+		clientId: credentials.CLIENT_ID,
+		clientSecret: credentials.CLIENT_SECRET,
+	};
+}
+
+/**
+ * The machine-tier credential source: env wins per-name, then the 0600
+ * provider.json at the data-dir root. Env stays the override/CI/test seam; the
+ * file is the durable default every worktree shares.
+ */
+export function gmailCredentialSource(dataDir: string): CredentialSource {
+	const file = readProviderFile(providerFilePath(dataDir));
+	return (name) => {
+		const fromEnv = process.env[name];
+		if (fromEnv !== undefined && fromEnv.length > 0) return fromEnv;
+		const fromFile = file[name];
+		return fromFile !== undefined && fromFile.length > 0
+			? fromFile
+			: undefined;
+	};
+}
+
+/** Cache env-supplied client creds to the machine file after a good grant, if absent. */
+export function persistGmailProviderCredentials(
+	dataDir: string,
+	creds: { clientId: string; clientSecret: string },
+): void {
+	writeProviderFileIfAbsent(providerFilePath(dataDir), {
+		GMAIL_CLIENT_ID: creds.clientId,
+		GMAIL_CLIENT_SECRET: creds.clientSecret,
+	});
 }

--- a/apps/local-mail/src/oauth.test.ts
+++ b/apps/local-mail/src/oauth.test.ts
@@ -31,7 +31,8 @@ let configId = 0;
 
 function config(overrides: Partial<AppConfig>): AppConfig {
 	const dataDir =
-		overrides.dataDir ?? `/tmp/local-mail-oauth-test-${process.pid}-${configId}`;
+		overrides.dataDir ??
+		`/tmp/local-mail-oauth-test-${process.pid}-${configId}`;
 	configId += 1;
 	return {
 		dataDir,

--- a/apps/local-mail/src/oauth.test.ts
+++ b/apps/local-mail/src/oauth.test.ts
@@ -27,16 +27,21 @@ import type { TokenSet } from './tokens.ts';
 process.env.GMAIL_CLIENT_ID = 'client-id-123';
 process.env.GMAIL_CLIENT_SECRET = 'client-secret-456';
 
+let configId = 0;
+
 function config(overrides: Partial<AppConfig>): AppConfig {
+	const dataDir =
+		overrides.dataDir ?? `/tmp/local-mail-oauth-test-${process.pid}-${configId}`;
+	configId += 1;
 	return {
-		dataDir: '/tmp/local-mail-oauth-test',
+		dataDir,
 		apiBase: 'http://127.0.0.1:0',
 		authorizeUrl: 'http://127.0.0.1:0/auth',
 		tokenUrl: 'http://127.0.0.1:0/token',
 		historySafeWindowDays: 5,
 		fullBackstopDays: 30,
 		pageSize: 100,
-		credentialsPath: '/tmp/local-mail-oauth-test/credentials.json',
+		credentialsPath: `${dataDir}/credentials.json`,
 		account: null,
 		readOnly: false,
 		...overrides,

--- a/apps/local-mail/src/oauth.ts
+++ b/apps/local-mail/src/oauth.ts
@@ -7,7 +7,11 @@ import {
 import { Ok, type Result } from 'wellcrafted/result';
 import type { AppConfig } from './config.ts';
 import { createGmailClient } from './gmail-client.ts';
-import { resolveGmailCredentials } from './gmail-credentials.ts';
+import {
+	gmailCredentialSource,
+	persistGmailProviderCredentials,
+	resolveGmailCredentials,
+} from './gmail-credentials.ts';
 import {
 	type TokenGrantError,
 	type TokenSet,
@@ -115,12 +119,12 @@ function httpOptions(config: AppConfig) {
  * Resolve the BYO Gmail OAuth client lazily at the connect/refresh site rather
  * than eagerly in `loadConfig`, so credential-free verbs never read secrets.
  */
-function loadGmailCredentials(): Result<
+function loadGmailCredentials(config: AppConfig): Result<
 	{ clientId: string; clientSecret: string },
 	OAuthError
 > {
 	try {
-		return Ok(resolveGmailCredentials());
+		return Ok(resolveGmailCredentials(gmailCredentialSource(config.dataDir)));
 	} catch (cause) {
 		return OAuthError.MissingCredentials({
 			reason: extractErrorMessage(cause),
@@ -198,7 +202,8 @@ export async function runAuthorizationFlow(
 ): GrantResult {
 	// Resolve the BYO OAuth keyset lazily; this is the connect path's only
 	// credentials read. Destructured so the narrowing survives the awaits.
-	const { data: credentials, error: credentialsError } = loadGmailCredentials();
+	const { data: credentials, error: credentialsError } =
+		loadGmailCredentials(config);
 	if (credentialsError) return { data: null, error: credentialsError };
 	const { clientId, clientSecret } = credentials;
 
@@ -265,11 +270,14 @@ export async function runAuthorizationFlow(
 			grant,
 		);
 		if (error) return { data: null, error };
-		return tokenSetFromGrant(grant, {
+		const { data: token, error: tokenError } = tokenSetFromGrant(grant, {
 			accountEmail,
 			clientIdUsed: clientId,
 			now: options.now(),
 		});
+		if (tokenError) return { data: null, error: tokenError };
+		persistGmailProviderCredentials(config.dataDir, credentials);
+		return Ok(token);
 	} catch (cause) {
 		if (cause instanceof oauth.AuthorizationResponseError) {
 			return OAuthError.AuthorizationDenied({
@@ -323,7 +331,8 @@ export async function refreshAccessToken(
 	token: TokenSet,
 	now: () => number,
 ): GrantResult {
-	const { data: credentials, error: credentialsError } = loadGmailCredentials();
+	const { data: credentials, error: credentialsError } =
+		loadGmailCredentials(config);
 	if (credentialsError) return { data: null, error: credentialsError };
 	// A refresh token is bound to the client that minted it; refreshing through a
 	// different client id (the environment's key was rotated) dies as a bare
@@ -342,6 +351,7 @@ export async function refreshAccessToken(
 		refreshToken: token.refreshToken,
 	});
 	if (error) return { data: null, error };
+	persistGmailProviderCredentials(config.dataDir, credentials);
 	// Rotation: Google may omit refresh_token when the old one stays valid.
 	return tokenSetFromGrant(grant, {
 		accountEmail: token.accountEmail,
@@ -364,7 +374,8 @@ export async function redeemRefreshToken(
 	refreshToken: string,
 	now: () => number,
 ): GrantResult {
-	const { data: credentials, error: credentialsError } = loadGmailCredentials();
+	const { data: credentials, error: credentialsError } =
+		loadGmailCredentials(config);
 	if (credentialsError) return { data: null, error: credentialsError };
 	const { data: grant, error } = await requestRefreshGrant({
 		config,
@@ -378,10 +389,13 @@ export async function redeemRefreshToken(
 		grant,
 	);
 	if (profileError) return { data: null, error: profileError };
-	return tokenSetFromGrant(grant, {
+	const { data: token, error: tokenError } = tokenSetFromGrant(grant, {
 		accountEmail,
 		clientIdUsed: credentials.clientId,
 		now: now(),
 		fallbackRefreshToken: refreshToken,
 	});
+	if (tokenError) return { data: null, error: tokenError };
+	persistGmailProviderCredentials(config.dataDir, credentials);
+	return Ok(token);
 }

--- a/apps/local-mail/src/oauth.ts
+++ b/apps/local-mail/src/oauth.ts
@@ -119,10 +119,9 @@ function httpOptions(config: AppConfig) {
  * Resolve the BYO Gmail OAuth client lazily at the connect/refresh site rather
  * than eagerly in `loadConfig`, so credential-free verbs never read secrets.
  */
-function loadGmailCredentials(config: AppConfig): Result<
-	{ clientId: string; clientSecret: string },
-	OAuthError
-> {
+function loadGmailCredentials(
+	config: AppConfig,
+): Result<{ clientId: string; clientSecret: string }, OAuthError> {
 	try {
 		return Ok(resolveGmailCredentials(gmailCredentialSource(config.dataDir)));
 	} catch (cause) {

--- a/apps/local-mail/src/paths.ts
+++ b/apps/local-mail/src/paths.ts
@@ -29,3 +29,8 @@ export function resolveDataDir(): string {
 export function credentialsFilePath(dataDir: string): string {
 	return join(dataDir, 'credentials.json');
 }
+
+/** The 0600 machine-level provider-credentials file, sibling to credentials.json. */
+export function providerFilePath(dataDir: string): string {
+	return join(dataDir, 'provider.json');
+}

--- a/apps/local-mail/src/provider-store.ts
+++ b/apps/local-mail/src/provider-store.ts
@@ -1,0 +1,47 @@
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	writeFileSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+
+/**
+ * Read the machine provider file as a flat name->value map. Absent/malformed
+ * => {}.
+ *
+ * The file is untrusted disk like `credentials.json`: the `0600` mode is the
+ * protection, not encryption, following the same ADR-0062 lineage. It stays a
+ * generic name->value source so any secret backend, including env, `.env`, or
+ * this file, projects identically into the flat map ADR-0108's resolver reads.
+ */
+export function readProviderFile(filePath: string): Record<string, string> {
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(filePath, 'utf8'));
+		if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+			return {};
+		}
+		const entries = Object.entries(parsed);
+		if (entries.some(([, value]) => typeof value !== 'string')) return {};
+		return Object.fromEntries(entries) as Record<string, string>;
+	} catch {
+		return {};
+	}
+}
+
+/**
+ * Write the map at 0600 (dir 0700) only if the file does not already exist.
+ * No-op if present.
+ */
+export function writeProviderFileIfAbsent(
+	filePath: string,
+	map: Record<string, string>,
+): void {
+	if (existsSync(filePath)) return;
+	const dir = dirname(filePath);
+	mkdirSync(dir, { recursive: true, mode: 0o700 });
+	chmodSync(dir, 0o700);
+	writeFileSync(filePath, JSON.stringify(map, null, 2));
+	chmodSync(filePath, 0o600);
+}

--- a/apps/local-mail/src/provider-store.ts
+++ b/apps/local-mail/src/provider-store.ts
@@ -19,7 +19,11 @@ import { dirname } from 'node:path';
 export function readProviderFile(filePath: string): Record<string, string> {
 	try {
 		const parsed: unknown = JSON.parse(readFileSync(filePath, 'utf8'));
-		if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+		if (
+			typeof parsed !== 'object' ||
+			parsed === null ||
+			Array.isArray(parsed)
+		) {
 			return {};
 		}
 		const entries = Object.entries(parsed);

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -68,7 +68,11 @@ shapes, see `docs/adr/`.
   at Epicenter's hosted/operator project, and personal local apps use ignored
   app-local configs that point at the operator's personal project. The ignored
   configs are per-person bring-your-own provider setup; the committed configs
-  are shared Epicenter infrastructure.
+  are shared Epicenter infrastructure. A single-provider local app may instead
+  cache its BYO client credentials to a machine-tier 0600 file after first
+  connect (Local Mail's <data-dir>/provider.json), so it reads no per-worktree
+  Infisical config on the run path; Infisical then only ever populates the
+  environment for that first connect.
 - **Infisical environment**: a value-stakes tier inside a project, not an
   owner. In the Epicenter project, `dev` holds substitute values that can hurt
   nothing (the local `wrangler dev` bindings) and `prod` holds hosted


### PR DESCRIPTION
Local Mail remembered the connected Gmail account at the machine tier, but refreshed it through a worktree-local `.infisical.json` pointer. That made new worktrees look connected while failing to refresh tokens because the BYO Google client pair was not injected.

This moves the client pair to the same machine tier as the token. The resolver now reads `GMAIL_CLIENT_ID` / `GMAIL_CLIENT_SECRET` from env first, then from a `0600` `<data-dir>/provider.json` sibling to `credentials.json`. A successful connect, seed, or refresh caches env-supplied credentials there if the file is absent, so the first working run repairs every other worktree on the machine.

```sh
# First run can still use any local secret source.
GMAIL_CLIENT_ID=... GMAIL_CLIENT_SECRET=... bun run --cwd apps/local-mail connect

# Later runs, including other worktrees, no longer need Infisical.
bun run --cwd apps/local-mail sync
bun run --cwd apps/local-mail status
```

Infisical is no longer on Local Mail's run path. The package scripts call the CLI directly, the tracked `.infisical.json.example` is deleted, and the docs now describe Infisical only as one optional way to inject env for the first connect.

## Changelog

- Local Mail now persists BYO Gmail OAuth client credentials to a machine-local `provider.json` after a successful credentialed run.
- Local Mail no longer requires a per-worktree `.infisical.json` for `connect`, `sync`, or `status`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786057660&installation_id=128463665&pr_number=2409&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2409&signature=3c98eea71731ff0602f52d7d1ecae6870cafe318a7bb01dde534458f728edc22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->