### PR TITLE
chore(deps): upgrade wellcrafted to ^0.44.0 (result*Options rename)

### DIFF
--- a/apps/api/ui/src/routes/dashboard/+layout.svelte
+++ b/apps/api/ui/src/routes/dashboard/+layout.svelte
@@ -3,14 +3,14 @@
 	import * as Card from '@epicenter/ui/card';
 	import { Spinner } from '@epicenter/ui/spinner';
 	import { createMutation } from '@tanstack/svelte-query';
-	import { mutationOptions } from 'wellcrafted/query';
+	import { resultMutationOptions } from 'wellcrafted/query';
 	import UserMenu from '$lib/components/UserMenu.svelte';
 	import { auth } from '$lib/platform/auth';
 
 	let { children } = $props();
 
 	const startSignIn = createMutation(() =>
-		mutationOptions({
+		resultMutationOptions({
 			mutationKey: ['auth', 'startSignIn'],
 			mutationFn: () => auth.startSignIn(),
 		}),

--- a/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
+++ b/apps/whispering/src/lib/components/settings/TranscriptionRuntimeConfig.svelte
@@ -11,7 +11,7 @@
 	import { Textarea } from '@epicenter/ui/textarea';
 	import { cn } from '@epicenter/ui/utils';
 	import { createMutation } from '@tanstack/svelte-query';
-	import { mutationOptions } from 'wellcrafted/query';
+	import { resultMutationOptions } from 'wellcrafted/query';
 	import CopyablePre from '$lib/components/copyable/CopyablePre.svelte';
 	import {
 		SUPPORTED_LANGUAGES_OPTIONS,
@@ -125,7 +125,7 @@
 	const isSignedIn = $derived(auth.state.status === 'signed-in');
 	const accountLocked = $derived(recordingActive.current);
 	const startSignIn = createMutation(() =>
-		mutationOptions({
+		resultMutationOptions({
 			mutationKey: ['transcription-setup', 'startSignIn'],
 			mutationFn: () => auth.startSignIn(),
 		}),

--- a/apps/whispering/src/routes/(app)/(config)/settings/account/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/account/+page.svelte
@@ -5,7 +5,7 @@
 	import { Spinner } from '@epicenter/ui/spinner';
 	import { createMutation } from '@tanstack/svelte-query';
 	import LogOut from '@lucide/svelte/icons/log-out';
-	import { mutationOptions } from 'wellcrafted/query';
+	import { resultMutationOptions } from 'wellcrafted/query';
 	import { auth } from '#platform/auth';
 	import { recordingActive } from '$lib/state/recording-active.svelte';
 
@@ -19,14 +19,14 @@
 	const accountLocked = $derived(recordingActive.current);
 
 	const startSignIn = createMutation(() =>
-		mutationOptions({
+		resultMutationOptions({
 			mutationKey: ['account', 'startSignIn'],
 			mutationFn: () => auth.startSignIn(),
 		}),
 	);
 
 	const signOut = createMutation(() =>
-		mutationOptions({
+		resultMutationOptions({
 			mutationKey: ['account', 'signOut'],
 			mutationFn: () => auth.signOut(),
 			onError: (error) => toastOnError(error, 'Failed to sign out'),

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
@@ -5,7 +5,7 @@
 	import { Link } from '@epicenter/ui/link';
 	import InfoIcon from '@lucide/svelte/icons/info';
 	import { createMutation } from '@tanstack/svelte-query';
-	import { mutationOptions } from 'wellcrafted/query';
+	import { resultMutationOptions } from 'wellcrafted/query';
 	import { SettingSelect, SettingSwitch } from '$lib/components/settings';
 	import {
 		BITRATE_OPTIONS,
@@ -24,7 +24,7 @@
 	import VadSelectRecordingDevice from './VadSelectRecordingDevice.svelte';
 
 	const exportRecordings = createMutation(() =>
-		mutationOptions({
+		resultMutationOptions({
 			mutationKey: ['recordings', 'export'],
 			mutationFn: whispering.actions.recordings_export_markdown,
 		}),

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",
@@ -1180,7 +1179,7 @@
     "virtua": "^0.48.5",
     "vite": "^7.3.5",
     "vite-plugin-singlefile": "^2.3.3",
-    "wellcrafted": "^0.43.0",
+    "wellcrafted": "^0.44.0",
     "wrangler": "^4.71.0",
     "y-indexeddb": "^9.0.12",
     "y-protocols": "^1.0.7",
@@ -4140,7 +4139,7 @@
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
-    "wellcrafted": ["wellcrafted@0.43.0", "", {}, "sha512-nJmIF0yVf+vwYI8ayLoDrGIlLSidkF9GiyPVROnjp4HTaSGtSwLWfby2UlRq5cH1mLbl1CT41czX7v8ogQ20Tg=="],
+    "wellcrafted": ["wellcrafted@0.44.0", "", {}, "sha512-tqmYveAIYitD1BsuYzYb64b1aXMmQRVqi2Vy/qyXICX99sn3TmKQcnGBrF/qNknGsWp5aZJNggroP+ICmalADQ=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 			"drizzle-kit": "^0.31.7",
 			"drizzle-orm": "^0.45.2",
 			"nanoid": "^5.1.14",
-			"wellcrafted": "^0.43.0",
+			"wellcrafted": "^0.44.0",
 			"@ricky0123/vad-web": "^0.0.30",
 			"date-fns": "^4.1.0",
 			"@biomejs/biome": "^2.4.10",

--- a/packages/app-shell/src/account-popover/account-popover.svelte
+++ b/packages/app-shell/src/account-popover/account-popover.svelte
@@ -16,7 +16,7 @@
 		QueryClient,
 	} from '@tanstack/svelte-query';
 	import { extractErrorMessage } from 'wellcrafted/error';
-	import { mutationOptions, queryOptions } from 'wellcrafted/query';
+	import { resultMutationOptions, resultQueryOptions } from 'wellcrafted/query';
 	import CreditBalance from '../credit-balance/credit-balance.svelte';
 	import { fetchCreditOverview } from '../credit-balance/credit-balance.js';
 	import InstanceSettingsModal from './instance-settings-modal.svelte';
@@ -144,10 +144,10 @@
 	// Identity lives on the auth client: `state` carries the principal partition,
 	// and `getProfile()` reads presentational identity (the email) on demand.
 	// TanStack Query owns the reactive cache here, keyed by account, and
-	// `queryOptions` bridges the Result into its throw-on-error contract.
+	// `resultQueryOptions` bridges the Result into its throw-on-error contract.
 	const profile = createQuery(
 		() =>
-			queryOptions({
+			resultQueryOptions({
 				queryKey: ['account-profile', accountCacheKey],
 				queryFn: () => auth.getProfile(),
 				enabled: auth.state.status !== 'signed-out' && !selfHostHost,
@@ -165,7 +165,7 @@
 	// to show. Keyed by account so switching identity refetches.
 	const credits = createQuery(
 		() =>
-			queryOptions({
+			resultQueryOptions({
 				queryKey: ['account-credits', accountCacheKey],
 				queryFn: () => fetchCreditOverview(auth.fetch, auth.deployment.baseURL),
 				enabled: auth.state.status === 'signed-in' && !selfHostHost,
@@ -181,7 +181,7 @@
 	);
 	const signOut = createMutation(
 		() =>
-			mutationOptions({
+			resultMutationOptions({
 				mutationKey: ['account', 'signOut'],
 				mutationFn: () => auth.signOut(),
 				onMutate: () => {


### PR DESCRIPTION
Upgrades Epicenter to `wellcrafted@^0.44.0` and adopts the hook-local Result adapter names that shipped with that release. The old `queryOptions` and `mutationOptions` exports are now `resultQueryOptions` and `resultMutationOptions`, so the catalog bump and call-site rename have to land together: either half by itself would leave the affected workspaces unable to typecheck.

The rename is intentionally narrow. The audited call sites are still local adapter usage, not candidates for promotion to `defineQuery` or `defineMutation`: they depend on reactive query keys, the shared account-popover package's local `QueryClient`, or surface-scoped one-shot mutations that already wrap callable `auth.*` identities. Keeping them as `createQuery(() => resultQueryOptions(...))` and `createMutation(() => resultMutationOptions(...))` preserves the current ownership model while moving to the supported API.

This updates the eight adapter references across app-shell, api-ui, and whispering, including the account popover queries and mutation, dashboard layout query setup, recording/account settings, and transcription runtime config. It also carries the dependency lockfile/package update for the same `wellcrafted` release published from wellcrafted-dev/wellcrafted#136.

Verification was run against the three affected workspaces: `@epicenter/app-shell`, `@epicenter/api-ui`, and `@epicenter/whispering` all typechecked with zero errors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786084401&installation_id=128463665&pr_number=2412&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2412&signature=a0bc4f5d34c355d8f9c2a3c9b6c150e1619a007c877a80eba8c10359fe7672cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->