### PR TITLE
test(matter): unwrap contracts with expectOk

### DIFF
--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing
-description: 'Test file conventions: setup functions, factories, organization, type testing, naming, and pruning low-value tests. Use when: "write tests", "add a test", "fix this test", "delete tests", "prune tests", "audit tests", or modifying *.test.ts files.'
+description: 'Test file conventions: setup functions, factories, Result assertion helpers, organization, type testing, naming, and pruning low-value tests. Use when: "write tests", "add a test", "fix this test", "delete tests", "prune tests", "audit tests", or modifying *.test.ts files.'
 metadata:
   author: epicenter
   version: '2.0'
@@ -17,6 +17,7 @@ Use this pattern when you need to:
 - Split large test files into focused behavior/type/scenario files.
 - Enforce behavior-based test naming and clear failure intent.
 - Add or review negative type tests using `@ts-expect-error`.
+- Assert wellcrafted `Result` values with `expectOk` / `expectErr`.
 - Audit a test file for assertions that cannot fail or fakes that don't earn their lines.
 - Prune tests that cannot name a real regression they would catch.
 
@@ -39,6 +40,27 @@ External reading:
 - Matt Pocock, [`shoehorn`](https://github.com/total-typescript/shoehorn) : partial mocks for test ergonomics
 
 > **Related Skills**: See `services-layer` for the service patterns being tested. See `typescript` for type testing conventions.
+
+## Result Assertions
+
+When a test asserts a wellcrafted `Result`, use `expectOk` and `expectErr`
+from `wellcrafted/testing` instead of hand-rolled error checks.
+
+```ts
+import { expectErr, expectOk } from 'wellcrafted/testing';
+
+const data = expectOk(await service.doThing());
+expect(data.id).toBe('1');
+
+const error = expectErr(await service.doThing({ invalid: true }));
+expect(error.name).toBe('InvalidInput');
+```
+
+Avoid local helper clones, `expect(error).toBeNull()` success checks, and
+`if (error) throw ...` unwrapping when the value is a wellcrafted `Result`.
+
+This rule does not apply to plain response bodies, UI snapshots, or other
+objects that merely have an `error` property.
 
 ## Tests vs. Benchmarks
 

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -8,19 +8,6 @@ metadata:
 
 # Test File Conventions
 
-## When to Apply This Skill
-
-Use this pattern when you need to:
-
-- Write or refactor `*.test.ts` files in this codebase.
-- Structure tests with `setup()` functions instead of mutable `beforeEach` setup.
-- Split large test files into focused behavior/type/scenario files.
-- Enforce behavior-based test naming and clear failure intent.
-- Add or review negative type tests using `@ts-expect-error`.
-- Assert wellcrafted `Result` values with `expectOk` / `expectErr`.
-- Audit a test file for assertions that cannot fail or fakes that don't earn their lines.
-- Prune tests that cannot name a real regression they would catch.
-
 ## References
 
 Load these on demand based on what you're working on:

--- a/apps/matter/src/lib/components/board.test.ts
+++ b/apps/matter/src/lib/components/board.test.ts
@@ -23,6 +23,7 @@ import {
 	type ViewSpec,
 	validateContract,
 } from '@epicenter/matter-core';
+import { expectOk } from 'wellcrafted/testing';
 import {
 	type BoardCard,
 	boardColumnsFor,
@@ -31,15 +32,15 @@ import {
 } from './board';
 
 function contract(): Contract {
-	const { data, error } = validateContract({
-		fields: {
-			title: { type: 'string' },
-			status: { type: 'string', enum: ['todo', 'doing', 'done'] },
-			platform: { type: 'string' },
-		},
-	});
-	if (error) throw new Error(error.message);
-	return data;
+	return expectOk(
+		validateContract({
+			fields: {
+				title: { type: 'string' },
+				status: { type: 'string', enum: ['todo', 'doing', 'done'] },
+				platform: { type: 'string' },
+			},
+		}),
+	);
 }
 
 function row(fileName: string, frontmatter: Record<string, unknown>): Row {
@@ -130,16 +131,17 @@ test('boardColumnsFor orders cards within a column by orderedStems', () => {
 test('boardColumnsFor defaults to up to three non-group fields when card is omitted', () => {
 	// A wider contract than the shared one: five fields so the fallback has to both
 	// drop the groupBy field AND cap at three, proving the slice is not a no-op.
-	const { data: model, error } = validateContract({
-		fields: {
-			title: { type: 'string' },
-			status: { type: 'string', enum: ['todo', 'doing', 'done'] },
-			platform: { type: 'string' },
-			owner: { type: 'string' },
-			priority: { type: 'string' },
-		},
-	});
-	if (error) throw new Error(error.message);
+	const model = expectOk(
+		validateContract({
+			fields: {
+				title: { type: 'string' },
+				status: { type: 'string', enum: ['todo', 'doing', 'done'] },
+				platform: { type: 'string' },
+				owner: { type: 'string' },
+				priority: { type: 'string' },
+			},
+		}),
+	);
 
 	const conformance = classifyRows(model.fields, [
 		row('alpha.md', {

--- a/packages/matter-core/src/core/conformance.test.ts
+++ b/packages/matter-core/src/core/conformance.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { expectOk } from 'wellcrafted/testing';
 import { classifyRow, classifyRows } from './conformance';
 import { validateContract } from './contract';
 import type { Row } from './parse';
@@ -7,9 +8,7 @@ function fields(
 	defs: Record<string, Record<string, unknown>>,
 	optional?: string[],
 ) {
-	const { data, error } = validateContract({ fields: defs, optional });
-	if (error) throw new Error(error.message);
-	return data.fields;
+	return expectOk(validateContract({ fields: defs, optional })).fields;
 }
 
 describe('classifyRow (per-cell conformance)', () => {

--- a/packages/matter-core/src/core/contract.test.ts
+++ b/packages/matter-core/src/core/contract.test.ts
@@ -1,19 +1,20 @@
 import { describe, expect, test } from 'bun:test';
+import { expectOk } from 'wellcrafted/testing';
 import { parseContract, validateContract } from './contract';
 
 describe('validateContract (the matter.json gate)', () => {
 	test('accepts the palette subset and derives kinds in declared order', () => {
-		const { data, error } = validateContract({
-			fields: {
-				title: { type: 'string' },
-				status: { type: 'string', enum: ['draft', 'published'] },
-				labels: { type: 'array', items: { enum: ['red', 'green'] } },
-				tags: { type: 'array', items: { type: 'string' } },
-				url: { type: 'string', format: 'uri' },
-			},
-		});
-		expect(error).toBeNull();
-		if (error) throw new Error(error.message);
+		const data = expectOk(
+			validateContract({
+				fields: {
+					title: { type: 'string' },
+					status: { type: 'string', enum: ['draft', 'published'] },
+					labels: { type: 'array', items: { enum: ['red', 'green'] } },
+					tags: { type: 'array', items: { type: 'string' } },
+					url: { type: 'string', format: 'uri' },
+				},
+			}),
+		);
 		expect(data.fields.map((c) => [c.name, c.kind])).toEqual([
 			['title', 'string'],
 			['status', 'select'],
@@ -33,15 +34,15 @@ describe('validateContract (the matter.json gate)', () => {
 	});
 
 	test('top-level optional marks typed fields as not required', () => {
-		const { data, error } = validateContract({
-			fields: {
-				title: { type: 'string' },
-				publishDate: { type: 'string', format: 'date' },
-			},
-			optional: ['publishDate'],
-		});
-		expect(error).toBeNull();
-		if (error) throw new Error(error.message);
+		const data = expectOk(
+			validateContract({
+				fields: {
+					title: { type: 'string' },
+					publishDate: { type: 'string', format: 'date' },
+				},
+				optional: ['publishDate'],
+			}),
+		);
 		expect(data.fields.map((c) => [c.name, c.required])).toEqual([
 			['title', true],
 			['publishDate', false],
@@ -59,43 +60,47 @@ describe('validateContract (the matter.json gate)', () => {
 	});
 
 	test('searchable defaults to body plus every TEXT-storage field', () => {
-		const { data, error } = validateContract({
-			fields: {
-				title: { type: 'string' },
-				count: { type: 'integer' },
-				live: { type: 'boolean' },
-				tags: { type: 'array', items: { type: 'string' } },
-			},
-		});
-		if (error) throw new Error(error.message);
+		const data = expectOk(
+			validateContract({
+				fields: {
+					title: { type: 'string' },
+					count: { type: 'integer' },
+					live: { type: 'boolean' },
+					tags: { type: 'array', items: { type: 'string' } },
+				},
+			}),
+		);
 		// body + the TEXT fields (title, tags); the integer and boolean fields are not full-text.
 		expect(data.searchable).toEqual(['body', 'title', 'tags']);
 	});
 
 	test('top-level searchable overrides the default and may drop body', () => {
-		const { data, error } = validateContract({
-			fields: { title: { type: 'string' }, note: { type: 'string' } },
-			searchable: ['note'],
-		});
-		if (error) throw new Error(error.message);
+		const data = expectOk(
+			validateContract({
+				fields: { title: { type: 'string' }, note: { type: 'string' } },
+				searchable: ['note'],
+			}),
+		);
 		expect(data.searchable).toEqual(['note']);
 	});
 
 	test('searchable drops names that are not real columns', () => {
-		const { data, error } = validateContract({
-			fields: { title: { type: 'string' } },
-			searchable: ['body', 'title', 'nope'],
-		});
-		if (error) throw new Error(error.message);
+		const data = expectOk(
+			validateContract({
+				fields: { title: { type: 'string' } },
+				searchable: ['body', 'title', 'nope'],
+			}),
+		);
 		expect(data.searchable).toEqual(['body', 'title']);
 	});
 
 	test('an empty searchable means no full-text index', () => {
-		const { data, error } = validateContract({
-			fields: { title: { type: 'string' } },
-			searchable: [],
-		});
-		if (error) throw new Error(error.message);
+		const data = expectOk(
+			validateContract({
+				fields: { title: { type: 'string' } },
+				searchable: [],
+			}),
+		);
 		expect(data.searchable).toEqual([]);
 	});
 
@@ -109,15 +114,15 @@ describe('validateContract (the matter.json gate)', () => {
 	});
 
 	test('reports optional entries that do not match typed fields', () => {
-		const { data, error } = validateContract({
-			fields: {
-				title: { type: 'string' },
-				meta: { type: 'object' },
-			},
-			optional: ['title', 'meta', 'missing'],
-		});
-		expect(error).toBeNull();
-		if (error) throw new Error(error.message);
+		const data = expectOk(
+			validateContract({
+				fields: {
+					title: { type: 'string' },
+					meta: { type: 'object' },
+				},
+				optional: ['title', 'meta', 'missing'],
+			}),
+		);
 		expect(data.fields.map((c) => [c.name, c.required])).toEqual([
 			['title', false],
 		]);
@@ -126,18 +131,18 @@ describe('validateContract (the matter.json gate)', () => {
 	});
 
 	test('views ride on a typed contract; malformed entries surface as viewErrors', () => {
-		const { data, error } = validateContract({
-			fields: {
-				title: { type: 'string' },
-				status: { type: 'string', enum: ['draft', 'published'] },
-			},
-			views: [
-				{ id: 'pipeline', type: 'board', groupBy: 'status' },
-				{ id: 'broken', type: 'board', groupBy: 'nope' },
-			],
-		});
-		expect(error).toBeNull();
-		if (error) throw new Error(error.message);
+		const data = expectOk(
+			validateContract({
+				fields: {
+					title: { type: 'string' },
+					status: { type: 'string', enum: ['draft', 'published'] },
+				},
+				views: [
+					{ id: 'pipeline', type: 'board', groupBy: 'status' },
+					{ id: 'broken', type: 'board', groupBy: 'nope' },
+				],
+			}),
+		);
 		expect(data.views).toEqual([
 			{ id: 'pipeline', type: 'board', groupBy: 'status' },
 		]);
@@ -150,10 +155,11 @@ describe('validateContract (the matter.json gate)', () => {
 	});
 
 	test('no views key means an empty views list, not a diagnostic', () => {
-		const { data, error } = validateContract({
-			fields: { title: { type: 'string' } },
-		});
-		if (error) throw new Error(error.message);
+		const data = expectOk(
+			validateContract({
+				fields: { title: { type: 'string' } },
+			}),
+		);
 		expect(data.views).toEqual([]);
 		expect(data.viewErrors).toEqual([]);
 	});
@@ -167,9 +173,7 @@ describe('validateContract (the matter.json gate)', () => {
 	// No `fields` map is no longer a contract error: it is the untyped marker, classified by
 	// `parseContract`. As a typed contract a fields-less object is simply zero declared fields.
 	test('an object with no fields map is a zero-field contract, not an error', () => {
-		const { data, error } = validateContract({ views: {} });
-		expect(error).toBeNull();
-		if (error) throw new Error(error.message);
+		const data = expectOk(validateContract({ views: {} }));
 		expect(data.fields).toEqual([]);
 		expect(data.untyped).toEqual([]);
 	});
@@ -177,26 +181,26 @@ describe('validateContract (the matter.json gate)', () => {
 	// Per-field degrade: a field outside the palette does not error the contract. It is
 	// recorded in `untyped` (shown raw), and the rest of the folder stays typed.
 	test('a non-object field is untyped, not a contract error', () => {
-		const { data, error } = validateContract({
-			fields: { title: { type: 'string' }, bad: 'string' },
-		});
-		expect(error).toBeNull();
-		if (error) throw new Error(error.message);
+		const data = expectOk(
+			validateContract({
+				fields: { title: { type: 'string' }, bad: 'string' },
+			}),
+		);
 		expect(data.fields.map((c) => c.name)).toEqual(['title']);
 		expect(data.untyped).toEqual(['bad']);
 		expect(data.unmatchedOptional).toEqual([]);
 	});
 
 	test('a shape outside the palette is untyped; the rest stays typed', () => {
-		const { data, error } = validateContract({
-			fields: {
-				title: { type: 'string' },
-				meta: { type: 'object' }, // not a palette shape
-				note: { anyOf: [{ type: 'string' }, { type: 'null' }] }, // nullable: deleted axis
-			},
-		});
-		expect(error).toBeNull();
-		if (error) throw new Error(error.message);
+		const data = expectOk(
+			validateContract({
+				fields: {
+					title: { type: 'string' },
+					meta: { type: 'object' }, // not a palette shape
+					note: { anyOf: [{ type: 'string' }, { type: 'null' }] }, // nullable: deleted axis
+				},
+			}),
+		);
 		expect(data.fields.map((c) => c.name)).toEqual(['title']);
 		expect(data.untyped).toEqual(['meta', 'note']);
 		expect(data.unmatchedOptional).toEqual([]);

--- a/packages/matter-core/src/core/expected.test.ts
+++ b/packages/matter-core/src/core/expected.test.ts
@@ -6,13 +6,13 @@
 
 import { describe, expect, test } from 'bun:test';
 import type { Field } from '@epicenter/field';
+import { expectOk } from 'wellcrafted/testing';
 import { validateContract } from './contract';
 import { describeExpected } from './expected';
 
 /** Recognize one at-rest field schema into a loaded {@link Field}. */
 function fieldFrom(schema: unknown): Field {
-	const { data, error } = validateContract({ fields: { f: schema } });
-	if (error) throw new Error(`contract invalid: ${error.message}`);
+	const data = expectOk(validateContract({ fields: { f: schema } }));
 	const [field] = data.fields;
 	if (!field) throw new Error('schema was not recognized as a field');
 	return field;

--- a/packages/matter-core/src/core/query.test.ts
+++ b/packages/matter-core/src/core/query.test.ts
@@ -1,5 +1,6 @@
 import { Database } from 'bun:sqlite';
 import { describe, expect, test } from 'bun:test';
+import { expectOk } from 'wellcrafted/testing';
 import { classifyRows } from './conformance';
 import { validateContract } from './contract';
 import type { Row } from './parse';
@@ -55,15 +56,15 @@ describe('buildStemQuery (the SQL shapes)', () => {
 });
 
 describe('buildStemQuery (executed against a real projection in bun:sqlite)', () => {
-	const built = validateContract({
-		fields: {
-			title: { type: 'string' },
-			rating: { type: 'integer' },
-			status: { type: 'string', enum: ['reading', 'done'] },
-		},
-	});
-	if (built.error) throw new Error(built.error.message);
-	const contract = built.data;
+	const contract = expectOk(
+		validateContract({
+			fields: {
+				title: { type: 'string' },
+				rating: { type: 'integer' },
+				status: { type: 'string', enum: ['reading', 'done'] },
+			},
+		}),
+	);
 
 	const rows: Row[] = [
 		{

--- a/packages/matter-core/src/core/sqlite.test.ts
+++ b/packages/matter-core/src/core/sqlite.test.ts
@@ -2,6 +2,7 @@ import { Database } from 'bun:sqlite';
 import { describe, expect, test } from 'bun:test';
 import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
+import { expectOk } from 'wellcrafted/testing';
 import { loadPath } from '../load/fs';
 import { classifyRows } from './conformance';
 import { validateContract } from './contract';
@@ -26,9 +27,7 @@ function contract(
 	fields: Record<string, Record<string, unknown>>,
 	optional?: string[],
 ) {
-	const { data, error } = validateContract({ fields, optional });
-	if (error) throw new Error(error.message);
-	return data;
+	return expectOk(validateContract({ fields, optional }));
 }
 
 const m = contract({
@@ -216,12 +215,13 @@ describe('FTS5 block (emitted when the contract is searchable)', () => {
 	});
 
 	test('no FTS create or trigger when searchable is empty, but the index drop still runs', () => {
-		const built = validateContract({
-			fields: { title: { type: 'string' } },
-			searchable: [],
-		});
-		if (built.error) throw new Error(built.error.message);
-		const { schema } = projectToSqlite('posts', built.data, []);
+		const built = expectOk(
+			validateContract({
+				fields: { title: { type: 'string' } },
+				searchable: [],
+			}),
+		);
+		const { schema } = projectToSqlite('posts', built, []);
 		expect(schema).not.toContain('fts5');
 		expect(schema).not.toContain('CREATE TRIGGER');
 		// The DROP still runs, so a folder that just lost searchability sheds its stale index.
@@ -251,15 +251,16 @@ describe('FTS5 block (emitted when the contract is searchable)', () => {
 		).toEqual({ n: 1 });
 
 		// Re-project the SAME folder as non-searchable, with a different row at the same rowid.
-		const bare = validateContract({
-			fields: { title: { type: 'string' } },
-			searchable: [],
-		});
-		if (bare.error) throw new Error(bare.error.message);
+		const bare = expectOk(
+			validateContract({
+				fields: { title: { type: 'string' } },
+				searchable: [],
+			}),
+		);
 		const nonSearchable = projectToSqlite(
 			'posts',
-			bare.data,
-			classifyRows(bare.data.fields, [
+			bare,
+			classifyRows(bare.fields, [
 				{
 					fileName: 'beta.md',
 					frontmatter: { title: 'Beta' },

--- a/packages/matter-core/src/core/view.test.ts
+++ b/packages/matter-core/src/core/view.test.ts
@@ -17,25 +17,27 @@
  */
 
 import { describe, expect, test } from 'bun:test';
+import { expectOk } from 'wellcrafted/testing';
 import { validateContract } from './contract';
 import type { Row } from './parse';
 import { groupRowsByField, parseViews } from './view';
 
 /** One contract with a field of every view-relevant kind, compiled once for all tests. */
 function setup() {
-	const built = validateContract({
-		fields: {
-			title: { type: 'string' },
-			status: { enum: ['idea', 'drafting', 'posted'] },
-			platform: { type: 'string' },
-			page: { type: 'string', 'x-ref': 'pages' },
-			publish_at: { type: 'string', format: 'date-time' },
-			rating: { type: 'integer' },
-		},
-		optional: ['platform', 'page', 'publish_at', 'rating'],
-	});
-	if (built.error) throw new Error(built.error.message);
-	return { fields: built.data.fields };
+	const built = expectOk(
+		validateContract({
+			fields: {
+				title: { type: 'string' },
+				status: { enum: ['idea', 'drafting', 'posted'] },
+				platform: { type: 'string' },
+				page: { type: 'string', 'x-ref': 'pages' },
+				publish_at: { type: 'string', format: 'date-time' },
+				rating: { type: 'integer' },
+			},
+			optional: ['platform', 'page', 'publish_at', 'rating'],
+		}),
+	);
+	return { fields: built.fields };
 }
 
 function row(fileName: string, frontmatter: Record<string, unknown>): Row {


### PR DESCRIPTION
Matter tests were manually unwrapping Result values with local error checks and throw paths. This replaces those success-path unwraps with expectOk from wellcrafted/testing, so the tests follow the same Result assertion convention used elsewhere in the repo.

The testing skill now records that convention: use expectOk / expectErr for wellcrafted Result assertions, while leaving plain response bodies and UI snapshots alone.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786085000&installation_id=128463665&pr_number=2413&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2413&signature=1f2a39b69999aac393670a85f2b07af65526a658eb93c42ad7451e33264f9a5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->