### PR TITLE
feat(attach-relay): add self-host host discovery

### DIFF
--- a/apps/self-host/server.ts
+++ b/apps/self-host/server.ts
@@ -58,6 +58,7 @@ import {
 	mountAttachGrantsApp,
 	mountAttachRelayApp,
 	mountBlobsApp,
+	mountHostDirectoryApp,
 	mountInferenceApp,
 	mountRoomsApp,
 	mountSessionApp,
@@ -188,6 +189,17 @@ export function startSelfHostServer(): void {
 	// device off. This is where "the desktop approves a device" lives on an
 	// instance (ADR-0115 clause 3); minting the secret here is the pairing step.
 	mountAttachGrantsApp(app, { auth, grants: attachGrants });
+	// The client's host-discovery read (`GET /attach/hosts`, ADR-0115 clause 3),
+	// gated by a per-device grant (the same credential a client attaches with, NOT
+	// the operator token): a paired phone lists this instance's desktop hosts and
+	// their `online`/`offline` liveness, then attaches to one. The directory is the
+	// relay's own retained membership joined with its live host set; the principal
+	// is stamped server-side, so a client only ever reads the instance principal's
+	// hosts. No write route: a host publishes itself by connecting as a host.
+	mountHostDirectoryApp(app, {
+		resolveBearerPrincipal: attachGrants.resolveBearerPrincipal,
+		resolveHostDirectory: () => attachRelay.hostDirectory,
+	});
 	// Inference spends the operator's house key on every request. Cap the burn
 	// rate so a leaked or overused bearer cannot run the provider bill up
 	// unbounded between invoices. This is the in-process backstop; the real

--- a/apps/super-chat/scripts/remote-dev-smoke.ts
+++ b/apps/super-chat/scripts/remote-dev-smoke.ts
@@ -134,6 +134,7 @@ async function main(): Promise<void> {
 		relayOrigin,
 		principalId: 'instance',
 		hostId: HOST_ID,
+		label: 'Desktop (dev smoke)',
 		bearer: hostGrant.token,
 	});
 	await relayHost.ready;

--- a/apps/super-chat/specs/host-discovery-connect-device.md
+++ b/apps/super-chat/specs/host-discovery-connect-device.md
@@ -1,0 +1,175 @@
+# Host discovery and the "Connect device" surface
+
+- **Status:** Draft
+- **Relates:** ADR-0115 (endpoint-addressed trusted relay), ADR-0079 (two planes), ADR-0080 (desktop host; remote is attach to the session), ADR-0075/0092 (self-host is a single-partition instance)
+- **After:** PR #2424, #2426 (AttachRelay backend on Bun + Cloudflare DO, `/attach` mount, device grants). This wave makes remote attach *discoverable* from a phone/client. It reopens no relay transport, sealing, PSK, capability routing, or route registry.
+
+## The gap
+
+The relay carries live Super Chat bytes between two authenticated endpoints of one
+principal. What is missing is the step *before* attach: a phone has no way to learn
+**which desktops it may attach to** or **whether one is live right now**.
+
+`host-directory.ts` already pins the closed shape a client may learn:
+`{ hostId, label, status }` and nothing else (`.onUndeclaredKey('reject')`). But it is
+schema-only. There is no store, no route, no liveness signal, no publish/discover wire.
+The dev smoke hard-codes `hostId=dev-mac` into the phone URL; nothing lists hosts.
+
+## What the phone flow needs
+
+1. Show this principal's known desktop hosts.
+2. Label each `online` / `offline` / `unreachable`.
+3. "Connect" attaches to the chosen `hostId` when `online`.
+4. `offline` / `unreachable` still read synced history (durable-replica read, ADR-0055)
+   but deny a new local-source question (`canAskLocalSource`, already built).
+5. No capability / action / tool / route field appears anywhere (the closed schema).
+
+"Connect" is UI copy. "Attach" stays the live-plane protocol word.
+
+## Decision: who owns discovery
+
+**The directory is a per-principal *projection* behind a `resolveHostDirectory(env)`
+DI seam, mirroring `resolveRelay` / `resolveRooms`. It is neither a synced workspace
+store nor part of the relay coordinator.**
+
+Three facts forced this:
+
+### 1. Liveness has exactly one honest source: the live host socket.
+The desktop host already holds a live WebSocket to the relay. Its presence in the
+coordinator *is* `online`. A separate app-level heartbeat or `PUT /attach/hosts/:id`
+would be a strictly weaker, driftable duplicate that can disagree with the socket that
+actually forwards frames. **Reject the heartbeat and the PUT.** (Answers open Q2, Q5:
+liveness comes from the relay layer, not a heartbeat; one route `GET /attach/hosts`, no
+write route — the socket is the write.)
+
+### 2. `online / offline / unreachable` decomposes into two facts that live in
+different places.
+- **membership + label** ("P's known desktops and their names") must outlive a
+  disconnect to render `offline` at all.
+- **liveness** ("is a host socket live now") is a live-plane fact only the coordinator
+  (or the attach attempt itself) knows.
+- `unreachable` = membership says the host exists **and** it last claimed live **but**
+  its socket is dead. It is the *join* of the two facts.
+
+A synced CRDT is the wrong owner: it would carry a stale `online` after a crash, and
+liveness is a live-plane property (ADR-0079), not durable truth. So the directory is a
+projection, computed per read. (Answers open Q1: **not** workspace/sync-backed; a real
+route over a per-deployment source.)
+
+### 3. The Bun singleton can enumerate a principal's hosts; the Cloudflare DO cannot.
+This is the whole asymmetry. On self-host one in-process coordinator holds every host
+socket in one `hosts` map. On Cloud the relay is **one DO per `(principalId, hostId)`
+pair** (`attachHostDoName = principals/<pid>/attach-hosts/<hostId>`); there is no
+per-principal actor that sees all of P's hosts, and nothing in the codebase does
+cross-DO enumeration. So "list my hosts" is free-ish on self-host and is **new
+infrastructure** on Cloud. One route, two sources, behind `resolveHostDirectory(env)` —
+the honest asymmetry the repo already runs for principal resolution (self-host instance
+vs Cloud OAuth, ADR-0075/0092).
+
+Keeping the directory out of `core.ts` also preserves the coordinator's deliberate
+frame/directory-blindness (ADR-0115 clause 1) and the Cloud DO's per-pair purity.
+
+### Per-deployment source
+
+- **Self-host:** membership is the **trace of the host-register act**, not a stored
+  attribute. A host publishes itself by connecting with `role=host` (the mount records
+  its `hostId` + `label`), retained after disconnect so an asleep desktop still lists;
+  a client never performs that act, so it is structurally absent. Liveness joins from
+  the coordinator's live host set. There is **no host/client discriminator** anywhere
+  (see the asymmetric-wins pass below). (Answers open Q3: the human label is the host's
+  own label announced at connect; an `offline` host persists for the relay's process
+  lifetime, the same durability floor as grants and the coordinator.)
+- **Cloud:** no grants and no per-principal index exist. Discovery needs a new
+  per-principal `HostDirectory` index (a DO named `principals/<pid>/host-directory`, or a
+  KV/D1 row) that the per-pair relay DOs write on host register / deregister. This is a
+  whole PR, not a slice.
+
+### Asymmetric-wins pass (why no `kind` discriminator, and what we defer not refuse)
+
+```
+Product sentence:
+  A signed-in phone lists this principal's desktop hosts with their liveness,
+  connects to a live one, and still reads synced history from an asleep one.
+
+Refuse: the host/client discriminator on the grant primitive.
+  Deletion prize: the `kind` union, every reader's branch on it, the "which
+    grants are hosts" filter. Membership becomes the trace of the host-register
+    act (only a role=host connect writes the directory); a client is structurally
+    absent. User loss: none. -> REFUSED.
+
+Keep (deferred, not refused): the Cloud per-principal index DO.
+  Refusing it would delete a whole DO, but it kills ADR-0115's headline promise
+  "sign in on your phone and your desktops are just there, no pairing." That
+  promise is load-bearing, so the index is EARNED; ship self-host now, add Cloud
+  discovery in its own PR (nobody loses a working feature: there is no Cloud phone
+  UI yet).
+
+Keep: offline rendering (the retained membership map).
+  Refusing it (list only live hosts) deletes ~30 lines but shows an empty connect
+  screen when you plainly own a sleeping desktop. Load-bearing product feel.
+
+Keep: one discovery shape (`GET /attach/hosts`) for both deployments.
+  Refuse the temptation to grow a second, client-side discovery model; a
+  half-server-half-client directory is the expensive "two mental models" trap.
+```
+
+## The seam (stable across all three PRs)
+
+```
+GET /attach/hosts        -> AttachHostDirectoryEntry[]   (bearer-gated, principal stamped server-side)
+resolveHostDirectory(env: ServerBindings): { list(principalId): Promise<AttachHostDirectoryEntry[]> }
+```
+
+Same route, same closed shape, both deployments. No per-host sub-route, no write route,
+no capability/route/action/tool field — the existing `host-directory.test.ts` guard
+already protects the entry shape and is reused verbatim.
+
+## Implementation split
+
+### PR 1 — Self-host `GET /attach/hosts` (Bun).
+- `core.ts`: expose the coordinator's conflict-correct live host set for a principal,
+  with no new wire field (stays frame- and directory-blind).
+- `host-directory.ts`: add a retained membership+label store (no status stored, no
+  discriminator) plus the `HostDirectoryReader` read seam.
+- `bun-server.ts`: record membership when a `role=host` connects; expose a directory
+  reader that joins retained membership with live host ids (live -> `online`, else
+  `offline`).
+- `contracts.ts` / `route.ts` / `mount.ts`: allow optional `label` on the host connect,
+  read by the mount into the directory, never handed to the coordinator.
+- `host-directory-app.ts`: add `mountHostDirectoryApp` for `GET /attach/hosts` behind
+  the attach bearer, backend bound via `resolveHostDirectory`.
+- `apps/self-host/server.ts`: wire the self-host reader. Leave `apps/api` untouched;
+  Cloud discovery is PR 2, not a placebo endpoint.
+- `apps/super-chat`: let `attachHostToRelay` pass a label; the dev smoke can list the
+  desktop instead of hard-coding it.
+- Tests: retained membership, principal partition, client-absent behavior,
+  conflict-correct liveness, E2E online -> offline over the real HTTP mount, and
+  discovery refused without a device grant.
+
+### PR 2 — Cloud host directory (per-principal index).
+- New per-principal `HostDirectory` DO (`principals/<pid>/host-directory`), written by
+  the per-pair `AttachRelay` DOs on host register / deregister (DO -> DO call). A crash
+  without deregister leaves a stale entry surfaced as `unreachable`, reconciled lazily.
+- Fills `resolveHostDirectory` on Cloud; the route and shape are unchanged from PR 1.
+- Load `durable-objects` skill; wrangler binding + migration like `ATTACH_RELAY`.
+
+### PR 3 — Super Chat phone connect UI.
+- A connect screen (a client-mode of the SPA, distinct from the loopback
+  `session.svelte.ts`) that fetches `GET /attach/hosts`, renders each host with its
+  status, and on "Connect" drives `createAttachRelayClient` to the chosen `hostId` when
+  `canAskLocalSource(status)`.
+- `offline` / `unreachable`: render read-only synced history with a disabled composer and
+  the right recovery copy ("Wake your desktop" vs "Reconnecting"). Copy says "Connect";
+  protocol stays "attach".
+- QR / deep link deferred (open Q4): the first UI is a host list only. The very first
+  pairing already carries `hostId` out of band in the grant/pairing artifact.
+
+## Refusals (do not reopen without a new ADR)
+- No capability / action / tool / route / method / topic field in the directory or its
+  wire. The closed `AttachHostDirectoryEntry` schema and its guard test stand.
+- No app-level heartbeat and no directory write route. Liveness is the host socket.
+- No synced-CRDT directory. It is a per-read projection.
+- No `principalId` trusted from the query. The bearer stamps it server-side, exactly as
+  `/attach` does.
+- No `kind` marker on grants. Grants are pure credentials; host directory membership is
+  the trace of a host connecting.

--- a/apps/super-chat/src/attach-relay-host.ts
+++ b/apps/super-chat/src/attach-relay-host.ts
@@ -43,6 +43,13 @@ export type AttachRelayHostOptions = {
 	/** This desktop's stable host id, the endpoint clients attach to. */
 	hostId: string;
 	/**
+	 * This desktop's human label for the host directory ("Braden's Mac"), what a
+	 * client sees before it attaches (ADR-0115 clause 3). Directory metadata only:
+	 * the mount records it beside the relay, never handing it to the coordinator.
+	 * Omitted, the directory lists this host under its `hostId`.
+	 */
+	label?: string;
+	/**
 	 * This host's attach credential. On self-host this is a per-device grant; on
 	 * Cloud it is the signed-in session bearer. Revoking the credential cuts the
 	 * host off on its next connect.
@@ -81,10 +88,14 @@ export type AttachRelayHost = {
 export function attachHostToRelay(
 	options: AttachRelayHostOptions,
 ): AttachRelayHost {
-	const { host, relayOrigin, principalId, hostId, bearer } = options;
+	const { host, relayOrigin, principalId, hostId, label, bearer } = options;
 	const open = options.openSocket ?? defaultOpenSocket;
 
-	const url = ATTACH_RELAY_ROUTE.hostUrl(relayOrigin, { principalId, hostId });
+	const url = ATTACH_RELAY_ROUTE.hostUrl(relayOrigin, {
+		principalId,
+		hostId,
+		label,
+	});
 	const socket = open(url, ATTACH_RELAY_ROUTE.subprotocols(bearer));
 
 	// The client endpoints currently attached to this host, keyed by

--- a/apps/super-chat/src/attach-relay-self-host.test.ts
+++ b/apps/super-chat/src/attach-relay-self-host.test.ts
@@ -43,6 +43,7 @@ import {
 	mergeBunWebSocketHandlers,
 	mountAttachGrantsApp,
 	mountAttachRelayApp,
+	mountHostDirectoryApp,
 	requireBearerPrincipal,
 } from '@epicenter/server/bun';
 import type { AgentEngine, EngineChunk } from '@epicenter/workspace/agent';
@@ -110,6 +111,11 @@ function serveSelfHostRelay(operatorToken: string): {
 	mountAttachGrantsApp(app, {
 		auth: requireBearerPrincipal(createEnvTokenResolver(operatorToken)),
 		grants,
+	});
+	// The client's host-discovery read, gated by a device grant (as on self-host).
+	mountHostDirectoryApp(app, {
+		resolveBearerPrincipal: grants.resolveBearerPrincipal,
+		resolveHostDirectory: () => attachRelay.hostDirectory,
 	});
 
 	const server = Bun.serve({
@@ -608,6 +614,71 @@ describe('AttachRelay: attach behind per-device grants', () => {
 			phone.close();
 			cli.close();
 			relayHost.close();
+			await server.stop(true);
+		}
+	});
+
+	test('a paired client discovers the host over GET /attach/hosts, online then offline', async () => {
+		await using host: SuperChatHost = await createTestHost(
+			scriptedEngine([[{ type: 'text-delta', delta: 'Discoverable.' }]]),
+		);
+		const { server, origin, httpOrigin, grants } =
+			serveSelfHostRelay(OPERATOR_TOKEN);
+		const phoneBearer = await pairDevice(grants, 'phone');
+		const listHosts = async () => {
+			const response = await fetch(`${httpOrigin}/attach/hosts`, {
+				headers: { authorization: `Bearer ${phoneBearer}` },
+			});
+			expect(response.status).toBe(200);
+			return (await response.json()) as {
+				hosts: { hostId: string; label: string; status: string }[];
+			};
+		};
+
+		try {
+			// Before any host connects, the directory is empty.
+			expect((await listHosts()).hosts).toEqual([]);
+
+			const relayHost = attachHostToRelay({
+				host,
+				relayOrigin: origin,
+				principalId: 'ignored-by-server',
+				hostId: HOST_ID,
+				label: "Braden's Mac",
+				bearer: await pairDevice(grants, 'host-mac'),
+			});
+			await relayHost.ready;
+
+			// The phone discovers exactly the closed entry: id, label, live status.
+			expect((await listHosts()).hosts).toEqual([
+				{ hostId: HOST_ID, label: "Braden's Mac", status: 'online' },
+			]);
+
+			// The desktop goes offline; the host is retained and lists offline, so the
+			// phone can still show it (and read synced history), never asking.
+			relayHost.close();
+			await Bun.sleep(50);
+			expect((await listHosts()).hosts).toEqual([
+				{ hostId: HOST_ID, label: "Braden's Mac", status: 'offline' },
+			]);
+		} finally {
+			await server.stop(true);
+		}
+	});
+
+	test('discovery is refused without a device grant', async () => {
+		const { server, httpOrigin } = serveSelfHostRelay(OPERATOR_TOKEN);
+		try {
+			const unauthenticated = await fetch(`${httpOrigin}/attach/hosts`);
+			expect(unauthenticated.status).toBe(401);
+
+			// The operator token administers grants but is not itself a device grant,
+			// so it does not resolve on the attach-credential-gated discovery read.
+			const withOperatorToken = await fetch(`${httpOrigin}/attach/hosts`, {
+				headers: { authorization: `Bearer ${OPERATOR_TOKEN}` },
+			});
+			expect(withOperatorToken.status).toBe(401);
+		} finally {
 			await server.stop(true);
 		}
 	});

--- a/packages/server/src/attach-relay/bun-server.ts
+++ b/packages/server/src/attach-relay/bun-server.ts
@@ -37,6 +37,11 @@ import {
 	createAttachRelay,
 	type HostConnection,
 } from './core.js';
+import {
+	type AttachHostDirectoryEntry,
+	createHostDirectory,
+	type HostDirectoryReader,
+} from './host-directory.js';
 
 /**
  * Per-connection identity Bun carries on `ws.data`, set at `server.upgrade` and
@@ -57,6 +62,13 @@ export type AttachRelayBunServer = {
 	/** Hand back the `Server` once `Bun.serve` returns, so `handleUpgrade` can upgrade. */
 	bindServer(server: Server<AttachRelaySocketData>): void;
 	websocket: WebSocketHandler<AttachRelaySocketData>;
+	/**
+	 * This process's host directory (ADR-0115 clause 3): the retained
+	 * membership+label of every host that has connected, joined at read time with
+	 * the coordinator's live host set. A self-host deployment hands this to
+	 * `mountHostDirectoryApp` so a signed-in client can `GET /attach/hosts`.
+	 */
+	hostDirectory: HostDirectoryReader;
 };
 
 /**
@@ -67,6 +79,9 @@ export type AttachRelayBunServer = {
  */
 export function createAttachRelayBunServer(): AttachRelayBunServer {
 	const relay = createAttachRelay();
+	// The retained membership+label half of the directory; the live half is
+	// `relay.liveHostIds`. The exposed `hostDirectory` joins the two at read time.
+	const directory = createHostDirectory();
 	const connections = new WeakMap<
 		ServerWebSocket<AttachRelaySocketData>,
 		HostConnection | ClientConnection
@@ -74,7 +89,15 @@ export function createAttachRelayBunServer(): AttachRelayBunServer {
 	let server: Server<AttachRelaySocketData> | null = null;
 
 	return {
-		handleUpgrade({ request, principalId, role, hostId, deviceId, attachId }) {
+		handleUpgrade({
+			request,
+			principalId,
+			role,
+			hostId,
+			deviceId,
+			attachId,
+			label,
+		}) {
 			if (!server) {
 				return new Response('attach relay server not bound', { status: 500 });
 			}
@@ -84,6 +107,7 @@ export function createAttachRelayBunServer(): AttachRelayBunServer {
 				hostId,
 				deviceId,
 				attachId,
+				label,
 			});
 			if (!data) {
 				return new Response('Bad attach request', { status: 400 });
@@ -103,8 +127,26 @@ export function createAttachRelayBunServer(): AttachRelayBunServer {
 			server = boundServer;
 		},
 
+		hostDirectory: {
+			list(principalId): AttachHostDirectoryEntry[] {
+				const live = new Set(relay.liveHostIds(principalId));
+				return directory.entries(principalId).map(({ hostId, label }) => ({
+					hostId,
+					label,
+					status: live.has(hostId) ? 'online' : 'offline',
+				}));
+			},
+		},
+
 		websocket: {
 			open(ws) {
+				if (ws.data.role === 'host') {
+					// Publish membership by the act of connecting as a host; a client
+					// never reaches this branch, so it is structurally absent from the
+					// directory. Liveness is not stored here: it is read from the
+					// coordinator at `hostDirectory.list` time.
+					directory.record(ws.data.principalId, ws.data.hostId, ws.data.label);
+				}
 				const connection =
 					ws.data.role === 'host'
 						? relay.registerHost({ ...ws.data, socket: ws })
@@ -137,6 +179,7 @@ function buildSocketData(params: {
 	hostId: string | undefined;
 	deviceId: string | undefined;
 	attachId: string | undefined;
+	label: string | undefined;
 }): AttachRelaySocketData | undefined {
 	const endpoint = parseAttachEndpoint(params);
 	return endpoint && { surface: 'attach', ...endpoint };

--- a/packages/server/src/attach-relay/contracts.ts
+++ b/packages/server/src/attach-relay/contracts.ts
@@ -83,6 +83,14 @@ export type AttachUpgrade = {
 	hostId: string | undefined;
 	deviceId: string | undefined;
 	attachId: string | undefined;
+	/**
+	 * A host endpoint's human label for the directory ("Braden's Mac"), read off
+	 * the connect query by the mount and recorded in the host directory
+	 * (ADR-0115 clause 3: a directory field, not a route/capability). It never
+	 * reaches the coordinator, which stays label-blind; only a `role=host`
+	 * connect carries it, and a client connect ignores it.
+	 */
+	label?: string;
 };
 
 /**
@@ -106,7 +114,7 @@ export type AttachRelayUpgradeHandler = {
  * channel, or capability field (ADR-0115 clause 1).
  */
 export type AttachEndpoint =
-	| { role: 'host'; principalId: string; hostId: string }
+	| { role: 'host'; principalId: string; hostId: string; label?: string }
 	| {
 			role: 'client';
 			principalId: string;
@@ -129,11 +137,14 @@ export function parseAttachEndpoint(params: {
 	hostId: string | undefined;
 	deviceId: string | undefined;
 	attachId: string | undefined;
+	label?: string | undefined;
 }): AttachEndpoint | undefined {
-	const { principalId, role, hostId, deviceId, attachId } = params;
+	const { principalId, role, hostId, deviceId, attachId, label } = params;
 	if (!principalId || !hostId) return undefined;
 	if (role === 'host') {
-		return { role: 'host', principalId, hostId };
+		// `label` is optional directory metadata; a host with no label is valid and
+		// the directory falls back to its `hostId`.
+		return { role: 'host', principalId, hostId, ...(label ? { label } : {}) };
 	}
 	if (role === 'client') {
 		if (!deviceId || !attachId) return undefined;

--- a/packages/server/src/attach-relay/core.ts
+++ b/packages/server/src/attach-relay/core.ts
@@ -96,10 +96,30 @@ export function createAttachRelay(): {
 		attachId: string;
 		socket: RelaySocket;
 	}): ClientConnection;
+	liveHostIds(principalId: string): string[];
 } {
 	const hosts = new Map<string, HostEntry>();
 
 	return {
+		/**
+		 * The `hostId`s currently registered under `principalId`, the single source
+		 * of truth for a host's `online` liveness (the host directory joins this
+		 * with its retained membership+label). This reads the coordinator's own
+		 * host set, so it is conflict-correct: a refused second registration
+		 * (HOST_CONFLICT) never owned the entry, so it never appears here, and the
+		 * incumbent stays listed. It exposes only host ids the coordinator already
+		 * tracks; it reads no `payload` and no `label`, so the coordinator stays
+		 * frame- and directory-blind (ADR-0115 clause 1).
+		 */
+		liveHostIds(principalId) {
+			const prefix = `${principalId}${SEPARATOR}`;
+			const ids: string[] = [];
+			for (const key of hosts.keys()) {
+				if (key.startsWith(prefix)) ids.push(key.slice(prefix.length));
+			}
+			return ids;
+		},
+
 		registerHost({ principalId, hostId, socket }) {
 			const key = hostKey(principalId, hostId);
 			if (hosts.has(key)) {

--- a/packages/server/src/attach-relay/host-directory-app.ts
+++ b/packages/server/src/attach-relay/host-directory-app.ts
@@ -1,0 +1,79 @@
+/**
+ * The client's host-discovery surface (ADR-0115 clause 3): `GET /attach/hosts`
+ * returns this principal's attachable Super Chat hosts, each as the closed
+ * `{ hostId, label, status }` entry and nothing else. It is the step before
+ * attach: a signed-in phone learns which desktops it may dial and whether one is
+ * live, then points the existing AttachRelay client at the chosen `hostId`.
+ *
+ * ## Read-only, and closed
+ *
+ * This is a plain HTTP read at the account-and-device layer, above the relay. It
+ * carries no route name, capability, action, tool, or topic: the response items
+ * are {@link AttachHostDirectoryEntry}s, whose schema rejects every such field, so
+ * the directory cannot grow into a capability registry (the PR #2277 guard). There
+ * is no write route here: a host publishes itself by the act of connecting as a
+ * host (the mount records its membership), and liveness is the live host socket,
+ * never a heartbeat the client PUTs. The one surface is this GET.
+ *
+ * ## Same shape, two sources
+ *
+ * The deployment binds the backend through `resolveHostDirectory`, exactly the
+ * `resolveRelay`/`resolveRooms` seam: a Bun self-host returns its process
+ * directory (`createAttachRelayBunServer().hostDirectory`), and a Cloud
+ * per-principal index is a later refinement behind the same seam. The mount stays
+ * backend-blind; the principal is stamped from the resolved bearer, never the
+ * query, so a client only ever reads its own principal's hosts.
+ */
+
+import { Hono } from 'hono';
+import { describeRoute } from 'hono-openapi';
+import { requireBearerPrincipal } from '../middleware/require-auth.js';
+import type { ServerBindings } from '../server-bindings.js';
+import type { Env, ResolveBearerPrincipal } from '../types.js';
+import type { HostDirectoryReader } from './host-directory.js';
+
+/**
+ * Mount the host-discovery surface on a deployment's server app.
+ *
+ * Bundles the bearer gate and the one `GET /attach/hosts` read, the same shape
+ * `mountAttachGrantsApp` uses. The bearer is the deployment's attach credential
+ * (a per-device grant on self-host, a signed-in session on Cloud): the same
+ * credential a client attaches with, so discovery and attach share one gate.
+ * `resolveHostDirectory` binds this runtime's directory backend from the
+ * per-request env, backend-blind here.
+ */
+export function mountHostDirectoryApp<E extends Env = Env>(
+	app: Hono<E>,
+	opts: {
+		resolveBearerPrincipal: ResolveBearerPrincipal<E>;
+		resolveHostDirectory: (env: ServerBindings) => HostDirectoryReader;
+	},
+): void {
+	app.use('/attach/hosts', requireBearerPrincipal(opts.resolveBearerPrincipal));
+	app.route('/', createHostDirectoryApp(opts.resolveHostDirectory));
+}
+
+/**
+ * The one `GET /attach/hosts` route, on the concrete portable {@link Env} so it
+ * reads the resolved `c.var.principal` and hands `c.env` to `resolveHostDirectory`
+ * (a {@link ServerBindings} consumer). The bearer gate is applied upstream by
+ * {@link mountHostDirectoryApp}; by the time this runs, `principal` is set. This
+ * mirrors how `mount.ts` splits its generic mount from its concrete route.
+ */
+function createHostDirectoryApp(
+	resolveHostDirectory: (env: ServerBindings) => HostDirectoryReader,
+): Hono<Env> {
+	return new Hono<Env>().get(
+		'/attach/hosts',
+		describeRoute({
+			description: "List this principal's attachable Super Chat hosts",
+			tags: ['attach-relay'],
+		}),
+		async (c) => {
+			// The principal is the resolved bearer's, stamped by the gate upstream,
+			// never the query's: a client reads only its own principal's hosts.
+			const hosts = await resolveHostDirectory(c.env).list(c.var.principal.id);
+			return c.json({ hosts });
+		},
+	);
+}

--- a/packages/server/src/attach-relay/host-directory-store.test.ts
+++ b/packages/server/src/attach-relay/host-directory-store.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Host directory store + Bun join proof (ADR-0115 clause 3): membership is the
+ * trace of the host-register act, liveness is the coordinator, and a status is
+ * their join.
+ *
+ * What this pins:
+ * - `createHostDirectory` retains a host after it disconnects (so an asleep
+ *   desktop still lists) and falls back to the `hostId` when no label is given;
+ * - the Bun server's `hostDirectory` records a host by the act of connecting as a
+ *   host, lists it `online` while its socket is live, and flips it to `offline`
+ *   (never dropping it) when the socket closes;
+ * - a client connect never enters the directory (no host/client discriminator to
+ *   get wrong: only a `role=host` connect writes membership);
+ * - the directory is partitioned by principal;
+ * - liveness is conflict-correct: a refused second host registration never
+ *   displaces the incumbent's `online`.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { ServerWebSocket } from 'bun';
+import {
+	type AttachRelayBunServer,
+	type AttachRelaySocketData,
+	createAttachRelayBunServer,
+} from './bun-server.js';
+import { createHostDirectory } from './host-directory.js';
+
+describe('createHostDirectory (membership store)', () => {
+	test('retains a host after disconnect and falls back to hostId', () => {
+		const directory = createHostDirectory();
+		directory.record('p', 'mac', "Braden's Mac");
+		directory.record('p', 'mini', undefined);
+
+		expect(directory.entries('p')).toEqual([
+			{ hostId: 'mac', label: "Braden's Mac" },
+			// A blank label falls back to the hostId so the closed schema accepts it.
+			{ hostId: 'mini', label: 'mini' },
+		]);
+	});
+
+	test('is partitioned by principal', () => {
+		const directory = createHostDirectory();
+		directory.record('p', 'mac', 'Mac');
+		directory.record('q', 'other', 'Other');
+
+		expect(directory.entries('p')).toEqual([{ hostId: 'mac', label: 'Mac' }]);
+		expect(directory.entries('other-principal')).toEqual([]);
+	});
+
+	test('re-recording a host refreshes its label without duplicating it', () => {
+		const directory = createHostDirectory();
+		directory.record('p', 'mac', 'Old name');
+		directory.record('p', 'mac', 'New name');
+
+		expect(directory.entries('p')).toEqual([
+			{ hostId: 'mac', label: 'New name' },
+		]);
+	});
+});
+
+/** A test double for a Bun `ServerWebSocket` the coordinator drives. */
+function fakeSocket(
+	data: AttachRelaySocketData,
+): ServerWebSocket<AttachRelaySocketData> {
+	return {
+		data,
+		readyState: 1,
+		send() {},
+		close() {},
+	} as unknown as ServerWebSocket<AttachRelaySocketData>;
+}
+
+/** Open a socket on the relay's websocket handler, as `Bun.serve` would. */
+function open(relay: AttachRelayBunServer, data: AttachRelaySocketData): void {
+	relay.websocket.open?.(fakeSocket(data));
+}
+
+describe("Bun server's host directory join", () => {
+	test('a host lists online while live and offline after it closes', () => {
+		const relay = createAttachRelayBunServer();
+		const hostSocket = fakeSocket({
+			surface: 'attach',
+			role: 'host',
+			principalId: 'instance',
+			hostId: 'mac',
+			label: "Braden's Mac",
+		});
+
+		relay.websocket.open?.(hostSocket);
+		expect(relay.hostDirectory.list('instance')).toEqual([
+			{ hostId: 'mac', label: "Braden's Mac", status: 'online' },
+		]);
+
+		relay.websocket.close?.(hostSocket, 1000, 'bye');
+		// Retained, not dropped: an asleep desktop still lists, now offline.
+		expect(relay.hostDirectory.list('instance')).toEqual([
+			{ hostId: 'mac', label: "Braden's Mac", status: 'offline' },
+		]);
+	});
+
+	test('a client connect never enters the directory', () => {
+		const relay = createAttachRelayBunServer();
+		// A live host so the client attach pairs rather than being refused.
+		open(relay, {
+			surface: 'attach',
+			role: 'host',
+			principalId: 'instance',
+			hostId: 'mac',
+			label: 'Mac',
+		});
+		open(relay, {
+			surface: 'attach',
+			role: 'client',
+			principalId: 'instance',
+			hostId: 'mac',
+			deviceId: 'phone',
+			attachId: 'a1',
+		});
+
+		// Only the host is in the directory; the client left no membership trace.
+		expect(relay.hostDirectory.list('instance')).toEqual([
+			{ hostId: 'mac', label: 'Mac', status: 'online' },
+		]);
+	});
+
+	test('is partitioned by principal', () => {
+		const relay = createAttachRelayBunServer();
+		open(relay, {
+			surface: 'attach',
+			role: 'host',
+			principalId: 'instance',
+			hostId: 'mac',
+			label: 'Mac',
+		});
+
+		expect(relay.hostDirectory.list('someone-else')).toEqual([]);
+	});
+
+	test('a refused second host registration keeps the incumbent online', async () => {
+		const relay = createAttachRelayBunServer();
+		const incumbent = fakeSocket({
+			surface: 'attach',
+			role: 'host',
+			principalId: 'instance',
+			hostId: 'mac',
+			label: 'Mac',
+		});
+		const conflicting = fakeSocket({
+			surface: 'attach',
+			role: 'host',
+			principalId: 'instance',
+			hostId: 'mac',
+			label: 'Mac (stale reconnect)',
+		});
+
+		relay.websocket.open?.(incumbent);
+		relay.websocket.open?.(conflicting);
+		// The coordinator refused the newcomer; the incumbent still owns the pair.
+		expect((await relay.hostDirectory.list('instance'))[0]?.status).toBe(
+			'online',
+		);
+
+		// The refused newcomer's socket closes; it never owned the entry, so the
+		// incumbent stays online (conflict-correct liveness from the coordinator).
+		relay.websocket.close?.(conflicting, 4409, 'host already registered');
+		expect((await relay.hostDirectory.list('instance'))[0]?.status).toBe(
+			'online',
+		);
+	});
+});

--- a/packages/server/src/attach-relay/host-directory.ts
+++ b/packages/server/src/attach-relay/host-directory.ts
@@ -23,17 +23,30 @@
  * the relay, beside the device grants (`device-grants.ts`), never inside the
  * relay coordinator (`core.ts`), which stays byte-, frame-, key-, and
  * directory-blind: it forwards opaque bytes addressed by `principalId`,
- * `hostId`, `deviceId`, `attachId`, and never learns a directory exists. No
- * runtime mount consumes this yet, so it is a schema plus its guard tests, not a
- * live product directory.
+ * `hostId`, `deviceId`, `attachId`, and never learns a directory exists.
  *
- * ## Deliberately not built here (smallest model, ADR-0115)
+ * ## How membership and liveness split (the two facts a status is)
  *
- * - There is no directory store, route, or presence feed: a host does not
- *   publish an entry anywhere yet. The wire and mount for discovery are a later
- *   refinement; this pins the shape the guard protects. The `unreachable` status
- *   has a consumer (Super Chat's ask-gate), but the live publish/discover wire
- *   stays deferred.
+ * A directory entry is a join of two facts that live in different owners:
+ * - **membership + label** ("this principal's known desktops and their names")
+ *   is what {@link createHostDirectory} retains. A host publishes itself by the
+ *   act of connecting as a host (`role=host`, the mount records `hostId`+`label`
+ *   here); a client never performs that act, so it is structurally absent. There
+ *   is no host/client discriminator to store or filter: membership IS the trace
+ *   of the host-register act. Membership is retained after disconnect, so an
+ *   asleep desktop still lists as `offline` rather than vanishing.
+ * - **liveness** ("is a host socket live right now") belongs to the coordinator
+ *   (`core.ts` `liveHostIds`), the single conflict-correct source. A
+ *   {@link HostDirectoryReader} joins the two at read time, so a crashed host is
+ *   never a stale `online`: the coordinator drops it, and the retained
+ *   membership renders `offline`.
+ *
+ * The store is in-memory and per-process (a restart forgets membership, exactly
+ * as the grant store and coordinator do); persisting it is deferred until a real
+ * need earns it. The `unreachable` status is emitted only by a store that can
+ * hold "claimed online but the socket is dead" (the Cloud per-principal index,
+ * deferred); the Bun self-host reader here emits only `online`/`offline`, and
+ * the client's ask-gate treats `offline` and `unreachable` identically.
  */
 
 import { type } from 'arktype';
@@ -72,3 +85,60 @@ export const AttachHostDirectoryEntry = type({
 	status: AttachHostStatus,
 }).onUndeclaredKey('reject');
 export type AttachHostDirectoryEntry = typeof AttachHostDirectoryEntry.infer;
+
+/**
+ * The read seam a discovery mount drives: given the server-stamped principal,
+ * return that principal's host directory entries. One deployment binds one
+ * backend behind it (the Bun self-host reader below; a Cloud per-principal index
+ * later), exactly the `resolveRelay`/`resolveRooms` shape, so the mount stays
+ * backend-blind. Async so a Durable-Object-backed index can satisfy it.
+ */
+export type HostDirectoryReader = {
+	list(
+		principalId: string,
+	): AttachHostDirectoryEntry[] | Promise<AttachHostDirectoryEntry[]>;
+};
+
+/** One retained host membership record: the id to dial and its human label. */
+type HostMembership = { hostId: string; label: string };
+
+/**
+ * The retained membership+label half of the directory (the liveness half is the
+ * coordinator's `liveHostIds`). A host is recorded by the act of connecting as a
+ * host and is kept after it disconnects, so an asleep desktop still lists. This
+ * holds no host/client discriminator and no status: status is computed at read
+ * time by joining with the coordinator, so this store can never drift into a
+ * stale `online`.
+ */
+export type HostDirectory = {
+	/**
+	 * Record (or refresh the label of) a host under a principal. Called by the
+	 * mount when a `role=host` endpoint connects; idempotent, so a reconnect or a
+	 * refused conflicting registration only upserts the same membership.
+	 */
+	record(principalId: string, hostId: string, label: string | undefined): void;
+	/** Every retained host membership under a principal, in insertion order. */
+	entries(principalId: string): HostMembership[];
+};
+
+/** Build one in-memory host directory. A Bun deployment holds one per process. */
+export function createHostDirectory(): HostDirectory {
+	/** principalId -> (hostId -> label). Partitioned by principal, never merged. */
+	const byPrincipal = new Map<string, Map<string, string>>();
+
+	return {
+		record(principalId, hostId, label) {
+			if (!hostId) return;
+			const hosts = byPrincipal.get(principalId) ?? new Map<string, string>();
+			// A blank label falls back to the hostId, so an entry always has a
+			// non-empty `label` the closed schema accepts.
+			hosts.set(hostId, label && label.length > 0 ? label : hostId);
+			byPrincipal.set(principalId, hosts);
+		},
+		entries(principalId) {
+			const hosts = byPrincipal.get(principalId);
+			if (!hosts) return [];
+			return Array.from(hosts, ([hostId, label]) => ({ hostId, label }));
+		},
+	};
+}

--- a/packages/server/src/attach-relay/mount.ts
+++ b/packages/server/src/attach-relay/mount.ts
@@ -121,6 +121,9 @@ function createAttachRelayApp(
 				hostId: c.req.query('hostId'),
 				deviceId: c.req.query('deviceId'),
 				attachId: c.req.query('attachId'),
+				// Directory metadata for a `role=host` connect; the backend records
+				// it in the host directory and never hands it to the coordinator.
+				label: c.req.query('label'),
 			});
 		},
 	);

--- a/packages/server/src/attach-relay/route.ts
+++ b/packages/server/src/attach-relay/route.ts
@@ -33,15 +33,21 @@ export const ATTACH_RELAY_ROUTE = {
 	subprotocols(bearer: string): string[] {
 		return [MAIN_SUBPROTOCOL, `${BEARER_SUBPROTOCOL_PREFIX}${bearer}`];
 	},
-	/** The host endpoint's connect URL: it registers under `(principalId, hostId)`. */
+	/**
+	 * The host endpoint's connect URL: it registers under `(principalId, hostId)`.
+	 * An optional `label` is directory metadata (ADR-0115 clause 3) the mount
+	 * records for the host directory; it never reaches the coordinator, which
+	 * stays label-blind. A host with no label lists under its `hostId`.
+	 */
 	hostUrl(
 		baseURL: string,
-		params: { principalId: string; hostId: string },
+		params: { principalId: string; hostId: string; label?: string },
 	): string {
 		const url = new URL(`${stripTrailing(baseURL)}/attach`);
 		url.searchParams.set('role', 'host');
 		url.searchParams.set('principalId', params.principalId);
 		url.searchParams.set('hostId', params.hostId);
+		if (params.label) url.searchParams.set('label', params.label);
 		return url.toString();
 	},
 	/** A client endpoint's connect URL: it attaches under the full quadruple. */

--- a/packages/server/src/bun.ts
+++ b/packages/server/src/bun.ts
@@ -49,12 +49,22 @@ export {
 // deployment's bearer gate, with the principal stamped server-side. On self-host
 // the bearer is a per-device grant.
 export { mountAttachGrantsApp } from './attach-relay/grants-app.js';
-// The attach host's three-valued liveness (ADR-0115): the `online` / `offline` /
-// `unreachable` status a Super Chat client reads to decide whether a new
-// local-source question may start. The closed directory-entry schema that wraps
-// it (`AttachHostDirectoryEntry`) stays package-internal: no deployable dials a
-// directory yet, so its only consumer is its own guard test.
-export { AttachHostStatus } from './attach-relay/host-directory.js';
+// The attach host directory (ADR-0115 clause 3): the closed
+// `{ hostId, label, status }` entry a client discovers a host by, its
+// three-valued liveness (`online`/`offline`/`unreachable`), and the read seam a
+// discovery mount drives (`HostDirectoryReader`, satisfied by a Bun server's
+// `.hostDirectory`). The entry schema stays closed so the directory can never
+// grow into a capability registry.
+export {
+	type AttachHostDirectoryEntry,
+	AttachHostStatus,
+	type HostDirectoryReader,
+} from './attach-relay/host-directory.js';
+// The client's host-discovery mount (ADR-0115 clause 3): `GET /attach/hosts`
+// behind the deployment's attach bearer, backend bound through
+// `resolveHostDirectory`. Read-only and closed; a host publishes itself by
+// connecting, never by a write route.
+export { mountHostDirectoryApp } from './attach-relay/host-directory-app.js';
 export { mountAttachRelayApp } from './attach-relay/mount.js';
 export { ATTACH_RELAY_ROUTE } from './attach-relay/route.js';
 // The single-partition instance's bearer resolver (self-host; ADR-0075): the


### PR DESCRIPTION
This adds the first host-discovery wave for Super Chat remote attach: self-host clients can list the desktop hosts they may connect to before opening the live attach socket.

A paired client can now call `GET /attach/hosts` and receive the closed directory shape:

```ts
{ hosts: Array<{ hostId: string; label: string; status: 'online' | 'offline' | 'unreachable' }> }
```

The implementation keeps the ownership split narrow. Host membership is the trace of a `role=host` connection, with an optional label recorded beside the relay. Liveness comes from the relay coordinator's live host set, so `online` is not stored and cannot drift from the socket that actually forwards frames. Grants remain pure credentials: there is no host/client kind, no heartbeat, no write route, and no capability registry.

Cloud discovery is intentionally left for a later per-principal index behind the same `HostDirectoryReader` seam. The phone UI can consume the same directory shape once the hosted source exists.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786156341&installation_id=128463665&pr_number=2427&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2427&signature=f4fd3654e20a61ef689ead292cfb14fbeadfa0386965c46b3a42b5440b6d70ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->