### PR TITLE
fix(local-mail): count material label patches

### DIFF
--- a/apps/local-mail/src/db.test.ts
+++ b/apps/local-mail/src/db.test.ts
@@ -383,6 +383,38 @@ describe('applyHistoryBatch', () => {
 		cleanup();
 	});
 
+	test('labelsChanged counts only patches that materially change the label set', () => {
+		const { db, cleanup } = openTmp();
+		db.ingestFullPullPage(
+			[
+				message({ id: 'a', labelIds: ['INBOX', 'UNREAD'] }),
+				message({ id: 'b', labelIds: ['INBOX'] }),
+				message({ id: 'c', labelIds: ['INBOX', 'UNREAD'] }),
+			],
+			's1',
+		);
+
+		const { labelsChanged } = db.applyHistoryBatch({
+			messagesToUpsert: [],
+			messagesToDelete: [],
+			labelPatches: [
+				// 'a': same set in a different order, no material change.
+				{ messageId: 'a', labelIds: ['UNREAD', 'INBOX'] },
+				// 'b': a real change (UNREAD added).
+				{ messageId: 'b', labelIds: ['INBOX', 'UNREAD'] },
+				// 'c': identical set, an idempotent echo.
+				{ messageId: 'c', labelIds: ['INBOX', 'UNREAD'] },
+				// missing row: not found, not counted.
+				{ messageId: 'gone', labelIds: ['INBOX'] },
+			],
+			newHistoryId: '650',
+			syncedAt: 's2',
+		});
+
+		expect(labelsChanged).toBe(1);
+		cleanup();
+	});
+
 	test('a labelPatch for a message not yet mirrored is silently skipped', () => {
 		const { db, cleanup } = openTmp();
 		db.applyHistoryBatch({

--- a/apps/local-mail/src/db.ts
+++ b/apps/local-mail/src/db.ts
@@ -75,6 +75,14 @@ export type LabelSummary = {
 	type: string | null;
 };
 
+/** Label sets are unordered: Gmail may echo the same labels in a different
+ * order, so a material change is a set difference, not an array inequality. */
+function sameLabelSet(a: string[], b: string[]): boolean {
+	if (a.length !== b.length) return false;
+	const present = new Set(a);
+	return b.every((id) => present.has(id));
+}
+
 function parseLabelIds(json: string | null): string[] {
 	if (!json) return [];
 	try {
@@ -283,18 +291,28 @@ export function openMailDb({ dataDir, accountEmail }: MailDbLocation) {
 		);
 	}
 
+	/**
+	 * Fold `labelIds` into one row's `raw`, reporting both whether the row was
+	 * `found` (a write-through fold cares only about this) and whether the label
+	 * set `changed` materially (the sync metric counts only these, so an
+	 * idempotent history echo of labels already current does not read as drift).
+	 * The write is unconditional either way: a no-op patch still refreshes
+	 * `synced_at`, matching the prior behaviour.
+	 */
 	function patchMessageLabelsRow(
 		messageId: string,
 		labelIds: string[],
 		syncedAt: string,
-	): boolean {
+	): { found: boolean; changed: boolean } {
 		const row = getMessageRawStmt.get(messageId);
-		if (!row) return false;
-		const patched = { ...JSON.parse(row.raw), labelIds };
-		return (
-			patchMessageLabelsStmt.run(JSON.stringify(patched), syncedAt, messageId)
-				.changes > 0
-		);
+		if (!row) return { found: false, changed: false };
+		const parsed = JSON.parse(row.raw);
+		const prevLabelIds: string[] = Array.isArray(parsed.labelIds)
+			? parsed.labelIds
+			: [];
+		const patched = { ...parsed, labelIds };
+		patchMessageLabelsStmt.run(JSON.stringify(patched), syncedAt, messageId);
+		return { found: true, changed: !sameLabelSet(prevLabelIds, labelIds) };
 	}
 
 	return {
@@ -322,12 +340,10 @@ export function openMailDb({ dataDir, accountEmail }: MailDbLocation) {
 			labelIds: string[],
 			syncedAt: string,
 		) {
-			let patched = false;
-			const tx = db.transaction(() => {
-				patched = patchMessageLabelsRow(messageId, labelIds, syncedAt);
-			});
-			tx.immediate();
-			return patched;
+			const tx = db.transaction(
+				() => patchMessageLabelsRow(messageId, labelIds, syncedAt).found,
+			);
+			return tx.immediate();
 		},
 
 		counts(): { messages: number; labels: number } {
@@ -514,15 +530,14 @@ export function openMailDb({ dataDir, accountEmail }: MailDbLocation) {
 		 * disappearing behind a post-pull cursor.
 		 */
 		finishFullPull(historyId: string, syncedAt: string): number {
-			let swept = 0;
 			const tx = db.transaction(() => {
-				swept = sweepMessagesStmt.run(syncedAt).changes;
+				const swept = sweepMessagesStmt.run(syncedAt).changes;
 				setMetaStmt.run('history_id', historyId);
 				setMetaStmt.run('last_full_pull_at', syncedAt);
 				setMetaStmt.run('last_synced_at', syncedAt);
+				return swept;
 			});
-			tx.immediate();
-			return swept;
+			return tx.immediate();
 		},
 
 		/**
@@ -539,6 +554,11 @@ export function openMailDb({ dataDir, accountEmail }: MailDbLocation) {
 		 * aimed at unmirrored rows into full refetches (`hasMessage`), so a
 		 * miss here means the message changed mid-pass and the next pass
 		 * converges.
+		 *
+		 * Returns `labelsChanged`: how many label patches materially changed a
+		 * row's label set. A patch whose labels already match (a history echo of
+		 * a change the write-through fold already applied) is applied but not
+		 * counted, so the sync metric reports convergence, not phantom drift.
 		 */
 		applyHistoryBatch({
 			messagesToUpsert,
@@ -552,18 +572,22 @@ export function openMailDb({ dataDir, accountEmail }: MailDbLocation) {
 			labelPatches: { messageId: string; labelIds: string[] }[];
 			newHistoryId: string;
 			syncedAt: string;
-		}): void {
+		}): { labelsChanged: number } {
 			const tx = db.transaction(() => {
+				let labelsChanged = 0;
 				for (const message of messagesToUpsert)
 					upsertMessage(message, syncedAt);
 				for (const id of messagesToDelete) deleteMessageStmt.run(id);
 				for (const { messageId, labelIds } of labelPatches) {
-					patchMessageLabelsRow(messageId, labelIds, syncedAt);
+					if (patchMessageLabelsRow(messageId, labelIds, syncedAt).changed) {
+						labelsChanged += 1;
+					}
 				}
 				setMetaStmt.run('history_id', newHistoryId);
 				setMetaStmt.run('last_synced_at', syncedAt);
+				return { labelsChanged };
 			});
-			tx.immediate();
+			return tx.immediate();
 		},
 
 		close(): void {

--- a/apps/local-mail/src/sync-mailbox.test.ts
+++ b/apps/local-mail/src/sync-mailbox.test.ts
@@ -574,6 +574,89 @@ describe('syncMailbox: INCREMENTAL', () => {
 		cleanup();
 	});
 
+	test('an idempotent history echo of already-current labels reports labelsPatched 0', async () => {
+		const { db, cleanup } = seededDb();
+		// The seeded row already carries exactly ['INBOX']; a labelsAdded echo of
+		// the same set (the shape a write-through fold produces, then Gmail replays
+		// through history) touches the row but changes nothing material.
+		const client = createFakeGmailClient({
+			mailbox: new Map(),
+			historyPages: [
+				{
+					historyId: '502',
+					history: [
+						{
+							id: 'h1',
+							labelsAdded: [
+								{
+									message: {
+										id: 'existing',
+										threadId: 't-existing',
+										labelIds: ['INBOX'],
+									},
+									labelIds: ['INBOX'],
+								},
+							],
+						},
+					],
+				},
+			],
+			profileHistoryId: '999',
+		});
+
+		const outcome = await syncMailbox(
+			{ db, client, config, now: () => Date.parse('2026-06-30T01:00:00.000Z') },
+			{ forceFull: false },
+		);
+
+		expect(outcome.failure).toBeNull();
+		expect(outcome.cursorAfter).toBe('502');
+		expect(outcome.labelsPatched).toBe(0);
+		cleanup();
+	});
+
+	test('a labels echo in a different order is not counted as a material change', async () => {
+		const { db, cleanup } = tempDb();
+		db.ingestFullPullPage(
+			[message('existing', { labelIds: ['INBOX', 'IMPORTANT'] })],
+			'2026-06-30T00:00:00.000Z',
+		);
+		db.finishFullPull('500', '2026-06-30T00:00:00.000Z');
+		const client = createFakeGmailClient({
+			mailbox: new Map(),
+			historyPages: [
+				{
+					historyId: '502',
+					history: [
+						{
+							id: 'h1',
+							labelsAdded: [
+								{
+									message: {
+										id: 'existing',
+										threadId: 't-existing',
+										labelIds: ['IMPORTANT', 'INBOX'],
+									},
+									labelIds: ['IMPORTANT'],
+								},
+							],
+						},
+					],
+				},
+			],
+			profileHistoryId: '999',
+		});
+
+		const outcome = await syncMailbox(
+			{ db, client, config, now: () => Date.parse('2026-06-30T01:00:00.000Z') },
+			{ forceFull: false },
+		);
+
+		expect(outcome.failure).toBeNull();
+		expect(outcome.labelsPatched).toBe(0);
+		cleanup();
+	});
+
 	test('labelsRemoved for an unmirrored message refetches it (untrash after a full-pull sweep)', async () => {
 		const { db, cleanup } = seededDb();
 		const mailbox = new Map([

--- a/apps/local-mail/src/sync.ts
+++ b/apps/local-mail/src/sync.ts
@@ -100,6 +100,9 @@ export type SyncOutcome = {
 	cursorAfter: string | null;
 	messagesUpserted: number;
 	messagesDeleted: number;
+	/** Mirrored rows whose label set materially changed this pass. An idempotent
+	 * history echo of labels the write-through fold already applied counts 0, so
+	 * this reads as "what the sync actually changed", like its sibling counts. */
 	labelsPatched: number;
 	failure: SyncFailure | null;
 };
@@ -316,7 +319,7 @@ async function incrementalPoll(
 		db.ingestLabels(labels.data, syncedAt);
 	}
 
-	db.applyHistoryBatch({
+	const { labelsChanged } = db.applyHistoryBatch({
 		messagesToUpsert,
 		messagesToDelete,
 		labelPatches,
@@ -331,7 +334,7 @@ async function incrementalPoll(
 		cursorAfter: newHistoryId,
 		messagesUpserted: messagesToUpsert.length,
 		messagesDeleted: messagesToDelete.length,
-		labelsPatched: labelPatches.length,
+		labelsPatched: labelsChanged,
 		failure: null,
 	};
 }


### PR DESCRIPTION
Local Mail was reporting idempotent Gmail history echoes as label activity. After a local archive or label change, the UI folds Gmail's response into SQLite immediately; a later `history.list` replay can echo the same labels back. That path converges correctly, but the sync outcome used to report the echo as `1 labels patched`, which made harmless replay look like drift.

This changes `labelsPatched` to mean rows whose label set materially changed, matching the sibling `messagesUpserted` and `messagesDeleted` counters. Write-through folds still return success when the row exists, even if the labels are already current.

The fix keeps the convergence-only model: no per-message history cursor, no schema change, and no stale-patch suppression layer.

## Changelog

- Fixed Local Mail sync diagnostics so idempotent Gmail label echoes no longer report phantom label patches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786173532&installation_id=128463665&pr_number=2430&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2430&signature=fb0f715538064413b58e62f6c03f12c18e96cdc9468be67ac9e9d2dc7a5c777a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->