### PR TITLE
refactor(workspace): clarify transaction-local reads

### DIFF
--- a/packages/workspace/src/document/create-table.write-guard.test.ts
+++ b/packages/workspace/src/document/create-table.write-guard.test.ts
@@ -12,7 +12,7 @@
  * - set() over same-version, corrupt, or absent rows writes as before
  * - set()/clear() over a fractional `_v` above the latest repair it (a fraction
  *   is corruption, not a newer writer); read and write share one newer rule
- * - the guard reads the pending view inside an open transaction
+ * - the guard sees transaction-local writes inside an open transaction
  * - bulkSet() skips refused rows per chunk and reports them as TableWriteError; onProgress unchanged
  * - clear() skips newer-stamped rows and reports them; delete(id) stays unguarded
  * - update() over a newer-stamped row refuses via NewerWriter (pinned)
@@ -149,12 +149,13 @@ describe('set write guard', () => {
 		expect(table.storedCount()).toBe(0);
 	});
 
-	test('guard reads the pending view inside an open transaction', () => {
+	test('guard sees transaction-local writes inside an open transaction', () => {
 		const { ydoc, ykv, table } = setup();
 
 		ydoc.transact(() => {
-			// Simulate a v2 row landing in the same transaction window: the
-			// observer has not fired, so the value lives only in `pending`.
+			// Simulate a v2 row landing in the same transaction. The observer has
+			// not run yet, so only YKeyValueLww's transaction-local read overlay
+			// can see it.
 			ykv.set('1', { id: '1', title: 'newer', rating: 1, _v: 2 });
 			const error = expectErr(table.set({ id: '1', title: 'stale' }));
 			expect(error.name).toBe('NewerWriterRefusal');

--- a/packages/workspace/src/document/create-table.write-guard.test.ts
+++ b/packages/workspace/src/document/create-table.write-guard.test.ts
@@ -154,8 +154,8 @@ describe('set write guard', () => {
 
 		ydoc.transact(() => {
 			// Simulate a v2 row landing in the same transaction. The observer has
-			// not run yet, so only YKeyValueLww's transaction-local read overlay
-			// can see it.
+			// not run yet, so the guard can see the row only through YKeyValueLww's
+			// transaction-local read overlay.
 			ykv.set('1', { id: '1', title: 'newer', rating: 1, _v: 2 });
 			const error = expectErr(table.set({ id: '1', title: 'stale' }));
 			expect(error.name).toBe('NewerWriterRefusal');

--- a/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.test.ts
+++ b/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.test.ts
@@ -2,12 +2,12 @@
  * YKeyValueLww Tests - Last-Write-Wins Conflict Resolution
  *
  * These tests verify timestamp-based last-write-wins semantics in `YKeyValueLww`
- * across local operations, batched transactions, and multi-client synchronization.
+ * across local operations, caller-owned transactions, and multi-client synchronization.
  * They ensure deterministic winner selection by timestamp and convergence after sync.
  *
  * Key behaviors:
  * - Higher timestamps win conflicts regardless of merge ordering.
- * - Transaction-local pending state and observer processing stay internally consistent.
+ * - Reads inside caller-owned Yjs transactions include local writes and deletes.
  *
  * See also:
  * - `y-keyvalue.ts` for positional (rightmost-wins) alternative
@@ -322,91 +322,92 @@ describe('YKeyValueLww', () => {
 		});
 	});
 
-	describe('Single-Writer Architecture', () => {
+	describe('Transaction-local reads', () => {
 		/**
-		 * These tests verify the single-writer architecture where:
-		 * - set() writes to `pending` and Y.Array, but NOT to `map`
-		 * - Observer is the sole writer to `map` and clears `pending` after processing
-		 * - get()/has() check `pending` first, then `map`
-		 * - entries() yields from both pending and map
+		 * When a caller opens a Yjs transaction, the Y.Array mutates
+		 * immediately but the observer-backed map is not refreshed until the
+		 * transaction closes. These tests cover the public read overlay: local
+		 * writes and deletes are visible through get(), has(), and entries() during
+		 * that transaction window.
 		 */
 
-		describe('Batch operations with nested reads', () => {
-			test('get() returns value set in same batch', () => {
+		describe('writes inside caller-owned transactions', () => {
+			test('get() returns value set in the same caller-owned transaction', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
 
-				let valueInBatch: string | undefined;
+				let valueDuringTransaction: string | undefined;
 
 				ydoc.transact(() => {
 					kv.set('foo', 'bar');
-					valueInBatch = kv.get('foo');
+					valueDuringTransaction = kv.get('foo');
 				});
 
-				expect(valueInBatch).toBe('bar');
-				expect(kv.get('foo')).toBe('bar'); // Still works after batch
+				expect(valueDuringTransaction).toBe('bar');
+				// The value remains visible after the observer-backed map catches up.
+				expect(kv.get('foo')).toBe('bar');
 			});
 
-			test('has() returns true for key set in same batch', () => {
+			test('has() returns true for key set in the same caller-owned transaction', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
 
-				let hasInBatch: boolean = false;
+				let hasDuringTransaction: boolean = false;
 
 				ydoc.transact(() => {
 					kv.set('foo', 'bar');
-					hasInBatch = kv.has('foo');
+					hasDuringTransaction = kv.has('foo');
 				});
 
-				expect(hasInBatch).toBe(true);
+				expect(hasDuringTransaction).toBe(true);
 			});
 
-			test('multiple updates to same key in batch - final value wins', () => {
+			test('get() returns each successive value in a caller-owned transaction', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
 
-				const valuesInBatch: Array<string | undefined> = [];
+				const valuesDuringTransaction: Array<string | undefined> = [];
 
 				ydoc.transact(() => {
 					kv.set('foo', 'first');
-					valuesInBatch.push(kv.get('foo'));
+					valuesDuringTransaction.push(kv.get('foo'));
 
 					kv.set('foo', 'second');
-					valuesInBatch.push(kv.get('foo'));
+					valuesDuringTransaction.push(kv.get('foo'));
 
 					kv.set('foo', 'third');
-					valuesInBatch.push(kv.get('foo'));
+					valuesDuringTransaction.push(kv.get('foo'));
 				});
 
-				expect(valuesInBatch).toEqual(['first', 'second', 'third']);
+				expect(valuesDuringTransaction).toEqual(['first', 'second', 'third']);
 				expect(kv.get('foo')).toBe('third');
 			});
 
-			test('get() returns updated value when updating existing key in batch', () => {
+			test('get() returns updated value for existing key in a caller-owned transaction', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
 
-				// Set initial value outside batch
+				// Set the initial value before the caller-owned transaction.
 				kv.set('foo', 'initial');
 
-				let valueInBatch: string | undefined;
+				let valueDuringTransaction: string | undefined;
 
 				ydoc.transact(() => {
 					kv.set('foo', 'updated');
-					valueInBatch = kv.get('foo');
+					valueDuringTransaction = kv.get('foo');
 				});
 
-				expect(valueInBatch).toBe('updated');
+				expect(valueDuringTransaction).toBe('updated');
 				expect(kv.get('foo')).toBe('updated');
 			});
 		});
 
-		describe('Batch with deletes', () => {
-			test('delete() removes key set in same batch', () => {
+		describe('deletes inside caller-owned transactions', () => {
+			test('delete() removes key set in the same caller-owned transaction', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
@@ -419,15 +420,14 @@ describe('YKeyValueLww', () => {
 					hasAfterDelete = kv.has('foo');
 				});
 
-				// During batch: pending was cleared by delete(), map doesn't have it yet
 				expect(hasAfterDelete).toBe(false);
 
-				// After batch: delete() now correctly removes the yarray entry even for
-				// keys that were set (pending-only) in the same transaction
+				// After the transaction closes, the observer has caught up and the key
+				// remains absent.
 				expect(kv.has('foo')).toBe(false);
 			});
 
-			test('set() after delete() in same batch restores key', () => {
+			test('set() after delete() in the same caller-owned transaction restores key', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
@@ -435,19 +435,19 @@ describe('YKeyValueLww', () => {
 				// Set initial value
 				kv.set('foo', 'initial');
 
-				let valueInBatch: string | undefined;
+				let valueDuringTransaction: string | undefined;
 
 				ydoc.transact(() => {
 					kv.delete('foo');
 					kv.set('foo', 'restored');
-					valueInBatch = kv.get('foo');
+					valueDuringTransaction = kv.get('foo');
 				});
 
-				expect(valueInBatch).toBe('restored');
+				expect(valueDuringTransaction).toBe('restored');
 				expect(kv.get('foo')).toBe('restored');
 			});
 
-			test('delete() on pre-existing key during batch', () => {
+			test('delete() hides pre-existing key during a caller-owned transaction', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
@@ -457,21 +457,21 @@ describe('YKeyValueLww', () => {
 
 				ydoc.transact(() => {
 					kv.delete('foo');
-					// During batch, map still has old value until observer fires
-					// But has() checks pending first (which was cleared)
+					// _map still has the old value until the observer fires, but the
+					// transaction-local delete overlay hides it from reads.
 				});
 
 				expect(kv.has('foo')).toBe(false);
 			});
 		});
 
-		describe('entries() iterator', () => {
-			test('entries() yields pending values during batch', () => {
+		describe('entries() during caller-owned transactions', () => {
+			test('entries() yields values set during a caller-owned transaction', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
 
-				const keysInBatch: string[] = [];
+				const keysDuringTransaction: string[] = [];
 
 				ydoc.transact(() => {
 					kv.set('a', '1');
@@ -479,14 +479,14 @@ describe('YKeyValueLww', () => {
 					kv.set('c', '3');
 
 					for (const { key } of kv.entries()) {
-						keysInBatch.push(key);
+						keysDuringTransaction.push(key);
 					}
 				});
 
-				expect(keysInBatch.sort()).toEqual(['a', 'b', 'c']);
+				expect(keysDuringTransaction.sort()).toEqual(['a', 'b', 'c']);
 			});
 
-			test('entries() yields both pending and map values', () => {
+			test('entries() yields both confirmed and transaction-local values', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
@@ -494,38 +494,38 @@ describe('YKeyValueLww', () => {
 				// Set initial values (will be in map after transaction)
 				kv.set('existing', 'old');
 
-				const entriesInBatch: Array<[string, string]> = [];
+				const entriesDuringTransaction: Array<[string, string]> = [];
 
 				ydoc.transact(() => {
 					kv.set('new', 'value');
 
 					for (const { key, val } of kv.entries()) {
-						entriesInBatch.push([key, val]);
+						entriesDuringTransaction.push([key, val]);
 					}
 				});
 
-				expect(entriesInBatch).toContainEqual(['existing', 'old']);
-				expect(entriesInBatch).toContainEqual(['new', 'value']);
+				expect(entriesDuringTransaction).toContainEqual(['existing', 'old']);
+				expect(entriesDuringTransaction).toContainEqual(['new', 'value']);
 			});
 
-			test('entries() prefers pending over map for same key', () => {
+			test('entries() prefers transaction-local value over confirmed value for same key', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
 
 				kv.set('foo', 'old');
 
-				let valueInBatch: string | undefined;
+				let valueDuringTransaction: string | undefined;
 
 				ydoc.transact(() => {
 					kv.set('foo', 'new');
 
 					for (const { key, val } of kv.entries()) {
-						if (key === 'foo') valueInBatch = val;
+						if (key === 'foo') valueDuringTransaction = val;
 					}
 				});
 
-				expect(valueInBatch).toBe('new');
+				expect(valueDuringTransaction).toBe('new');
 			});
 
 			test('entries() does not yield duplicates', () => {
@@ -549,7 +549,7 @@ describe('YKeyValueLww', () => {
 			});
 		});
 
-		describe('Pending cleanup', () => {
+		describe('overlay cleanup', () => {
 			test('multiple transactions preserve prior keys and apply updates', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
@@ -575,7 +575,7 @@ describe('YKeyValueLww', () => {
 		});
 
 		describe('Observer behavior', () => {
-			test('observer fires once per batch, not per set()', () => {
+			test('observer fires once per caller-owned transaction, not per set()', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
@@ -594,7 +594,7 @@ describe('YKeyValueLww', () => {
 				expect(observerCallCount).toBe(1);
 			});
 
-			test('observer receives all changes from batch', () => {
+			test('observer receives all changes from a caller-owned transaction', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
@@ -616,8 +616,8 @@ describe('YKeyValueLww', () => {
 			});
 		});
 
-		describe('Sync with pending values', () => {
-			test('remote sync during batch: synced values visible after batch ends', () => {
+		describe('Sync with transaction-local writes', () => {
+			test('remote sync during a caller-owned transaction is visible after it ends', () => {
 				const doc1 = new Y.Doc({ guid: 'shared' });
 				const doc2 = new Y.Doc({ guid: 'shared' });
 
@@ -633,21 +633,21 @@ describe('YKeyValueLww', () => {
 				// kv2 makes a change while kv1's change is not yet synced
 				doc2.transact(() => {
 					kv2.set('bar', 'from-kv2');
-					// Sync kv1's changes into kv2 during the batch
+					// Sync kv1's changes into kv2 during the caller-owned transaction.
 					Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
 
-					// During batch: local pending values are visible
 					expect(kv2.get('bar')).toBe('from-kv2');
-					// Remote synced values are in yarray but observer hasn't updated map yet
-					// So they won't be visible via get() until batch ends
+					// Remote synced values are in the Y.Array, but only local writes go
+					// through the transaction-local overlay. Remote values become visible
+					// after the observer runs at transaction close.
 				});
 
-				// After batch: both local and synced values are visible
+				// After the transaction closes, both local and synced values are visible.
 				expect(kv2.get('bar')).toBe('from-kv2');
 				expect(kv2.get('foo')).toBe('from-kv1');
 			});
 
-			test('LWW still works with pending entries', () => {
+			test('LWW conflict resolution still works with transaction-local writes', () => {
 				const doc1 = new Y.Doc({ guid: 'shared' });
 				const doc2 = new Y.Doc({ guid: 'shared' });
 
@@ -702,7 +702,7 @@ describe('YKeyValueLww', () => {
 				expect(kv.get('counter')).toBe(99);
 			});
 
-			test('batch with mixed operations on multiple keys', () => {
+			test('mixed operations expose their latest state in a caller-owned transaction', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
@@ -720,7 +720,7 @@ describe('YKeyValueLww', () => {
 					expect(kv.get('keep')).toBe('original');
 					expect(kv.get('update')).toBe('new');
 					expect(kv.get('new')).toBe('added');
-					// delete() adds key to pendingDeletes, so has() returns false immediately
+					// The transaction-local delete overlay hides the key immediately.
 					expect(kv.has('delete')).toBe(false);
 					expect(kv.get('delete')).toBeUndefined();
 				});
@@ -731,61 +731,60 @@ describe('YKeyValueLww', () => {
 				expect(kv.has('delete')).toBe(false);
 			});
 
-			test('delete during batch: has() returns false immediately', () => {
+			test('delete in a caller-owned transaction makes has() return false immediately', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
 
 				kv.set('foo', 'bar');
 
-				let hasDuringBatch: boolean = true;
+				let hasDuringTransaction: boolean = true;
 
 				ydoc.transact(() => {
 					kv.delete('foo');
-					hasDuringBatch = kv.has('foo');
+					hasDuringTransaction = kv.has('foo');
 				});
 
-				// During batch, has() correctly returns false via pendingDeletes
-				expect(hasDuringBatch).toBe(false);
-				// After batch, still correctly returns false
+				expect(hasDuringTransaction).toBe(false);
+				// After the transaction closes, the observer-backed map agrees.
 				expect(kv.has('foo')).toBe(false);
 			});
 
-			test('delete then get in batch returns undefined', () => {
+			test('delete then get in a caller-owned transaction returns undefined', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
 
 				kv.set('foo', 'bar');
 
-				let getDuringBatch: string | undefined = 'not-cleared';
+				let valueDuringTransaction: string | undefined = 'not-cleared';
 
 				ydoc.transact(() => {
 					kv.delete('foo');
-					getDuringBatch = kv.get('foo');
+					valueDuringTransaction = kv.get('foo');
 				});
 
-				expect(getDuringBatch).toBeUndefined();
+				expect(valueDuringTransaction).toBeUndefined();
 				expect(kv.get('foo')).toBeUndefined();
 			});
 
-			test('delete then set in batch returns new value', () => {
+			test('delete then set in a caller-owned transaction returns new value', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
 
 				kv.set('foo', 'bar');
 
-				let getDuringBatch: string | undefined;
+				let valueDuringTransaction: string | undefined;
 
 				ydoc.transact(() => {
 					kv.delete('foo');
 					expect(kv.get('foo')).toBeUndefined();
 					kv.set('foo', 'new');
-					getDuringBatch = kv.get('foo');
+					valueDuringTransaction = kv.get('foo');
 				});
 
-				expect(getDuringBatch).toBe('new');
+				expect(valueDuringTransaction).toBe('new');
 				expect(kv.get('foo')).toBe('new');
 				expect(kv.has('foo')).toBe(true);
 			});
@@ -807,7 +806,7 @@ describe('YKeyValueLww', () => {
 				expect(kv.get('foo')).toBeUndefined();
 			});
 
-			test('entries skips pending deletes', () => {
+			test('entries skips transaction-local deletes', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
@@ -816,19 +815,21 @@ describe('YKeyValueLww', () => {
 				kv.set('b', '2');
 				kv.set('c', '3');
 
-				let keysDuringBatch: string[] = [];
+				let keysDuringTransaction: string[] = [];
 
 				ydoc.transact(() => {
 					kv.delete('b');
-					keysDuringBatch = Array.from(kv.entries()).map((entry) => entry.key);
+					keysDuringTransaction = Array.from(kv.entries()).map(
+						(entry) => entry.key,
+					);
 				});
 
-				expect(keysDuringBatch).not.toContain('b');
-				expect(keysDuringBatch).toContain('a');
-				expect(keysDuringBatch).toContain('c');
+				expect(keysDuringTransaction).not.toContain('b');
+				expect(keysDuringTransaction).toContain('a');
+				expect(keysDuringTransaction).toContain('c');
 			});
 
-			test('observer clears pendingDeletes', () => {
+			test('observer clears transaction-local delete overlay', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
@@ -837,36 +838,36 @@ describe('YKeyValueLww', () => {
 
 				ydoc.transact(() => {
 					kv.delete('foo');
-					expect(kv.has('foo')).toBe(false); // pendingDeletes active
+					expect(kv.has('foo')).toBe(false);
 				});
 
-				// After transaction, observer has fired and cleared pendingDeletes
-				// Verify by setting a new value: if pendingDeletes wasn't cleared,
-				// has() would still return false incorrectly
+				// After the transaction closes, the observer has cleared the delete overlay.
+				// Verify by setting a new value: a sticky overlay would keep has() false.
 				kv.set('foo', 'baz');
 				expect(kv.has('foo')).toBe(true);
 				expect(kv.get('foo')).toBe('baz');
 			});
 
-			test('set+delete in same batch leaves no sticky pendingDeletes', () => {
+			test('set+delete in a caller-owned transaction leaves no sticky delete overlay', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
 
-				// set then delete in same batch: entry added+deleted from yarray
+				// Set then delete in one transaction: the Y.Array entry is added and removed
+				// before the observer runs.
 				ydoc.transact(() => {
 					kv.set('foo', 'bar');
 					kv.delete('foo');
 				});
 
-				// After transaction, pendingDeletes should be clear (observer processed deletion)
-				// Verify: a subsequent set should work correctly
+				// After the transaction closes, the delete overlay should be clear.
+				// A subsequent set verifies that the old delete no longer masks this key.
 				kv.set('foo', 'new');
 				expect(kv.has('foo')).toBe(true);
 				expect(kv.get('foo')).toBe('new');
 			});
 
-			test('remote set after local delete is not masked by pendingDeletes', () => {
+			test('remote set after local delete is not masked by delete overlay', () => {
 				const ydoc1 = new Y.Doc({ guid: 'test' });
 				const yarray1 = ydoc1.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv1 = new YKeyValueLww(yarray1);
@@ -889,12 +890,12 @@ describe('YKeyValueLww', () => {
 				// Sync client 2's update to client 1
 				Y.applyUpdate(ydoc1, Y.encodeStateAsUpdate(ydoc2));
 
-				// Client 1 should see the remote value: pendingDeletes must not mask it
+				// Client 1 should see the remote value: the delete overlay must not mask it.
 				expect(kv1.has('foo')).toBe(true);
 				expect(kv1.get('foo')).toBe('remote-value');
 			});
 
-			test('set→delete→set triple sequence in batch', () => {
+			test('get() returns final value after set-delete-set in a caller-owned transaction', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
@@ -916,7 +917,7 @@ describe('YKeyValueLww', () => {
 				expect(kv.has('foo')).toBe(true);
 			});
 
-			test('delete→set→delete triple sequence in batch', () => {
+			test('get() returns undefined after delete-set-delete in a caller-owned transaction', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
@@ -946,38 +947,38 @@ describe('YKeyValueLww', () => {
 				expect(kv.has('never-existed')).toBe(false);
 				expect(kv.get('never-existed')).toBeUndefined();
 
-				// Also test inside a batch
+				// The operation is also a no-op inside a caller-owned transaction.
 				ydoc.transact(() => {
 					kv.delete('also-never-existed');
 					expect(kv.has('also-never-existed')).toBe(false);
 				});
 			});
 
-			test('pendingDeletes beats pending: set then delete in batch', () => {
+			test('delete overlay wins after set then delete in a caller-owned transaction', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
 
 				kv.set('foo', 'original');
 
-				let getDuringBatch: string | undefined = 'sentinel';
+				let valueDuringTransaction: string | undefined = 'sentinel';
 
 				ydoc.transact(() => {
-					// set() adds to pending, clears pendingDeletes
+					// set() adds a write overlay and clears any delete overlay.
 					kv.set('foo', 'updated');
 					expect(kv.get('foo')).toBe('updated');
 
-					// delete() clears pending, adds to pendingDeletes
+					// delete() clears the write overlay and adds a delete overlay.
 					kv.delete('foo');
-					getDuringBatch = kv.get('foo');
+					valueDuringTransaction = kv.get('foo');
 				});
 
-				// During batch, pendingDeletes should have taken precedence
-				expect(getDuringBatch).toBeUndefined();
+				// During the transaction, the delete overlay should have taken precedence.
+				expect(valueDuringTransaction).toBeUndefined();
 				expect(kv.has('foo')).toBe(false);
 			});
 
-			test('remote add for different key does not clear unrelated pendingDeletes', () => {
+			test('remote add for different key does not clear unrelated delete overlay', () => {
 				const ydoc1 = new Y.Doc({ guid: 'test' });
 				const yarray1 = ydoc1.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv1 = new YKeyValueLww(yarray1);

--- a/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.test.ts
+++ b/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.test.ts
@@ -332,10 +332,8 @@ describe('YKeyValueLww', () => {
 		 */
 
 		describe('writes inside caller-owned transactions', () => {
-			test('get() returns value set in the same caller-owned transaction', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+			test('get() returns a value set earlier', () => {
+				const { ydoc, kv } = setupKv();
 
 				let valueDuringTransaction: string | undefined;
 
@@ -349,10 +347,8 @@ describe('YKeyValueLww', () => {
 				expect(kv.get('foo')).toBe('bar');
 			});
 
-			test('has() returns true for key set in the same caller-owned transaction', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+			test('has() returns true for a key set earlier', () => {
+				const { ydoc, kv } = setupKv();
 
 				let hasDuringTransaction: boolean = false;
 
@@ -364,10 +360,8 @@ describe('YKeyValueLww', () => {
 				expect(hasDuringTransaction).toBe(true);
 			});
 
-			test('get() returns each successive value in a caller-owned transaction', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+			test('get() returns each successive value', () => {
+				const { ydoc, kv } = setupKv();
 
 				const valuesDuringTransaction: Array<string | undefined> = [];
 
@@ -386,10 +380,8 @@ describe('YKeyValueLww', () => {
 				expect(kv.get('foo')).toBe('third');
 			});
 
-			test('get() returns updated value for existing key in a caller-owned transaction', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+			test('get() returns an updated value for an existing key', () => {
+				const { ydoc, kv } = setupKv();
 
 				// Set the initial value before the caller-owned transaction.
 				kv.set('foo', 'initial');
@@ -407,10 +399,8 @@ describe('YKeyValueLww', () => {
 		});
 
 		describe('deletes inside caller-owned transactions', () => {
-			test('delete() removes key set in the same caller-owned transaction', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+			test('delete() removes a key set earlier', () => {
+				const { ydoc, kv } = setupKv();
 
 				let hasAfterDelete: boolean = true;
 
@@ -427,10 +417,8 @@ describe('YKeyValueLww', () => {
 				expect(kv.has('foo')).toBe(false);
 			});
 
-			test('set() after delete() in the same caller-owned transaction restores key', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+			test('set() after delete() restores the key', () => {
+				const { ydoc, kv } = setupKv();
 
 				// Set initial value
 				kv.set('foo', 'initial');
@@ -447,29 +435,25 @@ describe('YKeyValueLww', () => {
 				expect(kv.get('foo')).toBe('restored');
 			});
 
-			test('delete() hides pre-existing key during a caller-owned transaction', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+			test('delete() hides a pre-existing key immediately', () => {
+				const { ydoc, kv } = setupKv();
 
 				kv.set('foo', 'bar');
 				expect(kv.has('foo')).toBe(true);
 
 				ydoc.transact(() => {
 					kv.delete('foo');
-					// _map still has the old value until the observer fires, but the
-					// transaction-local delete overlay hides it from reads.
+					expect(kv.has('foo')).toBe(false);
 				});
 
+				// After the transaction closes, the observer-backed map agrees.
 				expect(kv.has('foo')).toBe(false);
 			});
 		});
 
 		describe('entries() during caller-owned transactions', () => {
-			test('entries() yields values set during a caller-owned transaction', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+			test('entries() yields values set earlier', () => {
+				const { ydoc, kv } = setupKv();
 
 				const keysDuringTransaction: string[] = [];
 
@@ -487,9 +471,7 @@ describe('YKeyValueLww', () => {
 			});
 
 			test('entries() yields both observer-indexed and transaction-local values', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+				const { ydoc, kv } = setupKv();
 
 				// Set initial values (will be in map after transaction)
 				kv.set('existing', 'old');
@@ -509,9 +491,7 @@ describe('YKeyValueLww', () => {
 			});
 
 			test('entries() prefers transaction-local value over observer-indexed value for same key', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+				const { ydoc, kv } = setupKv();
 
 				kv.set('foo', 'old');
 
@@ -529,9 +509,7 @@ describe('YKeyValueLww', () => {
 			});
 
 			test('entries() does not yield duplicates', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+				const { ydoc, kv } = setupKv();
 
 				kv.set('foo', 'old');
 
@@ -551,9 +529,7 @@ describe('YKeyValueLww', () => {
 
 		describe('overlay cleanup', () => {
 			test('multiple transactions preserve prior keys and apply updates', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+				const { ydoc, kv } = setupKv();
 
 				ydoc.transact(() => {
 					kv.set('a', '1');
@@ -576,9 +552,7 @@ describe('YKeyValueLww', () => {
 
 		describe('Observer behavior', () => {
 			test('observer fires once per caller-owned transaction, not per set()', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+				const { ydoc, kv } = setupKv();
 
 				let observerCallCount = 0;
 				kv.observe(() => {
@@ -595,9 +569,7 @@ describe('YKeyValueLww', () => {
 			});
 
 			test('observer receives all changes from a caller-owned transaction', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+				const { ydoc, kv } = setupKv();
 
 				const changedKeys: string[] = [];
 				kv.observe((changes) => {
@@ -618,11 +590,7 @@ describe('YKeyValueLww', () => {
 
 		describe('Sync with transaction-local writes', () => {
 			test('remote sync during a caller-owned transaction is visible after it ends', () => {
-				const doc1 = new Y.Doc({ guid: 'shared' });
-				const doc2 = new Y.Doc({ guid: 'shared' });
-
-				const array1 = doc1.getArray<YKeyValueLwwEntry<string>>('data');
-				const array2 = doc2.getArray<YKeyValueLwwEntry<string>>('data');
+				const { doc1, doc2, array1, array2 } = setupSyncedArrays();
 
 				const kv1 = new YKeyValueLww(array1);
 				const kv2 = new YKeyValueLww(array2);
@@ -648,11 +616,7 @@ describe('YKeyValueLww', () => {
 			});
 
 			test('LWW conflict resolution still works with transaction-local writes', () => {
-				const doc1 = new Y.Doc({ guid: 'shared' });
-				const doc2 = new Y.Doc({ guid: 'shared' });
-
-				const array1 = doc1.getArray<YKeyValueLwwEntry<string>>('data');
-				const array2 = doc2.getArray<YKeyValueLwwEntry<string>>('data');
+				const { doc1, doc2, array1, array2 } = setupSyncedArrays();
 
 				// Manually insert with controlled timestamps
 				array1.push([{ key: 'x', val: 'old', ts: 1000 }]);
@@ -679,10 +643,7 @@ describe('YKeyValueLww', () => {
 
 		describe('Edge cases', () => {
 			test('undefined value reads as absent through get and has', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray =
-					ydoc.getArray<YKeyValueLwwEntry<string | undefined>>('data');
-				const kv = new YKeyValueLww(yarray);
+				const { kv } = setupKv<string | undefined>();
 
 				kv.set('foo', undefined);
 				expect(kv.get('foo')).toBeUndefined();
@@ -690,9 +651,7 @@ describe('YKeyValueLww', () => {
 			});
 
 			test('rapid set/get cycles always return the latest value', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<number>>('data');
-				const kv = new YKeyValueLww(yarray);
+				const { kv } = setupKv<number>();
 
 				for (let i = 0; i < 100; i++) {
 					kv.set('counter', i);
@@ -703,9 +662,7 @@ describe('YKeyValueLww', () => {
 			});
 
 			test('mixed operations expose their latest state in a caller-owned transaction', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+				const { ydoc, kv } = setupKv();
 
 				// Pre-populate
 				kv.set('keep', 'original');
@@ -731,29 +688,8 @@ describe('YKeyValueLww', () => {
 				expect(kv.has('delete')).toBe(false);
 			});
 
-			test('delete in a caller-owned transaction makes has() return false immediately', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
-
-				kv.set('foo', 'bar');
-
-				let hasDuringTransaction: boolean = true;
-
-				ydoc.transact(() => {
-					kv.delete('foo');
-					hasDuringTransaction = kv.has('foo');
-				});
-
-				expect(hasDuringTransaction).toBe(false);
-				// After the transaction closes, the observer-backed map agrees.
-				expect(kv.has('foo')).toBe(false);
-			});
-
-			test('delete then get in a caller-owned transaction returns undefined', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+			test('delete then get returns undefined immediately', () => {
+				const { ydoc, kv } = setupKv();
 
 				kv.set('foo', 'bar');
 
@@ -768,10 +704,8 @@ describe('YKeyValueLww', () => {
 				expect(kv.get('foo')).toBeUndefined();
 			});
 
-			test('delete then set in a caller-owned transaction returns new value', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+			test('delete then set returns the new value immediately', () => {
+				const { ydoc, kv } = setupKv();
 
 				kv.set('foo', 'bar');
 
@@ -790,9 +724,7 @@ describe('YKeyValueLww', () => {
 			});
 
 			test('double delete is idempotent', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+				const { ydoc, kv } = setupKv();
 
 				kv.set('foo', 'bar');
 
@@ -807,9 +739,7 @@ describe('YKeyValueLww', () => {
 			});
 
 			test('entries skips transaction-local deletes', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+				const { ydoc, kv } = setupKv();
 
 				kv.set('a', '1');
 				kv.set('b', '2');
@@ -830,9 +760,7 @@ describe('YKeyValueLww', () => {
 			});
 
 			test('observer clears transaction-local delete overlay', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+				const { ydoc, kv } = setupKv();
 
 				kv.set('foo', 'bar');
 
@@ -848,10 +776,8 @@ describe('YKeyValueLww', () => {
 				expect(kv.get('foo')).toBe('baz');
 			});
 
-			test('set+delete in a caller-owned transaction leaves no sticky delete overlay', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+			test('set then delete leaves no sticky delete overlay', () => {
+				const { ydoc, kv } = setupKv();
 
 				// Set then delete in one transaction: the Y.Array entry is added and removed
 				// before the observer runs.
@@ -868,17 +794,13 @@ describe('YKeyValueLww', () => {
 			});
 
 			test('remote set after local delete is not masked by delete overlay', () => {
-				const ydoc1 = new Y.Doc({ guid: 'test' });
-				const yarray1 = ydoc1.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv1 = new YKeyValueLww(yarray1);
-
-				const ydoc2 = new Y.Doc({ guid: 'test' });
-				const yarray2 = ydoc2.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv2 = new YKeyValueLww(yarray2);
+				const { doc1, doc2, array1, array2 } = setupSyncedArrays('test');
+				const kv1 = new YKeyValueLww(array1);
+				const kv2 = new YKeyValueLww(array2);
 
 				// Both clients have the key
 				kv1.set('foo', 'original');
-				Y.applyUpdate(ydoc2, Y.encodeStateAsUpdate(ydoc1));
+				Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
 
 				// Client 1 deletes
 				kv1.delete('foo');
@@ -888,17 +810,15 @@ describe('YKeyValueLww', () => {
 				kv2.set('foo', 'remote-value');
 
 				// Sync client 2's update to client 1
-				Y.applyUpdate(ydoc1, Y.encodeStateAsUpdate(ydoc2));
+				Y.applyUpdate(doc1, Y.encodeStateAsUpdate(doc2));
 
 				// Client 1 should see the remote value: the delete overlay must not mask it.
 				expect(kv1.has('foo')).toBe(true);
 				expect(kv1.get('foo')).toBe('remote-value');
 			});
 
-			test('get() returns final value after set-delete-set in a caller-owned transaction', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+			test('get() returns the final value after set-delete-set', () => {
+				const { ydoc, kv } = setupKv();
 
 				kv.set('foo', 'initial');
 
@@ -917,10 +837,8 @@ describe('YKeyValueLww', () => {
 				expect(kv.has('foo')).toBe(true);
 			});
 
-			test('get() returns undefined after delete-set-delete in a caller-owned transaction', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+			test('get() returns undefined after delete-set-delete', () => {
+				const { ydoc, kv } = setupKv();
 
 				kv.set('foo', 'original');
 
@@ -938,9 +856,7 @@ describe('YKeyValueLww', () => {
 			});
 
 			test('delete non-existent key is no-op', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+				const { ydoc, kv } = setupKv();
 
 				// Delete a key that was never set: should not throw
 				kv.delete('never-existed');
@@ -954,10 +870,8 @@ describe('YKeyValueLww', () => {
 				});
 			});
 
-			test('delete overlay wins after set then delete in a caller-owned transaction', () => {
-				const ydoc = new Y.Doc({ guid: 'test' });
-				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv = new YKeyValueLww(yarray);
+			test('delete overlay wins after set then delete', () => {
+				const { ydoc, kv } = setupKv();
 
 				kv.set('foo', 'original');
 
@@ -979,18 +893,14 @@ describe('YKeyValueLww', () => {
 			});
 
 			test('remote add for different key does not clear unrelated delete overlay', () => {
-				const ydoc1 = new Y.Doc({ guid: 'test' });
-				const yarray1 = ydoc1.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv1 = new YKeyValueLww(yarray1);
-
-				const ydoc2 = new Y.Doc({ guid: 'test' });
-				const yarray2 = ydoc2.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv2 = new YKeyValueLww(yarray2);
+				const { doc1, doc2, array1, array2 } = setupSyncedArrays('test');
+				const kv1 = new YKeyValueLww(array1);
+				const kv2 = new YKeyValueLww(array2);
 
 				// Both clients have keys 'a' and 'b'
 				kv1.set('a', '1');
 				kv1.set('b', '2');
-				Y.applyUpdate(ydoc2, Y.encodeStateAsUpdate(ydoc1));
+				Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
 
 				// Client 1 deletes 'a'
 				kv1.delete('a');
@@ -1000,7 +910,7 @@ describe('YKeyValueLww', () => {
 				kv2.set('c', '3');
 
 				// Sync client 2's update to client 1
-				Y.applyUpdate(ydoc1, Y.encodeStateAsUpdate(ydoc2));
+				Y.applyUpdate(doc1, Y.encodeStateAsUpdate(doc2));
 
 				// 'a' should still be deleted: the remote add of 'c' should not affect it
 				expect(kv1.has('a')).toBe(false);
@@ -1010,17 +920,13 @@ describe('YKeyValueLww', () => {
 			});
 
 			test('both clients delete same key', () => {
-				const ydoc1 = new Y.Doc({ guid: 'test' });
-				const yarray1 = ydoc1.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv1 = new YKeyValueLww(yarray1);
-
-				const ydoc2 = new Y.Doc({ guid: 'test' });
-				const yarray2 = ydoc2.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv2 = new YKeyValueLww(yarray2);
+				const { doc1, doc2, array1, array2 } = setupSyncedArrays('test');
+				const kv1 = new YKeyValueLww(array1);
+				const kv2 = new YKeyValueLww(array2);
 
 				// Both clients have the key
 				kv1.set('foo', 'shared');
-				Y.applyUpdate(ydoc2, Y.encodeStateAsUpdate(ydoc1));
+				Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
 				expect(kv2.get('foo')).toBe('shared');
 
 				// Both delete independently
@@ -1028,8 +934,8 @@ describe('YKeyValueLww', () => {
 				kv2.delete('foo');
 
 				// Sync both ways
-				Y.applyUpdate(ydoc2, Y.encodeStateAsUpdate(ydoc1));
-				Y.applyUpdate(ydoc1, Y.encodeStateAsUpdate(ydoc2));
+				Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
+				Y.applyUpdate(doc1, Y.encodeStateAsUpdate(doc2));
 
 				// Both should see it deleted
 				expect(kv1.has('foo')).toBe(false);
@@ -1037,17 +943,13 @@ describe('YKeyValueLww', () => {
 			});
 
 			test('local set then remote delete of same key', () => {
-				const ydoc1 = new Y.Doc({ guid: 'test' });
-				const yarray1 = ydoc1.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv1 = new YKeyValueLww(yarray1);
-
-				const ydoc2 = new Y.Doc({ guid: 'test' });
-				const yarray2 = ydoc2.getArray<YKeyValueLwwEntry<string>>('data');
-				const kv2 = new YKeyValueLww(yarray2);
+				const { doc1, doc2, array1, array2 } = setupSyncedArrays('test');
+				const kv1 = new YKeyValueLww(array1);
+				const kv2 = new YKeyValueLww(array2);
 
 				// Both clients have the key
 				kv1.set('foo', 'original');
-				Y.applyUpdate(ydoc2, Y.encodeStateAsUpdate(ydoc1));
+				Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
 
 				// Client 1 updates the key (gets higher timestamp)
 				kv1.set('foo', 'updated');
@@ -1056,8 +958,8 @@ describe('YKeyValueLww', () => {
 				kv2.delete('foo');
 
 				// Sync both ways
-				Y.applyUpdate(ydoc2, Y.encodeStateAsUpdate(ydoc1));
-				Y.applyUpdate(ydoc1, Y.encodeStateAsUpdate(ydoc2));
+				Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
+				Y.applyUpdate(doc1, Y.encodeStateAsUpdate(doc2));
 
 				// Client 1's set had a higher timestamp, so it should win over client 2's delete.
 				// After sync, both should converge to the same value.

--- a/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.test.ts
+++ b/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.test.ts
@@ -486,7 +486,7 @@ describe('YKeyValueLww', () => {
 				expect(keysDuringTransaction.sort()).toEqual(['a', 'b', 'c']);
 			});
 
-			test('entries() yields both confirmed and transaction-local values', () => {
+			test('entries() yields both observer-indexed and transaction-local values', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);
@@ -508,7 +508,7 @@ describe('YKeyValueLww', () => {
 				expect(entriesDuringTransaction).toContainEqual(['new', 'value']);
 			});
 
-			test('entries() prefers transaction-local value over confirmed value for same key', () => {
+			test('entries() prefers transaction-local value over observer-indexed value for same key', () => {
 				const ydoc = new Y.Doc({ guid: 'test' });
 				const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
 				const kv = new YKeyValueLww(yarray);

--- a/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.ts
+++ b/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.ts
@@ -235,10 +235,11 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	 *   delete(key) when present
 	 *     pending.delete(key)
 	 *     pendingDeletes.add(key)       // reads report the key as absent
-	 *     yarray.delete(entry)
+	 *     deleteEntryByKey(key)         // finds and deletes the Y.Array index
 	 *
-	 *   get(key), has(key), entries()
-	 *     read precedence: pendingDeletes (absent) -> pending -> _map
+	 *   read view
+	 *     pendingDeletes hides keys
+	 *     pending overrides _map
 	 *
 	 * transaction closes
 	 *   observer updates _map and clears the matching overlays
@@ -384,8 +385,8 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 				deletedItem.content
 					.getContent()
 					.forEach((entry: YKeyValueLwwEntry<T>) => {
-						// The observer has caught up with a local delete for this key.
-						// Clear the read overlay even if the deleted entry never reached _map
+						// A deletion for this key has reached the observer. Clear the local
+						// delete overlay even if the deleted entry never reached _map
 						// (for example, set+delete inside one outer transaction).
 						this.pendingDeletes.delete(entry.key);
 
@@ -591,17 +592,6 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	}
 
 	/**
-	 * Check if the Y.Doc is currently inside an active transaction.
-	 *
-	 * Yjs exposes no public transaction-depth API, so this uses the internal
-	 * `_transaction` field to let `set()` join a caller-owned transaction. The read
-	 * overlay above remains active until that transaction's observer runs.
-	 */
-	private isInTransaction(): boolean {
-		return this.doc._transaction !== null;
-	}
-
-	/**
 	 * Set a key-value pair with automatic timestamp.
 	 * The timestamp enables LWW conflict resolution during sync.
 	 *
@@ -644,17 +634,10 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 		this.pending.set(key, entry);
 		this.pendingDeletes.delete(key);
 
-		const doWork = () => {
+		this.doc.transact(() => {
 			if (this._map.has(key)) this.deleteEntryByKey(key);
 			this.yarray.push([entry]);
-		};
-
-		// Avoid nested transactions - if already in one, just do the work
-		if (this.isInTransaction()) {
-			doWork();
-		} else {
-			this.doc.transact(doWork);
-		}
+		});
 
 		// DO NOT update this.map here - observer is the sole writer to map
 	}

--- a/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.ts
+++ b/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.ts
@@ -214,65 +214,48 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	 * via iteration, `.get()`, and `.size`. The `set()` method never writes to
 	 * this map. The observer is the sole writer.
 	 *
-	 * @see pending for how immediate reads work after `set()`
+	 * @see pending for the transaction-local read overlay
 	 */
 	readonly map: ReadonlyMap<string, YKeyValueLwwEntry<T>> = this._map;
 
 	/**
-	 * Pending entries written by `set()` but not yet processed by the observer.
+	 * Local writes that have reached the Y.Array but not the observer-backed map.
 	 *
-	 * ## Why This Exists
+	 * Yjs observers run when the current transaction closes. If a caller opens a
+	 * transaction, `set()` mutates the Y.Array immediately, but `_map` remains one
+	 * observer turn behind. This overlay provides read-your-writes behavior until
+	 * the observer catches up.
 	 *
-	 * When `set()` is called inside a batch/transaction, the observer doesn't fire
-	 * until the outer transaction ends. Without `pending`, `get()` would return
-	 * undefined for values just written.
+	 * ```text
+	 * caller-owned transaction opens
+	 *   set(key, value)
+	 *     pending.set(key, entry)       // visible to reads now
+	 *     yarray.push([entry])          // CRDT source-of-truth write
 	 *
-	 * ## Data Flow
+	 *   delete(key) when present
+	 *     pending.delete(key)
+	 *     pendingDeletes.add(key)       // reads report the key as absent
+	 *     yarray.delete(entry)
 	 *
-	 * ```
-	 * set('foo', 1) is called:
-	 * ─────────────────────────────────────────────────────────────
+	 *   get(key), has(key), entries()
+	 *     read precedence: pendingDeletes (absent) -> pending -> _map
 	 *
-	 *   set()
-	 *     │
-	 *     ├───► pending.set('foo', entry)    ← For immediate reads
-	 *     │
-	 *     └───► yarray.push(entry)           ← Source of truth (CRDT)
-	 *                 │
-	 *                 │  (observer fires after transaction ends)
-	 *                 ▼
-	 *           Observer
-	 *                 │
-	 *                 ├───► map.set('foo', entry)      ← Observer writes to map
-	 *                 │
-	 *                 └───► pending.delete('foo')      ← Clears pending
-	 *
-	 *
-	 * get('foo') is called:
-	 * ─────────────────────────────────────────────────────────────
-	 *
-	 *   get()
-	 *     │
-	 *     ├───► Check pending.get('foo')  ← If found, return it
-	 *     │
-	 *     └───► Check map.get('foo')      ← Fallback to map
+	 * transaction closes
+	 *   observer updates _map and clears the matching overlays
 	 * ```
 	 *
-	 * ## Who Writes Where
-	 *
-	 * | Writer   | `pending` | `Y.Array` | `map`     |
-	 * |----------|-----------|-----------|-----------|
-	 * | `set()`  | ✅ writes | ✅ writes | ❌ never  |
-	 * | Observer | ❌ never  | ❌ never  | ✅ writes |
+	 * Outside a caller-owned transaction, `set()` opens and closes its own
+	 * transaction, so the observer normally clears this overlay before `set()`
+	 * returns.
 	 */
 	private pending: Map<string, YKeyValueLwwEntry<T>> = new Map();
 
 	/**
-	 * Keys deleted by `delete()` but not yet processed by the observer.
+	 * Local deletes that have reached the Y.Array but not the observer-backed map.
 	 *
-	 * Symmetric counterpart to `pending`: while `pending` tracks writes not yet
-	 * in `map`, `pendingDeletes` tracks deletions not yet removed from `map`.
-	 * This prevents stale reads after `delete()` during a batch/transaction.
+	 * This is the delete side of the overlay described above. After
+	 * `delete('foo')`, reads report the key as absent even if `_map` still holds the
+	 * old entry until the transaction closes.
 	 */
 	private pendingDeletes: Set<string> = new Set();
 
@@ -401,8 +384,9 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 				deletedItem.content
 					.getContent()
 					.forEach((entry: YKeyValueLwwEntry<T>) => {
-						// Always clear pendingDeletes for this key: even if the ref-equality
-						// check fails (e.g. set+delete in same txn where entry never reached map)
+						// The observer has caught up with a local delete for this key.
+						// Clear the read overlay even if the deleted entry never reached _map
+						// (for example, set+delete inside one outer transaction).
 						this.pendingDeletes.delete(entry.key);
 
 						// Reference equality: only process if this is the entry we have cached
@@ -609,8 +593,9 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	/**
 	 * Check if the Y.Doc is currently inside an active transaction.
 	 *
-	 * Uses Yjs internal `_transaction` property. This is stable across Yjs versions
-	 * but is technically internal API (underscore prefix).
+	 * Yjs exposes no public transaction-depth API, so this uses the internal
+	 * `_transaction` field to let `set()` join a caller-owned transaction. The read
+	 * overlay above remains active until that transaction's observer runs.
 	 */
 	private isInTransaction(): boolean {
 		return this.doc._transaction !== null;
@@ -655,7 +640,7 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	set(key: string, val: T): void {
 		const entry: YKeyValueLwwEntry<T> = { key, val, ts: this.getTimestamp() };
 
-		// Track in pending for immediate reads via get()
+		// Keep reads transaction-local until the observer updates _map.
 		this.pending.set(key, entry);
 		this.pendingDeletes.delete(key);
 
@@ -696,7 +681,8 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	 * - Importing 1K+ rows: `ykv.bulkSet(entries)` in a transaction
 	 * - For chunked imports with progress, use `Table.bulkSet()` which wraps
 	 *   this method with chunking, `onProgress`, and event-loop yielding
-	 * - For < 100 rows, `set()` in a `doc.transact()` is simpler and equivalent
+	 * - For fewer than 100 rows, repeated `set()` calls are usually simpler. Wrap
+	 *   them in `doc.transact()` when they form one logical change.
 	 *
 	 * @example
 	 * ```typescript
@@ -730,13 +716,13 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	 * one scan for all keys instead of one scan per key.
 	 *
 	 * Removes from `pending` immediately and triggers Y.Array deletion.
-	 * The observer will update `map` when the deletion is processed.
-	 * Adds the key to `pendingDeletes` so that `get()`, `has()`, and `entries()`
-	 * return correct results before the observer fires.
+	 * The observer will update `_map` when the deletion is processed.
+	 * Adds the key to `pendingDeletes` so transaction-local reads report the key
+	 * as absent before the observer fires.
 	 */
 	delete(key: string): void {
-		// Remove from pending if present. If it was pending, the entry is in the
-		// Y.Array (set() pushes immediately) but not yet in map (observer deferred).
+		// If this key was set earlier in the same outer transaction, it exists in
+		// the Y.Array but not _map yet. Delete still needs to remove that entry.
 		const wasPending = this.pending.delete(key);
 
 		// If already pending delete, no-op
@@ -807,16 +793,15 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	/**
 	 * Get value by key. O(1) via in-memory Map.
 	 *
-	 * Checks `pendingDeletes` first (a key deleted but not yet observed reads
-	 * absent, even if a stale write still sits in `pending`), then `pending`
-	 * (values written by `set()` but not yet processed by the observer), then
-	 * `map` (the authoritative cache).
+	 * Reads the observer-backed map plus the transaction-local overlay.
+	 *
+	 * `pendingDeletes` wins over `pending`: `set(); delete(); get()` inside one
+	 * outer transaction reads absent, matching the final state after the observer
+	 * catches up.
 	 */
 	get(key: string): T | undefined {
-		// Deleted but observer hasn't fired yet.
 		if (this.pendingDeletes.has(key)) return undefined;
 
-		// Written by set() but observer hasn't fired yet.
 		const pending = this.pending.get(key);
 		if (pending) return pending.val;
 
@@ -830,9 +815,9 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	}
 
 	/**
-	 * Walk every stored entry (both pending and confirmed). `pending` takes
-	 * precedence over `map` for keys in both, so reads inside an open transaction
-	 * see just-written values.
+	 * Walk every stored entry from the observer-backed map plus the
+	 * transaction-local overlay. Pending writes take precedence over `_map`; pending
+	 * deletes hide `_map` entries until the observer catches up.
 	 *
 	 * @example
 	 * ```typescript

--- a/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.ts
+++ b/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.ts
@@ -214,7 +214,7 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	 * via iteration, `.get()`, and `.size`. The `set()` method never writes to
 	 * this map. The observer is the sole writer.
 	 *
-	 * @see pending for the transaction-local read overlay
+	 * @see pendingWrites for the transaction-local read overlay
 	 */
 	readonly map: ReadonlyMap<string, YKeyValueLwwEntry<T>> = this._map;
 
@@ -229,17 +229,17 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	 * ```text
 	 * caller-owned transaction opens
 	 *   set(key, value)
-	 *     pending.set(key, entry)       // visible to reads now
+	 *     pendingWrites.set(key, entry) // visible to reads now
 	 *     yarray.push([entry])          // CRDT source-of-truth write
 	 *
 	 *   delete(key) when present
-	 *     pending.delete(key)
+	 *     pendingWrites.delete(key)
 	 *     pendingDeletes.add(key)       // reads report the key as absent
 	 *     deleteEntryByKey(key)         // finds and deletes the Y.Array index
 	 *
 	 *   read view
 	 *     pendingDeletes hides keys
-	 *     pending overrides _map
+	 *     pendingWrites overrides _map
 	 *
 	 * transaction closes
 	 *   observer updates _map and clears the matching overlays
@@ -249,7 +249,7 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	 * transaction, so the observer normally clears this overlay before `set()`
 	 * returns.
 	 */
-	private pending: Map<string, YKeyValueLwwEntry<T>> = new Map();
+	private pendingWrites: Map<string, YKeyValueLwwEntry<T>> = new Map();
 
 	/**
 	 * Local deletes that have reached the Y.Array but not the observer-backed map.
@@ -456,7 +456,7 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 					if (
 						transaction.local &&
 						deletedCurrentKeys.has(newEntry.key) &&
-						this.pending.get(newEntry.key) !== newEntry
+						this.pendingWrites.get(newEntry.key) !== newEntry
 					) {
 						const newIndex = getEntryIndex(newEntry);
 						if (newIndex !== -1) indicesToDelete.push(newIndex);
@@ -521,10 +521,10 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 					}
 				}
 
-				// Clear from pending once processed (whether entry won or lost).
+				// Clear the write overlay once processed (whether entry won or lost).
 				// Use reference equality to only clear if it's the exact entry we added.
-				if (this.pending.get(newEntry.key) === newEntry) {
-					this.pending.delete(newEntry.key);
+				if (this.pendingWrites.get(newEntry.key) === newEntry) {
+					this.pendingWrites.delete(newEntry.key);
 				}
 			}
 
@@ -631,9 +631,11 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 		const entry: YKeyValueLwwEntry<T> = { key, val, ts: this.getTimestamp() };
 
 		// Keep reads transaction-local until the observer updates _map.
-		this.pending.set(key, entry);
+		this.pendingWrites.set(key, entry);
 		this.pendingDeletes.delete(key);
 
+		// Yjs reuses an active outer transaction, so this preserves the caller's
+		// origin and batches observer delivery until that transaction closes.
 		this.doc.transact(() => {
 			if (this._map.has(key)) this.deleteEntryByKey(key);
 			this.yarray.push([entry]);
@@ -661,7 +663,7 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	 *
 	 * ## When to use
 	 *
-	 * - Importing 1K+ rows: `ykv.bulkSet(entries)` in a transaction
+	 * - Importing 1K+ rows: `ykv.bulkSet(entries)` opens one transaction
 	 * - For chunked imports with progress, use `Table.bulkSet()` which wraps
 	 *   this method with chunking, `onProgress`, and event-loop yielding
 	 * - For fewer than 100 rows, repeated `set()` calls are usually simpler. Wrap
@@ -684,7 +686,7 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 					ts: this.getTimestamp(),
 				};
 
-				this.pending.set(key, entry);
+				this.pendingWrites.set(key, entry);
 				this.pendingDeletes.delete(key);
 				this.yarray.push([entry]);
 			}
@@ -698,7 +700,7 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	 * For bulk deletions (1K+ keys), use {@link bulkDelete} which does
 	 * one scan for all keys instead of one scan per key.
 	 *
-	 * Removes from `pending` immediately and triggers Y.Array deletion.
+	 * Removes from `pendingWrites` immediately and triggers Y.Array deletion.
 	 * The observer will update `_map` when the deletion is processed.
 	 * Adds the key to `pendingDeletes` so transaction-local reads report the key
 	 * as absent before the observer fires.
@@ -706,12 +708,12 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	delete(key: string): void {
 		// If this key was set earlier in the same outer transaction, it exists in
 		// the Y.Array but not _map yet. Delete still needs to remove that entry.
-		const wasPending = this.pending.delete(key);
+		const hadPendingWrite = this.pendingWrites.delete(key);
 
 		// If already pending delete, no-op
 		if (this.pendingDeletes.has(key)) return;
 
-		if (!this._map.has(key) && !wasPending) return;
+		if (!this._map.has(key) && !hadPendingWrite) return;
 
 		this.pendingDeletes.add(key);
 		this.deleteEntryByKey(key);
@@ -760,7 +762,7 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 
 			indicesToDelete.push(i);
 			this.pendingDeletes.add(entry.key);
-			this.pending.delete(entry.key);
+			this.pendingWrites.delete(entry.key);
 		}
 
 		if (indicesToDelete.length === 0) return;
@@ -778,15 +780,15 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	 *
 	 * Reads the observer-backed map plus the transaction-local overlay.
 	 *
-	 * `pendingDeletes` wins over `pending`: `set(); delete(); get()` inside one
+	 * `pendingDeletes` wins over `pendingWrites`: `set(); delete(); get()` inside one
 	 * outer transaction reads absent, matching the final state after the observer
 	 * catches up.
 	 */
 	get(key: string): T | undefined {
 		if (this.pendingDeletes.has(key)) return undefined;
 
-		const pending = this.pending.get(key);
-		if (pending) return pending.val;
+		const pendingWrite = this.pendingWrites.get(key);
+		if (pendingWrite) return pendingWrite.val;
 
 		const entry = this._map.get(key);
 		return entry?.val;
@@ -810,20 +812,19 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	 * ```
 	 */
 	*entries(): IterableIterator<KvEntry<T>> {
-		// Track keys we've already yielded from pending
+		// Track keys already yielded from the write overlay.
 		const yieldedKeys = new Set<string>();
 
-		// Yield pending entries first (they take precedence)
-		for (const [key, entry] of this.pending) {
+		// Yield transaction-local writes first because they take precedence.
+		for (const [key, entry] of this.pendingWrites) {
 			yieldedKeys.add(key);
 			yield { key, val: entry.val };
 		}
 
-		// Yield map entries that weren't in pending and aren't pending delete
+		// Then yield indexed entries not replaced or deleted by the overlay.
 		for (const [key, entry] of this._map) {
-			if (!yieldedKeys.has(key) && !this.pendingDeletes.has(key)) {
-				yield { key, val: entry.val };
-			}
+			if (yieldedKeys.has(key) || this.pendingDeletes.has(key)) continue;
+			yield { key, val: entry.val };
 		}
 	}
 


### PR DESCRIPTION
`YKeyValueLww` needs a transaction-local overlay so reads can see writes and deletes before the `Y.Array` observer refreshes its in-memory index. The previous explanation mixed that public behavior with internal “batch” terminology and described parts of the observer lifecycle inaccurately.

This replaces the explanation with one compact state diagram, aligns the transaction-focused tests around caller-owned transactions, and delegates active-transaction reuse directly to Yjs. `set()` now always calls `doc.transact()`; Yjs reuses an existing transaction while preserving its origin, local flag, and observer batching, so the private `_transaction` probe and local wrapper are gone. Public behavior and API shape are unchanged.