### PR TITLE
fix(matter): report unreadable markdown files

### DIFF
--- a/apps/matter/src/routes/(vaults)/vault/[id]/IntegrityPanel.svelte
+++ b/apps/matter/src/routes/(vaults)/vault/[id]/IntegrityPanel.svelte
@@ -11,8 +11,8 @@
 	} from '@epicenter/matter-core';
 
 	// The one "what is wrong" surface for the whole vault, a pure selector over the live
-	// VaultIntegrity. It re-decides nothing: `toViolations` and `summarize` read the same assessed
-	// cells the grid renders, so the panel and the grid can never disagree.
+	// VaultIntegrity. It re-decides nothing: `toViolations` and `summarize` read the same vault
+	// assessment the grid renders, so the panel and the grid can never disagree.
 	let { integrity }: { integrity: VaultIntegrity } = $props();
 
 	const summary = $derived(summarize(integrity));
@@ -26,7 +26,11 @@
 		),
 	);
 
-	const clean = $derived(violations.length === 0 && fatals.length === 0);
+	const unreadableFiles = $derived(summary.unreadableFiles);
+	const issueCount = $derived(
+		violations.length + fatals.length + unreadableFiles.length,
+	);
+	const clean = $derived(issueCount === 0);
 
 	/** One human line per violation, expected computed at the edge for an invalid value. */
 	function describe(violation: Violation): string {
@@ -55,9 +59,8 @@
 		{:else}
 			<TriangleAlertIcon class="size-3.5 text-amber-600 dark:text-amber-400" />
 			<span>
-				{violations.length + fatals.length}
-				{violations.length + fatals.length === 1 ? 'issue' : 'issues'} · {summary
-					.totals.ready} ready
+				{issueCount}
+				{issueCount === 1 ? 'issue' : 'issues'} · {summary.totals.ready} ready
 			</span>
 		{/if}
 	</div>
@@ -71,6 +74,12 @@
 						{table.status === 'unreadable' ? "can't read" : 'invalid contract'}:
 						{'message' in table ? table.message : ''}
 					</span>
+				</li>
+			{/each}
+			{#each unreadableFiles as file (`${file.table}/${file.fileName}`)}
+				<li class="flex gap-2 text-destructive">
+					<span class="font-mono">{file.table}/{file.fileName}</span>
+					<span class="text-muted-foreground">can't read: {file.message}</span>
 				</li>
 			{/each}
 			{#each violations as violation, index (index)}

--- a/packages/cli/src/commands/matter.test.ts
+++ b/packages/cli/src/commands/matter.test.ts
@@ -8,7 +8,7 @@
  *             and has no marked children is "no tables", not a failure; references un-evaluable in
  *             isolation are a note, not a failure)
  *   - exit 1  a loaded row needs attention, or a cross-table reference does not resolve
- *   - exit 2  a folder is unreadable or a matter.json is a corrupt contract
+ *   - exit 2  a folder or Markdown file is unreadable, or a matter.json is a corrupt contract
  */
 
 import { describe, expect, test } from 'bun:test';
@@ -46,14 +46,16 @@ describe('matter check: single-table scope', () => {
 		expect(result.stdout).toBe('2 ready (1 table, 2 rows)\n');
 	});
 
-	test('exit 1 groups findings for the mixed fixture', async () => {
+	test('exit 2 groups findings and unreadable files for the mixed fixture', async () => {
 		const result = await runCheck([`${fixtureRoot}/mixed`]);
-		expect(result.exitCode).toBe(1);
+		expect(result.exitCode).toBe(2);
 		expect(result.stdout).toContain('needs value');
 		expect(result.stdout).toContain('invalid: got "five", expected integer');
 		expect(result.stdout).toContain(
 			'invalid: got "idea", expected one of draft, ready, published',
 		);
+		expect(result.stdout).toContain('mixed/broken-yaml.md');
+		expect(result.stdout).toContain('1 unreadable file');
 	});
 
 	test('exit 0 treats an untyped folder (a {} marker) as valid', async () => {
@@ -125,6 +127,36 @@ describe('matter check: vault scope', () => {
 });
 
 describe('matter check: fatal tiers', () => {
+	test('exit 2 names a Markdown file that cannot become a row', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'matter-check-'));
+		try {
+			await writeFile(
+				join(dir, 'matter.json'),
+				JSON.stringify({ fields: { title: { type: 'string' } } }),
+			);
+			await writeFile(join(dir, 'ready.md'), '---\ntitle: Ready\n---');
+			await writeFile(join(dir, 'broken.md'), '---\ntitle: [bad\n---');
+
+			const text = await runCheck([dir]);
+			expect(text.exitCode).toBe(2);
+			expect(text.stdout).toContain('broken.md');
+			expect(text.stdout).toContain('1 unreadable file');
+			expect(text.stdout).toContain('(1 table, 1 row)');
+
+			const json = await runCheck(['--json', dir]);
+			const report = JSON.parse(json.stdout);
+			expect(json.exitCode).toBe(2);
+			expect(report.summary.unreadableFiles).toEqual([
+				expect.objectContaining({
+					fileName: 'broken.md',
+					message: expect.stringContaining('Frontmatter is not valid YAML'),
+				}),
+			]);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
 	test('exit 2 for a corrupt matter.json', async () => {
 		const dir = await mkdtemp(join(tmpdir(), 'matter-check-'));
 		try {

--- a/packages/cli/src/commands/matter.ts
+++ b/packages/cli/src/commands/matter.ts
@@ -82,7 +82,7 @@ function writeJson(
  * `--json`, and the exit code, so every surface agrees by construction.
  *
  * Exit codes: 0 every loaded row is healthy; 1 a row needs attention or a reference does not resolve;
- * 2 a folder is unreadable or a `matter.json` is a corrupt contract.
+ * 2 a folder or Markdown file is unreadable, or a `matter.json` is a corrupt contract.
  *
  * A lone table (one folder, no siblings loaded) cannot resolve cross-table references, so every
  * reference reads as `missing-target`: those are surfaced as a note, never a failure.

--- a/packages/matter-core/src/core/integrity.test.ts
+++ b/packages/matter-core/src/core/integrity.test.ts
@@ -21,7 +21,7 @@ import {
 	type TableInput,
 	type VaultIntegrity,
 } from './integrity';
-import { readTable } from './table';
+import { MatterReadError, readTable } from './table';
 
 type Entries = Parameters<typeof readTable>[0];
 
@@ -315,6 +315,45 @@ describe('assess: table states', () => {
 			status: 'unreadable',
 			message: 'permission denied',
 		});
+	});
+
+	test('a file that cannot become a row stays located in the vault assessment', () => {
+		const v = assess([
+			loaded('pages', pagesModel, [
+				{ fileName: 'good.md', content: '---\ntitle: Good\n---' },
+				{ fileName: 'broken.md', content: '---\ntitle: [bad\n---' },
+			]),
+		]);
+
+		expect(v.unreadableFiles).toEqual([
+			{
+				table: 'pages',
+				fileName: 'broken.md',
+				message: expect.stringContaining('Frontmatter is not valid YAML'),
+			},
+		]);
+		expect(typed(v, 'pages').rows.map(({ row }) => row.fileName)).toEqual([
+			'good.md',
+		]);
+	});
+
+	test('a file read failure follows the same located path as a parse failure', () => {
+		const v = assess([
+			loaded('pages', pagesModel, [
+				{
+					fileName: 'undecodable.md',
+					error: MatterReadError.Undecodable().error,
+				},
+			]),
+		]);
+
+		expect(v.unreadableFiles).toEqual([
+			{
+				table: 'pages',
+				fileName: 'undecodable.md',
+				message: 'File is not readable as UTF-8 text',
+			},
+		]);
 	});
 });
 

--- a/packages/matter-core/src/core/integrity.ts
+++ b/packages/matter-core/src/core/integrity.ts
@@ -108,13 +108,23 @@ export type TableAssessment =
 			rows: RowAssessment[];
 	  };
 
+/** A Markdown file that could not become a row, located within its table. */
+export type LocatedUnreadableFile = {
+	table: string;
+	fileName: string;
+	message: string;
+};
+
 /**
  * The one composed structure: every table's assessment, in input order. Deliberately NOT
  * versioned: the prior collapse removed an unread `version` wrapper, and `VaultIntegrity` is an
  * in-memory return, never serialized. The `--json` output serializes the projected violations,
  * not this; a version, if a serialized contract ever needs one, rides on that projection.
  */
-export type VaultIntegrity = { tables: TableAssessment[] };
+export type VaultIntegrity = {
+	tables: TableAssessment[];
+	unreadableFiles: LocatedUnreadableFile[];
+};
 
 /** A table that was read into a {@link TableRead}: the input that contributes rows and stems. */
 type ReadableTable = { name: string; status: 'readable'; read: TableRead };
@@ -150,7 +160,20 @@ export function assess(tables: readonly TableInput[]): VaultIntegrity {
 		);
 	}
 
-	return { tables: tables.map((table) => assessTable(table, rowsByTable)) };
+	const unreadableFiles = tables.flatMap((table) =>
+		table.status === 'readable'
+			? table.read.unreadable.map(({ fileName, error }) => ({
+					table: table.name,
+					fileName,
+					message: error.message,
+				}))
+			: [],
+	);
+
+	return {
+		tables: tables.map((table) => assessTable(table, rowsByTable)),
+		unreadableFiles,
+	};
 }
 
 /** Classify one table into its four-state assessment. */

--- a/packages/matter-core/src/core/parse.test.ts
+++ b/packages/matter-core/src/core/parse.test.ts
@@ -41,6 +41,24 @@ describe('parseMarkdown', () => {
 		expect(parseMarkdown(raw).error?.name).toBe('ConflictMarkers');
 	});
 
+	test('conflict-marker examples in the opaque body stay readable and verbatim', () => {
+		const body =
+			'```txt\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> other\n```';
+		const raw = `---\ntitle: How conflicts work\n---\n${body}`;
+		const { data, error } = parseMarkdown(raw);
+
+		expect(error).toBeNull();
+		expect(data).toEqual({
+			frontmatter: { title: 'How conflicts work' },
+			body,
+		});
+	});
+
+	test('a body-only conflict-marker example is opaque text', () => {
+		const raw = '<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> other\n';
+		expect(parseMarkdown(raw).data).toEqual({ frontmatter: {}, body: raw });
+	});
+
 	test('malformed YAML is unreadable (and carries the parser error as cause)', () => {
 		const raw = '---\n: : :\n  bad\n indent\n---\nbody';
 		const { error } = parseMarkdown(raw);

--- a/packages/matter-core/src/core/parse.ts
+++ b/packages/matter-core/src/core/parse.ts
@@ -64,14 +64,18 @@ const CONFLICT_MARKER = /^(<<<<<<<|=======|>>>>>>>)/m;
 export function parseMarkdown(
 	raw: string,
 ): Result<ParsedFile, MatterParseError> {
-	if (CONFLICT_MARKER.test(raw)) return MatterParseError.ConflictMarkers();
-
 	const match = raw.match(FRONTMATTER);
 	// No frontmatter is fine: an empty mapping, the whole file is body.
 	if (!match) return Ok({ frontmatter: {}, body: raw });
 
+	// Only frontmatter is structural. Marker examples in the opaque Markdown body
+	// are content, not a parse failure; inspecting the whole file here would make
+	// Matter contradict its own frontmatter/body boundary.
+	const yaml = match[1] ?? '';
+	if (CONFLICT_MARKER.test(yaml)) return MatterParseError.ConflictMarkers();
+
 	const { data: parsed, error } = trySync({
-		try: () => parseYaml(match[1] ?? '') ?? {},
+		try: () => parseYaml(yaml) ?? {},
 		catch: (cause) => MatterParseError.InvalidYaml({ cause }),
 	});
 	if (error) return Err(error);

--- a/packages/matter-core/src/core/table.test.ts
+++ b/packages/matter-core/src/core/table.test.ts
@@ -9,6 +9,11 @@ describe('readTable', () => {
 			{ fileName: 'broken.md', content: '---\ntitle: [unclosed\n---\nbody' },
 			{
 				fileName: 'conflict.md',
+				content:
+					'---\ntitle: Conflict\n<<<<<<< HEAD\nstatus: a\n=======\nstatus: b\n>>>>>>> z\n---\nbody',
+			},
+			{
+				fileName: 'body-conflict.md',
 				content: '<<<<<<< HEAD\nx\n=======\ny\n>>>>>>> z\n',
 			},
 			{ fileName: 'raw.md', content: '# no frontmatter' },
@@ -17,6 +22,7 @@ describe('readTable', () => {
 		expect(result.rows.map((r) => r.fileName)).toEqual([
 			'a.md',
 			'b.md',
+			'body-conflict.md',
 			'raw.md',
 		]);
 		expect(result.unreadable.map((u) => [u.fileName, u.error.name])).toEqual([

--- a/packages/matter-core/src/core/violations.test.ts
+++ b/packages/matter-core/src/core/violations.test.ts
@@ -266,7 +266,8 @@ describe('summarize', () => {
 			rows: 2,
 			ready: 1,
 			needsAttention: 1,
-			unreadable: 0,
+			unreadableTables: 0,
+			unreadableFiles: 0,
 			invalidContract: 0,
 			untyped: 0,
 		});
@@ -351,8 +352,30 @@ describe('summarize', () => {
 			'unreadable',
 			'invalid-contract',
 		]);
-		expect(summary.totals.unreadable).toBe(1);
+		expect(summary.totals.unreadableTables).toBe(1);
 		expect(summary.totals.invalidContract).toBe(1);
+	});
+
+	test('unreadable files stay named and count separately from unreadable tables', () => {
+		const summary = summarize(
+			assess([
+				loaded('pages', pagesModel, [
+					{ fileName: 'good.md', content: '---\ntitle: Good\n---' },
+					{ fileName: 'broken.md', content: '---\ntitle: [bad\n---' },
+				]),
+			]),
+		);
+
+		expect(summary.unreadableFiles).toEqual([
+			{
+				table: 'pages',
+				fileName: 'broken.md',
+				message: expect.stringContaining('Frontmatter is not valid YAML'),
+			},
+		]);
+		expect(summary.totals.unreadableFiles).toBe(1);
+		expect(summary.totals.unreadableTables).toBe(0);
+		expect(summary.totals.rows).toBe(1);
 	});
 
 	test('an untyped table counts as untyped, valid, never a failure', () => {
@@ -368,7 +391,8 @@ describe('summarize', () => {
 		expect(table?.status).toBe('untyped');
 		expect(summary.totals.untyped).toBe(1);
 		expect(summary.totals.needsAttention).toBe(0);
-		expect(summary.totals.unreadable).toBe(0);
+		expect(summary.totals.unreadableTables).toBe(0);
+		expect(summary.totals.unreadableFiles).toBe(0);
 		expect(summary.totals.invalidContract).toBe(0);
 	});
 

--- a/packages/matter-core/src/core/violations.ts
+++ b/packages/matter-core/src/core/violations.ts
@@ -11,9 +11,9 @@
  * A {@link Violation} is a cell whose state needs attention. Only four of the seven `AssessedCell`
  * states project: `ok`, `missing-optional`, and `resolved` are healthy and never appear. `ok` and
  * `missing-optional` not appearing is the proof that this list is a PROJECTION of the cells, not
- * all of them. Table-load failures (`unreadable` / `invalid-contract`) are NOT violations either:
- * they have no cells, and they surface through {@link summarize} and the exit code, where a whole
- * table that could not be read is a different kind of answer than a row with a bad value.
+ * all of them. Table-load failures and Markdown files that could not become rows are NOT violations
+ * either: they have no cells, and they surface through {@link summarize} and the exit code, where
+ * unreadable input is a different kind of answer than a row with a bad value.
  *
  * `expected` is deliberately absent from the `invalid-type` violation: it is a render projection
  * (`describeExpected` in `./expected`), so the violation carries the {@link Field} itself and the
@@ -22,7 +22,11 @@
  */
 
 import type { Field } from '@epicenter/field';
-import type { TableAssessment, VaultIntegrity } from './integrity';
+import type {
+	LocatedUnreadableFile,
+	TableAssessment,
+	VaultIntegrity,
+} from './integrity';
 import { stemOf } from './parse';
 
 /**
@@ -168,6 +172,8 @@ export type ExtraNote = { table: string; row: string; keys: string[] };
 export type Summary = {
 	tables: TableSummary[];
 	extras: ExtraNote[];
+	/** Markdown files that could not become rows, already located by `assess`. */
+	unreadableFiles: LocatedUnreadableFile[];
 	totals: {
 		tables: number;
 		rows: number;
@@ -176,7 +182,9 @@ export type Summary = {
 		/** Typed rows with at least one attention cell (the exit-code signal). */
 		needsAttention: number;
 		/** Tables whose folder could not be read at all (a fatal). */
-		unreadable: number;
+		unreadableTables: number;
+		/** Markdown files omitted from classification because they could not parse or read. */
+		unreadableFiles: number;
 		/** Tables whose matter.json is present but corrupt (a fatal). */
 		invalidContract: number;
 		/** Untyped tables (no matter.json): valid, never a failure. */
@@ -295,14 +303,15 @@ export function summarize(integrity: VaultIntegrity): Summary {
 		rows: 0,
 		ready: 0,
 		needsAttention: 0,
-		unreadable: 0,
+		unreadableTables: 0,
+		unreadableFiles: integrity.unreadableFiles.length,
 		invalidContract: 0,
 		untyped: 0,
 	};
 	for (const table of tables) {
 		switch (table.status) {
 			case 'unreadable':
-				totals.unreadable += 1;
+				totals.unreadableTables += 1;
 				break;
 			case 'invalid-contract':
 				totals.invalidContract += 1;
@@ -319,5 +328,10 @@ export function summarize(integrity: VaultIntegrity): Summary {
 		}
 	}
 
-	return { tables, extras, totals };
+	return {
+		tables,
+		extras,
+		unreadableFiles: integrity.unreadableFiles,
+		totals,
+	};
 }

--- a/packages/matter-core/src/index.ts
+++ b/packages/matter-core/src/index.ts
@@ -43,6 +43,7 @@ export {
 export {
 	type AssessedCell,
 	assess,
+	type LocatedUnreadableFile,
 	type ReferenceVerdict,
 	type RowAssessment,
 	type TableAssessment,

--- a/packages/matter-core/src/report/exit-code.test.ts
+++ b/packages/matter-core/src/report/exit-code.test.ts
@@ -1,7 +1,7 @@
 /**
- * Exit-code tests: the three tiers derived from a {@link Summary}. Fatal (2) for a table that could
- * not load, problems (1) for data that needs attention, clean (0) otherwise. `untyped` is valid,
- * so an untyped-only vault exits 0.
+ * Exit-code tests: the three tiers derived from a {@link Summary}. Fatal (2) for a table or
+ * Markdown file that could not load, problems (1) for data that needs attention, clean (0)
+ * otherwise. `untyped` is valid, so an untyped-only vault exits 0.
  */
 
 import { describe, expect, test } from 'bun:test';
@@ -85,6 +85,17 @@ describe('exitCodeFor', () => {
 			exitCode([
 				loaded('bad', '{ not valid json', [
 					{ fileName: 'b1.md', content: '---\ntitle: X\n---' },
+				]),
+			]),
+		).toBe(2);
+	});
+
+	test('2 when a Markdown file cannot become a row', () => {
+		expect(
+			exitCode([
+				loaded('pages', pagesModel, [
+					{ fileName: 'good.md', content: '---\ntitle: Good\n---' },
+					{ fileName: 'broken.md', content: '---\ntitle: [bad\n---' },
 				]),
 			]),
 		).toBe(2);

--- a/packages/matter-core/src/report/exit-code.ts
+++ b/packages/matter-core/src/report/exit-code.ts
@@ -1,9 +1,8 @@
 /**
  * The CLI exit code. Three tiers, by how badly the vault failed:
  *
- *   - `2` a table could not be loaded at all: `unreadable` (folder unreadable) or
- *         `invalid-contract` (matter.json present but corrupt). The check could not run over that
- *         table, so this is the fatal tier, read from the {@link Summary}'s table-status totals.
+ *   - `2` a table could not be loaded, its contract was corrupt, or a Markdown file could not
+ *         become a row. The check could not cover the declared input, so this is the fatal tier.
  *   - `1` every table loaded, but there is at least one failing {@link Violation}.
  *   - `0` everything loaded and nothing failed. An `untyped` table (no matter.json) is a valid
  *         raw grid, never a failure, so an untyped-only vault exits 0.
@@ -22,7 +21,11 @@ export function exitCodeFor(
 	summary: Summary,
 	failures: readonly Violation[],
 ): ExitCode {
-	if (summary.totals.unreadable > 0 || summary.totals.invalidContract > 0) {
+	if (
+		summary.totals.unreadableTables > 0 ||
+		summary.totals.unreadableFiles > 0 ||
+		summary.totals.invalidContract > 0
+	) {
 		return 2;
 	}
 	return failures.length > 0 ? 1 : 0;

--- a/packages/matter-core/src/report/format.test.ts
+++ b/packages/matter-core/src/report/format.test.ts
@@ -87,4 +87,19 @@ describe('formatReport', () => {
 
 		expect(text).toBe('1 ready (1 table, 1 row)');
 	});
+
+	test('names every unreadable file and counts it in the roll-up', () => {
+		const integrity = assess([
+			loaded('pages', pagesModel, [
+				{ fileName: 'good.md', content: '---\ntitle: Good\nstatus: live\n---' },
+				{ fileName: 'broken.md', content: '---\ntitle: [bad\n---' },
+			]),
+		]);
+		const text = formatReport(toViolations(integrity), summarize(integrity));
+
+		expect(text).toContain('pages/broken.md');
+		expect(text).toContain("can't read: Frontmatter is not valid YAML");
+		expect(text).toContain('1 unreadable file');
+		expect(text).toContain('(1 table, 1 row)');
+	});
 });

--- a/packages/matter-core/src/report/format.ts
+++ b/packages/matter-core/src/report/format.ts
@@ -82,7 +82,8 @@ function summaryLine(summary: Summary): string {
 		rows,
 		ready,
 		needsAttention,
-		unreadable,
+		unreadableTables,
+		unreadableFiles,
 		invalidContract,
 		untyped,
 	} = summary.totals;
@@ -93,8 +94,10 @@ function summaryLine(summary: Summary): string {
 			`${needsAttention} ${needsAttention === 1 ? 'needs' : 'need'} attention`,
 		);
 	}
-	if (unreadable > 0)
-		parts.push(plural(unreadable, 'unreadable', 'unreadable'));
+	if (unreadableTables > 0)
+		parts.push(plural(unreadableTables, 'unreadable table'));
+	if (unreadableFiles > 0)
+		parts.push(plural(unreadableFiles, 'unreadable file'));
 	if (invalidContract > 0) parts.push(`${invalidContract} invalid contract`);
 	if (untyped > 0) parts.push(`${untyped} untyped`);
 
@@ -111,6 +114,9 @@ export function formatReport(
 ): string {
 	const sections = [
 		...fatalTableLines(summary),
+		...summary.unreadableFiles.map(
+			(file) => `${file.table}/${file.fileName}\n  can't read: ${file.message}`,
+		),
 		...groupByLocation(violations).map(([location, group]) =>
 			[location, ...group.map(violationLine)].join('\n'),
 		),


### PR DESCRIPTION
Markdown bodies are opaque content, not YAML input. Before this change, conflict-marker examples and other body text could be parsed as frontmatter, which made valid documents look unreadable.

Matter now stops YAML parsing at the frontmatter boundary and carries a Markdown read or parse failure through the vault assessment with its source location. The CLI reports those files alongside its other fatal diagnostics, so a broken document is actionable instead of silently disappearing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786304493&installation_id=128463665&pr_number=2443&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2443&signature=dc194ebfa283eb9d0e76dd4fdb41a30f8ef5421995ccb4c18ce12f82038a2c80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->