### PR TITLE
refactor(whispering): use semantic recording alerts

### DIFF
--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
@@ -66,9 +66,9 @@
 			/>
 		{:else if settings.get('recording.trigger') === 'vad'}
 			{#if os.isLinux}
-				<Alert.Root class="border-red-500/20 bg-red-500/5">
-					<InfoIcon class="size-4 text-red-600 dark:text-red-400" />
-					<Alert.Title class="text-red-600 dark:text-red-400">
+				<Alert.Root variant="destructive">
+					<InfoIcon class="size-4" />
+					<Alert.Title>
 						Voice Activated not supported on Linux
 					</Alert.Title>
 					<Alert.Description>
@@ -79,7 +79,6 @@
 						<Link
 							href="https://github.com/EpicenterHQ/epicenter/issues/839"
 							target="_blank"
-							class="font-medium underline underline-offset-4 hover:text-red-700 dark:hover:text-red-300"
 						>
 							Learn more →
 						</Link>
@@ -87,9 +86,9 @@
 				</Alert.Root>
 			{:else}
 				{#if tauri && os.isApple}
-					<Alert.Root class="border-warning/20 bg-warning/5">
-						<InfoIcon class="size-4 text-warning dark:text-warning" />
-						<Alert.Title class="text-warning dark:text-warning">
+					<Alert.Root variant="warning">
+						<InfoIcon class="size-4" />
+						<Alert.Title>
 							Global Shortcuts May Be Unreliable
 						</Alert.Title>
 						<Alert.Description>
@@ -98,9 +97,9 @@
 						</Alert.Description>
 					</Alert.Root>
 				{/if}
-				<Alert.Root class="border-blue-500/20 bg-blue-500/5">
-					<InfoIcon class="size-4 text-blue-600 dark:text-blue-400" />
-					<Alert.Title class="text-blue-600 dark:text-blue-400">
+				<Alert.Root>
+					<InfoIcon class="size-4" />
+					<Alert.Title>
 						Voice Activated Detection
 					</Alert.Title>
 					<Alert.Description>


### PR DESCRIPTION
Whispering's recording settings rebuilt the Alert component's severity styling locally for each VAD state. That made the page own borders, backgrounds, icon tones, title colors, and link hover behavior that already belong to the shared product system.

This moves the unsupported Linux state to the destructive variant, the macOS reliability notice to the warning variant, and the informational guidance to the default treatment. Platform conditions, copy, links, and settings behavior remain unchanged.

The recording pill was also reviewed as the counterexample: its exact overlay geometry, glanceable status tones, and recording-specific interaction styling remain app-owned because normalizing them would weaken product behavior without deleting meaningful code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786313139&installation_id=128463665&pr_number=2445&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2445&signature=61ee89fe8fcf440c99630e844793cc57638003cb090caa71648094185465d8d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->