### PR TITLE
refactor(whispering): clarify overlay runtime ownership

### DIFF
--- a/apps/epicenter/src-tauri/src/overlay.rs
+++ b/apps/epicenter/src-tauri/src/overlay.rs
@@ -19,8 +19,8 @@ use tauri::webview::NewWindowResponse;
 use tauri::{AppHandle, Manager, WebviewUrl};
 use tauri_nspanel::{tauri_panel, CollectionBehavior, PanelBuilder, PanelLevel, StyleMask};
 
-// Must stay in sync with the JS window manager's `WINDOW_LABEL` and the pill's
-// size in `src/lib/recording-overlay/`.
+// Must stay in sync with `RECORDING_OVERLAY_WINDOW_LABEL` and the pill's size in
+// Whispering's `recording-overlay/window-manager.tauri.ts`.
 pub const WINDOW_LABEL: &str = "recording-overlay";
 const OVERLAY_WIDTH: f64 = 224.0;
 const OVERLAY_HEIGHT: f64 = 40.0;

--- a/apps/epicenter/src-tauri/src/recorder/recorder.rs
+++ b/apps/epicenter/src-tauri/src/recorder/recorder.rs
@@ -42,8 +42,8 @@ const TARGET_RATE: u32 = 16_000;
 
 /// Overlay window label and event name for live mic levels. The recording
 /// overlay (a separate webview) renders these into its meter bars. Kept in
-/// sync with the JS window manager's `WINDOW_LABEL` and the `mic-level`
-/// channel in `src/lib/recording-overlay/`.
+/// sync with `RECORDING_OVERLAY_WINDOW_LABEL` and the `mic-level` channel in
+/// Whispering's `recording-overlay/events.ts`.
 const OVERLAY_WINDOW_LABEL: &str = "recording-overlay";
 const MIC_LEVEL_EVENT: &str = "mic-level";
 

--- a/apps/whispering/docs/recording-overlay.md
+++ b/apps/whispering/docs/recording-overlay.md
@@ -15,9 +15,10 @@ into Rust would split the source of truth, so we keep it in the main window.
 - **Window**: a separate, transparent, undecorated, always-on-top
   `recording-overlay` window, reused (shown/hidden) and positioned centered near
   the bottom of the active monitor. On macOS it is a non-activating `NSPanel`
-  created in Rust (`../epicenter/src-tauri/src/overlay.rs`, via tauri-nspanel) so clicking it
-  never activates the app or raises the main window; `focusable: false` alone
-  does not prevent app activation on click. On Windows and Linux it is a
+  created in Rust (`../../epicenter/src-tauri/src/overlay.rs`, via
+  tauri-nspanel) so clicking it never activates the app or raises the main
+  window; `focusable: false` alone does not prevent app activation on click. On
+  Windows and Linux it is a
   `focusable: false` + `alwaysOnTop` `WebviewWindow` created from the frontend.
   The window manager finds the macOS panel by label and only creates a window
   when none exists, so both paths share one show/hide/position code path.
@@ -31,8 +32,8 @@ into Rust would split the source of truth, so we keep it in the main window.
   event protocol and desktop mic-level transport. On desktop,
   the Tauri implementation of `#platform/recording-overlay-owner` projects the
   lifecycle, synchronizes the separate overlay window, and listens for overlay
-  actions and reveal requests. The browser implementation is a no-op because
-  its pill is mounted directly in the app layout.
+  actions and reveal requests. The browser implementation exports no runtime
+  owner because its pill is mounted directly in the app layout.
 - **Protocol** (`src/lib/recording-overlay/events.ts`): binds the shared pill
   model to Tauri event channels. The main window pushes a `status` to the overlay;
   the overlay pushes `action` (stop/cancel) and a `ready` handshake back. Actions
@@ -40,9 +41,10 @@ into Rust would split the source of truth, so we keep it in the main window.
   payload, so a click that races a state change is safe.
 - **Controls**: the stop and cancel buttons are filled chips (stop is red) so
   they read as buttons in the small pill, and they stop click propagation.
-  Clicking the pill body anywhere else emits `focus-main`, which brings the main
-  Whispering window forward (show + unminimize + setFocus); it is a separate
-  gesture from stop/cancel so finishing a recording never yanks the window up.
+  Clicking the pill body anywhere else emits `main-window:reveal`, which brings
+  the main Whispering window forward (show + unminimize + setFocus); it is a
+  separate gesture from stop/cancel so finishing a recording never yanks the
+  window up.
 - **Mic levels** (`mic-level` channel): the bars reflect real loudness, not a
   loop. Both producers send a raw RMS amplitude and the receiving pill mount
   applies the shared perceptual curve + smoothing:
@@ -52,9 +54,10 @@ into Rust would split the source of truth, so we keep it in the main window.
     the pill and updates the host's reactive meter; the Tauri implementation
     lives with the overlay transport and forwards the sample to its webview.
   - Manual (CPAL/Tauri): the PCM lives only in Rust, so the consumer worker
-    (`../epicenter/src-tauri/src/recorder/recorder.rs`) computes RMS and emits a throttled
-    (~20 Hz) targeted `emit_to("recording-overlay", "mic-level", rms)`, per
-    Tauri's guidance for high-frequency events. This is Handy's approach.
+    (`../../epicenter/src-tauri/src/recorder/recorder.rs`) computes RMS and emits
+    a throttled (~20 Hz) targeted
+    `emit_to("recording-overlay", "mic-level", rms)`, per Tauri's guidance for
+    high-frequency events. This is Handy's approach.
 
 The single source of recorder state means no parallel recording lifecycle is
 introduced: the overlay only reflects and triggers the existing operations.

--- a/apps/whispering/src/lib/recording-overlay/window-manager.tauri.ts
+++ b/apps/whispering/src/lib/recording-overlay/window-manager.tauri.ts
@@ -1,0 +1,141 @@
+import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
+import {
+	currentMonitor,
+	LogicalPosition,
+	primaryMonitor,
+} from '@tauri-apps/api/window';
+import { once } from 'wellcrafted/function';
+import { createLogger } from 'wellcrafted/logger';
+import { whisperingPath } from '$lib/constants/urls';
+import {
+	RECORDING_OVERLAY_WINDOW_LABEL,
+	recordingOverlayReady,
+	recordingOverlayStatus,
+} from '$lib/recording-overlay/events';
+import type { RecordingPillStatus } from '$lib/recording-pill/model';
+
+const log = createLogger('whispering/recording-overlay');
+
+// Fixed size in logical pixels. The width is the pill's max width (the cap in
+// RecordingPill); the transparent window centers the narrower states inside it.
+const OVERLAY_WIDTH = 224;
+const OVERLAY_HEIGHT = 40;
+// Distance from the bottom edge of the monitor, in logical pixels.
+const OVERLAY_BOTTOM_MARGIN = 72;
+
+let latestStatus: RecordingPillStatus | null = null;
+let queue: Promise<void> = Promise.resolve();
+
+async function computeOverlayPosition(): Promise<LogicalPosition | null> {
+	const monitor = (await currentMonitor()) ?? (await primaryMonitor());
+	if (!monitor) return null;
+
+	const scale = monitor.scaleFactor;
+	const monitorX = monitor.position.x / scale;
+	const monitorY = monitor.position.y / scale;
+	const monitorWidth = monitor.size.width / scale;
+	const monitorHeight = monitor.size.height / scale;
+
+	const x = monitorX + (monitorWidth - OVERLAY_WIDTH) / 2;
+	const y = monitorY + monitorHeight - OVERLAY_HEIGHT - OVERLAY_BOTTOM_MARGIN;
+	return new LogicalPosition(x, y);
+}
+
+/** Keep the ready listener live before a newly created overlay can emit. */
+const ensureReadyListener = once(
+	(): Promise<void> =>
+		recordingOverlayReady
+			.listen(() => {
+				if (latestStatus) void recordingOverlayStatus.emit(latestStatus);
+			})
+			.then(() => undefined),
+);
+
+async function createOverlayWindow(): Promise<WebviewWindow | null> {
+	await ensureReadyListener();
+	const overlayUrl = new URL(
+		whisperingPath('/recording-overlay'),
+		window.location.origin,
+	).href;
+
+	const overlay = new WebviewWindow(RECORDING_OVERLAY_WINDOW_LABEL, {
+		url: overlayUrl,
+		title: 'Recording',
+		width: OVERLAY_WIDTH,
+		height: OVERLAY_HEIGHT,
+		transparent: true,
+		decorations: false,
+		shadow: false,
+		alwaysOnTop: true,
+		visibleOnAllWorkspaces: true,
+		skipTaskbar: true,
+		resizable: false,
+		maximizable: false,
+		minimizable: false,
+		closable: false,
+		focus: false,
+		focusable: false,
+		visible: false,
+	});
+
+	return new Promise<WebviewWindow | null>((resolve) => {
+		overlay.once('tauri://created', () => resolve(overlay));
+		overlay.once('tauri://error', (event) => {
+			log.warn(
+				new Error(
+					`Failed to create recording overlay window: ${JSON.stringify(event.payload)}`,
+				),
+			);
+			resolve(null);
+		});
+	});
+}
+
+async function getOrCreateOverlayWindow(): Promise<WebviewWindow | null> {
+	const existing = await WebviewWindow.getByLabel(
+		RECORDING_OVERLAY_WINDOW_LABEL,
+	);
+	if (existing) return existing;
+	return createOverlayWindow();
+}
+
+async function applyOverlayStatus(status: RecordingPillStatus | null) {
+	const isSuperseded = () => status !== latestStatus;
+	if (isSuperseded()) return;
+
+	if (!status) {
+		const overlay = await WebviewWindow.getByLabel(
+			RECORDING_OVERLAY_WINDOW_LABEL,
+		);
+		if (overlay) await overlay.hide();
+		return;
+	}
+
+	const overlay = await getOrCreateOverlayWindow();
+	if (!overlay || isSuperseded()) return;
+
+	const position = await computeOverlayPosition();
+	if (isSuperseded()) return;
+	if (position) await overlay.setPosition(position);
+	if (isSuperseded()) return;
+
+	await overlay.show();
+	if (isSuperseded()) {
+		if (!latestStatus) await overlay.hide();
+		return;
+	}
+
+	await recordingOverlayStatus.emit(status);
+}
+
+/** Synchronize the native overlay without letting cosmetic failures stop capture. */
+export function synchronizeRecordingOverlayWindow(
+	status: RecordingPillStatus | null,
+): void {
+	latestStatus = status;
+	queue = queue
+		.then(() => applyOverlayStatus(status))
+		.catch((error) => {
+			log.warn(error instanceof Error ? error : new Error(String(error)));
+		});
+}

--- a/apps/whispering/src/routes/(app)/_runtime/attach-recording-overlay.browser.ts
+++ b/apps/whispering/src/routes/(app)/_runtime/attach-recording-overlay.browser.ts
@@ -1,4 +1,4 @@
-/** Browser renders the recording pill in-page, so it owns no overlay window. */
-export function attachRecordingOverlay() {
-	return () => {};
-}
+import type { RuntimeOwner } from './types';
+
+/** Browser renders the recording pill in-page, so it owns no overlay runtime. */
+export const recordingOverlayRuntimeOwner: RuntimeOwner | null = null;

--- a/apps/whispering/src/routes/(app)/_runtime/attach-recording-overlay.tauri.svelte.ts
+++ b/apps/whispering/src/routes/(app)/_runtime/attach-recording-overlay.tauri.svelte.ts
@@ -1,152 +1,17 @@
 import type { UnlistenFn } from '@tauri-apps/api/event';
-import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import {
-	currentMonitor,
-	LogicalPosition,
-	primaryMonitor,
-} from '@tauri-apps/api/window';
-import { once } from 'wellcrafted/function';
-import { createLogger } from 'wellcrafted/logger';
-import { whisperingPath } from '$lib/constants/urls';
-import {
-	RECORDING_OVERLAY_WINDOW_LABEL,
 	recordingOverlayAction,
-	recordingOverlayReady,
-	recordingOverlayStatus,
 	revealMainWindow,
 } from '$lib/recording-overlay/events';
-import type { RecordingPillStatus } from '$lib/recording-pill/model';
+import { synchronizeRecordingOverlayWindow } from '$lib/recording-overlay/window-manager.tauri';
 import { dispatchPillAction } from '$lib/recording-pill/pill-actions';
 import { projectLifecycleToStatus } from '$lib/recording-pill/projection';
 import { dictationLifecycle } from '$lib/state/dictation-lifecycle.svelte';
 import { tauriOnly } from '$lib/tauri.tauri';
-
-const log = createLogger('whispering/recording-overlay');
-
-// Fixed size in logical pixels. The width is the pill's max width (the cap in
-// RecordingPill); the transparent window centers the narrower states inside it.
-const OVERLAY_WIDTH = 224;
-const OVERLAY_HEIGHT = 40;
-// Distance from the bottom edge of the monitor, in logical pixels.
-const OVERLAY_BOTTOM_MARGIN = 72;
-
-let latestStatus: RecordingPillStatus | null = null;
-let queue: Promise<void> = Promise.resolve();
-
-async function computeOverlayPosition(): Promise<LogicalPosition | null> {
-	const monitor = (await currentMonitor()) ?? (await primaryMonitor());
-	if (!monitor) return null;
-
-	const scale = monitor.scaleFactor;
-	const monitorX = monitor.position.x / scale;
-	const monitorY = monitor.position.y / scale;
-	const monitorWidth = monitor.size.width / scale;
-	const monitorHeight = monitor.size.height / scale;
-
-	const x = monitorX + (monitorWidth - OVERLAY_WIDTH) / 2;
-	const y = monitorY + monitorHeight - OVERLAY_HEIGHT - OVERLAY_BOTTOM_MARGIN;
-	return new LogicalPosition(x, y);
-}
-
-/** Keep the ready listener live before a newly created overlay can emit. */
-const ensureReadyListener = once(
-	(): Promise<void> =>
-		recordingOverlayReady
-			.listen(() => {
-				if (latestStatus) void recordingOverlayStatus.emit(latestStatus);
-			})
-			.then(() => undefined),
-);
-
-async function createOverlayWindow(): Promise<WebviewWindow | null> {
-	await ensureReadyListener();
-	const overlayUrl = new URL(
-		whisperingPath('/recording-overlay'),
-		window.location.origin,
-	).href;
-
-	const overlay = new WebviewWindow(RECORDING_OVERLAY_WINDOW_LABEL, {
-		url: overlayUrl,
-		title: 'Recording',
-		width: OVERLAY_WIDTH,
-		height: OVERLAY_HEIGHT,
-		transparent: true,
-		decorations: false,
-		shadow: false,
-		alwaysOnTop: true,
-		visibleOnAllWorkspaces: true,
-		skipTaskbar: true,
-		resizable: false,
-		maximizable: false,
-		minimizable: false,
-		closable: false,
-		focus: false,
-		focusable: false,
-		visible: false,
-	});
-
-	return new Promise<WebviewWindow | null>((resolve) => {
-		overlay.once('tauri://created', () => resolve(overlay));
-		overlay.once('tauri://error', (event) => {
-			log.warn(
-				new Error(
-					`Failed to create recording overlay window: ${JSON.stringify(event.payload)}`,
-				),
-			);
-			resolve(null);
-		});
-	});
-}
-
-async function getOrCreateOverlayWindow(): Promise<WebviewWindow | null> {
-	const existing = await WebviewWindow.getByLabel(
-		RECORDING_OVERLAY_WINDOW_LABEL,
-	);
-	if (existing) return existing;
-	return createOverlayWindow();
-}
-
-async function applyOverlayStatus(status: RecordingPillStatus | null) {
-	const isSuperseded = () => status !== latestStatus;
-	if (isSuperseded()) return;
-
-	if (!status) {
-		const overlay = await WebviewWindow.getByLabel(
-			RECORDING_OVERLAY_WINDOW_LABEL,
-		);
-		if (overlay) await overlay.hide();
-		return;
-	}
-
-	const overlay = await getOrCreateOverlayWindow();
-	if (!overlay || isSuperseded()) return;
-
-	const position = await computeOverlayPosition();
-	if (isSuperseded()) return;
-	if (position) await overlay.setPosition(position);
-	if (isSuperseded()) return;
-
-	await overlay.show();
-	if (isSuperseded()) {
-		if (!latestStatus) await overlay.hide();
-		return;
-	}
-
-	await recordingOverlayStatus.emit(status);
-}
-
-/** Synchronize the native overlay without letting cosmetic failures stop capture. */
-function synchronizeOverlayStatus(status: RecordingPillStatus | null): void {
-	latestStatus = status;
-	queue = queue
-		.then(() => applyOverlayStatus(status))
-		.catch((error) => {
-			log.warn(error instanceof Error ? error : new Error(String(error)));
-		});
-}
+import type { RuntimeOwner } from './types';
 
 /** Own the Tauri recording overlay for the app session. */
-export function attachRecordingOverlay() {
+function attachRecordingOverlay() {
 	const unlisteners: UnlistenFn[] = [];
 	let isDestroyed = false;
 	const trackUnlistener = (unlisten: UnlistenFn) => {
@@ -159,7 +24,7 @@ export function attachRecordingOverlay() {
 	);
 
 	$effect(() => {
-		synchronizeOverlayStatus(overlayStatus);
+		synchronizeRecordingOverlayWindow(overlayStatus);
 	});
 
 	void recordingOverlayAction
@@ -174,3 +39,7 @@ export function attachRecordingOverlay() {
 		for (const unlisten of unlisteners) unlisten();
 	};
 }
+
+export const recordingOverlayRuntimeOwner: RuntimeOwner | null = {
+	attach: attachRecordingOverlay,
+};

--- a/apps/whispering/src/routes/(app)/_runtime/runtime-owners.ts
+++ b/apps/whispering/src/routes/(app)/_runtime/runtime-owners.ts
@@ -1,4 +1,4 @@
-import { attachRecordingOverlay } from '#platform/recording-overlay-owner';
+import { recordingOverlayRuntimeOwner } from '#platform/recording-overlay-owner';
 import { dictationCapability } from '$lib/state/dictation-capability.svelte';
 import { attachAnalytics } from './attach-analytics.svelte';
 import { attachAutoPasteIntent } from './attach-auto-paste-intent.svelte';
@@ -16,7 +16,7 @@ export const runtimeOwners = [
 	{ attach: attachAnalytics },
 	{ attach: attachLocalShortcutListener },
 	{ attach: attachShortcutSync },
-	{ attach: attachRecordingOverlay },
+	...(recordingOverlayRuntimeOwner ? [recordingOverlayRuntimeOwner] : []),
 	{ attach: attachDictationExceptions },
 	{ attach: attachUnloadPolicy },
 	{ attach: attachRecordingRetention },


### PR DESCRIPTION
Hosted Whispering renders its recording pill directly in the app layout, but the runtime registry still attached an empty browser overlay owner. That made absence look like a lifecycle and left native window mechanics mixed into the Tauri attachment module.

The platform seam now represents that capability honestly:

```ts
// Browser
export const recordingOverlayRuntimeOwner: RuntimeOwner | null = null;

// Tauri
export const recordingOverlayRuntimeOwner: RuntimeOwner | null = {
	attach: attachRecordingOverlay,
};
```

The shared runtime registry conditionally includes the owner, so the hosted build never registers or invokes overlay-window work. Its visible pill is unchanged: `RecordingPillHost` still reads the shared dictation lifecycle directly and renders inside the page.

On Tauri, the attachment module now owns lifecycle projection plus action and reveal listeners. A Tauri-only window manager owns the external window, positioning, ready handshake, serialized updates, and stale-update suppression. This keeps native mechanics physically outside the hosted graph without changing IPC strings or pill behavior.

The shared `/recording-overlay` route still compiles for both targets, so the browser window-event implementation remains an earned no-op. Making that route unavailable on web is a separate platform-boundary decision, not part of this refactor.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786313276&installation_id=128463665&pr_number=2446&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2446&signature=0a1d7e1e9167607d9d0125debb052d9780958d69463bb803836b2ea639778001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->