### PR TITLE
refactor(workspace): unify YKeyValueLww reconciliation

### DIFF
--- a/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.test.ts
+++ b/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.test.ts
@@ -17,6 +17,7 @@
  */
 import { describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';
+import type { KvStoreChange } from './observable-kv-store.js';
 import { YKeyValueLww, type YKeyValueLwwEntry } from './y-keyvalue-lww';
 
 /**
@@ -63,13 +64,6 @@ function syncBoth(doc1: Y.Doc, doc2: Y.Doc): void {
 
 describe('YKeyValueLww', () => {
 	describe('Basic Operations', () => {
-		test('set stores value and get retrieves it', () => {
-			const { kv } = setupKv();
-
-			kv.set('foo', 'bar');
-			expect(kv.get('foo')).toBe('bar');
-		});
-
 		test('get() reports stored values and undefined for absence', () => {
 			const { kv } = setupKv();
 
@@ -130,15 +124,6 @@ describe('YKeyValueLww', () => {
 					.map((entry) => entry.key)
 					.sort(),
 			).toEqual(['bar', 'foo']);
-		});
-
-		test('delete removes value', () => {
-			const { kv } = setupKv();
-
-			kv.set('foo', 'bar');
-			kv.delete('foo');
-			expect(kv.get('foo')).toBeUndefined();
-			expect(kv.has('foo')).toBe(false);
 		});
 
 		test('bulkDelete removes all specified keys', () => {
@@ -254,56 +239,23 @@ describe('YKeyValueLww', () => {
 	});
 
 	describe('Change Events', () => {
-		test('fires add event for new key', () => {
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-			const kv = new YKeyValueLww(yarray);
-
-			const events: Array<{ key: string; action: string }> = [];
+		test('emits add, update, and delete across a key lifecycle', () => {
+			const { kv } = setupKv();
+			const events: KvStoreChange<string>[] = [];
 			kv.observe((changes) => {
-				for (const [key, change] of changes) {
-					events.push({ key, action: change.action });
-				}
+				const change = changes.get('foo');
+				if (change) events.push(change);
 			});
-
-			kv.set('foo', 'bar');
-			expect(events).toEqual([{ key: 'foo', action: 'add' }]);
-		});
-
-		test('fires update event when value changes', () => {
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-			const kv = new YKeyValueLww(yarray);
 
 			kv.set('foo', 'first');
-
-			const events: Array<{ key: string; action: string }> = [];
-			kv.observe((changes) => {
-				for (const [key, change] of changes) {
-					events.push({ key, action: change.action });
-				}
-			});
-
 			kv.set('foo', 'second');
-			expect(events).toEqual([{ key: 'foo', action: 'update' }]);
-		});
-
-		test('fires delete event when key removed', () => {
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
-			const kv = new YKeyValueLww(yarray);
-
-			kv.set('foo', 'bar');
-
-			const events: Array<{ key: string; action: string }> = [];
-			kv.observe((changes) => {
-				for (const [key, change] of changes) {
-					events.push({ key, action: change.action });
-				}
-			});
-
 			kv.delete('foo');
-			expect(events).toEqual([{ key: 'foo', action: 'delete' }]);
+
+			expect(events).toEqual([
+				{ action: 'add', newValue: 'first' },
+				{ action: 'update', newValue: 'second' },
+				{ action: 'delete' },
+			]);
 		});
 	});
 
@@ -634,34 +586,6 @@ describe('YKeyValueLww', () => {
 		 */
 
 		describe('writes inside caller-owned transactions', () => {
-			test('get() returns a value set earlier', () => {
-				const { ydoc, kv } = setupKv();
-
-				let valueDuringTransaction: string | undefined;
-
-				ydoc.transact(() => {
-					kv.set('foo', 'bar');
-					valueDuringTransaction = kv.get('foo');
-				});
-
-				expect(valueDuringTransaction).toBe('bar');
-				// The value remains visible after the observer-backed map catches up.
-				expect(kv.get('foo')).toBe('bar');
-			});
-
-			test('has() returns true for a key set earlier', () => {
-				const { ydoc, kv } = setupKv();
-
-				let hasDuringTransaction: boolean = false;
-
-				ydoc.transact(() => {
-					kv.set('foo', 'bar');
-					hasDuringTransaction = kv.has('foo');
-				});
-
-				expect(hasDuringTransaction).toBe(true);
-			});
-
 			test('get() returns each successive value', () => {
 				const { ydoc, kv } = setupKv();
 
@@ -681,97 +605,25 @@ describe('YKeyValueLww', () => {
 				expect(valuesDuringTransaction).toEqual(['first', 'second', 'third']);
 				expect(kv.get('foo')).toBe('third');
 			});
-
-			test('get() returns an updated value for an existing key', () => {
-				const { ydoc, kv } = setupKv();
-
-				// Set the initial value before the caller-owned transaction.
-				kv.set('foo', 'initial');
-
-				let valueDuringTransaction: string | undefined;
-
-				ydoc.transact(() => {
-					kv.set('foo', 'updated');
-					valueDuringTransaction = kv.get('foo');
-				});
-
-				expect(valueDuringTransaction).toBe('updated');
-				expect(kv.get('foo')).toBe('updated');
-			});
 		});
 
 		describe('deletes inside caller-owned transactions', () => {
-			test('delete() removes a key set earlier', () => {
+			test('delete hides a pre-existing key from every read surface', () => {
 				const { ydoc, kv } = setupKv();
-
-				let hasAfterDelete: boolean = true;
-
-				ydoc.transact(() => {
-					kv.set('foo', 'bar');
-					kv.delete('foo');
-					hasAfterDelete = kv.has('foo');
-				});
-
-				expect(hasAfterDelete).toBe(false);
-
-				// After the transaction closes, the observer has caught up and the key
-				// remains absent.
-				expect(kv.has('foo')).toBe(false);
-			});
-
-			test('set() after delete() restores the key', () => {
-				const { ydoc, kv } = setupKv();
-
-				// Set initial value
-				kv.set('foo', 'initial');
-
-				let valueDuringTransaction: string | undefined;
-
-				ydoc.transact(() => {
-					kv.delete('foo');
-					kv.set('foo', 'restored');
-					valueDuringTransaction = kv.get('foo');
-				});
-
-				expect(valueDuringTransaction).toBe('restored');
-				expect(kv.get('foo')).toBe('restored');
-			});
-
-			test('delete() hides a pre-existing key immediately', () => {
-				const { ydoc, kv } = setupKv();
-
 				kv.set('foo', 'bar');
-				expect(kv.has('foo')).toBe(true);
 
 				ydoc.transact(() => {
 					kv.delete('foo');
+					expect(kv.get('foo')).toBeUndefined();
 					expect(kv.has('foo')).toBe(false);
+					expect([...kv.entries()]).toEqual([]);
 				});
 
-				// After the transaction closes, the observer-backed map agrees.
-				expect(kv.has('foo')).toBe(false);
+				expect(kv.get('foo')).toBeUndefined();
 			});
 		});
 
 		describe('entries() during caller-owned transactions', () => {
-			test('entries() yields values set earlier', () => {
-				const { ydoc, kv } = setupKv();
-
-				const keysDuringTransaction: string[] = [];
-
-				ydoc.transact(() => {
-					kv.set('a', '1');
-					kv.set('b', '2');
-					kv.set('c', '3');
-
-					for (const { key } of kv.entries()) {
-						keysDuringTransaction.push(key);
-					}
-				});
-
-				expect(keysDuringTransaction.sort()).toEqual(['a', 'b', 'c']);
-			});
-
 			test('entries() yields both observer-indexed and transaction-local values', () => {
 				const { ydoc, kv } = setupKv();
 
@@ -792,101 +644,26 @@ describe('YKeyValueLww', () => {
 				expect(entriesDuringTransaction).toContainEqual(['new', 'value']);
 			});
 
-			test('entries() prefers transaction-local value over observer-indexed value for same key', () => {
-				const { ydoc, kv } = setupKv();
-
-				kv.set('foo', 'old');
-
-				let valueDuringTransaction: string | undefined;
-
-				ydoc.transact(() => {
-					kv.set('foo', 'new');
-
-					for (const { key, val } of kv.entries()) {
-						if (key === 'foo') valueDuringTransaction = val;
-					}
-				});
-
-				expect(valueDuringTransaction).toBe('new');
-			});
-
 			test('entries() does not yield duplicates', () => {
 				const { ydoc, kv } = setupKv();
 
 				kv.set('foo', 'old');
 
 				let fooCount = 0;
+				let valueDuringTransaction: string | undefined;
 
 				ydoc.transact(() => {
 					kv.set('foo', 'new');
 
-					for (const { key } of kv.entries()) {
-						if (key === 'foo') fooCount++;
+					for (const { key, val } of kv.entries()) {
+						if (key !== 'foo') continue;
+						fooCount++;
+						valueDuringTransaction = val;
 					}
 				});
 
 				expect(fooCount).toBe(1);
-			});
-		});
-
-		describe('overlay cleanup', () => {
-			test('multiple transactions preserve prior keys and apply updates', () => {
-				const { ydoc, kv } = setupKv();
-
-				ydoc.transact(() => {
-					kv.set('a', '1');
-					kv.set('b', '2');
-				});
-
-				expect(kv.get('a')).toBe('1');
-				expect(kv.get('b')).toBe('2');
-
-				ydoc.transact(() => {
-					kv.set('c', '3');
-					kv.set('a', 'updated');
-				});
-
-				expect(kv.get('a')).toBe('updated');
-				expect(kv.get('b')).toBe('2');
-				expect(kv.get('c')).toBe('3');
-			});
-		});
-
-		describe('Observer behavior', () => {
-			test('observer fires once per caller-owned transaction, not per set()', () => {
-				const { ydoc, kv } = setupKv();
-
-				let observerCallCount = 0;
-				kv.observe(() => {
-					observerCallCount++;
-				});
-
-				ydoc.transact(() => {
-					kv.set('a', '1');
-					kv.set('b', '2');
-					kv.set('c', '3');
-				});
-
-				expect(observerCallCount).toBe(1);
-			});
-
-			test('observer receives all changes from a caller-owned transaction', () => {
-				const { ydoc, kv } = setupKv();
-
-				const changedKeys: string[] = [];
-				kv.observe((changes) => {
-					for (const [key] of changes) {
-						changedKeys.push(key);
-					}
-				});
-
-				ydoc.transact(() => {
-					kv.set('a', '1');
-					kv.set('b', '2');
-					kv.set('c', '3');
-				});
-
-				expect(changedKeys.sort()).toEqual(['a', 'b', 'c']);
+				expect(valueDuringTransaction).toBe('new');
 			});
 		});
 
@@ -916,31 +693,6 @@ describe('YKeyValueLww', () => {
 				expect(kv2.get('bar')).toBe('from-kv2');
 				expect(kv2.get('foo')).toBe('from-kv1');
 			});
-
-			test('LWW conflict resolution still works with transaction-local writes', () => {
-				const { doc1, doc2, array1, array2 } = setupSyncedArrays();
-
-				// Manually insert with controlled timestamps
-				array1.push([{ key: 'x', val: 'old', ts: 1000 }]);
-
-				const kv1 = new YKeyValueLww(array1);
-				const kv2 = new YKeyValueLww(array2);
-
-				// Sync initial state
-				Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
-				expect(kv2.get('x')).toBe('old');
-
-				// kv2 updates with higher timestamp
-				kv2.set('x', 'new'); // Will get ts > 1000
-
-				// Sync both ways
-				Y.applyUpdate(doc1, Y.encodeStateAsUpdate(doc2));
-				Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
-
-				// Higher timestamp should win
-				expect(kv1.get('x')).toBe('new');
-				expect(kv2.get('x')).toBe('new');
-			});
 		});
 
 		describe('Edge cases', () => {
@@ -950,17 +702,6 @@ describe('YKeyValueLww', () => {
 				kv.set('foo', undefined);
 				expect(kv.get('foo')).toBeUndefined();
 				expect(kv.has('foo')).toBe(false);
-			});
-
-			test('rapid set/get cycles always return the latest value', () => {
-				const { kv } = setupKv<number>();
-
-				for (let i = 0; i < 100; i++) {
-					kv.set('counter', i);
-					expect(kv.get('counter')).toBe(i);
-				}
-
-				expect(kv.get('counter')).toBe(99);
 			});
 
 			test('mixed operations expose their latest state in a caller-owned transaction', () => {
@@ -988,41 +729,6 @@ describe('YKeyValueLww', () => {
 				expect(kv.get('update')).toBe('new');
 				expect(kv.get('new')).toBe('added');
 				expect(kv.has('delete')).toBe(false);
-			});
-
-			test('delete then get returns undefined immediately', () => {
-				const { ydoc, kv } = setupKv();
-
-				kv.set('foo', 'bar');
-
-				let valueDuringTransaction: string | undefined = 'not-cleared';
-
-				ydoc.transact(() => {
-					kv.delete('foo');
-					valueDuringTransaction = kv.get('foo');
-				});
-
-				expect(valueDuringTransaction).toBeUndefined();
-				expect(kv.get('foo')).toBeUndefined();
-			});
-
-			test('delete then set returns the new value immediately', () => {
-				const { ydoc, kv } = setupKv();
-
-				kv.set('foo', 'bar');
-
-				let valueDuringTransaction: string | undefined;
-
-				ydoc.transact(() => {
-					kv.delete('foo');
-					expect(kv.get('foo')).toBeUndefined();
-					kv.set('foo', 'new');
-					valueDuringTransaction = kv.get('foo');
-				});
-
-				expect(valueDuringTransaction).toBe('new');
-				expect(kv.get('foo')).toBe('new');
-				expect(kv.has('foo')).toBe(true);
 			});
 
 			test('double delete is idempotent', () => {
@@ -1061,102 +767,6 @@ describe('YKeyValueLww', () => {
 				expect(keysDuringTransaction).toContain('c');
 			});
 
-			test('observer clears transaction-local delete overlay', () => {
-				const { ydoc, kv } = setupKv();
-
-				kv.set('foo', 'bar');
-
-				ydoc.transact(() => {
-					kv.delete('foo');
-					expect(kv.has('foo')).toBe(false);
-				});
-
-				// After the transaction closes, the observer has cleared the delete overlay.
-				// Verify by setting a new value: a sticky overlay would keep has() false.
-				kv.set('foo', 'baz');
-				expect(kv.has('foo')).toBe(true);
-				expect(kv.get('foo')).toBe('baz');
-			});
-
-			test('set then delete leaves no sticky delete overlay', () => {
-				const { ydoc, kv } = setupKv();
-
-				// Set then delete in one transaction: the Y.Array entry is added and removed
-				// before the observer runs.
-				ydoc.transact(() => {
-					kv.set('foo', 'bar');
-					kv.delete('foo');
-				});
-
-				// After the transaction closes, the delete overlay should be clear.
-				// A subsequent set verifies that the old delete no longer masks this key.
-				kv.set('foo', 'new');
-				expect(kv.has('foo')).toBe(true);
-				expect(kv.get('foo')).toBe('new');
-			});
-
-			test('remote set after local delete is not masked by delete overlay', () => {
-				const { doc1, doc2, array1, array2 } = setupSyncedArrays('test');
-				const kv1 = new YKeyValueLww(array1);
-				const kv2 = new YKeyValueLww(array2);
-
-				// Both clients have the key
-				kv1.set('foo', 'original');
-				Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
-
-				// Client 1 deletes
-				kv1.delete('foo');
-				expect(kv1.has('foo')).toBe(false);
-
-				// Client 2 sets a new value (higher timestamp)
-				kv2.set('foo', 'remote-value');
-
-				// Sync client 2's update to client 1
-				Y.applyUpdate(doc1, Y.encodeStateAsUpdate(doc2));
-
-				// Client 1 should see the remote value: the delete overlay must not mask it.
-				expect(kv1.has('foo')).toBe(true);
-				expect(kv1.get('foo')).toBe('remote-value');
-			});
-
-			test('get() returns the final value after set-delete-set', () => {
-				const { ydoc, kv } = setupKv();
-
-				kv.set('foo', 'initial');
-
-				let finalGet: string | undefined;
-
-				ydoc.transact(() => {
-					kv.set('foo', 'first');
-					kv.delete('foo');
-					expect(kv.get('foo')).toBeUndefined();
-					kv.set('foo', 'final');
-					finalGet = kv.get('foo');
-				});
-
-				expect(finalGet).toBe('final');
-				expect(kv.get('foo')).toBe('final');
-				expect(kv.has('foo')).toBe(true);
-			});
-
-			test('get() returns undefined after delete-set-delete', () => {
-				const { ydoc, kv } = setupKv();
-
-				kv.set('foo', 'original');
-
-				ydoc.transact(() => {
-					kv.delete('foo');
-					expect(kv.has('foo')).toBe(false);
-					kv.set('foo', 'revived');
-					expect(kv.get('foo')).toBe('revived');
-					kv.delete('foo');
-					expect(kv.has('foo')).toBe(false);
-				});
-
-				expect(kv.has('foo')).toBe(false);
-				expect(kv.get('foo')).toBeUndefined();
-			});
-
 			test('delete non-existent key is no-op', () => {
 				const { ydoc, kv } = setupKv();
 
@@ -1170,55 +780,6 @@ describe('YKeyValueLww', () => {
 					kv.delete('also-never-existed');
 					expect(kv.has('also-never-existed')).toBe(false);
 				});
-			});
-
-			test('delete overlay wins after set then delete', () => {
-				const { ydoc, kv } = setupKv();
-
-				kv.set('foo', 'original');
-
-				let valueDuringTransaction: string | undefined = 'sentinel';
-
-				ydoc.transact(() => {
-					// set() adds a write overlay and clears any delete overlay.
-					kv.set('foo', 'updated');
-					expect(kv.get('foo')).toBe('updated');
-
-					// delete() clears the write overlay and adds a delete overlay.
-					kv.delete('foo');
-					valueDuringTransaction = kv.get('foo');
-				});
-
-				// During the transaction, the delete overlay should have taken precedence.
-				expect(valueDuringTransaction).toBeUndefined();
-				expect(kv.has('foo')).toBe(false);
-			});
-
-			test('remote add for different key does not clear unrelated delete overlay', () => {
-				const { doc1, doc2, array1, array2 } = setupSyncedArrays('test');
-				const kv1 = new YKeyValueLww(array1);
-				const kv2 = new YKeyValueLww(array2);
-
-				// Both clients have keys 'a' and 'b'
-				kv1.set('a', '1');
-				kv1.set('b', '2');
-				Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
-
-				// Client 1 deletes 'a'
-				kv1.delete('a');
-				expect(kv1.has('a')).toBe(false);
-
-				// Client 2 adds a completely new key 'c'
-				kv2.set('c', '3');
-
-				// Sync client 2's update to client 1
-				Y.applyUpdate(doc1, Y.encodeStateAsUpdate(doc2));
-
-				// 'a' should still be deleted: the remote add of 'c' should not affect it
-				expect(kv1.has('a')).toBe(false);
-				expect(kv1.get('a')).toBeUndefined();
-				// 'c' should be visible
-				expect(kv1.get('c')).toBe('3');
 			});
 
 			test('both clients delete same key', () => {

--- a/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.test.ts
+++ b/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.test.ts
@@ -7,7 +7,9 @@
  *
  * Key behaviors:
  * - Higher timestamps win conflicts regardless of merge ordering.
+ * - Equal timestamps use final Y.Array position, both at construction and sync.
  * - Reads inside caller-owned Yjs transactions include local writes and deletes.
+ * - Reconciliation preserves origins, event batching, and unchanged references.
  *
  * See also:
  * - `y-keyvalue.ts` for positional (rightmost-wins) alternative
@@ -320,6 +322,306 @@ describe('YKeyValueLww', () => {
 			expect(kv.get('x')).toBe('second');
 			expect(yarray.length).toBe(1); // Duplicate should be cleaned up
 		});
+
+		test('live conflicts choose the same rightmost winner as constructor hydration', () => {
+			const { doc1, doc2, array1, array2 } = setupSyncedArrays();
+			array1.push([{ key: 'x', val: 'client-1', ts: 1000 }]);
+			array2.push([{ key: 'x', val: 'client-2', ts: 1000 }]);
+
+			const mergedDoc = new Y.Doc();
+			Y.applyUpdate(mergedDoc, Y.encodeStateAsUpdate(doc1));
+			Y.applyUpdate(mergedDoc, Y.encodeStateAsUpdate(doc2));
+			const mergedEntries = mergedDoc
+				.getArray<YKeyValueLwwEntry<string>>('data')
+				.toArray();
+			const expected = mergedEntries.at(-1)?.val;
+
+			const kv1 = new YKeyValueLww(array1);
+			const kv2 = new YKeyValueLww(array2);
+			syncBoth(doc1, doc2);
+
+			expect(kv1.get('x')).toBe(expected);
+			expect(kv2.get('x')).toBe(expected);
+			expect(array1).toHaveLength(1);
+			expect(array2).toHaveLength(1);
+		});
+	});
+
+	describe('Resolution pipeline contracts', () => {
+		test('nested transactions preserve the outer origin and emit once', () => {
+			const { ydoc, kv } = setupKv();
+			const outerOrigin = Symbol('outer');
+			const innerOrigin = Symbol('inner');
+			const batches: Array<{ changes: Map<string, unknown>; origin: unknown }> =
+				[];
+			kv.observe((changes, origin) => batches.push({ changes, origin }));
+
+			ydoc.transact(() => {
+				kv.set('a', 'first');
+				ydoc.transact(() => kv.set('a', 'second'), innerOrigin);
+				kv.set('b', 'value');
+			}, outerOrigin);
+
+			expect(batches).toHaveLength(1);
+			expect(batches[0]?.origin).toBe(outerOrigin);
+			expect([...(batches[0]?.changes.keys() ?? [])].sort()).toEqual([
+				'a',
+				'b',
+			]);
+		});
+
+		test('remote updates emit their applyUpdate origin', () => {
+			const { doc1, doc2, array1, array2 } = setupSyncedArrays();
+			const kv1 = new YKeyValueLww(array1);
+			const kv2 = new YKeyValueLww(array2);
+			const remoteOrigin = Symbol('remote');
+			const origins: unknown[] = [];
+			kv2.observe((_changes, origin) => origins.push(origin));
+
+			kv1.set('remote', 'value');
+			Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1), remoteOrigin);
+
+			expect(origins).toEqual([remoteOrigin]);
+			expect(kv2.get('remote')).toBe('value');
+		});
+
+		test('a lower-timestamp remote loser emits nothing and keeps winner identity', () => {
+			const { doc1, doc2, array1, array2 } = setupSyncedArrays();
+			array1.push([{ key: 'x', val: 'winner', ts: 2000 }]);
+			const kv1 = new YKeyValueLww(array1);
+			const winner = kv1.map.get('x');
+			let observerCalls = 0;
+			kv1.observe(() => observerCalls++);
+
+			array2.push([{ key: 'x', val: 'loser', ts: 1000 }]);
+			Y.applyUpdate(doc1, Y.encodeStateAsUpdate(doc2), Symbol('remote'));
+
+			expect(kv1.map.get('x')).toBe(winner);
+			expect(kv1.get('x')).toBe('winner');
+			expect(array1).toHaveLength(1);
+			expect(observerCalls).toBe(0);
+		});
+
+		test('conflict cleanup adds one private raw transaction but one public batch', () => {
+			const { ydoc, yarray, kv } = setupKv();
+			kv.set('x', 'old');
+			const origin = Symbol('bulk-update');
+			const rawOrigins: unknown[] = [];
+			const publicOrigins: unknown[] = [];
+			yarray.observe((_event, transaction) =>
+				rawOrigins.push(transaction.origin),
+			);
+			kv.observe((_changes, transactionOrigin) =>
+				publicOrigins.push(transactionOrigin),
+			);
+
+			ydoc.transact(() => kv.bulkSet([{ key: 'x', val: 'new' }]), origin);
+
+			expect(publicOrigins).toEqual([origin]);
+			expect(rawOrigins).toHaveLength(2);
+			expect(rawOrigins[0]).toBe(origin);
+			expect(typeof rawOrigins[1]).toBe('symbol');
+		});
+
+		test('constructor conflict cleanup keeps its origin-null raw transaction', () => {
+			const ydoc = new Y.Doc();
+			const yarray = ydoc.getArray<YKeyValueLwwEntry<string>>('data');
+			yarray.push([
+				{ key: 'x', val: 'old', ts: 1 },
+				{ key: 'x', val: 'new', ts: 2 },
+			]);
+			const origins: unknown[] = [];
+			yarray.observe((_event, transaction) => origins.push(transaction.origin));
+
+			const kv = new YKeyValueLww(yarray);
+
+			expect(kv.get('x')).toBe('new');
+			expect(origins).toEqual([null]);
+		});
+
+		test('unchanged entries keep their entry and value references through cleanup', () => {
+			const { kv } = setupKv<{ label: string }>();
+			const stableValue = { label: 'stable' };
+			kv.bulkSet([
+				{ key: 'stable', val: stableValue },
+				{ key: 'changed', val: { label: 'old' } },
+			]);
+			const stableEntry = kv.map.get('stable');
+
+			kv.bulkSet([{ key: 'changed', val: { label: 'new' } }]);
+
+			expect(kv.map.get('stable')).toBe(stableEntry);
+			expect(kv.get('stable')).toBe(stableValue);
+		});
+
+		test('bulk conflict cleanup keeps one entry per key and emits one batch', () => {
+			const { yarray, kv } = setupKv<number>();
+			const count = 1000;
+			const initial = Array.from({ length: count }, (_, index) => ({
+				key: `key-${index}`,
+				val: index,
+			}));
+			kv.bulkSet(initial);
+			const batches: Map<string, unknown>[] = [];
+			kv.observe((changes) => batches.push(changes));
+
+			kv.bulkSet(initial.map(({ key, val }) => ({ key, val: val + 1 })));
+
+			expect(batches).toHaveLength(1);
+			expect(batches[0]?.size).toBe(count);
+			expect(yarray).toHaveLength(count);
+			expect(kv.get('key-999')).toBe(1000);
+		});
+
+		test('bulkSet resolves several versions of one absent key in one pass', () => {
+			const { yarray, kv } = setupKv();
+			const actions: string[] = [];
+			kv.observe((changes) => {
+				const change = changes.get('x');
+				if (change) actions.push(change.action);
+			});
+
+			kv.bulkSet([
+				{ key: 'x', val: 'first' },
+				{ key: 'x', val: 'second' },
+				{ key: 'x', val: 'third' },
+			]);
+
+			expect(kv.get('x')).toBe('third');
+			expect(yarray).toHaveLength(1);
+			expect(actions).toEqual(['update']);
+		});
+
+		test('repeated writes to an absent key retain the update event contract', () => {
+			const { ydoc, kv } = setupKv();
+			const actions: string[] = [];
+			kv.observe((changes) => {
+				const change = changes.get('x');
+				if (change) actions.push(change.action);
+			});
+
+			ydoc.transact(() => {
+				kv.set('x', 'first');
+				kv.set('x', 'second');
+			});
+
+			expect(actions).toEqual(['update']);
+			expect(kv.get('x')).toBe('second');
+		});
+
+		test('bulk writes followed by delete leave an absent key absent', () => {
+			const { ydoc, yarray, kv } = setupKv();
+			const actions: string[] = [];
+			kv.observe((changes) => {
+				const change = changes.get('x');
+				if (change) actions.push(change.action);
+			});
+
+			ydoc.transact(() => {
+				kv.bulkSet([
+					{ key: 'x', val: 'first' },
+					{ key: 'x', val: 'second' },
+				]);
+				kv.delete('x');
+			});
+
+			expect(kv.get('x')).toBeUndefined();
+			expect(yarray).toHaveLength(0);
+			expect(actions).toEqual([]);
+		});
+
+		test('a remote set applied after a local delete in one transaction survives', () => {
+			const { doc1, doc2, array1, array2 } = setupSyncedArrays();
+			const kv1 = new YKeyValueLww(array1);
+			const kv2 = new YKeyValueLww(array2);
+			kv1.set('x', 'original');
+			Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
+			const doc1State = Y.encodeStateVector(doc1);
+			kv2.set('x', 'remote');
+			const remoteUpdate = Y.encodeStateAsUpdate(doc2, doc1State);
+			const outerOrigin = Symbol('outer');
+			const origins: unknown[] = [];
+			kv1.observe((_changes, origin) => origins.push(origin));
+
+			doc1.transact(() => {
+				kv1.delete('x');
+				Y.applyUpdate(doc1, remoteUpdate, Symbol('nested-remote'));
+			}, outerOrigin);
+
+			expect(kv1.get('x')).toBe('remote');
+			expect(origins).toEqual([outerOrigin]);
+		});
+
+		const permutations = [
+			{
+				name: 'set-delete on an absent key stays absent without an event',
+				initial: undefined,
+				operations: ['set', 'delete'],
+				expected: undefined,
+				actions: [],
+			},
+			{
+				name: 'set-set-delete on an absent key leaves no surviving write',
+				initial: undefined,
+				operations: ['set', 'set', 'delete'],
+				expected: undefined,
+				actions: [],
+			},
+			{
+				name: 'set-delete-set on an absent key emits add for the final value',
+				initial: undefined,
+				operations: ['set', 'delete', 'set'],
+				expected: 'value-1',
+				actions: ['add'],
+			},
+			{
+				name: 'delete-set on an existing key emits update',
+				initial: 'initial',
+				operations: ['delete', 'set'],
+				expected: 'value-0',
+				actions: ['update'],
+			},
+			{
+				name: 'set-delete on an existing key emits delete',
+				initial: 'initial',
+				operations: ['set', 'delete'],
+				expected: undefined,
+				actions: ['delete'],
+			},
+			{
+				name: 'delete-set-delete on an existing key emits delete',
+				initial: 'initial',
+				operations: ['delete', 'set', 'delete'],
+				expected: undefined,
+				actions: ['delete'],
+			},
+		] as const;
+
+		for (const scenario of permutations) {
+			test(scenario.name, () => {
+				const { ydoc, yarray, kv } = setupKv();
+				if (scenario.initial !== undefined) kv.set('x', scenario.initial);
+				const actions: string[] = [];
+				kv.observe((changes) => {
+					const change = changes.get('x');
+					if (change) actions.push(change.action);
+				});
+
+				let setIndex = 0;
+				ydoc.transact(() => {
+					for (const operation of scenario.operations) {
+						if (operation === 'set') kv.set('x', `value-${setIndex++}`);
+						else kv.delete('x');
+					}
+				});
+
+				expect(kv.get('x')).toBe(scenario.expected);
+				expect(actions).toEqual([...scenario.actions]);
+				expect(
+					yarray.toArray().filter((entry) => entry.key === 'x'),
+				).toHaveLength(scenario.expected === undefined ? 0 : 1);
+			});
+		}
 	});
 
 	describe('Transaction-local reads', () => {

--- a/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.ts
+++ b/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.ts
@@ -79,19 +79,19 @@
  *
  * Both pairs produce identical results. The difference is internal:
  *
- * **`set()` eagerly cleans up the old entry** before pushing the new one.
- * It calls `deleteEntryByKey()` which scans the Y.Array (O(n)) to find and
- * remove the old entry. The observer then sees a clean add with no conflicts. This
+ * **`set()` eagerly cleans up old entries** before pushing the new one.
+ * It calls `deleteEntriesByKey()` which scans the Y.Array (O(n)) to find and
+ * remove matching entries. The observer then sees a clean add with no conflicts. This
  * is fast for individual calls but O(n²) when called 10K times in a loop,
  * because each call re-scans the (mutating) array.
  *
  * **`bulkSet()` defers cleanup to the observer.** It pushes all entries without
  * deleting old ones, then the observer fires once, builds an entry→index Map from
  * one `toArray()` call, and resolves all conflicts with O(1) Map lookups. Total:
- * O(n) instead of O(n²). The observer's cleanup deletion uses `DEDUP_ORIGIN` to
- * prevent a re-entrant observer call (which would be a no-op anyway).
+ * O(n) instead of O(n²). The observer's cleanup deletion uses `DEDUP_ORIGIN` so
+ * its queued follow-up observer pass can return immediately.
  *
- * **`delete()` eagerly scans** to find and remove one entry. Same O(n) as `set()`.
+ * **`delete()` eagerly scans** to remove matching visible entries. Same O(n) as `set()`.
  *
  * **`bulkDelete()` scans once** to collect all matching indices, then batch-deletes
  * right-to-left. Unlike `bulkSet`, it does NOT defer anything to the observer:
@@ -99,8 +99,8 @@
  *
  * ```
  * Single ops (fine for individual use, O(n²) in a loop):
- *   set():    deleteEntryByKey O(n) + push O(1) → observer: no conflicts
- *   delete(): deleteEntryByKey O(n)              → observer: processes deletion
+ *   set():    deleteEntriesByKey O(n) + push O(1) → observer: no conflicts
+ *   delete(): deleteEntriesByKey O(n)              → observer: processes deletion
  *
  * Bulk ops:
  *   bulkSet():    push × N + observer resolves all via Map   [DEDUP_ORIGIN]
@@ -118,16 +118,16 @@
  *   chunking into groups of 2500. The Yjs linked-list walk compounds when many
  *   deletes happen in a single transaction.
  * - **For `bulkSet`**: Inserting 25K items in one call forces the observer to build
- *   one massive entryIndexMap. Chunking into groups of 1000 is ~10x faster.
+ *   one massive entry-position map. Chunking into groups of 1000 is ~10x faster.
  *
  * Because of this, the `Table` layer (in `create-table.ts`) wraps these
  * methods with chunked async loops. The optimal chunk sizes differ:
  * - `bulkSet`: 1000 (observer conflict resolution is the bottleneck)
  * - `bulkDelete`: 2500 (Yjs linked-list deletion is the bottleneck)
  *
- * The observer's conflict resolution logic is shared with multi-node sync. When
- * two clients set the same key while offline, the observer resolves that conflict
- * using the same entryIndexMap and DEDUP_ORIGIN path that `bulkSet` uses.
+ * Constructor hydration, bulk writes, and multi-node sync all enter the same
+ * reconciliation pipeline. It selects one winner per affected key, updates the
+ * confirmed index, deletes visible losers, and emits one change batch.
  *
  * ## Limitations
  *
@@ -168,34 +168,71 @@ import type {
 export type YKeyValueLwwEntry<T> = { key: string; val: T; ts: number };
 
 /**
- * Transaction origin that marks observer cleanup deletions as "internal."
+ * Transaction origin that marks observer cleanup deletions as internal.
  *
  * ## When this fires
  *
  * The observer resolves LWW conflicts by keeping the winner and deleting losers.
- * That deletion happens in a nested `doc.transact()`. Without this origin, the
- * nested transaction would trigger the observer AGAIN, but the re-entrant call
- * is always a no-op:
- * - `_map` already points to the winner (updated in the first observer pass)
- * - Reference equality `_map.get(key) === loserEntry` fails → nothing happens
- * - No change events emitted
- *
- * Marking the transaction with DEDUP_ORIGIN lets the observer skip the re-entrant
- * call entirely (`if (transaction.origin === DEDUP_ORIGIN) return`).
+ * Yjs queues a transaction opened from an observer until the current transaction
+ * finishes its observer and update lifecycle. The deletion mutates the array
+ * immediately, but its observer notification is a later follow-up pass. This
+ * origin lets that pass return without reconciling an already-confirmed result.
  *
  * ## What triggers conflicts
  *
  * 1. `bulkSet()`: pushes entries without deleting old ones, observer resolves
  * 2. Multi-node sync: two clients set the same key offline, observer resolves
- * 3. Constructor initial dedup: runs before observer is registered, doesn't need this
+ * 3. Constructor initial dedup: runs before this observer is registered
  *
- * Note: `set()` eagerly deletes via `deleteEntryByKey` so the observer sees no
+ * Note: `set()` eagerly deletes via `deleteEntriesByKey` so the observer sees no
  * conflicts. `delete()` and `bulkDelete()` only remove entries, so there are no conflicts.
  * DEDUP_ORIGIN is only relevant for the conflict-resolution path.
  *
  * Keeps the observer from re-processing its own cleanup transaction.
  */
 const DEDUP_ORIGIN = Symbol('dedup');
+
+type PendingIntent<T> =
+	| {
+			action: 'set';
+			entry: YKeyValueLwwEntry<T>;
+			transaction: Y.Transaction;
+	  }
+	| { action: 'delete'; transaction: Y.Transaction };
+
+type Reconciliation<T> = {
+	addedEntries: YKeyValueLwwEntry<T>[];
+	deletedEntries: Set<YKeyValueLwwEntry<T>>;
+	origin: unknown;
+	snapshot?: YKeyValueLwwEntry<T>[];
+	cleanupOrigin?: unknown;
+};
+
+/**
+ * Select one LWW winner. Timestamp is the policy; final Y.Array position is the
+ * deterministic equal-timestamp boundary.
+ */
+function selectWinner<T>(
+	candidates: YKeyValueLwwEntry<T>[],
+	positionOf: (entry: YKeyValueLwwEntry<T>) => number,
+): YKeyValueLwwEntry<T> | undefined {
+	let winner = candidates[0];
+	for (let i = 1; i < candidates.length; i++) {
+		const candidate = candidates[i];
+		if (!candidate || !winner) continue;
+		if (candidate.ts > winner.ts) {
+			winner = candidate;
+			continue;
+		}
+		if (
+			candidate.ts === winner.ts &&
+			positionOf(candidate) > positionOf(winner)
+		) {
+			winner = candidate;
+		}
+	}
+	return winner;
+}
 
 export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	/** The underlying Y.Array that stores `{key, val, ts}` entries. */
@@ -214,7 +251,7 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	 * via iteration, `.get()`, and `.size`. The `set()` method never writes to
 	 * this map. The observer is the sole writer.
 	 *
-	 * @see pendingWrites for the transaction-local read overlay
+	 * @see pending for the transaction-local read overlay
 	 */
 	readonly map: ReadonlyMap<string, YKeyValueLwwEntry<T>> = this._map;
 
@@ -229,36 +266,26 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	 * ```text
 	 * caller-owned transaction opens
 	 *   set(key, value)
-	 *     pendingWrites.set(key, entry) // visible to reads now
+	 *     pending.set(key, { action: 'set', entry }) // visible to reads now
 	 *     yarray.push([entry])          // CRDT source-of-truth write
 	 *
 	 *   delete(key) when present
-	 *     pendingWrites.delete(key)
-	 *     pendingDeletes.add(key)       // reads report the key as absent
-	 *     deleteEntryByKey(key)         // finds and deletes the Y.Array index
+	 *     pending.set(key, { action: 'delete' }) // reads report absence
+	 *     deleteEntriesByKey(key)              // deletes visible versions
 	 *
 	 *   read view
-	 *     pendingDeletes hides keys
-	 *     pendingWrites overrides _map
+	 *     a pending delete hides the key
+	 *     a pending set overrides _map
 	 *
 	 * transaction closes
-	 *   observer updates _map and clears the matching overlays
+	 *   observer reconciles _map and acknowledges the transaction overlay
 	 * ```
 	 *
 	 * Outside a caller-owned transaction, `set()` opens and closes its own
 	 * transaction, so the observer normally clears this overlay before `set()`
 	 * returns.
 	 */
-	private pendingWrites: Map<string, YKeyValueLwwEntry<T>> = new Map();
-
-	/**
-	 * Local deletes that have reached the Y.Array but not the observer-backed map.
-	 *
-	 * This is the delete side of the overlay described above. After
-	 * `delete('foo')`, reads report the key as absent even if `_map` still holds the
-	 * old entry until the transaction closes.
-	 */
-	private pendingDeletes: Set<string> = new Set();
+	private readonly pending = new Map<string, PendingIntent<T>>();
 
 	/** Registered change handlers. */
 	private changeHandlers: Set<KvStoreChangeHandler<T>> = new Set();
@@ -310,242 +337,152 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 		this.yarray = yarray;
 		this.doc = yarray.doc as Y.Doc;
 
-		const entries = yarray.toArray();
-		const indicesToDelete: number[] = [];
-
-		// First pass: find winners by timestamp
-		for (let i = 0; i < entries.length; i++) {
-			const entry = entries[i];
-			if (!entry) continue;
-			const existing = this._map.get(entry.key);
-
-			if (!existing) {
-				this._map.set(entry.key, entry);
-			} else {
-				if (entry.ts > existing.ts) {
-					// New entry wins, mark old for deletion
-					const oldIndex = entries.indexOf(existing);
-					if (oldIndex !== -1) indicesToDelete.push(oldIndex);
-					this._map.set(entry.key, entry);
-				} else if (entry.ts < existing.ts) {
-					// Old entry wins, mark new for deletion
-					indicesToDelete.push(i);
-				} else {
-					// Equal timestamps: keep later one (rightmost), delete earlier
-					const oldIndex = entries.indexOf(existing);
-					if (oldIndex !== -1 && oldIndex < i) {
-						indicesToDelete.push(oldIndex);
-						this._map.set(entry.key, entry);
-					} else {
-						indicesToDelete.push(i);
-					}
-				}
-			}
-
-			// Track max timestamp for monotonic clock (including remote entries)
-			// This ensures our next local write will have a higher timestamp than
-			// any entry we've seen, preventing us from writing "old" timestamps
-			// that would lose conflicts to nodes with faster clocks
-			if (entry.ts > this.lastTimestamp) this.lastTimestamp = entry.ts;
-		}
-
-		// Delete losers
-		if (indicesToDelete.length > 0) {
-			this.doc.transact(() => {
-				// Sort descending to preserve indices during deletion
-				indicesToDelete.sort((a, b) => b - a);
-				for (const index of indicesToDelete) {
-					yarray.delete(index);
-				}
-			});
-		}
+		const snapshot = yarray.toArray();
+		this.reconcile({
+			addedEntries: snapshot,
+			deletedEntries: new Set(),
+			origin: undefined,
+			snapshot,
+		});
 
 		// Set up observer for future changes
 		this._observer = (event, transaction) => {
-			// Dedup deletions are always no-ops: _map already has the winner.
-			// Skip entirely to avoid useless work on re-entrant observer calls.
+			// Cleanup is a queued follow-up transaction. It cannot acknowledge a
+			// newer overlay created by a change handler, so return before detaching it.
 			if (transaction.origin === DEDUP_ORIGIN) return;
-			const changes = new Map<string, KvStoreChange<T>>();
-			const addedEntries: YKeyValueLwwEntry<T>[] = [];
-			const deletedCurrentKeys = new Set<string>();
 
-			// Collect added entries
-			for (const addedItem of event.changes.added) {
+			// YEvent changes are only safe to derive before another mutation. Capture
+			// the net entries now, before reconciliation deletes any losers.
+			const addedEntries: YKeyValueLwwEntry<T>[] = [];
+			const deletedEntries = new Set<YKeyValueLwwEntry<T>>();
+			const eventChanges = event.changes;
+			for (const addedItem of eventChanges.added) {
 				for (const addedEntry of addedItem.content.getContent() as YKeyValueLwwEntry<T>[]) {
 					addedEntries.push(addedEntry);
-
-					// Track max timestamp from synced entries (self-healing behavior)
-					if (addedEntry.ts > this.lastTimestamp)
-						this.lastTimestamp = addedEntry.ts;
+				}
+			}
+			for (const deletedItem of eventChanges.deleted) {
+				for (const deletedEntry of deletedItem.content.getContent() as YKeyValueLwwEntry<T>[]) {
+					deletedEntries.add(deletedEntry);
 				}
 			}
 
-			// Handle deletions first
-			event.changes.deleted.forEach((deletedItem) => {
-				deletedItem.content
-					.getContent()
-					.forEach((entry: YKeyValueLwwEntry<T>) => {
-						// A deletion for this key has reached the observer. Clear the local
-						// delete overlay even if the deleted entry never reached _map
-						// (for example, set+delete inside one outer transaction).
-						this.pendingDeletes.delete(entry.key);
+			// Acknowledge only intents owned by this transaction. Another observer may
+			// already have queued a later transaction whose read overlay must survive
+			// this pass and the DEDUP follow-up.
+			for (const [key, intent] of this.pending) {
+				if (intent.transaction !== transaction) continue;
+				this.pending.delete(key);
+			}
 
-						// Reference equality: only process if this is the entry we have cached
-						if (this._map.get(entry.key) === entry) {
-							deletedCurrentKeys.add(entry.key);
-							this._map.delete(entry.key);
-							changes.set(entry.key, { action: 'delete' });
-						}
-					});
+			this.reconcile({
+				addedEntries,
+				deletedEntries,
+				origin: transaction.origin,
+				cleanupOrigin: DEDUP_ORIGIN,
 			});
-
-			// Process added entries with LWW logic
-			const indicesToDelete: number[] = [];
-
-			/**
-			 * Once-per-observer memoized array snapshot and entry-to-index map for
-			 * conflict resolution.
-			 *
-			 * Each getter computes its value on first call, then returns the cached
-			 * result on later calls. Neither runs until a conflict forces it, so we
-			 * avoid the O(n) `toArray()` copy entirely when there are no conflicts
-			 * (the common case for bulk inserts of new keys).
-			 *
-			 * `getEntryIndexMap` builds on `getAllEntries`: calling it triggers the
-			 * `toArray()` if it hasn't happened yet, then builds a Map<entry, index>
-			 * for O(1) index lookups. This replaces the old `.indexOf()` calls that
-			 * were O(n) each, which caused O(n²) behavior during bulk updates.
-			 *
-			 * Both caches are local to this single observer invocation. They're
-			 * garbage collected when the callback returns. No manual cleanup needed.
-			 */
-			let allEntries: YKeyValueLwwEntry<T>[] | undefined;
-			const getAllEntries = (): YKeyValueLwwEntry<T>[] =>
-				(allEntries ??= yarray.toArray());
-
-			let entryIndexMap: Map<YKeyValueLwwEntry<T>, number> | undefined;
-			const getEntryIndexMap = (): Map<YKeyValueLwwEntry<T>, number> => {
-				if (!entryIndexMap) {
-					const entries = getAllEntries();
-					entryIndexMap = new Map();
-					for (let i = 0; i < entries.length; i++) {
-						const entry = entries[i];
-						if (entry) entryIndexMap.set(entry, i);
-					}
-				}
-				return entryIndexMap;
-			};
-
-			const getEntryIndex = (entry: YKeyValueLwwEntry<T>): number => {
-				// For small conflict batches (<= 4 added entries, typically a remote
-				// sync of a few changed keys) reference-equality indexOf beats the
-				// Map: indexOf scans only until it hits each target, while the Map
-				// build touches all N entries. Measured 26x-266x faster up to N=25K.
-				// The Map only wins once many keys conflict at once (bulk re-import
-				// over existing keys), where repeated indexOf would be O(n²).
-				if (addedEntries.length <= 4) {
-					return getAllEntries().indexOf(entry);
-				}
-				return getEntryIndexMap().get(entry) ?? -1;
-			};
-
-			for (const newEntry of addedEntries) {
-				const existing = this._map.get(newEntry.key);
-
-				if (!existing) {
-					if (
-						transaction.local &&
-						deletedCurrentKeys.has(newEntry.key) &&
-						this.pendingWrites.get(newEntry.key) !== newEntry
-					) {
-						const newIndex = getEntryIndex(newEntry);
-						if (newIndex !== -1) indicesToDelete.push(newIndex);
-						continue;
-					}
-
-					// New key: just update the map. No array operations needed.
-					const deleteEvent = changes.get(newEntry.key);
-					if (deleteEvent && deleteEvent.action === 'delete') {
-						// Was deleted in same transaction, now re-added
-						changes.set(newEntry.key, {
-							action: 'update',
-							newValue: newEntry.val,
-						});
-					} else {
-						changes.set(newEntry.key, {
-							action: 'add',
-							newValue: newEntry.val,
-						});
-					}
-					this._map.set(newEntry.key, newEntry);
-					this.pendingDeletes.delete(newEntry.key);
-				} else {
-					// Conflict: key exists in map. Must compare timestamps to determine winner,
-					// then find the loser's index in the array to delete it. This is the only
-					// path that calls getAllEntries(), triggering the O(n) toArray() copy.
-					if (newEntry.ts > existing.ts) {
-						// New entry wins: delete old from array
-						changes.set(newEntry.key, {
-							action: 'update',
-							newValue: newEntry.val,
-						});
-
-						// Mark old entry for deletion
-						const oldIndex = getEntryIndex(existing);
-						if (oldIndex !== -1) indicesToDelete.push(oldIndex);
-
-						this._map.set(newEntry.key, newEntry);
-						this.pendingDeletes.delete(newEntry.key);
-					} else if (newEntry.ts < existing.ts) {
-						// Old entry wins: delete new from array
-						const newIndex = getEntryIndex(newEntry);
-						if (newIndex !== -1) indicesToDelete.push(newIndex);
-					} else {
-						// Equal timestamps: positional tiebreaker (rightmost wins)
-						const oldIndex = getEntryIndex(existing);
-						const newIndex = getEntryIndex(newEntry);
-
-						if (newIndex > oldIndex) {
-							// New is rightmost, it wins
-							changes.set(newEntry.key, {
-								action: 'update',
-								newValue: newEntry.val,
-							});
-							if (oldIndex !== -1) indicesToDelete.push(oldIndex);
-							this._map.set(newEntry.key, newEntry);
-							this.pendingDeletes.delete(newEntry.key);
-						} else {
-							// Old is rightmost, delete new
-							if (newIndex !== -1) indicesToDelete.push(newIndex);
-						}
-					}
-				}
-
-				// Clear the write overlay once processed (whether entry won or lost).
-				// Use reference equality to only clear if it's the exact entry we added.
-				if (this.pendingWrites.get(newEntry.key) === newEntry) {
-					this.pendingWrites.delete(newEntry.key);
-				}
-			}
-
-			// Delete loser entries
-			if (indicesToDelete.length > 0) {
-				this.doc.transact(() => {
-					indicesToDelete.sort((a, b) => b - a);
-					for (const index of indicesToDelete) {
-						yarray.delete(index);
-					}
-				}, DEDUP_ORIGIN);
-			}
-
-			// Emit change events
-			if (changes.size > 0) {
-				for (const handler of this.changeHandlers) {
-					handler(changes, transaction.origin);
-				}
-			}
 		};
 		yarray.observe(this._observer);
+	}
+
+	/**
+	 * Reconcile one final Y.Array state through five explicit phases: collect the
+	 * affected candidates, select winners, commit the confirmed index, delete
+	 * losers, and emit the observable change batch.
+	 */
+	private reconcile({
+		addedEntries,
+		deletedEntries,
+		origin,
+		snapshot: initialSnapshot,
+		cleanupOrigin,
+	}: Reconciliation<T>): void {
+		const additionsByKey = new Map<string, YKeyValueLwwEntry<T>[]>();
+		const affectedKeys = new Set<string>();
+
+		// Deleted keys lead so public change ordering matches the previous observer.
+		for (const entry of deletedEntries) affectedKeys.add(entry.key);
+		for (const entry of addedEntries) {
+			affectedKeys.add(entry.key);
+			const additions = additionsByKey.get(entry.key);
+			if (additions) additions.push(entry);
+			else additionsByKey.set(entry.key, [entry]);
+			if (entry.ts > this.lastTimestamp) this.lastTimestamp = entry.ts;
+		}
+
+		// Positions are irrelevant on the no-conflict fast path. When conflicts do
+		// need them, preserve the measured small-batch indexOf optimization and use
+		// one entry-index map for large bulk reconciliation.
+		let snapshot = initialSnapshot;
+		let positions: Map<YKeyValueLwwEntry<T>, number> | undefined;
+		const getSnapshot = (): YKeyValueLwwEntry<T>[] =>
+			(snapshot ??= this.yarray.toArray());
+		const positionOf = (entry: YKeyValueLwwEntry<T>): number => {
+			if (addedEntries.length <= 4) return getSnapshot().indexOf(entry);
+			if (!positions) {
+				positions = new Map();
+				const entries = getSnapshot();
+				for (let i = 0; i < entries.length; i++) {
+					const current = entries[i];
+					if (current) positions.set(current, i);
+				}
+			}
+			return positions.get(entry) ?? -1;
+		};
+
+		const changes = new Map<string, KvStoreChange<T>>();
+		const losers: YKeyValueLwwEntry<T>[] = [];
+
+		for (const key of affectedKeys) {
+			const before = this._map.get(key);
+			const additions = additionsByKey.get(key) ?? [];
+			const candidates: YKeyValueLwwEntry<T>[] = [];
+			if (before && !deletedEntries.has(before)) candidates.push(before);
+			candidates.push(...additions);
+
+			const winner = selectWinner(candidates, positionOf);
+			for (const candidate of candidates) {
+				if (candidate !== winner) losers.push(candidate);
+			}
+
+			if (winner) this._map.set(key, winner);
+			else this._map.delete(key);
+
+			if (winner === before) continue;
+			if (before) {
+				changes.set(
+					key,
+					winner
+						? { action: 'update', newValue: winner.val }
+						: { action: 'delete' },
+				);
+				continue;
+			}
+			if (winner) {
+				// Preserve the existing event contract: if an absent key changes winner
+				// within one transaction, the final action is update rather than add.
+				changes.set(key, {
+					action: winner === additions[0] ? 'add' : 'update',
+					newValue: winner.val,
+				});
+			}
+		}
+
+		if (losers.length > 0) {
+			const indices = losers
+				.map(positionOf)
+				.filter((index) => index !== -1)
+				.sort((a, b) => b - a);
+			const deleteLosers = () => {
+				for (const index of indices) this.yarray.delete(index);
+			};
+			if (cleanupOrigin === undefined) this.doc.transact(deleteLosers);
+			else this.doc.transact(deleteLosers, cleanupOrigin);
+		}
+
+		if (changes.size > 0) {
+			for (const handler of this.changeHandlers) handler(changes, origin);
+		}
 	}
 
 	/**
@@ -581,14 +518,17 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	}
 
 	/**
-	 * Delete the entry with the given key from the Y.Array.
+	 * Delete every visible entry with the given key from the Y.Array.
 	 *
-	 * The data structure maintains at most one entry per key (duplicates are
-	 * cleaned up on construction and during sync), so this only deletes one entry.
+	 * Confirmed state has at most one entry per key, but a caller-owned transaction
+	 * can append several unconfirmed writes before the observer runs. Removing all
+	 * matches makes a final delete authoritative without observer-only repair logic.
 	 */
-	private deleteEntryByKey(key: string): void {
-		const index = this.yarray.toArray().findIndex((e) => e.key === key);
-		if (index !== -1) this.yarray.delete(index);
+	private deleteEntriesByKey(key: string): void {
+		const entries = this.yarray.toArray();
+		for (let i = entries.length - 1; i >= 0; i--) {
+			if (entries[i]?.key === key) this.yarray.delete(i);
+		}
 	}
 
 	/**
@@ -604,7 +544,7 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	 *
 	 * ## Why `set()` eagerly deletes but `bulkSet()` defers
 	 *
-	 * `deleteEntryByKey()` scans the Y.Array to find the old entry: O(n) per call.
+	 * `deleteEntriesByKey()` scans the Y.Array to find old entries: O(n) per call.
 	 * For a single `set()`, that O(n) is fine. For 10K `set()` calls in a loop,
 	 * it's 10K × O(n) = O(n²). `bulkSet` avoids this by pushing all entries first,
 	 * then letting the observer find and remove old entries using a pre-built index
@@ -613,7 +553,7 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	 * ```
 	 * set('foo', newVal) where 'foo' exists:
 	 *   ┌─ same transaction ───────────────────────────────────┐
-	 *   │  deleteEntryByKey('foo')  ← O(n) scan, removes old entry  │
+	 *   │  deleteEntriesByKey('foo') ← O(n) scan, removes old entries │
 	 *   │  yarray.push([newEntry])  ← O(1)                         │
 	 *   └────────────────────────────────────────────────┘
 	 *   observer fires ONCE → sees 1 delete + 1 add → emits 'update'
@@ -623,21 +563,20 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	 *   ┌─ single transaction ─────────────────────────────────┐
 	 *   │  for each: yarray.push([entry])  ← O(1) × 10K, NO delete  │
 	 *   └────────────────────────────────────────────────┘
-	 *   observer fires (1st) → 10K conflicts → entryIndexMap → batch delete losers
+	 *   observer fires (1st) → 10K conflicts → position Map → batch delete losers
 	 *   observer fires (2nd) → DEDUP_ORIGIN → skipped (free)
 	 * ```
 	 */
 	set(key: string, val: T): void {
 		const entry: YKeyValueLwwEntry<T> = { key, val, ts: this.getTimestamp() };
 
-		// Keep reads transaction-local until the observer updates _map.
-		this.pendingWrites.set(key, entry);
-		this.pendingDeletes.delete(key);
-
 		// Yjs reuses an active outer transaction, so this preserves the caller's
 		// origin and batches observer delivery until that transaction closes.
-		this.doc.transact(() => {
-			if (this._map.has(key)) this.deleteEntryByKey(key);
+		this.doc.transact((transaction) => {
+			// Keep reads transaction-local until this transaction's observer updates
+			// the confirmed index.
+			this.pending.set(key, { action: 'set', entry, transaction });
+			if (this._map.has(key)) this.deleteEntriesByKey(key);
 			this.yarray.push([entry]);
 		});
 
@@ -647,15 +586,15 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	/**
 	 * Set many key-value pairs in one transaction.
 	 *
-	 * Unlike {@link set}, this intentionally skips `deleteEntryByKey()` for existing
+	 * Unlike {@link set}, this intentionally skips `deleteEntriesByKey()` for existing
 	 * keys. Instead, all entries are pushed to the Y.Array, and the observer resolves
 	 * duplicate-key conflicts in a single pass when the transaction ends.
 	 *
 	 * ## Why this is faster than calling `set()` in a loop
 	 *
-	 * `set()` calls `deleteEntryByKey()` per key: an O(n) array scan. In a loop:
+	 * `set()` calls `deleteEntriesByKey()` per key: an O(n) array scan. In a loop:
 	 * N calls × O(n) scan = O(n²). `bulkSet` defers all cleanup to the observer,
-	 * which builds an `entryIndexMap` (Map<Entry, index>) from one `toArray()` call
+	 * which builds an entry-position Map from one `toArray()` call
 	 * and resolves each conflict with an O(1) Map lookup. Total: O(n).
 	 *
 	 * The observer's conflict resolution already exists for multi-node sync.
@@ -678,7 +617,7 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	 * ```
 	 */
 	bulkSet(entries: Array<{ key: string; val: T }>): void {
-		this.doc.transact(() => {
+		this.doc.transact((transaction) => {
 			for (const { key, val } of entries) {
 				const entry: YKeyValueLwwEntry<T> = {
 					key,
@@ -686,8 +625,7 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 					ts: this.getTimestamp(),
 				};
 
-				this.pendingWrites.set(key, entry);
-				this.pendingDeletes.delete(key);
+				this.pending.set(key, { action: 'set', entry, transaction });
 				this.yarray.push([entry]);
 			}
 		});
@@ -700,23 +638,18 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	 * For bulk deletions (1K+ keys), use {@link bulkDelete} which does
 	 * one scan for all keys instead of one scan per key.
 	 *
-	 * Removes from `pendingWrites` immediately and triggers Y.Array deletion.
-	 * The observer will update `_map` when the deletion is processed.
-	 * Adds the key to `pendingDeletes` so transaction-local reads report the key
-	 * as absent before the observer fires.
+	 * Replaces any pending set intent with a delete intent, removes every visible
+	 * version in one transaction, and lets the observer update `_map`.
 	 */
 	delete(key: string): void {
-		// If this key was set earlier in the same outer transaction, it exists in
-		// the Y.Array but not _map yet. Delete still needs to remove that entry.
-		const hadPendingWrite = this.pendingWrites.delete(key);
+		const pending = this.pending.get(key);
+		if (pending?.action === 'delete') return;
+		if (!this._map.has(key) && pending?.action !== 'set') return;
 
-		// If already pending delete, no-op
-		if (this.pendingDeletes.has(key)) return;
-
-		if (!this._map.has(key) && !hadPendingWrite) return;
-
-		this.pendingDeletes.add(key);
-		this.deleteEntryByKey(key);
+		this.doc.transact((transaction) => {
+			this.pending.set(key, { action: 'delete', transaction });
+			this.deleteEntriesByKey(key);
+		});
 		// DO NOT update this.map here - observer is the sole writer to map
 	}
 
@@ -761,13 +694,16 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 			if (!entry || !keySet.has(entry.key)) continue;
 
 			indicesToDelete.push(i);
-			this.pendingDeletes.add(entry.key);
-			this.pendingWrites.delete(entry.key);
 		}
 
 		if (indicesToDelete.length === 0) return;
 
-		this.doc.transact(() => {
+		this.doc.transact((transaction) => {
+			for (const index of indicesToDelete) {
+				const entry = entries[index];
+				if (entry)
+					this.pending.set(entry.key, { action: 'delete', transaction });
+			}
 			for (let i = indicesToDelete.length - 1; i >= 0; i--) {
 				const index = indicesToDelete[i];
 				if (index !== undefined) this.yarray.delete(index);
@@ -780,15 +716,13 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	 *
 	 * Reads the observer-backed map plus the transaction-local overlay.
 	 *
-	 * `pendingDeletes` wins over `pendingWrites`: `set(); delete(); get()` inside one
-	 * outer transaction reads absent, matching the final state after the observer
-	 * catches up.
+	 * A pending delete wins over a pending set: `set(); delete(); get()` inside one
+	 * outer transaction reads absent, matching the final confirmed state.
 	 */
 	get(key: string): T | undefined {
-		if (this.pendingDeletes.has(key)) return undefined;
-
-		const pendingWrite = this.pendingWrites.get(key);
-		if (pendingWrite) return pendingWrite.val;
+		const pending = this.pending.get(key);
+		if (pending?.action === 'delete') return undefined;
+		if (pending?.action === 'set') return pending.entry.val;
 
 		const entry = this._map.get(key);
 		return entry?.val;
@@ -816,14 +750,16 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 		const yieldedKeys = new Set<string>();
 
 		// Yield transaction-local writes first because they take precedence.
-		for (const [key, entry] of this.pendingWrites) {
+		for (const [key, intent] of this.pending) {
+			if (intent.action === 'delete') continue;
 			yieldedKeys.add(key);
-			yield { key, val: entry.val };
+			yield { key, val: intent.entry.val };
 		}
 
 		// Then yield indexed entries not replaced or deleted by the overlay.
 		for (const [key, entry] of this._map) {
-			if (yieldedKeys.has(key) || this.pendingDeletes.has(key)) continue;
+			if (yieldedKeys.has(key) || this.pending.get(key)?.action === 'delete')
+				continue;
 			yield { key, val: entry.val };
 		}
 	}

--- a/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.ts
+++ b/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.ts
@@ -205,7 +205,7 @@ type Reconciliation<T> = {
 	deletedEntries: Set<YKeyValueLwwEntry<T>>;
 	origin: unknown;
 	snapshot?: YKeyValueLwwEntry<T>[];
-	cleanupOrigin?: unknown;
+	cleanupOrigin: unknown;
 };
 
 /**
@@ -343,6 +343,7 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 			deletedEntries: new Set(),
 			origin: undefined,
 			snapshot,
+			cleanupOrigin: null,
 		});
 
 		// Set up observer for future changes
@@ -398,12 +399,10 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 		cleanupOrigin,
 	}: Reconciliation<T>): void {
 		const additionsByKey = new Map<string, YKeyValueLwwEntry<T>[]>();
-		const affectedKeys = new Set<string>();
 
 		// Deleted keys lead so public change ordering matches the previous observer.
-		for (const entry of deletedEntries) affectedKeys.add(entry.key);
+		for (const entry of deletedEntries) additionsByKey.set(entry.key, []);
 		for (const entry of addedEntries) {
-			affectedKeys.add(entry.key);
 			const additions = additionsByKey.get(entry.key);
 			if (additions) additions.push(entry);
 			else additionsByKey.set(entry.key, [entry]);
@@ -433,9 +432,8 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 		const changes = new Map<string, KvStoreChange<T>>();
 		const losers: YKeyValueLwwEntry<T>[] = [];
 
-		for (const key of affectedKeys) {
+		for (const [key, additions] of additionsByKey) {
 			const before = this._map.get(key);
-			const additions = additionsByKey.get(key) ?? [];
 			const candidates: YKeyValueLwwEntry<T>[] = [];
 			if (before && !deletedEntries.has(before)) candidates.push(before);
 			candidates.push(...additions);
@@ -476,8 +474,7 @@ export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 			const deleteLosers = () => {
 				for (const index of indices) this.yarray.delete(index);
 			};
-			if (cleanupOrigin === undefined) this.doc.transact(deleteLosers);
-			else this.doc.transact(deleteLosers, cleanupOrigin);
+			this.doc.transact(deleteLosers, cleanupOrigin);
 		}
 
 		if (changes.size > 0) {


### PR DESCRIPTION
YKeyValueLww had two conflict resolvers: constructor hydration and a roughly 180-line observer callback. They implemented the same timestamp and positional policy through different branch trees, while overlay cleanup depended on Yjs net-delta entries that do not include add-then-delete operations.

This makes reconciliation one owned transition:

```text
constructor snapshot ─┐
                      ├─> reconcile affected keys
Y.Array event facts ──┘     -> select one winner per key
                             -> update the confirmed index
                             -> delete visible losers
                             -> emit one original-origin batch
```

`selectWinner` is the single policy boundary: higher timestamp wins, with final Y.Array position deciding equal timestamps. The transaction-local read state is one discriminated, transaction-owned overlay rather than independent write and delete collections. Constructor hydration and live events preserve the same stored entry objects, so unchanged values keep the reference identity required by ADR-0077.

The no-conflict path stays delta-sized. Array snapshots and entry-position maps remain lazy, so unique bulk inserts avoid an O(total rows) scan while bulk conflicts still resolve from one snapshot. Single-key writes keep eager cleanup; a final delete now removes every visible version for the key, preventing repeated unconfirmed writes from resurrecting it.

Persisted `{ key, val, ts }` data, the published class and `ObservableKvStore` surfaces, original transaction origins, cleanup transactions, observer batching, stable references, and existing event actions remain unchanged.

One existing boundary remains deliberately unresolved: a public change handler that writes while conflict cleanup is queued joins the private cleanup transaction in Yjs. Defining whether that write should emit a second public batch, and under which origin, is an event-contract decision outside this internal ownership rewrite.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786316358&installation_id=128463665&pr_number=2447&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2447&signature=9c9ef68b85fea561b2ae21f62731cb54e510bc42b26b4018491f3a6fab000979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->