### PR TITLE
[codex] enable audio compression by default

### DIFF
--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -205,6 +205,10 @@ function defineTranscriptionSettings(
 			field.string(),
 			() => PROVIDERS.Mistral.defaultModel as string,
 		),
+		'transcription.compressAudioBeforeTranscription': defineKv(
+			field.boolean(),
+			() => true,
+		),
 		'transcription.language': defineKv(
 			field.select(SUPPORTED_LANGUAGES),
 			() => 'auto' as const,


### PR DESCRIPTION
# Enable audio compression by default

Keep Whispering's "compress audio before transcription" setting enabled by default.

Why:
- It speeds up remote transcription materially. The setting has been about 5x faster for me.
- It is a no-brainer default to leave on, while still letting users opt out in the transcription settings panel.

Impact:
- Fresh installs and resets start with compression enabled.
- The existing checkbox still controls the preference for users who want to turn it off.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786619393&installation_id=128463665&pr_number=2453&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2453&signature=ae84a7809145b8940843c86caf3203b0333f0a76cbb7ddecf4b07a03e2d9c2c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->