### PR TITLE
fix(whispering): constrain Mistral transcription models

### DIFF
--- a/apps/whispering/src/lib/services/transcription/providers.ts
+++ b/apps/whispering/src/lib/services/transcription/providers.ts
@@ -293,7 +293,7 @@ export const PROVIDERS = {
 		modelSettingKey: 'transcription.mistral.model',
 		modelsDoc: {
 			label: 'Mistral docs',
-			href: 'https://mistral.ai/news/voxtral/',
+			href: 'https://docs.mistral.ai/studio-api/audio/speech_to_text/offline_transcription',
 		},
 		defaultModel: 'voxtral-mini-latest',
 		models: [

--- a/apps/whispering/src/lib/services/transcription/providers.ts
+++ b/apps/whispering/src/lib/services/transcription/providers.ts
@@ -300,14 +300,14 @@ export const PROVIDERS = {
 			{
 				name: 'voxtral-mini-latest',
 				description:
-					'API-optimized Voxtral Mini model delivering unparalleled cost and latency efficiency. Supports multilingual transcription with high accuracy.',
-				cost: '$0.12/hour',
+					"Mistral's latest Voxtral Mini model optimized for multilingual transcription.",
+				cost: '$0.18/hour',
 			},
 			{
-				name: 'voxtral-small-latest',
+				name: 'voxtral-mini-2602',
 				description:
-					'Voxtral Small model for higher accuracy and broader language support. Suitable for most transcription needs with a balance of cost and performance.',
-				cost: '$0.24/hour',
+					'Pinned February 2026 release of Voxtral Mini Transcribe 2.',
+				cost: '$0.18/hour',
 			},
 		],
 	},

--- a/apps/whispering/src/lib/workspace/definition.test-d.ts
+++ b/apps/whispering/src/lib/workspace/definition.test-d.ts
@@ -1,0 +1,20 @@
+/**
+ * Whispering Workspace Definition Type Tests
+ *
+ * Verifies provider-specific synced settings reject values that their runtime
+ * endpoints cannot use.
+ *
+ * Key behaviors:
+ * - Supported Mistral transcription models are writable
+ * - Voxtral Small cannot be stored as a transcription model
+ */
+
+import { defineWhispering } from './definition';
+
+using workspace = defineWhispering('OpenAI').create();
+
+workspace.kv.set('transcription.mistral.model', 'voxtral-mini-latest');
+workspace.kv.set('transcription.mistral.model', 'voxtral-mini-2602');
+
+// @ts-expect-error — Voxtral Small is a chat model, not a transcription model
+workspace.kv.set('transcription.mistral.model', 'voxtral-small-latest');

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -202,8 +202,8 @@ function defineTranscriptionSettings(
 			() => PROVIDERS.Deepgram.defaultModel as string,
 		),
 		'transcription.mistral.model': defineKv(
-			field.string(),
-			() => PROVIDERS.Mistral.defaultModel as string,
+			field.select(PROVIDERS.Mistral.models.map(({ name }) => name)),
+			() => PROVIDERS.Mistral.defaultModel,
 		),
 		'transcription.language': defineKv(
 			field.select(SUPPORTED_LANGUAGES),


### PR DESCRIPTION

This Closes #1787

Mistral's audio transcription endpoint rejects voxtral-small-latest, even though Whispering currently offers it in the transcription model picker. Selecting it therefore makes every Mistral transcription fail with a 400 response.

This removes Voxtral Small, adds the supported voxtral-mini-2602 snapshot, and constrains the synced Mistral setting to models declared by the transcription catalog. Existing Small selections now read as voxtral-mini-latest through the workspace KV's validate-or-default behavior. The model picker also links to Mistral's current transcription documentation.


## Changelog
- Fix Mistral transcription failing when Voxtral Small is selected

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786677489&installation_id=128463665&pr_number=2454&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2454&signature=19c81a38e5b39bf59f763b2788289c35b216728292bf09838a972b88bc76d1d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->