### PR TITLE
feat(whispering): integrate Google Gemini transcription provider

### DIFF
--- a/apps/whispering/src/lib/constants/icons/google.svg
+++ b/apps/whispering/src/lib/constants/icons/google.svg
@@ -1,0 +1,12 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gemini-gradient" x1="2" y1="22" x2="22" y2="2" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#439DDF"/>
+      <stop offset="0.524" stop-color="#4F87ED"/>
+      <stop offset="0.781" stop-color="#9476C5"/>
+      <stop offset="0.888" stop-color="#BC688E"/>
+      <stop offset="1" stop-color="#D6645D"/>
+    </linearGradient>
+  </defs>
+  <path d="M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81" fill="url(#gemini-gradient)"/>
+</svg>

--- a/apps/whispering/src/lib/operations/transcribe.ts
+++ b/apps/whispering/src/lib/operations/transcribe.ts
@@ -20,6 +20,7 @@ import { report } from '$lib/report';
 import { services } from '$lib/services';
 import { DeepgramTranscriptionServiceLive } from '$lib/services/transcription/cloud/deepgram';
 import { ElevenLabsTranscriptionServiceLive } from '$lib/services/transcription/cloud/elevenlabs';
+import { GoogleTranscriptionServiceLive } from '$lib/services/transcription/cloud/google';
 import { MistralTranscriptionServiceLive } from '$lib/services/transcription/cloud/mistral';
 import {
 	isOnDeviceProviderId,
@@ -145,6 +146,16 @@ const UPLOAD_DISPATCH = {
 				customFetch,
 			),
 		model: () => settings.get(PROVIDERS.OpenAI.modelSettingKey),
+	},
+	Google: {
+		kind: 'bespoke',
+		transcribe: (audio, { prompt, spokenLanguage }) =>
+			GoogleTranscriptionServiceLive.transcribe(audio, {
+				prompt,
+				spokenLanguage,
+				apiKey: secretApiKey(PROVIDERS.Google.apiKeyConfigKey) ?? '',
+				modelName: settings.get(PROVIDERS.Google.modelSettingKey),
+			}),
 	},
 	Groq: {
 		kind: 'wire',

--- a/apps/whispering/src/lib/services/transcription/cloud/google.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/google.ts
@@ -1,0 +1,136 @@
+import {
+	defineErrors,
+	extractErrorMessage,
+	type InferErrors,
+} from 'wellcrafted/error';
+import { Err, Ok, type Result, tryAsync } from 'wellcrafted/result';
+import { customFetch } from '#platform/http';
+
+export const GoogleTranscriptionError = defineErrors({
+	MissingApiKey: () => ({ message: 'Google API key is required' }),
+	FileTooLarge: ({ sizeMb, maxMb }: { sizeMb: number; maxMb: number }) => ({
+		message: `File size ${sizeMb.toFixed(1)}MB exceeds ${maxMb}MB limit`,
+		sizeMb,
+		maxMb,
+	}),
+	FileConversionFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to process audio for transcription: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	ApiError: ({ message, status }: { message: string; status: number }) => ({
+		message: `Google API Error (${status}): ${message}`,
+		status,
+	}),
+	InvalidResponse: () => ({
+		message: 'Google API returned an invalid response format',
+	}),
+	Unexpected: ({ cause }: { cause: unknown }) => ({
+		message: extractErrorMessage(cause),
+		cause,
+	}),
+});
+export type GoogleTranscriptionError = InferErrors<
+	typeof GoogleTranscriptionError
+>;
+
+export const GoogleTranscriptionServiceLive = {
+	async transcribe(
+		audioBlob: Blob,
+		options: {
+			prompt: string;
+			spokenLanguage: string;
+			apiKey: string;
+			modelName: string;
+		},
+	): Promise<Result<string, GoogleTranscriptionError>> {
+		if (!options.apiKey) return GoogleTranscriptionError.MissingApiKey();
+
+		const sizeMb = audioBlob.size / (1024 * 1024);
+		if (sizeMb > 19) {
+			// Google payload limit via REST JSON inlineData is ~20MB
+			return GoogleTranscriptionError.FileTooLarge({ sizeMb, maxMb: 19 });
+		}
+
+		let base64Data: string;
+		try {
+			const arrayBuffer = await audioBlob.arrayBuffer();
+			const buffer = new Uint8Array(arrayBuffer);
+			// Convert to base64 safely without call stack limits for large buffers
+			let binary = '';
+			const len = buffer.byteLength;
+			for (let i = 0; i < len; i++) {
+				binary += String.fromCharCode(buffer[i]!);
+			}
+			base64Data = btoa(binary);
+		} catch (cause) {
+			return GoogleTranscriptionError.FileConversionFailed({ cause });
+		}
+
+		let instructions =
+			'Transcribe the following audio accurately. Output ONLY the transcription text without any conversational filler, markdown formatting, or explanations.';
+		if (options.spokenLanguage && options.spokenLanguage !== 'auto') {
+			instructions += ` The spoken language is ${options.spokenLanguage}.`;
+		}
+		if (options.prompt) {
+			instructions += ` Ensure that you follow these instructions/glossary for context: ${options.prompt}.`;
+		}
+
+		const url = `https://generativelanguage.googleapis.com/v1beta/models/${options.modelName}:generateContent?key=${options.apiKey}`;
+
+		const { data: response, error: fetchError } = await tryAsync({
+			try: () =>
+				(customFetch ?? fetch)(url, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({
+						contents: [
+							{
+								parts: [
+									{ text: instructions },
+									{
+										inlineData: {
+											mimeType: audioBlob.type || 'audio/ogg',
+											data: base64Data,
+										},
+									},
+								],
+							},
+						],
+					}),
+				}),
+			catch: (cause) => GoogleTranscriptionError.Unexpected({ cause }),
+		});
+
+		if (fetchError) return Err(fetchError);
+
+		if (!response.ok) {
+			let errorMessage = response.statusText;
+			try {
+				const errorJson = await response.json();
+				if (errorJson.error?.message) {
+					errorMessage = errorJson.error.message;
+				}
+			} catch (e) {
+				// Ignore JSON parse errors
+			}
+			return GoogleTranscriptionError.ApiError({
+				message: errorMessage,
+				status: response.status,
+			});
+		}
+
+		let responseJson;
+		try {
+			responseJson = await response.json();
+		} catch (cause) {
+			return GoogleTranscriptionError.InvalidResponse();
+		}
+
+		const text = responseJson?.candidates?.[0]?.content?.parts?.[0]?.text;
+		if (typeof text !== 'string') {
+			return GoogleTranscriptionError.InvalidResponse();
+		}
+
+		return Ok(text.trim());
+	},
+};

--- a/apps/whispering/src/lib/services/transcription/provider-ui.ts
+++ b/apps/whispering/src/lib/services/transcription/provider-ui.ts
@@ -10,6 +10,7 @@ import deepgramIcon from '$lib/constants/icons/deepgram.svg?raw';
 import elevenlabsIcon from '$lib/constants/icons/elevenlabs.svg?raw';
 import epicenterIcon from '$lib/constants/icons/epicenter.svg?raw';
 import ggmlIcon from '$lib/constants/icons/ggml.svg?raw';
+import googleIcon from '$lib/constants/icons/google.svg?raw';
 import groqIcon from '$lib/constants/icons/groq.svg?raw';
 import mistralIcon from '$lib/constants/icons/mistral.svg?raw';
 import openaiIcon from '$lib/constants/icons/openai.svg?raw';
@@ -23,6 +24,7 @@ import {
 export const PROVIDER_ICONS = {
 	epicenter: { icon: epicenterIcon, invertInDarkMode: false },
 	OpenAI: { icon: openaiIcon, invertInDarkMode: true },
+	Google: { icon: googleIcon, invertInDarkMode: false },
 	Groq: { icon: groqIcon, invertInDarkMode: false },
 	ElevenLabs: { icon: elevenlabsIcon, invertInDarkMode: true },
 	Deepgram: { icon: deepgramIcon, invertInDarkMode: true },

--- a/apps/whispering/src/lib/services/transcription/providers.ts
+++ b/apps/whispering/src/lib/services/transcription/providers.ts
@@ -179,6 +179,33 @@ export const PROVIDERS = {
 			},
 		],
 	},
+	Google: {
+		access: 'key',
+		label: 'Google (Gemini)',
+		description: 'Multimodal transcription via Gemini',
+		capabilities: { supportsPrompt: true, supportsLanguage: false },
+		apiKeyConfigKey: 'providers.google.apiKey',
+		modelSettingKey: 'transcription.google.model',
+		endpointConfigKey: null,
+		modelsDoc: {
+			label: 'Gemini models',
+			href: 'https://ai.google.dev/models/gemini',
+		},
+		defaultModel: 'gemini-3.5-flash',
+		models: [
+			{
+				name: 'gemini-3.5-flash',
+				description: 'Fast and versatile multimodal model (latest version).',
+				cost: 'Free tier available',
+			},
+			{
+				name: 'gemini-3.1-flash-lite',
+				description:
+					'Lightweight and fast multimodal model for everyday tasks.',
+				cost: 'Free tier available',
+			},
+		],
+	},
 	Groq: {
 		access: 'key',
 		label: 'Groq',

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -185,6 +185,10 @@ function defineTranscriptionSettings(
 			field.select(TRANSCRIPTION_SERVICE_IDS),
 			() => defaultTranscriptionService,
 		),
+		'transcription.google.model': defineKv(
+			field.string(),
+			() => PROVIDERS.Google.defaultModel as string,
+		),
 		'transcription.openai.model': defineKv(
 			field.string(),
 			() => PROVIDERS.OpenAI.defaultModel as string,


### PR DESCRIPTION
Because I currently only have access to Gemini models, I implemented Google Gemini as a first-class transcription provider for audio transcription. Users can now plug in their Google AI Studio API key to transcribe recordings using Google's multimodal endpoints.

The shape of the change centers on adding the  Google  provider into the existing  PROVIDERS  registry and wiring it as a  bespoke  dispatcher inside  transcribe.ts . Because the Gemini API requires audio to be serialized as Base64  rather than  standard multipart form data, it uses its own dedicated client wrapper instead of the  OpenAI wire method. The integration defaults to  gemini-3.5-flash  with  gemini-3.1-flash-lite  available as a lighter alternative, and introduces the official  Gemini logo into the UI's icon registry.

## Screenshots

<img width="1900" height="1031" alt="image" src="https://github.com/user-attachments/assets/8a8a3b9b-a6fb-4797-a569-86a216ca5e40" />
<img width="1900" height="1031" alt="image" src="https://github.com/user-attachments/assets/5f8fe501-8987-4e76-bd99-1ece757b4268" />


## Changelog

  • Add support for Google Gemini (3.5 Flash and 3.1 Flash Lite) as a transcription provider

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786732479&installation_id=128463665&pr_number=2455&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2455&signature=15b13ba506997aa0d2b25a766392a8e21ab4b78a7035561275b949e38ad1ad25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->