### PR TITLE
docs(adr): correct Room migration prerequisites

### DIFF
--- a/apps/epicenter/src/workspace.ts
+++ b/apps/epicenter/src/workspace.ts
@@ -1,16 +1,11 @@
 /** Epicenter Home's device-owned durable conversation workspace. */
 
 import { conversationsTable } from '@epicenter/chat';
-import {
-	defineWorkspace,
-	type Workspace,
-} from '@epicenter/workspace/sqlite';
+import { defineWorkspace, type Workspace } from '@epicenter/workspace/sqlite';
 
 export const conversationsWorkspace = defineWorkspace({
 	id: 'epicenter-conversations',
 	tables: { conversations: conversationsTable },
 });
 
-export type ConversationsWorkspace = Workspace<
-	typeof conversationsWorkspace
->;
+export type ConversationsWorkspace = Workspace<typeof conversationsWorkspace>;

--- a/apps/honeycrisp/src/lib/application.ts
+++ b/apps/honeycrisp/src/lib/application.ts
@@ -2,10 +2,7 @@ import {
 	type HoneycrispWorkspace,
 	honeycrispWorkspace,
 } from '@epicenter/honeycrisp';
-import type {
-	WorkspaceLens,
-	Workspace,
-} from '@epicenter/workspace/sqlite';
+import type { Workspace, WorkspaceLens } from '@epicenter/workspace/sqlite';
 import { createHoneycrispState } from '../routes/state/index.js';
 
 type ApplicationRuntime = {

--- a/apps/skills/src/lib/application.ts
+++ b/apps/skills/src/lib/application.ts
@@ -1,8 +1,5 @@
 import { skillsWorkspace } from '@epicenter/skills';
-import type {
-	WorkspaceLens,
-	Workspace,
-} from '@epicenter/workspace/sqlite';
+import type { Workspace, WorkspaceLens } from '@epicenter/workspace/sqlite';
 import { createDeviceBrowserWorkspaceRuntime } from '@epicenter/workspace/sqlite/browser';
 import { createSkillsState } from './state/skills-state.svelte.js';
 

--- a/apps/skills/src/lib/state/skills-state.svelte.ts
+++ b/apps/skills/src/lib/state/skills-state.svelte.ts
@@ -6,10 +6,7 @@ import {
 	scanSkills,
 	type skillsWorkspace,
 } from '@epicenter/skills';
-import type {
-	RowLensError,
-	Workspace,
-} from '@epicenter/workspace/sqlite';
+import type { RowLensError, Workspace } from '@epicenter/workspace/sqlite';
 
 type SkillsWorkspace = Workspace<typeof skillsWorkspace>;
 

--- a/apps/whispering/src/lib/whispering/app.ts
+++ b/apps/whispering/src/lib/whispering/app.ts
@@ -1,7 +1,4 @@
-import type {
-	WorkspaceLens,
-	Workspace,
-} from '@epicenter/workspace/sqlite';
+import type { Workspace, WorkspaceLens } from '@epicenter/workspace/sqlite';
 import type { TranscriptionServiceId } from '../services/transcription/providers';
 import {
 	createWhisperingSettingDefaults,

--- a/apps/whispering/src/lib/whispering/recipes.ts
+++ b/apps/whispering/src/lib/whispering/recipes.ts
@@ -1,7 +1,4 @@
-import type {
-	RowLensError,
-	Workspace,
-} from '@epicenter/workspace/sqlite';
+import type { RowLensError, Workspace } from '@epicenter/workspace/sqlite';
 import { BUILTIN_RECIPES } from '../state/builtin-recipes';
 import type { Recipe, whisperingWorkspace } from '../workspace';
 

--- a/apps/whispering/src/lib/whispering/recordings.ts
+++ b/apps/whispering/src/lib/whispering/recordings.ts
@@ -7,10 +7,7 @@ import {
 	generateBlobId,
 	type RemoteBlobNotFound,
 } from '@epicenter/blobs';
-import type {
-	RowLensError,
-	Workspace,
-} from '@epicenter/workspace/sqlite';
+import type { RowLensError, Workspace } from '@epicenter/workspace/sqlite';
 import {
 	defineErrors,
 	extractErrorMessage,
@@ -75,9 +72,7 @@ export type WhisperingRecordings = {
 		id: Recording['id'],
 		partial: Partial<Omit<Recording, 'id' | 'audioBlobId' | 'uploadedAt'>>,
 	): ReturnType<
-		Workspace<
-			typeof whisperingWorkspace
-		>['tables']['recordings']['update']
+		Workspace<typeof whisperingWorkspace>['tables']['recordings']['update']
 	>;
 	delete(
 		toDelete: Recording['id'] | Recording['id'][],

--- a/docs/adr/0177-the-generic-room-actor-is-withdrawn.md
+++ b/docs/adr/0177-the-generic-room-actor-is-withdrawn.md
@@ -10,9 +10,11 @@
 
 The generic Room actor predates row-owned Yjs documents. The accepted Epicenter
 model now gives each ordinary row one latent document synchronized through the
-selected owner's actor. Tab Manager, Opensidian, and the legacy workspace API
-still produce Room traffic, but none requires Room as a distinct product
-concept; they are inherited consumers that must leave before deletion.
+selected owner's actor. Tab Manager, Vocab, Opensidian, and the legacy workspace
+API still produce Room traffic, but none requires Room as a distinct product
+concept; they are inherited consumers that must leave before deletion. The Tab
+Manager and Opensidian daemon mounts have no live repository caller and are
+deleted rather than ported.
 Cross-principal collaboration would require new ownership and authorization
 semantics that the current Room does not provide.
 
@@ -36,8 +38,10 @@ Room.
   composition branch.
 - There is one durable collaboration address: table key, row ID, and document.
 - Existing generic-room imports and tests are deleted rather than redirected.
-- Tab Manager, Opensidian, and the legacy Yjs 13 workspace family must leave the
-  Room route before its actor is removed.
+- Tab Manager, Vocab, Opensidian, and the legacy Yjs 13 workspace family must
+  leave the Room route before its actor is removed.
+- The unused Tab Manager and Opensidian daemon mounts disappear instead of
+  earning a second canonical runtime.
 
 ## Considered alternatives
 

--- a/packages/skills/src/workspace.ts
+++ b/packages/skills/src/workspace.ts
@@ -1,7 +1,4 @@
-import {
-	defineWorkspace,
-	type Workspace,
-} from '@epicenter/workspace/sqlite';
+import { defineWorkspace, type Workspace } from '@epicenter/workspace/sqlite';
 import { SKILLS_WORKSPACE_ID } from './constants.js';
 import { referencesTable, skillsTable } from './tables.js';
 

--- a/specs/20260719T222716-one-epicenter-clean-break.md
+++ b/specs/20260719T222716-one-epicenter-clean-break.md
@@ -633,30 +633,6 @@ Remove:
 - Append a new Cloudflare migration that deletes the class. Never rewrite its
   historical creation migration.
 
-### Wave B: retire every generic Room producer and actor
-
-Build:
-
-- Move any surviving product behavior to row-owned Yjs 14 documents.
-
-Stop importing:
-
-- Remove or migrate the legacy Yjs 13 workspace producers, including Tab
-  Manager and Opensidian mounts, before changing the server route.
-- Stop hosted and self-hosted deployments from mounting `/api/rooms/:roomId`.
-
-Prove:
-
-- Every remaining product document opens through its table key and row ID.
-- Hosted and self-hosted document smokes pass with no generic Room route.
-
-Remove:
-
-- Delete the Room actor, both backends, registry, update logs, route, bindings,
-  migrations, package exports, dependencies, tests, and documentation.
-- Append a new Cloudflare migration that deletes the class. Never allocate the
-  Room and Epicenter class migration tags on parallel branches.
-
 ### Wave 0: establish proof harnesses
 
 Build:
@@ -719,6 +695,47 @@ Remove:
 
 Primary paths: `packages/workspace/src/sqlite/{workspace-lens,runtime,bun-runtime,browser-runtime,browser-runtime-worker,desktop-owner,desktop-runtime,account-runtime,local-workspace-storage}.ts`
 and `apps/epicenter/src/{main,server,workspace-owner}.ts`.
+
+### Wave B: retire every generic Room producer and actor
+
+This wave follows the selected-owner runtime because migrated application UI
+needs owner selection, readiness, status, and whole-owner forget semantics. Do
+not preserve the old `Collaboration` or `wipe()` surfaces through adapters.
+
+Build:
+
+- Move shared app-shell chat from `@epicenter/chat/legacy-root-yjs` to the
+  canonical conversations table and row-document message store.
+- Migrate Vocab, Tab Manager, and Opensidian to the selected-owner SQLite
+  runtime. Migrate `@epicenter/filesystem` before Opensidian.
+- Keep browser-owned ephemeral state device-local. Put durable scalar state in
+  rows and KV, and collaborative content in each live row's document.
+
+Stop importing:
+
+- Delete the unused Tab Manager and Opensidian daemon mounts and their package
+  exports instead of porting them.
+- Remove every shipped `connectDoc`, `openCollaboration`, `roomWsUrl`,
+  `legacy-root-yjs`, and `.mount()` Room producer.
+- Stop hosted and self-hosted deployments from mounting `/api/rooms/:roomId`.
+
+Prove:
+
+- Every remaining product document opens through its table key and row ID.
+- Vocab, Tab Manager, Opensidian, shared chat, and filesystem persistence tests
+  pass across restart and row deletion.
+- Hosted and self-hosted document smokes pass with no generic Room route.
+
+Remove:
+
+- Delete the Room actor, both backends, registry, update logs, route, bindings,
+  package exports, dependencies, tests, and current documentation.
+- Delete the legacy root-Yjs collaboration client only after local-only callers
+  such as Todos and in-memory callers such as Wiki have migrated or explicitly
+  retained a smaller local-only primitive.
+- Append a new Cloudflare migration that deletes the class. Never rewrite its
+  historical creation migration or allocate Room and Epicenter migration tags
+  on parallel branches.
 
 ### Wave 2: replace the SQL relation
 


### PR DESCRIPTION
The Room retirement plan named only Tab Manager and Opensidian, but the caller audit found a third shipped producer: Vocab. It also placed Room migration before the selected-owner runtime even though migrated account UI needs that runtime to own selection, readiness, sync status, and whole-owner forget behavior.

```txt
selected-owner runtime
  -> canonical shared chat
  -> Vocab
  -> Tab Manager
  -> filesystem package
  -> Opensidian
  -> delete unused daemon mounts
  -> stop mounting Room
  -> delete Room actor
```

This corrects ADR-0177 and the execution spec before implementation starts. Tab Manager and Opensidian daemon mounts have no repository callers, so the plan now deletes them instead of porting an unshipped daemon product. Vocab, Tab Manager, and Opensidian browser data migrate to scalar rows, typed KV, and row-owned documents. Opensidian follows a dedicated filesystem-package migration.

The clean break explicitly refuses adapters that impersonate the old synchronous `Collaboration` or `wipe()` surfaces. Room imports stop only after shared chat and all three shipped apps use the selected-owner runtime. Historical Cloudflare migrations remain immutable; the final Room PR appends a class-deletion migration.

Document paths pass and the generated spec history is unchanged.

Stacks on #2460; merge #2459 and #2460 first.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787122370&installation_id=128463665&pr_number=2461&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2461&signature=36ab91b2e9da57839fb07fdd870e8f8d56fc481422fe72eb7a29c057a75a9ed0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->