### PR TITLE
Build the minimal Ark projection plane

### DIFF
--- a/apps/theark/README.md
+++ b/apps/theark/README.md
@@ -80,11 +80,13 @@ zero write paths (see the ADR-0160 amendment):
   publicly-unroutable `.artifact` ownership marker via create-if-absent (R2
   `onlyIf: { etagDoesNotMatch: '*' }`), so two racing publishers cannot both
   win. The marker records the private artifact id plus the immutable
-  expression digest (Vault ADR-0064; never `integrity_digest`): only an
-  exact match converges, another artifact is refused the slug forever, and
-  the same artifact with a different frozen expression is refused because a
-  permalink never changes its words. Generated HTML and media are not
-  hashed, so theme and output rebuilds stay free. It writes generated media
+  expression digest (Vault ADR-0064; never `integrity_digest`) and the first
+  declared publication date. Only an exact identity/expression match
+  converges; another artifact is refused the slug forever, and the same
+  artifact with a different frozen expression is refused because a permalink
+  never changes its words. A retry receives the first reserved date rather
+  than rewriting history. Generated HTML and media are not hashed, so theme
+  and output rebuilds stay free. It writes generated media
   (`video.mp4`/`narration.mp3`/`cover.png`, the complete media vocabulary)
   before activating `index.html` last, and read-back-verifies every object.
   Keys are derived through the delivery Worker's own `resolveProjection`, so
@@ -92,23 +94,24 @@ zero write paths (see the ADR-0160 amendment):
 
 The kernel runs wherever an authenticated caller holds bucket credentials: an
 operator CLI first, the Vault's injected `ArkPublisher` port behind it. The
-caller supplies `publishedOn` (the date it declares for this publication and
-must record identically on the canonical receipt afterward; the receipt does
-not exist yet when the kernel runs) and `expressionDigest`, and owns
-public-URL verification against the expected canonical URL.
+caller supplies a proposed `publishedOn` and the `expressionDigest`, owns
+public-URL verification against the expected canonical URL, and records the
+kernel's returned authoritative date on the receipt. An exact retry may return
+an earlier date already preserved by the route reservation.
 
-Two Vault-side contract changes are required before the port can drive this
-kernel, both already implied by its own ADRs and neither implemented there
-yet:
+The paired Vault publishing change owns the two cross-repository inputs this
+kernel requires:
 
 1. The freeze gate must validate that an artifact frozen with a canonical
    Ark slug has a body opening with exactly one lead `# Title` heading
    (ADR-0059 already states the lead H1 becomes the web title; nothing
    enforces it at freeze).
-2. Freeze must mint the immutable expression-and-production-input digest
-   ADR-0064 specifies (its text notes the digest is "still absent") and the
-   Vault's `ArkPublisher` adapter must pass it, with `publishedOn`, through
-   to the kernel; the port today carries neither.
+2. `artifactExpressionDigest` mints the immutable
+   expression-and-production-input digest ADR-0064 specifies and
+   `ArkProjection` carries it, together with the proposed publication date.
+
+The remaining seam is a credential-holding adapter from that Vault port to
+this kernel and its public-URL verification.
 
 ## Develop
 

--- a/apps/theark/README.md
+++ b/apps/theark/README.md
@@ -89,8 +89,11 @@ zero write paths (see the ADR-0160 amendment):
   never changes its words. A retry receives the first reserved date rather
   than rewriting history. Generated HTML and media are not hashed, so theme
   and output rebuilds stay free. It writes generated media
-  (`video.mp4`/`narration.mp3`/`cover.png`, the complete media vocabulary)
-  before activating `index.html` last, and read-back-verifies every object.
+  (`video.mp4`/`narration.mp3`/`cover.png`, the complete media vocabulary the
+  reader also enforces) before activating `index.html` last. A store `put` is
+  a checked durable write by contract (the adapter has R2 verify a content
+  checksum server-side); the kernel never re-downloads objects to prove its
+  own writes, and end-to-end proof is the caller's public-URL verification.
   Keys are derived through the delivery Worker's own `resolveProjection`, so
   the kernel cannot write an address the Worker would refuse to serve.
 

--- a/apps/theark/README.md
+++ b/apps/theark/README.md
@@ -7,7 +7,7 @@ of content:
    the one constrained reading theme (`/assets/theark.css`), the favicon, and
    the home and not-found shells. Changing the theme is a redeploy of this
    Worker.
-2. **Immutable public artifact projections** streamed from the
+2. **Rebuildable public artifact projections** streamed from the
    `theark-projections` R2 bucket (EU jurisdiction). The publishing side (the
    Vault) writes projection objects; a publication appears by writing R2 keys,
    never by redeploying this Worker.
@@ -25,23 +25,34 @@ Canonical artifact permalinks are `https://theark.so/braden/<artifact-slug>`.
 | --- | --- |
 | `/` | `public/home.html` (deploy-time shell) |
 | `/assets/theark.css`, `/favicon.svg` | Static Assets, literal paths |
-| `/<identity>` | R2 `routes/<identity>/index.html`, as a person route |
-| `/<identity>/<slug-or-facet>` | R2 `routes/<identity>/<slug-or-facet>/index.html`, as an artifact permalink or facet route |
-| `/_artifacts/<uuidv7>/<file.ext>` | R2 `artifacts/<uuidv7>/<file.ext>`, as an artifact output |
+| `/<identity>` | R2 `<identity>/index.html`, as a person route |
+| `/<identity>/<slug-or-facet>` | R2 `<identity>/<slug-or-facet>/index.html`, as an artifact permalink or facet route |
+| `/<identity>/<artifact-slug>/<file.ext>` | R2 `<identity>/<artifact-slug>/<file.ext>`, as generated media belonging to that expression |
 
-A human-readable route has one or two lowercase-hyphenated segments. Artifact
-outputs instead live beneath a reserved `/_artifacts/` prefix and the artifact's
-immutable UUIDv7 identity. This separation prevents `index.html` aliases and
-keeps output identity independent from a human-readable route. Percent-encoded
-aliases and anything outside these exact families are 404 before R2 is
-consulted. Trailing slashes 308-redirect to the slashless form. Only GET and HEAD
-are allowed. Range, `If-None-Match`/`If-Match`, and HEAD behave per HTTP so
-short-video files stream correctly.
+A human-readable page route has one or two lowercase-hyphenated segments. An
+artifact's generated files live directly beneath its permanent permalink, so
+the public URL tree and R2 tree say the same thing. Because the canonical page
+URL is slashless, generated HTML must use root-absolute media URLs such as
+`/braden/<slug>/video.mp4`; a bare `video.mp4` would resolve outside the artifact
+subtree. Explicit `index.html` aliases, percent-encoded aliases, the reserved
+`/assets` identity, and anything outside these exact families are 404 before R2
+is consulted. Trailing slashes 308-redirect to the slashless form. Only GET and
+HEAD are allowed. Cloudflare Workers Caching owns byte-range delivery from the
+Worker's full streamed responses; conditional reads and HEAD remain Worker/R2
+behavior.
 
 Delivery policy is Worker-owned: every projection is served with
 `cache-control: public, max-age=300, must-revalidate` (bytes at a key are
 regenerable, so nothing is `immutable`), and missing objects are `no-store`
-so a new publication is visible immediately.
+so a new publication is visible immediately. The Worker also applies a CSP that
+refuses executable per-artifact code while allowing the shared stylesheet,
+images, fonts, and media.
+
+The second path segment is one shared publisher-owned namespace: a facet and an
+artifact cannot both own `/braden/codes`. The future authenticated publisher
+must refuse cross-owner collisions, reserve a route forever to its first
+artifact owner, write media first, and conditionally activate `index.html` last.
+The delivery Worker deliberately has no route registry.
 
 This Worker deliberately has **no** auth, billing, Postgres, Durable Objects,
 Epicenter blob-store access, write routes, or renderer plugins. A future

--- a/apps/theark/README.md
+++ b/apps/theark/README.md
@@ -27,12 +27,14 @@ Canonical artifact permalinks are `https://theark.so/braden/<artifact-slug>`.
 | `/assets/theark.css`, `/favicon.svg` | Static Assets, literal paths |
 | `/<identity>` | R2 `<identity>/index.html`, as a person route |
 | `/<identity>/<slug-or-facet>` | R2 `<identity>/<slug-or-facet>/index.html`, as an artifact permalink or facet route |
-| `/<identity>/<artifact-slug>/<file.ext>` | R2 `<identity>/<artifact-slug>/<file.ext>`, as generated media belonging to that expression |
+| `/<identity>/<artifact-slug>/<file>` | R2 `<identity>/<artifact-slug>/<file>`, where `<file>` is exactly `video.mp4`, `narration.mp3`, or `cover.png` |
 
 A human-readable page route has one or two lowercase-hyphenated segments. An
 artifact's generated files live directly beneath its permanent permalink, so
-the public URL tree and R2 tree say the same thing. Because the canonical page
-URL is slashless, generated HTML must use root-absolute media URLs such as
+the public URL tree and R2 tree say the same thing. The third segment is the
+closed generated-media vocabulary; no other filename resolves, so even a stray
+bucket object outside that set is publicly unroutable. Because the canonical
+page URL is slashless, generated HTML must use root-absolute media URLs such as
 `/braden/<slug>/video.mp4`; a bare `video.mp4` would resolve outside the artifact
 subtree. Explicit `index.html` aliases, percent-encoded aliases, the reserved
 `/assets` identity, and anything outside these exact families are 404 before R2

--- a/apps/theark/README.md
+++ b/apps/theark/README.md
@@ -63,31 +63,52 @@ The trusted publishing code lives beside the delivery Worker as library
 modules the Worker entry never imports, so the deployed public plane keeps
 zero write paths (see the ADR-0160 amendment):
 
-- `src/render.ts` is the constrained renderer: one pure, total function from a
+- `src/render.ts` is the constrained renderer: one pure function from a
   frozen-artifact-shaped input to one complete semantic HTML document. It
   emits no JavaScript and references only `/assets/theark.css` plus
-  root-absolute sibling media. Its explicit Markdown subset is documented in
-  the module header; everything outside the subset (raw HTML, executable URL
-  schemes, tables, deeper headings, foreign images) renders as visibly
-  escaped literal text. It never throws: Publish freezes the artifact before
-  projecting it, and projection HTML is disposable, so degraded output is
-  always recoverable by a renderer improvement plus a rebuild.
+  root-absolute sibling media. The page title is the frozen body's own lead
+  `# Title` heading (Vault ADR-0059: the lead H1 becomes the web title),
+  consumed as plain text and never duplicated into the article, so a mutable
+  page-row title can never leak into a frozen page. Below the lead title the
+  renderer is total: everything outside its explicit Markdown subset (raw
+  HTML, executable URL schemes, tables, deeper headings, foreign images)
+  renders as visibly escaped literal text, never a throw, because Publish
+  freezes before it projects and HTML is disposable. The one throw is a
+  missing lead title, which asserts a violated freeze-gate contract.
 - `src/publish.ts` is the publisher kernel: given an injected R2-shaped
-  object store, it reserves the `<identity>/<slug>` subtree with a
-  publicly-unroutable `.artifact` ownership marker (dotfiles fail the public
-  route allowlist by construction), writes generated media
-  (`video.mp4`/`narration.mp3`/`cover.png`, the complete media vocabulary),
-  renders and activates `index.html` last, and read-back-verifies every
-  object. Republish by the same artifact converges idempotently; any other
-  artifact is refused the slug forever. Keys are derived through the delivery
-  Worker's own `resolveProjection`, so the kernel cannot write an address the
-  Worker would refuse to serve.
+  object store, it atomically reserves the `<identity>/<slug>` subtree with a
+  publicly-unroutable `.artifact` ownership marker via create-if-absent (R2
+  `onlyIf: { etagDoesNotMatch: '*' }`), so two racing publishers cannot both
+  win. The marker records the private artifact id plus the immutable
+  expression digest (Vault ADR-0064; never `integrity_digest`): only an
+  exact match converges, another artifact is refused the slug forever, and
+  the same artifact with a different frozen expression is refused because a
+  permalink never changes its words. Generated HTML and media are not
+  hashed, so theme and output rebuilds stay free. It writes generated media
+  (`video.mp4`/`narration.mp3`/`cover.png`, the complete media vocabulary)
+  before activating `index.html` last, and read-back-verifies every object.
+  Keys are derived through the delivery Worker's own `resolveProjection`, so
+  the kernel cannot write an address the Worker would refuse to serve.
 
 The kernel runs wherever an authenticated caller holds bucket credentials: an
-operator CLI first, the Vault's injected `ArkPublisher` port behind it. That
-caller must supply the page `title` and receipt `publishedOn`, which the
-Vault port does not carry, and owns public-URL verification against the
-expected canonical URL.
+operator CLI first, the Vault's injected `ArkPublisher` port behind it. The
+caller supplies `publishedOn` (the date it declares for this publication and
+must record identically on the canonical receipt afterward; the receipt does
+not exist yet when the kernel runs) and `expressionDigest`, and owns
+public-URL verification against the expected canonical URL.
+
+Two Vault-side contract changes are required before the port can drive this
+kernel, both already implied by its own ADRs and neither implemented there
+yet:
+
+1. The freeze gate must validate that an artifact frozen with a canonical
+   Ark slug has a body opening with exactly one lead `# Title` heading
+   (ADR-0059 already states the lead H1 becomes the web title; nothing
+   enforces it at freeze).
+2. Freeze must mint the immutable expression-and-production-input digest
+   ADR-0064 specifies (its text notes the digest is "still absent") and the
+   Vault's `ArkPublisher` adapter must pass it, with `publishedOn`, through
+   to the kernel; the port today carries neither.
 
 ## Develop
 

--- a/apps/theark/README.md
+++ b/apps/theark/README.md
@@ -127,14 +127,13 @@ bun run --cwd apps/theark typegen     # regenerate worker-configuration.d.ts aft
 bun dev:theark                        # wrangler dev (see note below)
 ```
 
-## Deploy prerequisites (external actions, in order)
+## Deploy
 
-1. Create the EU-jurisdiction bucket (jurisdiction is permanent; the bucket
-   must not be created without it):
-   `bun x wrangler r2 bucket create theark-projections --jurisdiction eu`
-2. Delegate `theark.so` DNS to Cloudflare (today it sits on registrar
-   nameservers), then uncomment the `routes` block in `wrangler.jsonc`.
-3. `bun run --cwd apps/theark deploy`
+The one-time infrastructure prerequisites are an EU-jurisdiction
+`theark-projections` bucket and an active Cloudflare zone for `theark.so`.
+Jurisdiction is permanent once the bucket is created. `wrangler.jsonc` owns the
+canonical custom domain, R2 binding, fixed asset bundle, and Worker deployment:
 
-Until DNS is delegated, the Worker can deploy without the route and serve on
-its `workers.dev` URL.
+```bash
+bun run --cwd apps/theark deploy
+```

--- a/apps/theark/README.md
+++ b/apps/theark/README.md
@@ -49,15 +49,45 @@ refuses executable per-artifact code while allowing the shared stylesheet,
 images, fonts, and media.
 
 The second path segment is one shared publisher-owned namespace: a facet and an
-artifact cannot both own `/braden/codes`. The future authenticated publisher
-must refuse cross-owner collisions, reserve a route forever to its first
-artifact owner, write media first, and conditionally activate `index.html` last.
-The delivery Worker deliberately has no route registry.
+artifact cannot both own `/braden/codes`. The publisher kernel (below) refuses
+cross-owner collisions, reserves a route forever to its first artifact owner,
+writes media first, and activates `index.html` last. The delivery Worker
+deliberately has no route registry.
 
 This Worker deliberately has **no** auth, billing, Postgres, Durable Objects,
-Epicenter blob-store access, write routes, or renderer plugins. A future
-authenticated creator application publishes *into* the bucket; it does not
-live here.
+Epicenter blob-store access, write routes, or renderer plugins.
+
+## Publishing side: renderer and kernel
+
+The trusted publishing code lives beside the delivery Worker as library
+modules the Worker entry never imports, so the deployed public plane keeps
+zero write paths (see the ADR-0160 amendment):
+
+- `src/render.ts` is the constrained renderer: one pure, total function from a
+  frozen-artifact-shaped input to one complete semantic HTML document. It
+  emits no JavaScript and references only `/assets/theark.css` plus
+  root-absolute sibling media. Its explicit Markdown subset is documented in
+  the module header; everything outside the subset (raw HTML, executable URL
+  schemes, tables, deeper headings, foreign images) renders as visibly
+  escaped literal text. It never throws: Publish freezes the artifact before
+  projecting it, and projection HTML is disposable, so degraded output is
+  always recoverable by a renderer improvement plus a rebuild.
+- `src/publish.ts` is the publisher kernel: given an injected R2-shaped
+  object store, it reserves the `<identity>/<slug>` subtree with a
+  publicly-unroutable `.artifact` ownership marker (dotfiles fail the public
+  route allowlist by construction), writes generated media
+  (`video.mp4`/`narration.mp3`/`cover.png`, the complete media vocabulary),
+  renders and activates `index.html` last, and read-back-verifies every
+  object. Republish by the same artifact converges idempotently; any other
+  artifact is refused the slug forever. Keys are derived through the delivery
+  Worker's own `resolveProjection`, so the kernel cannot write an address the
+  Worker would refuse to serve.
+
+The kernel runs wherever an authenticated caller holds bucket credentials: an
+operator CLI first, the Vault's injected `ArkPublisher` port behind it. That
+caller must supply the page `title` and receipt `publishedOn`, which the
+Vault port does not carry, and owns public-URL verification against the
+expected canonical URL.
 
 ## Develop
 

--- a/apps/theark/public/assets/theark.css
+++ b/apps/theark/public/assets/theark.css
@@ -1,21 +1,34 @@
 /*
  * The Ark's one reading theme. Every generated projection page references
  * this stylesheet at its stable URL (/assets/theark.css); changing the theme
- * is a redeploy of this Worker, never a rewrite of published HTML. Keep it
- * small, low-dopamine, and readable in both color schemes.
+ * is a redeploy of this Worker, never a rewrite of published HTML.
+ *
+ * The grammar is bradenwong.com's: warm stone paper, a single brick accent,
+ * Georgia for reading type, a Franklin-style sans for metadata and subheads,
+ * one prose-width column, and light/dark from the system preference alone.
+ * No JavaScript, no web fonts, no per-artifact styling.
  */
 :root {
 	color-scheme: light dark;
-	--ink: #1c1b18;
-	--paper: #faf8f3;
-	--muted: #6d6a62;
+	--paper: oklch(0.993 0.003 75);
+	--ink: oklch(0.22 0.005 60);
+	--muted: oklch(0.45 0.01 75);
+	--brick: oklch(0.55 0.106 40);
+	--border: oklch(0.905 0.007 75);
+	--code-bg: oklch(0.955 0.007 75);
+	--sans:
+		"Libre Franklin", -apple-system, "Segoe UI", "Helvetica Neue", Arial,
+		sans-serif;
 }
 
 @media (prefers-color-scheme: dark) {
 	:root {
-		--ink: #e8e4da;
-		--paper: #131215;
-		--muted: #94908a;
+		--paper: oklch(0.18 0.005 60);
+		--ink: oklch(0.93 0.005 75);
+		--muted: oklch(0.71 0.01 75);
+		--brick: oklch(0.67 0.117 40);
+		--border: oklch(0.28 0.005 60);
+		--code-bg: oklch(0.26 0.005 60);
 	}
 }
 
@@ -29,48 +42,209 @@ body {
 	color: var(--ink);
 	font-family: Georgia, "Times New Roman", serif;
 	font-size: 1.125rem;
-	line-height: 1.6;
+	line-height: 1.7;
+	text-rendering: optimizeLegibility;
 }
 
 main {
-	max-width: 40rem;
+	max-width: 42rem;
 	margin: 0 auto;
 	padding: 4rem 1.25rem 6rem;
 }
 
-h1,
+:focus-visible {
+	outline: 2px solid var(--brick);
+	outline-offset: 2px;
+}
+
+/* ── Article header: uppercase tracked date, Georgia title, muted subtitle ── */
+
+article > header {
+	border-bottom: 1px solid var(--border);
+	padding-bottom: 1.75rem;
+	margin-bottom: 2rem;
+}
+
+article > header time {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	font-family: var(--sans);
+	font-size: 0.8125rem;
+	font-weight: 500;
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+	color: var(--muted);
+}
+
+/* Resonant artifacts carry the brick diamond beside their date. */
+.resonance {
+	width: 0.375rem;
+	height: 0.375rem;
+	transform: rotate(45deg);
+	background: var(--brick);
+	flex: none;
+}
+
+h1 {
+	margin: 1.25rem 0 0;
+	font-size: 2rem;
+	font-weight: 700;
+	line-height: 1.15;
+	text-wrap: pretty;
+}
+
+@media (min-width: 40rem) {
+	h1 {
+		font-size: 2.75rem;
+	}
+}
+
+.subtitle {
+	margin: 1.25rem 0 0;
+	font-family: var(--sans);
+	font-size: 1.125rem;
+	line-height: 1.6;
+	color: var(--muted);
+}
+
+/* ── Prose ── */
+
+p {
+	margin: 1.1em 0;
+	text-wrap: pretty;
+}
+
 h2,
 h3 {
-	line-height: 1.25;
-	font-weight: 600;
+	font-family: var(--sans);
+	font-weight: 650;
+	line-height: 1.3;
+	text-wrap: balance;
+}
+
+h2 {
+	margin: 2.4em 0 0.7em;
+	font-size: 1.45rem;
+}
+
+h3 {
+	margin: 2em 0 0.65em;
+	font-size: 1.15rem;
 }
 
 a {
-	color: inherit;
+	color: var(--brick);
+	font-weight: 400;
+	text-decoration-color: transparent;
+	text-decoration-thickness: 1px;
+	text-underline-offset: 3px;
+	transition: text-decoration-color 150ms ease;
 }
 
-img,
-video {
-	max-width: 100%;
-	height: auto;
+a:hover {
+	text-decoration-color: var(--brick);
 }
 
-pre {
-	overflow-x: auto;
-	padding: 1rem;
-	font-size: 0.875rem;
-	line-height: 1.5;
+ul,
+ol {
+	margin: 1.1em 0;
+	padding-left: 1.5rem;
+}
+
+li {
+	margin: 0.3em 0;
+	text-wrap: pretty;
 }
 
 blockquote {
 	margin: 1.5rem 0;
 	padding-left: 1rem;
-	border-left: 2px solid var(--muted);
-	color: var(--muted);
+	border-left: 2px solid var(--brick);
+	font-size: 1.25rem;
+	line-height: 1.6;
 }
+
+hr {
+	margin: 3em 0;
+	border: 0;
+	border-top: 1px solid var(--border);
+}
+
+/* ── Code: warm inline pill, dark evidence block in both modes ── */
+
+code {
+	font-family:
+		ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+		"Courier New", monospace;
+	font-size: 0.8em;
+	background: var(--code-bg);
+	border: 1px solid var(--border);
+	border-radius: 0.35rem;
+	padding: 0.12em 0.4em;
+	box-decoration-break: clone;
+	-webkit-box-decoration-break: clone;
+}
+
+pre {
+	margin: 1.8em 0;
+	padding: 1rem 1.15rem;
+	border-radius: 0.6rem;
+	background: oklch(0.245 0.008 60);
+	color: oklch(0.985 0 0);
+	font-size: 0.85em;
+	line-height: 1.6;
+	overflow-x: auto;
+	scrollbar-width: thin;
+}
+
+pre code {
+	background: none;
+	border: 0;
+	padding: 0;
+	font-size: inherit;
+	color: inherit;
+}
+
+/* ── Media ── */
+
+img {
+	max-width: 100%;
+	height: auto;
+	margin: 2.25rem 0;
+	border-radius: 0.5rem;
+	border: 1px solid var(--border);
+}
+
+.artifact-video {
+	margin: 2rem 0;
+}
+
+video {
+	display: block;
+	max-width: 100%;
+	max-height: 80vh;
+	margin: 0 auto;
+	border-radius: 0.5rem;
+	background: black;
+}
+
+/* ── Footer ── */
 
 footer {
 	margin-top: 4rem;
-	color: var(--muted);
+	padding-top: 1.5rem;
+	border-top: 1px solid var(--border);
+	font-family: var(--sans);
 	font-size: 0.875rem;
+	color: var(--muted);
+}
+
+footer a {
+	color: var(--muted);
+}
+
+footer a:hover {
+	color: var(--brick);
+	text-decoration-color: var(--brick);
 }

--- a/apps/theark/src/index.test.ts
+++ b/apps/theark/src/index.test.ts
@@ -88,7 +88,7 @@ function setup(objects: Record<string, StoredObject> = {}) {
 
 	const fetch = (path: string, init?: RequestInit) =>
 		handleRequest(new Request(`https://theark.so${path}`, init), env as Env);
-	return { fetch, requestedKeys };
+	return { fetch, requestedKeys, env: env as Env };
 }
 
 // ============================================================================
@@ -201,6 +201,19 @@ test('trailing slash 308-redirects to the slashless canonical URL', async () => 
 	const response = await fetch('/braden/foo/');
 	expect(response.status).toBe(308);
 	expect(response.headers.get('location')).toBe('https://theark.so/braden/foo');
+	expect(requestedKeys).toEqual([]);
+});
+
+test('canonical redirects stay HTTPS when Cloudflare presents an internal HTTP URL', async () => {
+	const { env, requestedKeys } = setup();
+	const response = await handleRequest(
+		new Request('http://theark.epicenter.workers.dev/braden/foo/'),
+		env,
+	);
+	expect(response.status).toBe(308);
+	expect(response.headers.get('location')).toBe(
+		'https://theark.epicenter.workers.dev/braden/foo',
+	);
 	expect(requestedKeys).toEqual([]);
 });
 

--- a/apps/theark/src/index.test.ts
+++ b/apps/theark/src/index.test.ts
@@ -3,21 +3,19 @@
  *
  * Pure fetch-handler tests over a stub Env. The stub R2 mirrors the binding
  * semantics this Worker actually relies on (onlyIf preconditions return a
- * body-less object, an unsatisfiable Range throws), so these tests pin the
+ * body-less object), so these tests pin the
  * routing, key-mapping, and streaming-header invariants without Miniflare.
  *
  * Key behaviors:
- * - URL to R2 key mapping: human routes and artifact outputs stay disjoint
+ * - URL to R2 key mapping: each artifact owns one page-and-media subtree
  * - Hostile paths (traversal, encoding, uppercase) 404 before touching R2
  * - Trailing slashes 308-redirect to the slashless canonical URL
- * - Only GET and HEAD are allowed; conditional and Range reads behave
+ * - Only GET and HEAD are allowed; conditional reads behave
  * - The Worker owns cache policy; the publisher owns bytes and content-type
  */
 import { describe, expect, test } from 'bun:test';
 
 import { handleRequest, resolveProjection } from './index';
-
-const ARTIFACT_ID = '019f79b2-a3f1-7000-97ea-04851c5323f2';
 
 type StoredObject = {
 	data: string;
@@ -28,16 +26,11 @@ type StoredObject = {
 function setup(objects: Record<string, StoredObject> = {}) {
 	const requestedKeys: string[] = [];
 
-	const makeMeta = (
-		key: string,
-		stored: StoredObject,
-		range?: { offset: number; length: number },
-	) => ({
+	const makeMeta = (key: string, stored: StoredObject) => ({
 		key,
 		// Test payloads are ASCII, so string length is byte length.
 		size: stored.data.length,
 		httpEtag: `"etag-${key}"`,
-		range,
 		writeHttpMetadata(headers: Headers) {
 			if (stored.contentType) headers.set('content-type', stored.contentType);
 			if (stored.cacheControl)
@@ -52,11 +45,10 @@ function setup(objects: Record<string, StoredObject> = {}) {
 				const stored = objects[key];
 				return stored ? makeMeta(key, stored) : null;
 			},
-			async get(key: string, options?: { onlyIf?: Headers; range?: Headers }) {
+			async get(key: string, options?: { onlyIf?: Headers }) {
 				requestedKeys.push(key);
 				const stored = objects[key];
 				if (!stored) return null;
-				const bytes = stored.data;
 				const etag = `"etag-${key}"`;
 
 				const ifNoneMatch = options?.onlyIf?.get('if-none-match');
@@ -65,36 +57,9 @@ function setup(objects: Record<string, StoredObject> = {}) {
 					return makeMeta(key, stored);
 				}
 
-				let range: { offset: number; length: number } | undefined;
-				let slice = bytes;
-				const rangeHeader = options?.range?.get('range');
-				if (rangeHeader) {
-					const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader);
-					if (match && (match[1] || match[2])) {
-						let offset: number;
-						let length: number;
-						if (match[1]) {
-							offset = Number(match[1]);
-							const end = match[2]
-								? Math.min(Number(match[2]), bytes.length - 1)
-								: bytes.length - 1;
-							length = end - offset + 1;
-						} else {
-							length = Math.min(Number(match[2]), bytes.length);
-							offset = bytes.length - length;
-						}
-						if (offset >= bytes.length || length <= 0) {
-							throw new Error(
-								'get: The requested range is not satisfiable (10039)',
-							);
-						}
-						range = { offset, length };
-						slice = bytes.slice(offset, offset + length);
-					}
-				}
 				return {
-					...makeMeta(key, stored, range),
-					body: new Response(slice).body,
+					...makeMeta(key, stored),
+					body: new Response(stored.data).body,
 				};
 			},
 		},
@@ -131,21 +96,21 @@ function setup(objects: Record<string, StoredObject> = {}) {
 describe('resolveProjection', () => {
 	test('artifact permalink maps to its index.html object', () => {
 		expect(resolveProjection('/braden/first-artifact')).toEqual({
-			key: 'routes/braden/first-artifact/index.html',
+			key: 'braden/first-artifact/index.html',
 			isPage: true,
 		});
 	});
 
 	test('single-segment person route maps to its index.html object', () => {
 		expect(resolveProjection('/braden')).toEqual({
-			key: 'routes/braden/index.html',
+			key: 'braden/index.html',
 			isPage: true,
 		});
 	});
 
-	test('artifact output maps through its immutable UUIDv7 namespace', () => {
-		expect(resolveProjection(`/_artifacts/${ARTIFACT_ID}/video.mp4`)).toEqual({
-			key: `artifacts/${ARTIFACT_ID}/video.mp4`,
+	test('artifact output lives beside its human-readable permalink', () => {
+		expect(resolveProjection('/braden/first-artifact/video.mp4')).toEqual({
+			key: 'braden/first-artifact/video.mp4',
 			isPage: false,
 		});
 	});
@@ -153,24 +118,29 @@ describe('resolveProjection', () => {
 	test('rejects uppercase, underscores, dotfiles, double dots, and empty segments', () => {
 		expect(resolveProjection('/Braden/foo')).toBeNull();
 		expect(resolveProjection('/braden/some_slug')).toBeNull();
-		expect(resolveProjection(`/_artifacts/${ARTIFACT_ID}/.hidden`)).toBeNull();
-		expect(resolveProjection(`/_artifacts/${ARTIFACT_ID}/a..b`)).toBeNull();
+		expect(resolveProjection('/braden/first-artifact/.hidden')).toBeNull();
+		expect(resolveProjection('/braden/first-artifact/a..b')).toBeNull();
 		expect(resolveProjection('/braden//foo')).toBeNull();
+		expect(resolveProjection('/assets/theark')).toBeNull();
 	});
 
-	test('rejects route file aliases, arbitrary route depth, and non-v7 artifact IDs', () => {
+	test('rejects route file aliases, extensionless outputs, and arbitrary depth', () => {
 		expect(resolveProjection('/braden/first-artifact/index.html')).toBeNull();
 		expect(resolveProjection('/braden/first-artifact/extra')).toBeNull();
-		expect(
-			resolveProjection(
-				'/_artifacts/019f79b2-a3f1-6000-97ea-04851c5323f2/video.mp4',
-			),
-		).toBeNull();
+		expect(resolveProjection('/braden/first-artifact/video/mp4')).toBeNull();
+		expect(resolveProjection('/_artifacts/anything/video.mp4')).toBeNull();
 	});
 
 	test('rejects percent-encoded aliases', () => {
 		expect(resolveProjection('/braden/%zz')).toBeNull();
 		expect(resolveProjection('/br%61den/first-artifact')).toBeNull();
+	});
+
+	test('rejects syntactically valid paths that exceed the R2 key limit', () => {
+		expect(resolveProjection(`/braden/${'a'.repeat(1010)}`)).toBeNull();
+		expect(
+			resolveProjection(`/braden/slug/${'a'.repeat(1010)}.png`),
+		).toBeNull();
 	});
 });
 
@@ -192,6 +162,15 @@ test('root serves the deploy-time home shell', async () => {
 	const response = await fetch('/');
 	expect(response.status).toBe(200);
 	expect(await response.text()).toBe('<home shell>');
+});
+
+test('deploy-time shell filenames are not alternate public page URLs', async () => {
+	const { fetch, requestedKeys } = setup();
+	for (const path of ['/home.html', '/not-found.html']) {
+		const response = await fetch(path);
+		expect(response.status).toBe(404);
+	}
+	expect(requestedKeys).toEqual([]);
 });
 
 test('HEAD on root returns the shell headers without a body', async () => {
@@ -225,7 +204,7 @@ test('encoded traversal 404s without ever touching the bucket', async () => {
 // Projection reads
 // ============================================================================
 
-const PAGE_KEY = 'routes/braden/first-artifact/index.html';
+const PAGE_KEY = 'braden/first-artifact/index.html';
 
 test('published page serves with html content-type, etag, and delivery cache policy', async () => {
 	const { fetch } = setup({
@@ -239,7 +218,9 @@ test('published page serves with html content-type, etag, and delivery cache pol
 	expect(response.headers.get('cache-control')).toBe(
 		'public, max-age=300, must-revalidate',
 	);
-	expect(response.headers.get('accept-ranges')).toBe('bytes');
+	expect(response.headers.get('content-security-policy')).toContain(
+		"default-src 'none'",
+	);
 });
 
 test('query strings do not change the resolved object', async () => {
@@ -278,18 +259,18 @@ test('HEAD on a missing projection has a 404 status and empty body', async () =>
 });
 
 test('artifact output without stored content-type falls back to octet-stream', async () => {
-	const key = `artifacts/${ARTIFACT_ID}/blob.bin`;
+	const key = 'braden/first-artifact/blob.bin';
 	const { fetch } = setup({ [key]: { data: 'binary' } });
-	const response = await fetch(`/_artifacts/${ARTIFACT_ID}/blob.bin`);
+	const response = await fetch('/braden/first-artifact/blob.bin');
 	expect(response.headers.get('content-type')).toBe('application/octet-stream');
 });
 
 test('stored content-type wins over the fallback', async () => {
-	const key = `artifacts/${ARTIFACT_ID}/cover.png`;
+	const key = 'braden/first-artifact/cover.png';
 	const { fetch } = setup({
 		[key]: { data: 'png-bytes', contentType: 'image/png' },
 	});
-	const response = await fetch(`/_artifacts/${ARTIFACT_ID}/cover.png`);
+	const response = await fetch('/braden/first-artifact/cover.png');
 	expect(response.headers.get('content-type')).toBe('image/png');
 });
 
@@ -302,7 +283,7 @@ test('HEAD on a projection reports size without a body', async () => {
 });
 
 // ============================================================================
-// Conditional and Range reads
+// Conditional reads
 // ============================================================================
 
 test('matching If-None-Match returns 304 with the etag and no body', async () => {
@@ -321,55 +302,4 @@ test('failing If-Match returns 412', async () => {
 		headers: { 'if-match': '"some-other-etag"' },
 	});
 	expect(response.status).toBe(412);
-});
-
-const VIDEO_KEY = `artifacts/${ARTIFACT_ID}/video.mp4`;
-
-test('bounded range returns 206 with content-range and the exact slice', async () => {
-	const { fetch } = setup({
-		[VIDEO_KEY]: { data: '0123456789', contentType: 'video/mp4' },
-	});
-	const response = await fetch(`/_artifacts/${ARTIFACT_ID}/video.mp4`, {
-		headers: { range: 'bytes=0-4' },
-	});
-	expect(response.status).toBe(206);
-	expect(response.headers.get('content-range')).toBe('bytes 0-4/10');
-	expect(response.headers.get('content-length')).toBe('5');
-	expect(await response.text()).toBe('01234');
-});
-
-test('suffix range returns the final bytes', async () => {
-	const { fetch } = setup({
-		[VIDEO_KEY]: { data: '0123456789', contentType: 'video/mp4' },
-	});
-	const response = await fetch(`/_artifacts/${ARTIFACT_ID}/video.mp4`, {
-		headers: { range: 'bytes=-3' },
-	});
-	expect(response.status).toBe(206);
-	expect(response.headers.get('content-range')).toBe('bytes 7-9/10');
-	expect(await response.text()).toBe('789');
-});
-
-test('unsatisfiable range returns 416', async () => {
-	const { fetch } = setup({
-		[VIDEO_KEY]: { data: '0123456789', contentType: 'video/mp4' },
-	});
-	const response = await fetch(`/_artifacts/${ARTIFACT_ID}/video.mp4`, {
-		headers: { range: 'bytes=99-' },
-	});
-	expect(response.status).toBe(416);
-	expect(response.headers.get('content-range')).toBe('bytes */10');
-});
-
-test('malformed and multi-part ranges return 416', async () => {
-	const { fetch } = setup({
-		[VIDEO_KEY]: { data: '0123456789', contentType: 'video/mp4' },
-	});
-	for (const range of ['bytes=oops', 'bytes=0-1,4-5']) {
-		const response = await fetch(`/_artifacts/${ARTIFACT_ID}/video.mp4`, {
-			headers: { range },
-		});
-		expect(response.status).toBe(416);
-		expect(response.headers.get('content-range')).toBe('bytes */10');
-	}
 });

--- a/apps/theark/src/index.test.ts
+++ b/apps/theark/src/index.test.ts
@@ -8,6 +8,8 @@
  *
  * Key behaviors:
  * - URL to R2 key mapping: each artifact owns one page-and-media subtree
+ * - Only the closed media vocabulary (video.mp4, narration.mp3, cover.png)
+ *   names a file projection; every other filename is 404 before touching R2
  * - Hostile paths (traversal, encoding, uppercase) 404 before touching R2
  * - Trailing slashes 308-redirect to the slashless canonical URL
  * - Only GET and HEAD are allowed; conditional reads behave
@@ -108,11 +110,25 @@ describe('resolveProjection', () => {
 		});
 	});
 
-	test('artifact output lives beside its human-readable permalink', () => {
-		expect(resolveProjection('/braden/first-artifact/video.mp4')).toEqual({
-			key: 'braden/first-artifact/video.mp4',
-			isPage: false,
-		});
+	test('the closed media vocabulary resolves beside its human-readable permalink', () => {
+		for (const file of ['video.mp4', 'narration.mp3', 'cover.png']) {
+			expect(resolveProjection(`/braden/first-artifact/${file}`)).toEqual({
+				key: `braden/first-artifact/${file}`,
+				isPage: false,
+			});
+		}
+	});
+
+	test('filenames outside the closed media vocabulary are refused', () => {
+		for (const file of [
+			'blob.bin',
+			'notes.txt',
+			'cover.jpg',
+			'video.mp4.bak',
+			'poster.png',
+		]) {
+			expect(resolveProjection(`/braden/first-artifact/${file}`)).toBeNull();
+		}
 	});
 
 	test('rejects uppercase, underscores, dotfiles, double dots, and empty segments', () => {
@@ -139,7 +155,7 @@ describe('resolveProjection', () => {
 	test('rejects syntactically valid paths that exceed the R2 key limit', () => {
 		expect(resolveProjection(`/braden/${'a'.repeat(1010)}`)).toBeNull();
 		expect(
-			resolveProjection(`/braden/slug/${'a'.repeat(1010)}.png`),
+			resolveProjection(`/braden/${'a'.repeat(1010)}/video.mp4`),
 		).toBeNull();
 	});
 });
@@ -258,11 +274,20 @@ test('HEAD on a missing projection has a 404 status and empty body', async () =>
 	expect(await response.text()).toBe('');
 });
 
-test('artifact output without stored content-type falls back to octet-stream', async () => {
-	const key = 'braden/first-artifact/blob.bin';
+test('media without stored content-type falls back to octet-stream', async () => {
+	const key = 'braden/first-artifact/video.mp4';
 	const { fetch } = setup({ [key]: { data: 'binary' } });
-	const response = await fetch('/braden/first-artifact/blob.bin');
+	const response = await fetch('/braden/first-artifact/video.mp4');
 	expect(response.headers.get('content-type')).toBe('application/octet-stream');
+});
+
+test('media outside the closed vocabulary 404s even when a stray object exists', async () => {
+	const { fetch, requestedKeys } = setup({
+		'braden/first-artifact/blob.bin': { data: 'stray' },
+	});
+	const response = await fetch('/braden/first-artifact/blob.bin');
+	expect(response.status).toBe(404);
+	expect(requestedKeys).toEqual([]);
 });
 
 test('stored content-type wins over the fallback', async () => {

--- a/apps/theark/src/index.ts
+++ b/apps/theark/src/index.ts
@@ -2,8 +2,9 @@
  * The Ark public delivery plane.
  *
  * One responsibility: resolve a public URL to a rebuildable projection object
- * in R2 and stream it. The publishing side (the Vault) writes the objects;
- * a publication appears by writing R2 keys, never by redeploying this Worker.
+ * in R2 and stream it. The Vault initiates Publish through an injected port;
+ * an authenticated Epicenter publisher writes the objects. A publication
+ * appears by writing R2 keys, never by redeploying this Worker.
  *
  * URL contract (the canonical artifact permalink is
  * `https://theark.so/braden/<artifact-slug>`):

--- a/apps/theark/src/index.ts
+++ b/apps/theark/src/index.ts
@@ -13,10 +13,11 @@
  *   /<identity>[/<slug-or-facet>]         R2 `<path>/index.html`
  *   /<identity>/<artifact-slug>/<file>    R2 `<path>/<file>`
  *
- * A pretty segment is lowercase-hyphenated ([a-z0-9-]); a file segment adds
- * dot-separated extensions. Anything else is 404 before R2 is consulted, so
- * traversal or encoded surprises never become object keys. Trailing slashes
- * 308-redirect to the slashless canonical form.
+ * A pretty segment is lowercase-hyphenated ([a-z0-9-]); a file segment must be
+ * exactly one of the three generated media names (the closed vocabulary
+ * below). Anything else is 404 before R2 is consulted, so traversal, encoded
+ * surprises, or a stray bucket object never become public addresses. Trailing
+ * slashes 308-redirect to the slashless canonical form.
  *
  * Only GET and HEAD exist. There is no write route, no auth, no API: the
  * bucket binding's write capability is deliberately unused (see the ADR).
@@ -34,7 +35,15 @@
 const PROJECTION_CACHE_CONTROL = 'public, max-age=300, must-revalidate';
 
 const PRETTY_SEGMENT = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
-const FILE_SEGMENT = /^[a-z0-9][a-z0-9-]*(?:\.[a-z0-9]+)+$/;
+/**
+ * The complete generated-media vocabulary. There is no general upload
+ * pipeline, so no other filename can ever name a projection; refusing the
+ * rest here means even a stray object at another key is publicly unroutable.
+ * The publisher kernel derives every key it writes through
+ * `resolveProjection`, so this set and the kernel's media list cannot drift
+ * apart without publishing failing loudly.
+ */
+const MEDIA_FILES = new Set(['video.mp4', 'narration.mp3', 'cover.png']);
 const RESERVED_IDENTITIES = new Set(['assets']);
 // The Assets binding resolves by pathname. A deliberately non-public host
 // prevents its internal fetch from re-entering this Worker's workers.dev or
@@ -63,8 +72,7 @@ export function resolveProjection(pathname: string): ResolvedProjection | null {
 		segments.length === 3 &&
 		PRETTY_SEGMENT.test(segments[0] ?? '') &&
 		PRETTY_SEGMENT.test(segments[1] ?? '') &&
-		FILE_SEGMENT.test(segments[2] ?? '') &&
-		segments[2] !== 'index.html'
+		MEDIA_FILES.has(segments[2] ?? '')
 	) {
 		const key = segments.join('/');
 		if (key.length > 1024) return null;

--- a/apps/theark/src/index.ts
+++ b/apps/theark/src/index.ts
@@ -162,6 +162,10 @@ export async function handleRequest(
 
 	if (url.pathname.endsWith('/')) {
 		const canonical = new URL(url);
+		// The Ark is HTTPS-only. Cloudflare may present an internal `http:` URL
+		// to the Worker even when the public request arrived over TLS, so never
+		// let that implementation detail become a downgrade redirect.
+		canonical.protocol = 'https:';
 		canonical.pathname = url.pathname.replace(/\/+$/, '') || '/';
 		return Response.redirect(canonical.toString(), 308);
 	}

--- a/apps/theark/src/index.ts
+++ b/apps/theark/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * The Ark public delivery plane.
  *
- * One responsibility: resolve a public URL to an immutable projection object
+ * One responsibility: resolve a public URL to a rebuildable projection object
  * in R2 and stream it. The publishing side (the Vault) writes the objects;
  * a publication appears by writing R2 keys, never by redeploying this Worker.
  *
@@ -9,8 +9,8 @@
  * `https://theark.so/braden/<artifact-slug>`):
  *
  *   /                              deploy-time home shell from static assets
- *   /<identity>[/<slug-or-facet>]  R2 `routes/<path>/index.html`
- *   /_artifacts/<uuid>/<file.ext>  R2 `artifacts/<uuid>/<file.ext>`
+ *   /<identity>[/<slug-or-facet>]         R2 `<path>/index.html`
+ *   /<identity>/<artifact-slug>/<file>    R2 `<path>/<file>`
  *
  * A pretty segment is lowercase-hyphenated ([a-z0-9-]); a file segment adds
  * dot-separated extensions. Anything else is 404 before R2 is consulted, so
@@ -34,8 +34,7 @@ const PROJECTION_CACHE_CONTROL = 'public, max-age=300, must-revalidate';
 
 const PRETTY_SEGMENT = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const FILE_SEGMENT = /^[a-z0-9][a-z0-9-]*(?:\.[a-z0-9]+)+$/;
-const ARTIFACT_ID =
-	/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const RESERVED_IDENTITIES = new Set(['assets']);
 // The Assets binding resolves by pathname. A deliberately non-public host
 // prevents its internal fetch from re-entering this Worker's workers.dev or
 // custom-domain route (Cloudflare error 1042).
@@ -49,24 +48,27 @@ type ResolvedProjection = {
 
 /**
  * Map a slashless pathname to its R2 object key, or null when the path can
- * never name a projection. Human-readable routes and immutable artifact
- * outputs occupy disjoint namespaces: a route has one or two pretty
- * segments, while an output is addressed only through its UUIDv7 artifact
- * identity. Percent-encoded aliases are refused so every accepted pathname
- * is already its one canonical ASCII spelling.
+ * never name a projection. Every artifact owns one public subtree: its page
+ * lives at `/<identity>/<slug>` and its generated files live immediately
+ * beneath that permalink. Percent-encoded aliases are refused so every
+ * accepted pathname is already its one canonical ASCII spelling.
  */
 export function resolveProjection(pathname: string): ResolvedProjection | null {
 	if (!pathname.startsWith('/') || pathname.includes('%')) return null;
 	const segments = pathname.slice(1).split('/');
+	if (RESERVED_IDENTITIES.has(segments[0] ?? '')) return null;
 
 	if (
 		segments.length === 3 &&
-		segments[0] === '_artifacts' &&
-		ARTIFACT_ID.test(segments[1] ?? '') &&
-		FILE_SEGMENT.test(segments[2] ?? '')
+		PRETTY_SEGMENT.test(segments[0] ?? '') &&
+		PRETTY_SEGMENT.test(segments[1] ?? '') &&
+		FILE_SEGMENT.test(segments[2] ?? '') &&
+		segments[2] !== 'index.html'
 	) {
+		const key = segments.join('/');
+		if (key.length > 1024) return null;
 		return {
-			key: `artifacts/${segments[1]}/${segments[2]}`,
+			key,
 			isPage: false,
 		};
 	}
@@ -75,8 +77,10 @@ export function resolveProjection(pathname: string): ResolvedProjection | null {
 		(segments.length === 1 || segments.length === 2) &&
 		segments.every((segment) => PRETTY_SEGMENT.test(segment))
 	) {
+		const key = `${segments.join('/')}/index.html`;
+		if (key.length > 1024) return null;
 		return {
-			key: `routes/${segments.join('/')}/index.html`,
+			key,
 			isPage: true,
 		};
 	}
@@ -98,38 +102,12 @@ function projectionHeaders(
 	}
 	headers.set('etag', object.httpEtag);
 	headers.set('cache-control', PROJECTION_CACHE_CONTROL);
-	headers.set('accept-ranges', 'bytes');
+	headers.set(
+		'content-security-policy',
+		"default-src 'none'; style-src 'self'; img-src 'self' data:; media-src 'self'; font-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'",
+	);
 	headers.set('x-content-type-options', 'nosniff');
 	return headers;
-}
-
-/** Resolve the one HTTP byte-range form The Ark supports. */
-function resolveByteRange(
-	header: string,
-	size: number,
-): { offset: number; length: number } | null {
-	const match = /^bytes=(\d*)-(\d*)$/.exec(header);
-	if (!match || (!match[1] && !match[2])) return null;
-
-	if (!match[1]) {
-		const suffix = Number(match[2]);
-		if (!Number.isSafeInteger(suffix) || suffix <= 0) return null;
-		const length = Math.min(suffix, size);
-		return { offset: size - length, length };
-	}
-
-	const offset = Number(match[1]);
-	const requestedEnd = match[2] ? Number(match[2]) : size - 1;
-	if (
-		!Number.isSafeInteger(offset) ||
-		!Number.isSafeInteger(requestedEnd) ||
-		offset >= size ||
-		requestedEnd < offset
-	) {
-		return null;
-	}
-	const end = Math.min(requestedEnd, size - 1);
-	return { offset, length: end - offset + 1 };
 }
 
 async function serveNotFound(request: Request, env: Env): Promise<Response> {
@@ -148,10 +126,6 @@ async function serveNotFound(request: Request, env: Env): Promise<Response> {
 			'x-content-type-options': 'nosniff',
 		},
 	});
-}
-
-function isUnsatisfiableRange(error: unknown): boolean {
-	return error instanceof Error && error.message.includes('(10039)');
 }
 
 export async function handleRequest(
@@ -194,29 +168,9 @@ export async function handleRequest(
 		return new Response(null, { status: 200, headers });
 	}
 
-	let object: R2Object | R2ObjectBody | null;
-	try {
-		object = await env.PROJECTIONS.get(projection.key, {
-			onlyIf: request.headers,
-			range: request.headers,
-		});
-	} catch (error) {
-		// R2 rejects a malformed or unsatisfiable Range instead of returning
-		// null. Only its documented range error becomes 416; an unrelated R2
-		// failure must remain a 5xx rather than being mislabeled as client input.
-		if (request.headers.has('range') && isUnsatisfiableRange(error)) {
-			const metadata = await env.PROJECTIONS.head(projection.key);
-			const headers = new Headers({ 'accept-ranges': 'bytes' });
-			if (metadata) {
-				headers.set('content-range', `bytes */${metadata.size}`);
-			}
-			return new Response('Range Not Satisfiable', {
-				status: 416,
-				headers,
-			});
-		}
-		throw error;
-	}
+	const object = await env.PROJECTIONS.get(projection.key, {
+		onlyIf: request.headers,
+	});
 	if (!object) return serveNotFound(request, env);
 
 	const headers = projectionHeaders(object, projection);
@@ -231,25 +185,6 @@ export async function handleRequest(
 			status: wantsNotModified ? 304 : 412,
 			headers,
 		});
-	}
-
-	const rangeHeader = request.headers.get('range');
-	if (rangeHeader) {
-		const range = resolveByteRange(rangeHeader, object.size);
-		if (!range) {
-			headers.set('content-range', `bytes */${object.size}`);
-			return new Response('Range Not Satisfiable', {
-				status: 416,
-				headers,
-			});
-		}
-		const { offset, length } = range;
-		headers.set(
-			'content-range',
-			`bytes ${offset}-${offset + length - 1}/${object.size}`,
-		);
-		headers.set('content-length', String(length));
-		return new Response(object.body, { status: 206, headers });
 	}
 
 	headers.set('content-length', String(object.size));

--- a/apps/theark/src/publish.test.ts
+++ b/apps/theark/src/publish.test.ts
@@ -82,8 +82,7 @@ describe('publishProjection', () => {
 			'braden/first-artifact/index.html',
 		]);
 		expect(result.url).toBe('https://theark.so/braden/first-artifact');
-		expect(result.republished).toBe(false);
-		expect(result.keys).toEqual(putOrder.slice(1));
+		expect(result.publishedOn).toBe('2026-07-20');
 		expect(objects.get('braden/first-artifact/video.mp4')?.contentType).toBe(
 			'video/mp4',
 		);
@@ -107,6 +106,7 @@ describe('publishProjection', () => {
 		expect(marker).toEqual({
 			artifact: '01880000-0000-7000-8000-000000000001',
 			expression: DIGEST_A,
+			publishedOn: '2026-07-20',
 		});
 	});
 
@@ -120,12 +120,29 @@ describe('publishProjection', () => {
 		const { store, putOrder } = memoryStore();
 		await publishProjection(store, publication());
 		const retry = await publishProjection(store, publication());
-		expect(retry.republished).toBe(true);
+		expect(retry.publishedOn).toBe('2026-07-20');
 		// The page was rewritten (theme rebuilds stay free); the marker was not.
 		expect(putOrder.filter((key) => key === MARKER_KEY)).toHaveLength(1);
 		expect(putOrder.filter((key) => key.endsWith('index.html'))).toHaveLength(
 			2,
 		);
+	});
+
+	test('an exact retry preserves the first reservation date', async () => {
+		const { store, objects } = memoryStore();
+		await publishProjection(store, publication());
+		const retry = await publishProjection(
+			store,
+			publication({
+				page: { ...publication().page, publishedOn: '2026-07-21' },
+			}),
+		);
+		expect(retry.publishedOn).toBe('2026-07-20');
+		expect(
+			new TextDecoder().decode(
+				objects.get('braden/first-artifact/index.html')?.value,
+			),
+		).toContain('datetime="2026-07-20"');
 	});
 
 	test('a different artifact can never take over a frozen permalink', async () => {
@@ -163,6 +180,17 @@ describe('publishProjection', () => {
 				publishProjection(store, publication({ expressionDigest })),
 			).rejects.toThrow('64 lowercase hex');
 		}
+		expect(putOrder).toEqual([]);
+	});
+
+	test('refuses a malformed publication date before touching the store', async () => {
+		const { store, putOrder } = memoryStore();
+		await expect(
+			publishProjection(store, {
+				...publication(),
+				page: { ...publication().page, publishedOn: 'someday' },
+			}),
+		).rejects.toThrow('YYYY-MM-DD');
 		expect(putOrder).toEqual([]);
 	});
 
@@ -245,6 +273,7 @@ describe('reservation race', () => {
 		const { store, putOrder } = racingStore({
 			artifact: '01880000-0000-7000-8000-00000000beef',
 			expression: DIGEST_B,
+			publishedOn: '2026-07-20',
 		});
 		await expect(publishProjection(store, publication())).rejects.toThrow(
 			'already published by another artifact',
@@ -256,9 +285,10 @@ describe('reservation race', () => {
 		const { store, putOrder } = racingStore({
 			artifact: '01880000-0000-7000-8000-000000000001',
 			expression: DIGEST_A,
+			publishedOn: '2026-07-19',
 		});
 		const result = await publishProjection(store, publication());
-		expect(result.republished).toBe(true);
+		expect(result.publishedOn).toBe('2026-07-19');
 		expect(putOrder).toEqual(['braden/first-artifact/index.html']);
 	});
 

--- a/apps/theark/src/publish.test.ts
+++ b/apps/theark/src/publish.test.ts
@@ -2,10 +2,11 @@
  * Publisher kernel tests.
  *
  * An in-memory store proves the whole authenticated orchestration without
- * credentials or production resources: reserve-first ownership, route-last
- * activation, idempotent retry, collision refusal, and read-back
- * verification. The final tests close the seam end to end: bytes written by
- * the kernel are served back through the delivery Worker's real
+ * credentials or production resources: atomic reserve-first ownership keyed
+ * on artifact id plus expression digest, route-last activation, idempotent
+ * retry, collision and changed-expression refusal, the creation race, and
+ * read-back verification. The final tests close the seam end to end: bytes
+ * written by the kernel are served back through the delivery Worker's real
  * `handleRequest` over the same store.
  */
 import { describe, expect, test } from 'bun:test';
@@ -30,22 +31,33 @@ function memoryStore() {
 			putOrder.push(key);
 			objects.set(key, { value, contentType });
 		},
+		// Mirrors R2 `onlyIf: { etagDoesNotMatch: '*' }`: an existing key makes
+		// the write a no-op that resolves unsuccessful.
+		async createExclusive(key, value, { contentType }) {
+			if (objects.has(key)) return false;
+			putOrder.push(key);
+			objects.set(key, { value, contentType });
+			return true;
+		},
 	};
 	return { store, objects, putOrder };
 }
 
 const bytes = (text: string) => new TextEncoder().encode(text);
+const DIGEST_A = 'ab'.repeat(32);
+const DIGEST_B = 'cd'.repeat(32);
+const MARKER_KEY = 'braden/first-artifact/.artifact';
 
 const publication = (
 	overrides: Partial<ArkPublication> = {},
 ): ArkPublication => ({
 	artifactId: '01880000-0000-7000-8000-000000000001',
+	expressionDigest: DIGEST_A,
 	page: {
 		identity: 'braden',
 		slug: 'first-artifact',
-		title: 'First Artifact',
 		publishedOn: '2026-07-20',
-		body: 'Frozen words.',
+		body: '# First Artifact\n\nFrozen words.',
 	},
 	...overrides,
 });
@@ -63,7 +75,7 @@ describe('publishProjection', () => {
 		});
 
 		expect(putOrder).toEqual([
-			'braden/first-artifact/.artifact',
+			MARKER_KEY,
 			'braden/first-artifact/video.mp4',
 			'braden/first-artifact/narration.mp3',
 			'braden/first-artifact/cover.png',
@@ -86,21 +98,34 @@ describe('publishProjection', () => {
 		);
 	});
 
+	test('the marker records artifact id and expression digest', async () => {
+		const { store, objects } = memoryStore();
+		await publishProjection(store, publication());
+		const marker = JSON.parse(
+			new TextDecoder().decode(objects.get(MARKER_KEY)?.value),
+		);
+		expect(marker).toEqual({
+			artifact: '01880000-0000-7000-8000-000000000001',
+			expression: DIGEST_A,
+		});
+	});
+
 	test('a text-only publication writes exactly the marker and the page', async () => {
 		const { store, putOrder } = memoryStore();
 		await publishProjection(store, publication());
-		expect(putOrder).toEqual([
-			'braden/first-artifact/.artifact',
-			'braden/first-artifact/index.html',
-		]);
+		expect(putOrder).toEqual([MARKER_KEY, 'braden/first-artifact/index.html']);
 	});
 
-	test('republishing the same artifact converges without re-reserving', async () => {
+	test('republishing the same artifact and expression converges without re-reserving', async () => {
 		const { store, putOrder } = memoryStore();
 		await publishProjection(store, publication());
 		const retry = await publishProjection(store, publication());
 		expect(retry.republished).toBe(true);
-		expect(putOrder.filter((key) => key.endsWith('.artifact'))).toHaveLength(1);
+		// The page was rewritten (theme rebuilds stay free); the marker was not.
+		expect(putOrder.filter((key) => key === MARKER_KEY)).toHaveLength(1);
+		expect(putOrder.filter((key) => key.endsWith('index.html'))).toHaveLength(
+			2,
+		);
 	});
 
 	test('a different artifact can never take over a frozen permalink', async () => {
@@ -114,6 +139,43 @@ describe('publishProjection', () => {
 			),
 		).rejects.toThrow('already published by another artifact');
 		expect(putOrder).toHaveLength(writesBefore);
+	});
+
+	test('the same artifact with a different frozen expression is refused', async () => {
+		const { store, putOrder } = memoryStore();
+		await publishProjection(store, publication());
+		const writesBefore = putOrder.length;
+		await expect(
+			publishProjection(store, publication({ expressionDigest: DIGEST_B })),
+		).rejects.toThrow('different frozen expression');
+		expect(putOrder).toHaveLength(writesBefore);
+	});
+
+	test('refuses a malformed expression digest before touching the store', async () => {
+		const { store, putOrder } = memoryStore();
+		for (const expressionDigest of [
+			'',
+			'not-hex',
+			'AB'.repeat(32),
+			'ab'.repeat(31),
+		]) {
+			await expect(
+				publishProjection(store, publication({ expressionDigest })),
+			).rejects.toThrow('64 lowercase hex');
+		}
+		expect(putOrder).toEqual([]);
+	});
+
+	test('refuses to publish over an unrecognized ownership marker', async () => {
+		const { store, objects, putOrder } = memoryStore();
+		objects.set(MARKER_KEY, {
+			value: bytes('legacy-or-corrupt'),
+			contentType: 'text/plain',
+		});
+		await expect(publishProjection(store, publication())).rejects.toThrow(
+			'unrecognized ownership marker',
+		);
+		expect(putOrder).toEqual([]);
 	});
 
 	test('refuses addresses the delivery Worker would refuse to serve', async () => {
@@ -149,6 +211,69 @@ describe('publishProjection', () => {
 
 	test('the ownership marker is publicly unroutable by construction', () => {
 		expect(resolveProjection('/braden/first-artifact/.artifact')).toBeNull();
+	});
+});
+
+// ============================================================================
+// The reservation race
+// ============================================================================
+
+/**
+ * A store where a competitor lands its marker between this publisher's
+ * absence check and its atomic create, so `createExclusive` must lose.
+ */
+function racingStore(competitorMarker: object) {
+	const { store, objects, putOrder } = memoryStore();
+	const raced: ArkObjectStore = {
+		...store,
+		async createExclusive(key, value, options) {
+			if (!objects.has(key)) {
+				objects.set(key, {
+					value: bytes(JSON.stringify(competitorMarker)),
+					contentType: 'application/json',
+				});
+				return false;
+			}
+			return store.createExclusive(key, value, options);
+		},
+	};
+	return { store: raced, objects, putOrder };
+}
+
+describe('reservation race', () => {
+	test('losing the atomic create to another artifact refuses with zero public writes', async () => {
+		const { store, putOrder } = racingStore({
+			artifact: '01880000-0000-7000-8000-00000000beef',
+			expression: DIGEST_B,
+		});
+		await expect(publishProjection(store, publication())).rejects.toThrow(
+			'already published by another artifact',
+		);
+		expect(putOrder).toEqual([]);
+	});
+
+	test('losing the atomic create to our own duplicate retry converges', async () => {
+		const { store, putOrder } = racingStore({
+			artifact: '01880000-0000-7000-8000-000000000001',
+			expression: DIGEST_A,
+		});
+		const result = await publishProjection(store, publication());
+		expect(result.republished).toBe(true);
+		expect(putOrder).toEqual(['braden/first-artifact/index.html']);
+	});
+
+	test('createExclusive never overwrites an existing key', async () => {
+		const { store, objects } = memoryStore();
+		await store.createExclusive(MARKER_KEY, bytes('first'), {
+			contentType: 'application/json',
+		});
+		const second = await store.createExclusive(MARKER_KEY, bytes('second'), {
+			contentType: 'application/json',
+		});
+		expect(second).toBe(false);
+		expect(new TextDecoder().decode(objects.get(MARKER_KEY)?.value)).toBe(
+			'first',
+		);
 	});
 });
 
@@ -198,11 +323,10 @@ describe('publish-to-read round trip', () => {
 				page: {
 					identity: 'braden',
 					slug: 'first-artifact',
-					title: 'First Artifact',
 					subtitle: 'The words as released',
 					publishedOn: '2026-07-20',
 					resonant: true,
-					body: 'Frozen words with a [link](https://example.com).\n\n> Kept exactly.',
+					body: '# First Artifact\n\nFrozen words with a [link](https://example.com).\n\n> Kept exactly.',
 				},
 			}),
 			files: { video: bytes('vvv'), cover: bytes('ccc') },
@@ -231,7 +355,7 @@ describe('publish-to-read round trip', () => {
 	test('the ownership marker never serves publicly even though it exists', async () => {
 		const { store, objects } = memoryStore();
 		const { url } = await publishProjection(store, publication());
-		expect(objects.has('braden/first-artifact/.artifact')).toBe(true);
+		expect(objects.has(MARKER_KEY)).toBe(true);
 		const response = await handleRequest(
 			new Request(`${url}/.artifact`),
 			workerEnvOver(objects),

--- a/apps/theark/src/publish.test.ts
+++ b/apps/theark/src/publish.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Publisher kernel tests.
+ *
+ * An in-memory store proves the whole authenticated orchestration without
+ * credentials or production resources: reserve-first ownership, route-last
+ * activation, idempotent retry, collision refusal, and read-back
+ * verification. The final tests close the seam end to end: bytes written by
+ * the kernel are served back through the delivery Worker's real
+ * `handleRequest` over the same store.
+ */
+import { describe, expect, test } from 'bun:test';
+
+import { handleRequest, resolveProjection } from './index';
+import {
+	type ArkObjectStore,
+	type ArkPublication,
+	publishProjection,
+} from './publish';
+
+type StoredObject = { value: Uint8Array; contentType: string };
+
+function memoryStore() {
+	const objects = new Map<string, StoredObject>();
+	const putOrder: string[] = [];
+	const store: ArkObjectStore = {
+		async get(key) {
+			return objects.get(key)?.value ?? null;
+		},
+		async put(key, value, { contentType }) {
+			putOrder.push(key);
+			objects.set(key, { value, contentType });
+		},
+	};
+	return { store, objects, putOrder };
+}
+
+const bytes = (text: string) => new TextEncoder().encode(text);
+
+const publication = (
+	overrides: Partial<ArkPublication> = {},
+): ArkPublication => ({
+	artifactId: '01880000-0000-7000-8000-000000000001',
+	page: {
+		identity: 'braden',
+		slug: 'first-artifact',
+		title: 'First Artifact',
+		publishedOn: '2026-07-20',
+		body: 'Frozen words.',
+	},
+	...overrides,
+});
+
+// ============================================================================
+// Ordering, ownership, and idempotency
+// ============================================================================
+
+describe('publishProjection', () => {
+	test('reserves first, writes media, activates the page last', async () => {
+		const { store, objects, putOrder } = memoryStore();
+		const result = await publishProjection(store, {
+			...publication(),
+			files: { video: bytes('v'), narration: bytes('n'), cover: bytes('c') },
+		});
+
+		expect(putOrder).toEqual([
+			'braden/first-artifact/.artifact',
+			'braden/first-artifact/video.mp4',
+			'braden/first-artifact/narration.mp3',
+			'braden/first-artifact/cover.png',
+			'braden/first-artifact/index.html',
+		]);
+		expect(result.url).toBe('https://theark.so/braden/first-artifact');
+		expect(result.republished).toBe(false);
+		expect(result.keys).toEqual(putOrder.slice(1));
+		expect(objects.get('braden/first-artifact/video.mp4')?.contentType).toBe(
+			'video/mp4',
+		);
+		expect(
+			objects.get('braden/first-artifact/narration.mp3')?.contentType,
+		).toBe('audio/mpeg');
+		expect(objects.get('braden/first-artifact/cover.png')?.contentType).toBe(
+			'image/png',
+		);
+		expect(objects.get('braden/first-artifact/index.html')?.contentType).toBe(
+			'text/html; charset=utf-8',
+		);
+	});
+
+	test('a text-only publication writes exactly the marker and the page', async () => {
+		const { store, putOrder } = memoryStore();
+		await publishProjection(store, publication());
+		expect(putOrder).toEqual([
+			'braden/first-artifact/.artifact',
+			'braden/first-artifact/index.html',
+		]);
+	});
+
+	test('republishing the same artifact converges without re-reserving', async () => {
+		const { store, putOrder } = memoryStore();
+		await publishProjection(store, publication());
+		const retry = await publishProjection(store, publication());
+		expect(retry.republished).toBe(true);
+		expect(putOrder.filter((key) => key.endsWith('.artifact'))).toHaveLength(1);
+	});
+
+	test('a different artifact can never take over a frozen permalink', async () => {
+		const { store, putOrder } = memoryStore();
+		await publishProjection(store, publication());
+		const writesBefore = putOrder.length;
+		await expect(
+			publishProjection(
+				store,
+				publication({ artifactId: '01880000-0000-7000-8000-000000000002' }),
+			),
+		).rejects.toThrow('already published by another artifact');
+		expect(putOrder).toHaveLength(writesBefore);
+	});
+
+	test('refuses addresses the delivery Worker would refuse to serve', async () => {
+		const { store, putOrder } = memoryStore();
+		for (const [identity, slug] of [
+			['Braden', 'ok'],
+			['braden', 'Not_A_Slug'],
+			['assets', 'theark'],
+		] as const) {
+			await expect(
+				publishProjection(store, {
+					...publication(),
+					page: { ...publication().page, identity, slug },
+				}),
+			).rejects.toThrow('not a servable artifact address');
+		}
+		expect(putOrder).toEqual([]);
+	});
+
+	test('read-back verification catches a store that lies', async () => {
+		const { store } = memoryStore();
+		const lying: ArkObjectStore = {
+			...store,
+			async get(key) {
+				// Honest about the unclaimed marker, corrupt on every read-back.
+				return key.endsWith('.artifact') ? null : bytes('corrupted');
+			},
+		};
+		await expect(publishProjection(lying, publication())).rejects.toThrow(
+			'read-back after write did not match',
+		);
+	});
+
+	test('the ownership marker is publicly unroutable by construction', () => {
+		expect(resolveProjection('/braden/first-artifact/.artifact')).toBeNull();
+	});
+});
+
+// ============================================================================
+// End to end: kernel writes, the public Worker serves
+// ============================================================================
+
+/** Adapt the in-memory store to the R2 read surface handleRequest uses. */
+function workerEnvOver(objects: Map<string, StoredObject>) {
+	const meta = (key: string, stored: StoredObject) => ({
+		key,
+		size: stored.value.length,
+		httpEtag: `"etag-${key}"`,
+		writeHttpMetadata(headers: Headers) {
+			headers.set('content-type', stored.contentType);
+		},
+	});
+	return {
+		PROJECTIONS: {
+			async head(key: string) {
+				const stored = objects.get(key);
+				return stored ? meta(key, stored) : null;
+			},
+			async get(key: string) {
+				const stored = objects.get(key);
+				return stored
+					? { ...meta(key, stored), body: new Response(stored.value).body }
+					: null;
+			},
+		},
+		ASSETS: {
+			async fetch() {
+				return new Response('<not-found shell>', {
+					status: 200,
+					headers: { 'content-type': 'text/html; charset=utf-8' },
+				});
+			},
+		},
+	} as unknown as Env;
+}
+
+describe('publish-to-read round trip', () => {
+	test('a published artifact serves through the delivery plane under its CSP', async () => {
+		const { store, objects } = memoryStore();
+		const { url } = await publishProjection(store, {
+			...publication({
+				page: {
+					identity: 'braden',
+					slug: 'first-artifact',
+					title: 'First Artifact',
+					subtitle: 'The words as released',
+					publishedOn: '2026-07-20',
+					resonant: true,
+					body: 'Frozen words with a [link](https://example.com).\n\n> Kept exactly.',
+				},
+			}),
+			files: { video: bytes('vvv'), cover: bytes('ccc') },
+		});
+		const env = workerEnvOver(objects);
+
+		const pageResponse = await handleRequest(new Request(url), env);
+		expect(pageResponse.status).toBe(200);
+		expect(pageResponse.headers.get('content-type')).toBe(
+			'text/html; charset=utf-8',
+		);
+		expect(pageResponse.headers.get('content-security-policy')).toContain(
+			"default-src 'none'",
+		);
+		const html = await pageResponse.text();
+		expect(html).toContain('<h1>First Artifact</h1>');
+		expect(html).toContain('<a href="https://example.com">link</a>');
+		expect(html).toContain('poster="/braden/first-artifact/cover.png"');
+
+		const video = await handleRequest(new Request(`${url}/video.mp4`), env);
+		expect(video.status).toBe(200);
+		expect(video.headers.get('content-type')).toBe('video/mp4');
+		expect(await video.text()).toBe('vvv');
+	});
+
+	test('the ownership marker never serves publicly even though it exists', async () => {
+		const { store, objects } = memoryStore();
+		const { url } = await publishProjection(store, publication());
+		expect(objects.has('braden/first-artifact/.artifact')).toBe(true);
+		const response = await handleRequest(
+			new Request(`${url}/.artifact`),
+			workerEnvOver(objects),
+		);
+		expect(response.status).toBe(404);
+	});
+});

--- a/apps/theark/src/publish.test.ts
+++ b/apps/theark/src/publish.test.ts
@@ -4,8 +4,8 @@
  * An in-memory store proves the whole authenticated orchestration without
  * credentials or production resources: atomic reserve-first ownership keyed
  * on artifact id plus expression digest, route-last activation, idempotent
- * retry, collision and changed-expression refusal, the creation race, and
- * read-back verification. The final tests close the seam end to end: bytes
+ * retry, collision and changed-expression refusal, and the creation race.
+ * The final tests close the seam end to end: bytes
  * written by the kernel are served back through the delivery Worker's real
  * `handleRequest` over the same store.
  */
@@ -221,20 +221,6 @@ describe('publishProjection', () => {
 			).rejects.toThrow('not a servable artifact address');
 		}
 		expect(putOrder).toEqual([]);
-	});
-
-	test('read-back verification catches a store that lies', async () => {
-		const { store } = memoryStore();
-		const lying: ArkObjectStore = {
-			...store,
-			async get(key) {
-				// Honest about the unclaimed marker, corrupt on every read-back.
-				return key.endsWith('.artifact') ? null : bytes('corrupted');
-			},
-		};
-		await expect(publishProjection(lying, publication())).rejects.toThrow(
-			'read-back after write did not match',
-		);
 	});
 
 	test('the ownership marker is publicly unroutable by construction', () => {

--- a/apps/theark/src/publish.ts
+++ b/apps/theark/src/publish.ts
@@ -207,9 +207,10 @@ export async function publishProjection(
 		);
 	}
 
-	// Reserve-first, atomically. The dotfile name is publicly unroutable by
-	// construction: the Worker's FILE_SEGMENT pattern refuses dotfiles, so
-	// the ownership marker can never be fetched through the public plane.
+	// Reserve-first, atomically. The marker name is publicly unroutable by
+	// construction: the Worker's closed media vocabulary can never name
+	// `.artifact`, so the ownership marker cannot be fetched through the
+	// public plane.
 	const claim: MarkerFacts = {
 		artifact: artifactId,
 		expression: expressionDigest,

--- a/apps/theark/src/publish.ts
+++ b/apps/theark/src/publish.ts
@@ -89,10 +89,8 @@ export type ArkPublication = {
 
 export type PublishedProjection = {
 	readonly url: string;
-	/** Every object key written, media first, page last. */
-	readonly keys: readonly string[];
-	/** True when the slug was already reserved by this exact artifact and expression. */
-	readonly republished: boolean;
+	/** The first reservation's date; exact retries preserve this value. */
+	readonly publishedOn: string;
 };
 
 const encoder = new TextEncoder();
@@ -122,9 +120,11 @@ async function putVerified(
 type MarkerFacts = {
 	readonly artifact: string;
 	readonly expression: string;
+	readonly publishedOn: string;
 };
 
 const DIGEST_PATTERN = /^[a-f0-9]{64}$/;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
 function parseMarker(key: string, bytes: Uint8Array): MarkerFacts {
 	let parsed: unknown;
@@ -139,14 +139,16 @@ function parseMarker(key: string, bytes: Uint8Array): MarkerFacts {
 		typeof parsed !== 'object' ||
 		parsed === null ||
 		typeof (parsed as MarkerFacts).artifact !== 'string' ||
-		typeof (parsed as MarkerFacts).expression !== 'string'
+		typeof (parsed as MarkerFacts).expression !== 'string' ||
+		typeof (parsed as MarkerFacts).publishedOn !== 'string' ||
+		!DATE_PATTERN.test((parsed as MarkerFacts).publishedOn)
 	) {
 		throw new Error(
 			`${key}: unrecognized ownership marker; refusing to publish over it`,
 		);
 	}
-	const { artifact, expression } = parsed as MarkerFacts;
-	return { artifact, expression };
+	const { artifact, expression, publishedOn } = parsed as MarkerFacts;
+	return { artifact, expression, publishedOn };
 }
 
 /**
@@ -189,6 +191,11 @@ export async function publishProjection(
 			`${artifactId}: expressionDigest must be 64 lowercase hex characters (Vault ADR-0064 expression digest, not integrity_digest)`,
 		);
 	}
+	if (!DATE_PATTERN.test(page.publishedOn)) {
+		throw new Error(
+			`${artifactId}: publishedOn must be a YYYY-MM-DD calendar date`,
+		);
+	}
 
 	// Route agreement: the delivery Worker's resolver is the single truth for
 	// which addresses exist. Anything it refuses, the kernel refuses to write.
@@ -206,21 +213,22 @@ export async function publishProjection(
 	const claim: MarkerFacts = {
 		artifact: artifactId,
 		expression: expressionDigest,
+		publishedOn: page.publishedOn,
 	};
 	const markerKey = `${page.identity}/${page.slug}/.artifact`;
 	const markerBytes = encoder.encode(JSON.stringify(claim));
 
-	let republished: boolean;
+	let reservation: MarkerFacts;
 	const existingMarker = await store.get(markerKey);
 	if (existingMarker) {
-		assertSameOwner(pageAddress, parseMarker(markerKey, existingMarker), claim);
-		republished = true;
+		reservation = parseMarker(markerKey, existingMarker);
+		assertSameOwner(pageAddress, reservation, claim);
 	} else {
 		const created = await store.createExclusive(markerKey, markerBytes, {
 			contentType: 'application/json',
 		});
 		if (created) {
-			republished = false;
+			reservation = claim;
 		} else {
 			// Lost the creation race. The winner is authoritative: converge if
 			// it was our own duplicate retry, refuse anything else.
@@ -228,13 +236,12 @@ export async function publishProjection(
 			if (!winner) {
 				throw new Error(`${markerKey}: reservation race could not be resolved`);
 			}
-			assertSameOwner(pageAddress, parseMarker(markerKey, winner), claim);
-			republished = true;
+			reservation = parseMarker(markerKey, winner);
+			assertSameOwner(pageAddress, reservation, claim);
 		}
 	}
 
 	// Media before the page, so activation is route-last.
-	const keys: string[] = [];
 	const media: { video?: boolean; narration?: boolean; cover?: boolean } = {};
 	for (const [name, fileName, contentType] of MEDIA_OBJECTS) {
 		const bytes = files?.[name];
@@ -245,22 +252,23 @@ export async function publishProjection(
 			throw new Error(`${fileAddress}: not a servable media address`);
 		}
 		await putVerified(store, resolvedFile.key, bytes, contentType);
-		keys.push(resolvedFile.key);
 		media[name] = true;
 	}
 
-	const html = renderArtifactPage({ ...page, media });
+	const html = renderArtifactPage({
+		...page,
+		publishedOn: reservation.publishedOn,
+		media,
+	});
 	await putVerified(
 		store,
 		resolved.key,
 		encoder.encode(html),
 		'text/html; charset=utf-8',
 	);
-	keys.push(resolved.key);
 
 	return {
 		url: `https://theark.so${pageAddress}`,
-		keys,
-		republished,
+		publishedOn: reservation.publishedOn,
 	};
 }

--- a/apps/theark/src/publish.ts
+++ b/apps/theark/src/publish.ts
@@ -10,11 +10,16 @@
  * provable in-memory without credentials or production resources.
  *
  * Invariants owned here, and nowhere else:
- * - Reserve-first: a publicly-unroutable `.artifact` marker claims the
- *   `<identity>/<slug>` subtree for one private artifact id before any
- *   public byte lands. The marker is the entire collision registry: a second
- *   artifact publishing to the same slug is refused; the same artifact
- *   re-publishing (crash retry, theme rebuild) converges idempotently.
+ * - Reserve-first, atomically: a publicly-unroutable `.artifact` marker
+ *   claims the `<identity>/<slug>` subtree via create-if-absent before any
+ *   public byte lands, so two racing publishers cannot both win. The marker
+ *   records the private artifact id AND the immutable expression digest
+ *   (Vault ADR-0064: idempotent inserts key on the expression digest, never
+ *   `integrity_digest`). It is the entire collision registry: another
+ *   artifact is refused the slug forever; the same artifact with a different
+ *   frozen expression is refused (a permalink never changes its words); only
+ *   an exact match converges. Generated HTML and media are deliberately NOT
+ *   hashed, so theme rebuilds and free output rebuilds stay allowed.
  * - Route-last: generated media is written before `index.html`, so the page
  *   address only ever answers with its media already in place.
  * - Verification: every written object is read back and byte-compared before
@@ -33,7 +38,7 @@ import {
 
 /**
  * The minimal R2-shaped write contract the kernel needs. An `R2Bucket`
- * satisfies it with a two-line adapter; tests satisfy it with a Map.
+ * satisfies it with a thin adapter; tests satisfy it with a Map.
  */
 export type ArkObjectStore = {
 	get(key: string): Promise<Uint8Array | null>;
@@ -42,6 +47,17 @@ export type ArkObjectStore = {
 		value: Uint8Array,
 		options: { contentType: string },
 	): Promise<void>;
+	/**
+	 * Atomic create-if-absent; resolves false when the key already exists,
+	 * without touching the stored value. On R2 this is
+	 * `put(key, value, { onlyIf: { etagDoesNotMatch: '*' }, ... }) !== null`
+	 * (a failed precondition resolves null instead of writing).
+	 */
+	createExclusive(
+		key: string,
+		value: Uint8Array,
+		options: { contentType: string },
+	): Promise<boolean>;
 };
 
 /** Generated media bytes, keyed by the renderer's closed media vocabulary. */
@@ -58,6 +74,14 @@ const MEDIA_OBJECTS = [
 export type ArkPublication = {
 	/** Private artifact identity for ownership; never appears in public routes. */
 	readonly artifactId: string;
+	/**
+	 * The immutable expression-and-production-input digest (64 lowercase hex)
+	 * from Vault ADR-0064. It identifies the exact frozen expression, so a
+	 * retry converges and changed words are refused. Never `integrity_digest`
+	 * (a checklist-bound state checksum), and never a hash of generated
+	 * HTML/media (rebuilds must stay free).
+	 */
+	readonly expressionDigest: string;
 	/** The page input, minus `media`, which is derived from `files` here. */
 	readonly page: Omit<ArkArtifactPage, 'media'>;
 	readonly files?: ArkMediaFiles;
@@ -67,7 +91,7 @@ export type PublishedProjection = {
 	readonly url: string;
 	/** Every object key written, media first, page last. */
 	readonly keys: readonly string[];
-	/** True when the slug was already reserved by this same artifact. */
+	/** True when the slug was already reserved by this exact artifact and expression. */
 	readonly republished: boolean;
 };
 
@@ -94,17 +118,77 @@ async function putVerified(
 	}
 }
 
+/** What the ownership marker records about the slug's one publication. */
+type MarkerFacts = {
+	readonly artifact: string;
+	readonly expression: string;
+};
+
+const DIGEST_PATTERN = /^[a-f0-9]{64}$/;
+
+function parseMarker(key: string, bytes: Uint8Array): MarkerFacts {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(decoder.decode(bytes));
+	} catch {
+		throw new Error(
+			`${key}: unrecognized ownership marker; refusing to publish over it`,
+		);
+	}
+	if (
+		typeof parsed !== 'object' ||
+		parsed === null ||
+		typeof (parsed as MarkerFacts).artifact !== 'string' ||
+		typeof (parsed as MarkerFacts).expression !== 'string'
+	) {
+		throw new Error(
+			`${key}: unrecognized ownership marker; refusing to publish over it`,
+		);
+	}
+	const { artifact, expression } = parsed as MarkerFacts;
+	return { artifact, expression };
+}
+
+/**
+ * Refuse unless the recorded owner is exactly this artifact and this frozen
+ * expression. Anything else is permanent: another artifact never takes over
+ * a permalink, and the same artifact never changes its published words.
+ */
+function assertSameOwner(
+	pageAddress: string,
+	recorded: MarkerFacts,
+	claim: MarkerFacts,
+): void {
+	if (recorded.artifact !== claim.artifact) {
+		throw new Error(
+			`${pageAddress}: already published by another artifact (${recorded.artifact}); a frozen permalink is never reassigned`,
+		);
+	}
+	if (recorded.expression !== claim.expression) {
+		throw new Error(
+			`${pageAddress}: artifact ${claim.artifact} is already published with a different frozen expression (${recorded.expression}); a permalink never changes its words`,
+		);
+	}
+}
+
 /**
  * Render and publish one frozen artifact projection. Idempotent for the same
- * artifact id; refuses the slug for any other artifact. Throws on any
- * violated invariant; a throw after the marker is written leaves a reserved,
- * retryable subtree and never a half-activated page over wrong media.
+ * artifact id and expression digest; refuses the slug for anything else.
+ * Throws on any violated invariant; a throw after the marker is written
+ * leaves a reserved, retryable subtree and never a half-activated page over
+ * wrong media.
  */
 export async function publishProjection(
 	store: ArkObjectStore,
 	publication: ArkPublication,
 ): Promise<PublishedProjection> {
-	const { artifactId, page, files } = publication;
+	const { artifactId, expressionDigest, page, files } = publication;
+
+	if (!DIGEST_PATTERN.test(expressionDigest)) {
+		throw new Error(
+			`${artifactId}: expressionDigest must be 64 lowercase hex characters (Vault ADR-0064 expression digest, not integrity_digest)`,
+		);
+	}
 
 	// Route agreement: the delivery Worker's resolver is the single truth for
 	// which addresses exist. Anything it refuses, the kernel refuses to write.
@@ -116,26 +200,37 @@ export async function publishProjection(
 		);
 	}
 
-	// Reserve-first. The dotfile name is publicly unroutable by construction:
-	// the Worker's FILE_SEGMENT pattern refuses dotfiles, so the ownership
-	// marker can never be fetched through the public plane.
+	// Reserve-first, atomically. The dotfile name is publicly unroutable by
+	// construction: the Worker's FILE_SEGMENT pattern refuses dotfiles, so
+	// the ownership marker can never be fetched through the public plane.
+	const claim: MarkerFacts = {
+		artifact: artifactId,
+		expression: expressionDigest,
+	};
 	const markerKey = `${page.identity}/${page.slug}/.artifact`;
+	const markerBytes = encoder.encode(JSON.stringify(claim));
+
+	let republished: boolean;
 	const existingMarker = await store.get(markerKey);
-	const owner = existingMarker
-		? decoder.decode(existingMarker).trim()
-		: undefined;
-	if (owner !== undefined && owner !== artifactId) {
-		throw new Error(
-			`${pageAddress}: already published by another artifact (${owner}); a frozen permalink is never reassigned`,
-		);
-	}
-	if (owner === undefined) {
-		await putVerified(
-			store,
-			markerKey,
-			encoder.encode(artifactId),
-			'text/plain',
-		);
+	if (existingMarker) {
+		assertSameOwner(pageAddress, parseMarker(markerKey, existingMarker), claim);
+		republished = true;
+	} else {
+		const created = await store.createExclusive(markerKey, markerBytes, {
+			contentType: 'application/json',
+		});
+		if (created) {
+			republished = false;
+		} else {
+			// Lost the creation race. The winner is authoritative: converge if
+			// it was our own duplicate retry, refuse anything else.
+			const winner = await store.get(markerKey);
+			if (!winner) {
+				throw new Error(`${markerKey}: reservation race could not be resolved`);
+			}
+			assertSameOwner(pageAddress, parseMarker(markerKey, winner), claim);
+			republished = true;
+		}
 	}
 
 	// Media before the page, so activation is route-last.
@@ -166,6 +261,6 @@ export async function publishProjection(
 	return {
 		url: `https://theark.so${pageAddress}`,
 		keys,
-		republished: owner !== undefined,
+		republished,
 	};
 }

--- a/apps/theark/src/publish.ts
+++ b/apps/theark/src/publish.ts
@@ -1,0 +1,171 @@
+/**
+ * The Ark publisher kernel: the one owner of how a rendered projection
+ * becomes public bytes.
+ *
+ * This module is trusted, private-side code. It is NOT imported by the public
+ * Worker entry (src/index.ts), so the deployed public plane keeps zero write
+ * paths; the kernel runs wherever an authenticated caller holds bucket
+ * credentials (an operator CLI today, an authenticated endpoint only if one
+ * is ever earned). The object store is injected so the whole orchestration is
+ * provable in-memory without credentials or production resources.
+ *
+ * Invariants owned here, and nowhere else:
+ * - Reserve-first: a publicly-unroutable `.artifact` marker claims the
+ *   `<identity>/<slug>` subtree for one private artifact id before any
+ *   public byte lands. The marker is the entire collision registry: a second
+ *   artifact publishing to the same slug is refused; the same artifact
+ *   re-publishing (crash retry, theme rebuild) converges idempotently.
+ * - Route-last: generated media is written before `index.html`, so the page
+ *   address only ever answers with its media already in place.
+ * - Verification: every written object is read back and byte-compared before
+ *   the kernel reports success. Public-URL verification stays with the
+ *   caller, which knows the expected URL (the Vault port's contract).
+ * - Route agreement: keys are derived through the delivery Worker's own
+ *   `resolveProjection`, so the kernel cannot write an object the Worker
+ *   would refuse to serve.
+ */
+import { resolveProjection } from './index';
+import {
+	type ArkArtifactPage,
+	type ArkMediaSet,
+	renderArtifactPage,
+} from './render';
+
+/**
+ * The minimal R2-shaped write contract the kernel needs. An `R2Bucket`
+ * satisfies it with a two-line adapter; tests satisfy it with a Map.
+ */
+export type ArkObjectStore = {
+	get(key: string): Promise<Uint8Array | null>;
+	put(
+		key: string,
+		value: Uint8Array,
+		options: { contentType: string },
+	): Promise<void>;
+};
+
+/** Generated media bytes, keyed by the renderer's closed media vocabulary. */
+export type ArkMediaFiles = {
+	readonly [Name in keyof ArkMediaSet]?: Uint8Array;
+};
+
+const MEDIA_OBJECTS = [
+	['video', 'video.mp4', 'video/mp4'],
+	['narration', 'narration.mp3', 'audio/mpeg'],
+	['cover', 'cover.png', 'image/png'],
+] as const;
+
+export type ArkPublication = {
+	/** Private artifact identity for ownership; never appears in public routes. */
+	readonly artifactId: string;
+	/** The page input, minus `media`, which is derived from `files` here. */
+	readonly page: Omit<ArkArtifactPage, 'media'>;
+	readonly files?: ArkMediaFiles;
+};
+
+export type PublishedProjection = {
+	readonly url: string;
+	/** Every object key written, media first, page last. */
+	readonly keys: readonly string[];
+	/** True when the slug was already reserved by this same artifact. */
+	readonly republished: boolean;
+};
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+	if (left.length !== right.length) return false;
+	return left.every((byte, index) => byte === right[index]);
+}
+
+async function putVerified(
+	store: ArkObjectStore,
+	key: string,
+	value: Uint8Array,
+	contentType: string,
+): Promise<void> {
+	await store.put(key, value, { contentType });
+	const readBack = await store.get(key);
+	if (!readBack || !bytesEqual(readBack, value)) {
+		throw new Error(
+			`${key}: read-back after write did not match written bytes`,
+		);
+	}
+}
+
+/**
+ * Render and publish one frozen artifact projection. Idempotent for the same
+ * artifact id; refuses the slug for any other artifact. Throws on any
+ * violated invariant; a throw after the marker is written leaves a reserved,
+ * retryable subtree and never a half-activated page over wrong media.
+ */
+export async function publishProjection(
+	store: ArkObjectStore,
+	publication: ArkPublication,
+): Promise<PublishedProjection> {
+	const { artifactId, page, files } = publication;
+
+	// Route agreement: the delivery Worker's resolver is the single truth for
+	// which addresses exist. Anything it refuses, the kernel refuses to write.
+	const pageAddress = `/${page.identity}/${page.slug}`;
+	const resolved = resolveProjection(pageAddress);
+	if (!resolved?.isPage) {
+		throw new Error(
+			`${pageAddress}: not a servable artifact address (lowercase-hyphenated identity and slug required)`,
+		);
+	}
+
+	// Reserve-first. The dotfile name is publicly unroutable by construction:
+	// the Worker's FILE_SEGMENT pattern refuses dotfiles, so the ownership
+	// marker can never be fetched through the public plane.
+	const markerKey = `${page.identity}/${page.slug}/.artifact`;
+	const existingMarker = await store.get(markerKey);
+	const owner = existingMarker
+		? decoder.decode(existingMarker).trim()
+		: undefined;
+	if (owner !== undefined && owner !== artifactId) {
+		throw new Error(
+			`${pageAddress}: already published by another artifact (${owner}); a frozen permalink is never reassigned`,
+		);
+	}
+	if (owner === undefined) {
+		await putVerified(
+			store,
+			markerKey,
+			encoder.encode(artifactId),
+			'text/plain',
+		);
+	}
+
+	// Media before the page, so activation is route-last.
+	const keys: string[] = [];
+	const media: { video?: boolean; narration?: boolean; cover?: boolean } = {};
+	for (const [name, fileName, contentType] of MEDIA_OBJECTS) {
+		const bytes = files?.[name];
+		if (!bytes) continue;
+		const fileAddress = `${pageAddress}/${fileName}`;
+		const resolvedFile = resolveProjection(fileAddress);
+		if (!resolvedFile) {
+			throw new Error(`${fileAddress}: not a servable media address`);
+		}
+		await putVerified(store, resolvedFile.key, bytes, contentType);
+		keys.push(resolvedFile.key);
+		media[name] = true;
+	}
+
+	const html = renderArtifactPage({ ...page, media });
+	await putVerified(
+		store,
+		resolved.key,
+		encoder.encode(html),
+		'text/html; charset=utf-8',
+	);
+	keys.push(resolved.key);
+
+	return {
+		url: `https://theark.so${pageAddress}`,
+		keys,
+		republished: owner !== undefined,
+	};
+}

--- a/apps/theark/src/publish.ts
+++ b/apps/theark/src/publish.ts
@@ -22,9 +22,12 @@
  *   hashed, so theme rebuilds and free output rebuilds stay allowed.
  * - Route-last: generated media is written before `index.html`, so the page
  *   address only ever answers with its media already in place.
- * - Verification: every written object is read back and byte-compared before
- *   the kernel reports success. Public-URL verification stays with the
- *   caller, which knows the expected URL (the Vault port's contract).
+ * - Verification boundary: a resolved `put` IS the write proof. The store
+ *   contract requires a checked durable write (have R2 verify a content
+ *   checksum server-side; never a kernel re-download of regenerable bytes).
+ *   End-to-end proof stays with the caller, which fetches the expected
+ *   canonical public URL after the kernel returns (the Vault port's
+ *   contract).
  * - Route agreement: keys are derived through the delivery Worker's own
  *   `resolveProjection`, so the kernel cannot write an object the Worker
  *   would refuse to serve.
@@ -42,6 +45,12 @@ import {
  */
 export type ArkObjectStore = {
 	get(key: string): Promise<Uint8Array | null>;
+	/**
+	 * Durable checked write: resolve only after the backing store confirmed
+	 * the write succeeded. Adapters should pass a content checksum (R2 `md5`,
+	 * S3 `Content-MD5`) so the store verifies the bytes server-side; the
+	 * kernel never re-reads objects to prove its own writes.
+	 */
 	put(
 		key: string,
 		value: Uint8Array,
@@ -95,26 +104,6 @@ export type PublishedProjection = {
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
-
-function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
-	if (left.length !== right.length) return false;
-	return left.every((byte, index) => byte === right[index]);
-}
-
-async function putVerified(
-	store: ArkObjectStore,
-	key: string,
-	value: Uint8Array,
-	contentType: string,
-): Promise<void> {
-	await store.put(key, value, { contentType });
-	const readBack = await store.get(key);
-	if (!readBack || !bytesEqual(readBack, value)) {
-		throw new Error(
-			`${key}: read-back after write did not match written bytes`,
-		);
-	}
-}
 
 /** What the ownership marker records about the slug's one publication. */
 type MarkerFacts = {
@@ -252,7 +241,7 @@ export async function publishProjection(
 		if (!resolvedFile) {
 			throw new Error(`${fileAddress}: not a servable media address`);
 		}
-		await putVerified(store, resolvedFile.key, bytes, contentType);
+		await store.put(resolvedFile.key, bytes, { contentType });
 		media[name] = true;
 	}
 
@@ -261,12 +250,9 @@ export async function publishProjection(
 		publishedOn: reservation.publishedOn,
 		media,
 	});
-	await putVerified(
-		store,
-		resolved.key,
-		encoder.encode(html),
-		'text/html; charset=utf-8',
-	);
+	await store.put(resolved.key, encoder.encode(html), {
+		contentType: 'text/html; charset=utf-8',
+	});
 
 	return {
 		url: `https://theark.so${pageAddress}`,

--- a/apps/theark/src/render.test.ts
+++ b/apps/theark/src/render.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Constrained renderer tests.
+ *
+ * These pin the whole public HTML contract: the explicit Markdown subset, the
+ * escape-everything-else refusal behavior, static canonical/OG metadata, and
+ * the no-JavaScript guarantee. The renderer is total: hostile or unsupported
+ * input degrades to visible escaped text, never markup and never a throw,
+ * because Publish freezes before it projects and HTML is rebuildable.
+ */
+import { describe, expect, test } from 'bun:test';
+
+import { type ArkArtifactPage, renderArtifactPage, renderBody } from './render';
+
+const page = (overrides: Partial<ArkArtifactPage> = {}): ArkArtifactPage => ({
+	identity: 'braden',
+	slug: 'first-artifact',
+	title: 'First Artifact',
+	publishedOn: '2026-07-20',
+	body: 'Frozen words.',
+	...overrides,
+});
+
+// ============================================================================
+// Document shape and metadata
+// ============================================================================
+
+describe('renderArtifactPage', () => {
+	test('emits one complete semantic document', () => {
+		const html = renderArtifactPage(page());
+		expect(html).toStartWith('<!doctype html>\n<html lang="en">');
+		expect(html).toContain('<meta charset="utf-8">');
+		expect(html).toContain('<title>First Artifact · The Ark</title>');
+		expect(html).toContain('<main>\n<article>');
+		expect(html).toContain('<h1>First Artifact</h1>');
+		expect(html).toContain('<p>Frozen words.</p>');
+		expect(html).toContain('<footer><a href="/">The Ark</a></footer>');
+	});
+
+	test('is deterministic', () => {
+		expect(renderArtifactPage(page())).toBe(renderArtifactPage(page()));
+	});
+
+	test('canonical and OG metadata are static tags with the permalink', () => {
+		const html = renderArtifactPage(page({ subtitle: 'A subtitle' }));
+		expect(html).toContain(
+			'<link rel="canonical" href="https://theark.so/braden/first-artifact">',
+		);
+		expect(html).toContain('<meta property="og:type" content="article">');
+		expect(html).toContain(
+			'<meta property="og:title" content="First Artifact">',
+		);
+		expect(html).toContain(
+			'<meta property="og:url" content="https://theark.so/braden/first-artifact">',
+		);
+		expect(html).toContain(
+			'<meta property="og:description" content="A subtitle">',
+		);
+		expect(html).toContain(
+			'<meta property="article:published_time" content="2026-07-20">',
+		);
+	});
+
+	test('description and og:description exist only when a subtitle does', () => {
+		const html = renderArtifactPage(page());
+		expect(html).not.toContain('name="description"');
+		expect(html).not.toContain('og:description');
+	});
+
+	test('og:image is absolute and exists only when a cover does', () => {
+		const withCover = renderArtifactPage(page({ media: { cover: true } }));
+		expect(withCover).toContain(
+			'<meta property="og:image" content="https://theark.so/braden/first-artifact/cover.png">',
+		);
+		expect(renderArtifactPage(page())).not.toContain('og:image');
+	});
+
+	test('the only stylesheet is the shared deploy-time theme', () => {
+		const html = renderArtifactPage(page());
+		const links = html.match(/<link rel="stylesheet"[^>]*>/g);
+		expect(links).toEqual([
+			'<link rel="stylesheet" href="/assets/theark.css">',
+		]);
+		expect(html).not.toContain('style=');
+	});
+
+	test('date renders as prose with a machine datetime, without Date parsing', () => {
+		const html = renderArtifactPage(page());
+		expect(html).toContain('<time datetime="2026-07-20">July 20, 2026</time>');
+		const odd = renderArtifactPage(page({ publishedOn: 'someday' }));
+		expect(odd).toContain('<time datetime="someday">someday</time>');
+	});
+
+	test('resonance shows the diamond only when earned', () => {
+		expect(renderArtifactPage(page({ resonant: true }))).toContain(
+			'<span class="resonance" aria-hidden="true"></span>',
+		);
+		expect(renderArtifactPage(page())).not.toContain('resonance');
+	});
+
+	test('subtitle renders in the header only when present', () => {
+		expect(renderArtifactPage(page({ subtitle: 'Why it matters' }))).toContain(
+			'<p class="subtitle">Why it matters</p>',
+		);
+		expect(renderArtifactPage(page())).not.toContain('class="subtitle"');
+	});
+
+	test('title metadata is attribute-escaped', () => {
+		const html = renderArtifactPage(
+			page({ title: 'Ampersands & "quotes"', subtitle: '<b>sub</b>' }),
+		);
+		expect(html).toContain(
+			'<title>Ampersands &amp; &quot;quotes&quot; · The Ark</title>',
+		);
+		expect(html).toContain('content="&lt;b&gt;sub&lt;/b&gt;"');
+		expect(html).not.toContain('<b>');
+	});
+
+	test('short-video artifacts lead with the video, cover as poster', () => {
+		const html = renderArtifactPage(
+			page({ media: { video: true, narration: true, cover: true } }),
+		);
+		expect(html).toContain(
+			'<video controls playsinline preload="metadata" poster="/braden/first-artifact/cover.png" src="/braden/first-artifact/video.mp4"></video>',
+		);
+		// Narration ships as an addressable file but earns no player while the
+		// video already carries the narration track.
+		expect(html).not.toContain('<audio');
+	});
+
+	test('video without a cover omits the poster', () => {
+		const html = renderArtifactPage(page({ media: { video: true } }));
+		expect(html).toContain(
+			'<video controls playsinline preload="metadata" src="/braden/first-artifact/video.mp4"></video>',
+		);
+	});
+
+	test('never emits JavaScript, even from hostile input', () => {
+		const html = renderArtifactPage(
+			page({
+				title: '<script>alert(1)</script>',
+				body: '<script>alert(2)</script>\n\n[x](javascript:alert(3))',
+			}),
+		);
+		expect(html).not.toContain('<script');
+		expect(html).not.toContain('href="javascript');
+		// The refused constructs stay visible as escaped literal text.
+		expect(html).toContain('&lt;script&gt;alert(2)&lt;/script&gt;');
+		expect(html).toContain('<p>[x](javascript:alert(3))</p>');
+	});
+});
+
+// ============================================================================
+// Markdown subset
+// ============================================================================
+
+describe('renderBody', () => {
+	test('paragraphs split on blank lines, soft wraps join', () => {
+		expect(renderBody('one\ntwo\n\nthree')).toBe(
+			'<p>one\ntwo</p>\n<p>three</p>',
+		);
+	});
+
+	test('headings demote below the artifact title; deeper stays literal', () => {
+		expect(renderBody('# Top')).toBe('<h2>Top</h2>');
+		expect(renderBody('## Section')).toBe('<h2>Section</h2>');
+		expect(renderBody('### Detail')).toBe('<h3>Detail</h3>');
+		expect(renderBody('#### Too deep')).toBe('<p>#### Too deep</p>');
+	});
+
+	test('single-level lists render; ordered and unordered stay distinct', () => {
+		expect(renderBody('- a\n- b')).toBe('<ul>\n<li>a</li>\n<li>b</li>\n</ul>');
+		expect(renderBody('1. a\n2. b')).toBe(
+			'<ol>\n<li>a</li>\n<li>b</li>\n</ol>',
+		);
+	});
+
+	test('blockquotes carry paragraphs and keep the frozen words', () => {
+		expect(renderBody('> quoted\n> words')).toBe(
+			'<blockquote>\n<p>quoted\nwords</p>\n</blockquote>',
+		);
+	});
+
+	test('fenced code escapes everything and applies no inline transforms', () => {
+		expect(renderBody('```\nconst a = "<b>" && *x*;\n```')).toBe(
+			'<pre><code>const a = &quot;&lt;b&gt;&quot; &amp;&amp; *x*;</code></pre>',
+		);
+	});
+
+	test('an unclosed fence consumes the rest as code instead of leaking markup', () => {
+		expect(renderBody('```\n<script>')).toBe(
+			'<pre><code>&lt;script&gt;</code></pre>',
+		);
+	});
+
+	test('thematic break', () => {
+		expect(renderBody('a\n\n---\n\nb')).toBe('<p>a</p>\n<hr>\n<p>b</p>');
+	});
+
+	test('inline code, bold, and italic; code contents stay untransformed', () => {
+		expect(renderBody('use `**not bold**` and **bold** and *em*')).toBe(
+			'<p>use <code>**not bold**</code> and <strong>bold</strong> and <em>em</em></p>',
+		);
+	});
+
+	test('https, http, and mailto links become anchors', () => {
+		expect(renderBody('[site](https://example.com/a?b=1)')).toBe(
+			'<p><a href="https://example.com/a?b=1">site</a></p>',
+		);
+		expect(renderBody('[mail](mailto:braden@example.com)')).toBe(
+			'<p><a href="mailto:braden@example.com">mail</a></p>',
+		);
+	});
+
+	test('executable and unknown schemes stay escaped literal text', () => {
+		expect(renderBody('[x](javascript:alert(1))')).toBe(
+			'<p>[x](javascript:alert(1))</p>',
+		);
+		expect(renderBody('[x](data:text/html,hi)')).toBe(
+			'<p>[x](data:text/html,hi)</p>',
+		);
+		expect(renderBody('[x](/braden)')).toBe('<p>[x](/braden)</p>');
+	});
+
+	test('entity-smuggled schemes cannot survive escaping', () => {
+		expect(renderBody('[x](&#106;avascript:alert(1))')).toBe(
+			'<p>[x](&amp;#106;avascript:alert(1))</p>',
+		);
+	});
+
+	test('raw HTML is refused by escaping, visibly', () => {
+		expect(renderBody('<img src=x onerror=alert(1)>')).toBe(
+			'<p>&lt;img src=x onerror=alert(1)&gt;</p>',
+		);
+	});
+
+	test('tables are refused: literal escaped lines, revisit when an artifact needs one', () => {
+		expect(renderBody('| a | b |\n| - | - |')).toBe(
+			'<p>| a | b |\n| - | - |</p>',
+		);
+	});
+
+	test('the cover is the only publishable image, root-absolute beside the page', () => {
+		expect(
+			renderBody('![the cover](cover.png)', '/braden/first-artifact/cover.png'),
+		).toBe(
+			'<p><img src="/braden/first-artifact/cover.png" alt="the cover"></p>',
+		);
+	});
+
+	test('image references outside the generated set stay literal', () => {
+		expect(renderBody('![shot](/assets/CleanShot.jpg)')).toBe(
+			'<p>![shot](/assets/CleanShot.jpg)</p>',
+		);
+		// Even cover.png stays literal when the publication has no cover.
+		expect(renderBody('![alt](cover.png)')).toBe('<p>![alt](cover.png)</p>');
+	});
+});

--- a/apps/theark/src/render.test.ts
+++ b/apps/theark/src/render.test.ts
@@ -1,11 +1,13 @@
 /**
  * Constrained renderer tests.
  *
- * These pin the whole public HTML contract: the explicit Markdown subset, the
- * escape-everything-else refusal behavior, static canonical/OG metadata, and
- * the no-JavaScript guarantee. The renderer is total: hostile or unsupported
- * input degrades to visible escaped text, never markup and never a throw,
- * because Publish freezes before it projects and HTML is rebuildable.
+ * These pin the whole public HTML contract: the lead-title ownership (Vault
+ * ADR-0059: the lead H1 becomes the web title), the explicit Markdown
+ * subset, the escape-everything-else refusal behavior, static canonical/OG
+ * metadata, and the no-JavaScript guarantee. Below the lead title the
+ * renderer is total: hostile or unsupported input degrades to visible
+ * escaped text, never markup and never a throw, because Publish freezes
+ * before it projects and HTML is rebuildable.
  */
 import { describe, expect, test } from 'bun:test';
 
@@ -14,9 +16,8 @@ import { type ArkArtifactPage, renderArtifactPage, renderBody } from './render';
 const page = (overrides: Partial<ArkArtifactPage> = {}): ArkArtifactPage => ({
 	identity: 'braden',
 	slug: 'first-artifact',
-	title: 'First Artifact',
 	publishedOn: '2026-07-20',
-	body: 'Frozen words.',
+	body: '# First Artifact\n\nFrozen words.',
 	...overrides,
 });
 
@@ -38,6 +39,35 @@ describe('renderArtifactPage', () => {
 
 	test('is deterministic', () => {
 		expect(renderArtifactPage(page())).toBe(renderArtifactPage(page()));
+	});
+
+	test('the lead H1 is the frozen body: consumed as title, never duplicated', () => {
+		const html = renderArtifactPage(page());
+		expect(html.match(/First Artifact/g)?.length).toBe(3); // <title>, og:title, <h1>
+		expect(html).not.toContain('<h2>First Artifact</h2>');
+	});
+
+	test('blank lines before the lead title are tolerated', () => {
+		const html = renderArtifactPage(page({ body: '\n\n# Padded\n\nWords.' }));
+		expect(html).toContain('<h1>Padded</h1>');
+		expect(html).toContain('<p>Words.</p>');
+	});
+
+	test('a body without its lead title violates the freeze-gate contract and throws', () => {
+		expect(() => renderArtifactPage(page({ body: 'No title here.' }))).toThrow(
+			'lead "# Title" heading (Vault ADR-0059)',
+		);
+		expect(() => renderArtifactPage(page({ body: '## Not a lead' }))).toThrow(
+			'Vault ADR-0059',
+		);
+	});
+
+	test('inline markup in the lead title is not interpreted', () => {
+		const html = renderArtifactPage(
+			page({ body: '# A *literal* title\n\nWords.' }),
+		);
+		expect(html).toContain('<h1>A *literal* title</h1>');
+		expect(html).toContain('<title>A *literal* title · The Ark</title>');
 	});
 
 	test('canonical and OG metadata are static tags with the permalink', () => {
@@ -106,7 +136,10 @@ describe('renderArtifactPage', () => {
 
 	test('title metadata is attribute-escaped', () => {
 		const html = renderArtifactPage(
-			page({ title: 'Ampersands & "quotes"', subtitle: '<b>sub</b>' }),
+			page({
+				body: '# Ampersands & "quotes"\n\nWords.',
+				subtitle: '<b>sub</b>',
+			}),
 		);
 		expect(html).toContain(
 			'<title>Ampersands &amp; &quot;quotes&quot; · The Ark</title>',
@@ -137,20 +170,20 @@ describe('renderArtifactPage', () => {
 	test('never emits JavaScript, even from hostile input', () => {
 		const html = renderArtifactPage(
 			page({
-				title: '<script>alert(1)</script>',
-				body: '<script>alert(2)</script>\n\n[x](javascript:alert(3))',
+				body: '# <script>alert(1)</script>\n\n<script>alert(2)</script>\n\n[x](javascript:alert(3))',
 			}),
 		);
 		expect(html).not.toContain('<script');
 		expect(html).not.toContain('href="javascript');
 		// The refused constructs stay visible as escaped literal text.
+		expect(html).toContain('<h1>&lt;script&gt;alert(1)&lt;/script&gt;</h1>');
 		expect(html).toContain('&lt;script&gt;alert(2)&lt;/script&gt;');
 		expect(html).toContain('<p>[x](javascript:alert(3))</p>');
 	});
 });
 
 // ============================================================================
-// Markdown subset
+// Markdown subset (body below the lead title)
 // ============================================================================
 
 describe('renderBody', () => {
@@ -160,7 +193,7 @@ describe('renderBody', () => {
 		);
 	});
 
-	test('headings demote below the artifact title; deeper stays literal', () => {
+	test('headings below the lead demote; deeper stays literal', () => {
 		expect(renderBody('# Top')).toBe('<h2>Top</h2>');
 		expect(renderBody('## Section')).toBe('<h2>Section</h2>');
 		expect(renderBody('### Detail')).toBe('<h3>Detail</h3>');

--- a/apps/theark/src/render.test.ts
+++ b/apps/theark/src/render.test.ts
@@ -180,6 +180,19 @@ describe('renderArtifactPage', () => {
 		expect(html).toContain('&lt;script&gt;alert(2)&lt;/script&gt;');
 		expect(html).toContain('<p>[x](javascript:alert(3))</p>');
 	});
+
+	test('route values stay attribute data even when a caller violates the path contract', () => {
+		const html = renderArtifactPage(
+			page({
+				identity: 'braden"><script>alert(1)</script>',
+				media: { video: true, cover: true },
+			}),
+		);
+		expect(html).not.toContain('<script>');
+		expect(html).toContain(
+			'braden&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;',
+		);
+	});
 });
 
 // ============================================================================
@@ -198,6 +211,7 @@ describe('renderBody', () => {
 		expect(renderBody('## Section')).toBe('<h2>Section</h2>');
 		expect(renderBody('### Detail')).toBe('<h3>Detail</h3>');
 		expect(renderBody('#### Too deep')).toBe('<p>#### Too deep</p>');
+		expect(renderBody('# ')).toBe('<p># </p>');
 	});
 
 	test('single-level lists render; ordered and unordered stay distinct', () => {
@@ -242,6 +256,9 @@ describe('renderBody', () => {
 		expect(renderBody('[mail](mailto:braden@example.com)')).toBe(
 			'<p><a href="mailto:braden@example.com">mail</a></p>',
 		);
+		expect(renderBody('[path](https://example.com/*literal*)')).toBe(
+			'<p><a href="https://example.com/*literal*">path</a></p>',
+		);
 	});
 
 	test('executable and unknown schemes stay escaped literal text', () => {
@@ -277,6 +294,14 @@ describe('renderBody', () => {
 			renderBody('![the cover](cover.png)', '/braden/first-artifact/cover.png'),
 		).toBe(
 			'<p><img src="/braden/first-artifact/cover.png" alt="the cover"></p>',
+		);
+		expect(
+			renderBody(
+				'![*literal alt*](cover.png)',
+				'/braden/first-artifact/cover.png',
+			),
+		).toBe(
+			'<p><img src="/braden/first-artifact/cover.png" alt="*literal alt*"></p>',
 		);
 	});
 

--- a/apps/theark/src/render.test.ts
+++ b/apps/theark/src/render.test.ts
@@ -62,6 +62,18 @@ describe('renderArtifactPage', () => {
 		);
 	});
 
+	test('a whitespace-only or space-led lead title is the same violation, exactly as the Vault gate refuses it', () => {
+		expect(() => renderArtifactPage(page({ body: '#  \n\nWords.' }))).toThrow(
+			'Vault ADR-0059',
+		);
+		expect(() =>
+			renderArtifactPage(page({ body: '#  Space-led title\n\nWords.' })),
+		).toThrow('Vault ADR-0059');
+		// Trailing whitespace after a real title stays legal in both gates.
+		const html = renderArtifactPage(page({ body: '# Trailing  \n\nWords.' }));
+		expect(html).toContain('<h1>Trailing</h1>');
+	});
+
 	test('inline markup in the lead title is not interpreted', () => {
 		const html = renderArtifactPage(
 			page({ body: '# A *literal* title\n\nWords.' }),

--- a/apps/theark/src/render.ts
+++ b/apps/theark/src/render.ts
@@ -8,14 +8,20 @@
  * subset below is the whole vocabulary, and everything outside it renders as
  * visibly escaped literal source text instead of throwing or emitting markup.
  *
- * Total, never throwing, is load-bearing: Publish freezes the artifact BEFORE
- * projecting it (Vault ADR-0065), so a renderer that rejects a frozen body
- * would strand it permanently unpublishable. Degraded output is recoverable:
+ * Totality below the title is load-bearing: Publish freezes the artifact
+ * BEFORE projecting it (Vault ADR-0065), so rejecting frozen content would
+ * strand it permanently unpublishable. Degraded output is recoverable:
  * projection HTML is disposable and rebuildable (Vault ADR-0064), so a later
- * renderer improvement plus a rebuild upgrades every published page.
+ * renderer improvement plus a rebuild upgrades every published page. The one
+ * structural requirement is the lead `# Title` heading that opens the body
+ * (Vault ADR-0059: the lead H1 becomes the web title); the Vault freeze gate
+ * owns that guarantee for every Ark-bound artifact, so the renderer throwing
+ * on its absence asserts a violated upstream contract, exactly like the
+ * kernel throwing on an unservable address.
  *
  * The Markdown subset (sized by the 68 frozen artifacts in the Vault):
- * - paragraphs; `#`/`##` -> h2, `###` -> h3 (h1 belongs to the artifact title)
+ * - the lead `# Title` opens the body and is consumed as the page title
+ * - below it: paragraphs; `#`/`##` -> h2, `###` -> h3
  * - single-level `-` and `1.` lists
  * - `>` blockquotes
  * - fenced code blocks (no highlighting; contents fully escaped)
@@ -32,10 +38,9 @@
  */
 
 /**
- * The frozen expression the renderer projects. The Vault's `ArkPublisher`
- * port hands over the frozen artifact and its resource folder; the caller
- * supplies `title` (from the artifact's page row) and `publishedOn` (the
- * receipt date) because the port does not carry them. Facets and byline are
+ * The frozen expression the renderer projects. The page title is not a field:
+ * it is the frozen body's own lead H1 (Vault ADR-0059), so a mutable page-row
+ * title can never leak into a frozen permanent page. Facets and byline are
  * deliberately absent: no facet page exists to link to and the identity is
  * already the first URL segment, so neither earns visible behavior yet.
  */
@@ -44,13 +49,22 @@ export type ArkArtifactPage = {
 	readonly identity: string;
 	/** Frozen permalink slug under the identity. */
 	readonly slug: string;
-	readonly title: string;
 	readonly subtitle?: string;
-	/** Calendar date on the publication receipt, `YYYY-MM-DD`. */
+	/**
+	 * Calendar date the caller declares for this publication, `YYYY-MM-DD`.
+	 * The caller records this same date on the canonical receipt after
+	 * publish returns; it is an input to the receipt, not a preexisting fact.
+	 */
 	readonly publishedOn: string;
-	/** Resonant artifacts show the brick diamond beside the date. */
+	/**
+	 * Resonant artifacts show the brick diamond beside the date. Presentation
+	 * metadata, not frozen words: a rebuild may legitimately refresh it.
+	 */
 	readonly resonant?: boolean;
-	/** The exact frozen Markdown-subset body. */
+	/**
+	 * The exact frozen Markdown-subset body, opening with the lead `# Title`
+	 * heading that becomes the page title (Vault ADR-0059).
+	 */
 	readonly body: string;
 	/** Which generated files exist beside the page. */
 	readonly media?: ArkMediaSet;
@@ -288,16 +302,40 @@ export function renderBody(body: string, coverUrl?: string): string {
 }
 
 /**
+ * The frozen body opens with the lead `# Title` (Vault ADR-0059: the lead H1
+ * becomes the web title). The line is consumed as plain text for the visible
+ * h1 and the document metadata; it is never re-rendered into the article
+ * body, and inline markup inside it is not interpreted.
+ */
+function splitLeadTitle(body: string): { title: string; rest: string } {
+	const lines = body.replaceAll('\r\n', '\n').split('\n');
+	let start = 0;
+	while (start < lines.length && (lines[start] ?? '').trim() === '') start += 1;
+	const lead = /^# (.+)$/.exec(lines[start] ?? '');
+	if (!lead) {
+		throw new Error(
+			'frozen body must open with its lead "# Title" heading (Vault ADR-0059); the Vault freeze gate owns this guarantee for Ark-bound artifacts',
+		);
+	}
+	return {
+		title: (lead[1] ?? '').trim(),
+		rest: lines.slice(start + 1).join('\n'),
+	};
+}
+
+/**
  * Render the complete artifact page document. The output references only
  * /assets/theark.css plus root-absolute sibling media, carries correct
- * canonical/OG metadata as static tags, and contains no JavaScript.
+ * canonical/OG metadata as static tags, and contains no JavaScript. Throws
+ * only when the body violates the lead-title contract above.
  */
 export function renderArtifactPage(page: ArkArtifactPage): string {
 	const canonical = `https://theark.so/${page.identity}/${page.slug}`;
 	const mediaBase = `/${page.identity}/${page.slug}`;
 	const coverUrl = page.media?.cover ? `${mediaBase}/cover.png` : undefined;
 
-	const title = escapeHtml(page.title);
+	const { title: leadTitle, rest } = splitLeadTitle(page.body);
+	const title = escapeHtml(leadTitle);
 	const head = [
 		'<meta charset="utf-8">',
 		'<meta name="viewport" content="width=device-width, initial-scale=1">',
@@ -361,7 +399,7 @@ export function renderArtifactPage(page: ArkArtifactPage): string {
 		'<article>',
 		...header,
 		...video,
-		renderBody(page.body, coverUrl),
+		renderBody(rest, coverUrl),
 		'<footer><a href="/">The Ark</a></footer>',
 		'</article>',
 		'</main>',

--- a/apps/theark/src/render.ts
+++ b/apps/theark/src/render.ts
@@ -121,37 +121,44 @@ function formatDate(publishedOn: string): string {
 	return `${month} ${Number(match[3])}, ${match[1]}`;
 }
 
-/** Only these schemes may become anchors; anything else stays literal text. */
-const LINK_PATTERN = /\[([^\]]+)\]\((https:\/\/|http:\/\/|mailto:)([^)\s]*)\)/g;
+/**
+ * Closed inline vocabulary. Matching source tokens before emitting tags keeps
+ * later emphasis handling away from generated attributes.
+ */
+const INLINE_PATTERN =
+	/`([^`\n]+)`|!\[([^\]\n]*)\]\(cover\.png\)|\[([^\]\n]+)\]\(((?:https?:\/\/|mailto:)[^)\s]*)\)|\*\*([^*\n]+)\*\*|\*([^*\n]+)\*/g;
 
 /**
- * Inline transforms over already-escaped text. Code spans are carved out
- * first so their contents never receive link/emphasis markup.
+ * Parse inline source tokens, then escape at final emission. Generated tags
+ * never re-enter another regex transform, so punctuation in an href or image
+ * alt cannot manufacture markup inside an attribute.
  */
 function renderInline(text: string, coverUrl: string | undefined): string {
-	return text
-		.split(/(`[^`]+`)/)
-		.map((part) => {
-			const codeSpan = /^`([^`]+)`$/.exec(part);
-			if (codeSpan) return `<code>${escapeHtml(codeSpan[1] ?? '')}</code>`;
-			let html = escapeHtml(part);
-			if (coverUrl !== undefined) {
-				// The only publishable image is the artifact's own cover.
-				html = html.replaceAll(
-					/!\[([^\]]*)\]\(cover\.png\)/g,
-					(_, alt: string) => `<img src="${coverUrl}" alt="${alt}">`,
-				);
-			}
-			html = html.replace(
-				LINK_PATTERN,
-				(_, label: string, scheme: string, rest: string) =>
-					`<a href="${scheme}${rest}">${label}</a>`,
-			);
-			html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
-			html = html.replace(/\*([^*]+)\*/g, '<em>$1</em>');
-			return html;
-		})
-		.join('');
+	let html = '';
+	let cursor = 0;
+	for (const match of text.matchAll(INLINE_PATTERN)) {
+		const start = match.index;
+		html += escapeHtml(text.slice(cursor, start));
+		const [source, code, alt, label, url, strong, emphasis] = match;
+		if (code !== undefined) {
+			html += `<code>${escapeHtml(code)}</code>`;
+		} else if (alt !== undefined) {
+			html +=
+				coverUrl === undefined
+					? escapeHtml(source)
+					: `<img src="${escapeHtml(coverUrl)}" alt="${escapeHtml(alt)}">`;
+		} else if (label !== undefined && url !== undefined) {
+			html += `<a href="${escapeHtml(url)}">${renderInline(label, undefined)}</a>`;
+		} else if (strong !== undefined) {
+			html += `<strong>${renderInline(strong, undefined)}</strong>`;
+		} else if (emphasis !== undefined) {
+			html += `<em>${escapeHtml(emphasis)}</em>`;
+		} else {
+			html += escapeHtml(source);
+		}
+		cursor = start + source.length;
+	}
+	return html + escapeHtml(text.slice(cursor));
 }
 
 type Block =
@@ -160,6 +167,8 @@ type Block =
 	| { kind: 'heading'; level: 2 | 3; text: string }
 	| { kind: 'list'; ordered: boolean; items: string[] }
 	| { kind: 'rule' };
+
+const HEADING_PATTERN = /^(#{1,3}) (.+)$/;
 
 function parseBlocks(body: string): Block[] {
 	const lines = body.replaceAll('\r\n', '\n').split('\n');
@@ -185,7 +194,7 @@ function parseBlocks(body: string): Block[] {
 			continue;
 		}
 
-		const heading = /^(#{1,3}) (.+)$/.exec(line);
+		const heading = HEADING_PATTERN.exec(line);
 		if (heading) {
 			// `#` demotes to h2: the page h1 is the artifact title. `####`+ fails
 			// the pattern and stays a literal paragraph.
@@ -236,7 +245,7 @@ function parseBlocks(body: string): Block[] {
 			if (
 				current.trim() === '' ||
 				/^```/.test(current) ||
-				/^(#{1,3}) /.test(current) ||
+				HEADING_PATTERN.test(current) ||
 				/^---\s*$/.test(current) ||
 				unordered.test(current) ||
 				ordered.test(current) ||
@@ -343,12 +352,12 @@ export function renderArtifactPage(page: ArkArtifactPage): string {
 		...(page.subtitle
 			? [`<meta name="description" content="${escapeHtml(page.subtitle)}">`]
 			: []),
-		`<link rel="canonical" href="${canonical}">`,
+		`<link rel="canonical" href="${escapeHtml(canonical)}">`,
 		'<link rel="icon" href="/favicon.svg" type="image/svg+xml">',
 		'<link rel="stylesheet" href="/assets/theark.css">',
 		'<meta property="og:type" content="article">',
 		`<meta property="og:title" content="${title}">`,
-		`<meta property="og:url" content="${canonical}">`,
+		`<meta property="og:url" content="${escapeHtml(canonical)}">`,
 		...(page.subtitle
 			? [
 					`<meta property="og:description" content="${escapeHtml(page.subtitle)}">`,
@@ -357,7 +366,9 @@ export function renderArtifactPage(page: ArkArtifactPage): string {
 		// OG images must be absolute; everything else on the page is
 		// root-relative so the document is origin-portable for local preview.
 		...(coverUrl
-			? [`<meta property="og:image" content="https://theark.so${coverUrl}">`]
+			? [
+					`<meta property="og:image" content="${escapeHtml(`https://theark.so${coverUrl}`)}">`,
+				]
 			: []),
 		`<meta property="article:published_time" content="${escapeHtml(page.publishedOn)}">`,
 	];
@@ -382,8 +393,8 @@ export function renderArtifactPage(page: ArkArtifactPage): string {
 		? [
 				'<figure class="artifact-video">',
 				`<video controls playsinline preload="metadata"${
-					coverUrl ? ` poster="${coverUrl}"` : ''
-				} src="${mediaBase}/video.mp4"></video>`,
+					coverUrl ? ` poster="${escapeHtml(coverUrl)}"` : ''
+				} src="${escapeHtml(`${mediaBase}/video.mp4`)}"></video>`,
 				'</figure>',
 			]
 		: [];

--- a/apps/theark/src/render.ts
+++ b/apps/theark/src/render.ts
@@ -1,0 +1,372 @@
+/**
+ * The Ark's trusted constrained renderer.
+ *
+ * One pure, total function maps a frozen-artifact-shaped input to one complete
+ * semantic HTML document that references only the deploy-time stylesheet
+ * (/assets/theark.css) and root-absolute sibling media under the artifact's
+ * own permalink subtree. It is deliberately not a Markdown engine: the input
+ * subset below is the whole vocabulary, and everything outside it renders as
+ * visibly escaped literal source text instead of throwing or emitting markup.
+ *
+ * Total, never throwing, is load-bearing: Publish freezes the artifact BEFORE
+ * projecting it (Vault ADR-0065), so a renderer that rejects a frozen body
+ * would strand it permanently unpublishable. Degraded output is recoverable:
+ * projection HTML is disposable and rebuildable (Vault ADR-0064), so a later
+ * renderer improvement plus a rebuild upgrades every published page.
+ *
+ * The Markdown subset (sized by the 68 frozen artifacts in the Vault):
+ * - paragraphs; `#`/`##` -> h2, `###` -> h3 (h1 belongs to the artifact title)
+ * - single-level `-` and `1.` lists
+ * - `>` blockquotes
+ * - fenced code blocks (no highlighting; contents fully escaped)
+ * - `---` thematic breaks
+ * - inline `code`, **bold**, *italic*
+ * - [text](url) links, https/http/mailto only
+ * - ![alt](cover.png) only when the publication actually has a cover
+ *
+ * Refused, by rendering as escaped literal text: raw HTML, executable or
+ * unknown URL schemes, tables, nested lists, deeper headings, and media
+ * references outside the fixed generated set. No <script>, no inline styles,
+ * no JavaScript of any kind is ever emitted; pages work under the delivery
+ * Worker's CSP exactly because there is nothing to block.
+ */
+
+/**
+ * The frozen expression the renderer projects. The Vault's `ArkPublisher`
+ * port hands over the frozen artifact and its resource folder; the caller
+ * supplies `title` (from the artifact's page row) and `publishedOn` (the
+ * receipt date) because the port does not carry them. Facets and byline are
+ * deliberately absent: no facet page exists to link to and the identity is
+ * already the first URL segment, so neither earns visible behavior yet.
+ */
+export type ArkArtifactPage = {
+	/** Public identity segment, e.g. `braden`. */
+	readonly identity: string;
+	/** Frozen permalink slug under the identity. */
+	readonly slug: string;
+	readonly title: string;
+	readonly subtitle?: string;
+	/** Calendar date on the publication receipt, `YYYY-MM-DD`. */
+	readonly publishedOn: string;
+	/** Resonant artifacts show the brick diamond beside the date. */
+	readonly resonant?: boolean;
+	/** The exact frozen Markdown-subset body. */
+	readonly body: string;
+	/** Which generated files exist beside the page. */
+	readonly media?: ArkMediaSet;
+};
+
+/**
+ * The complete generated-media vocabulary. The short-video renderer is the
+ * only conditional producer and it yields exactly these three files; there is
+ * no general upload pipeline to name anything else.
+ */
+export type ArkMediaSet = {
+	readonly video?: boolean;
+	readonly narration?: boolean;
+	readonly cover?: boolean;
+};
+
+const ESCAPES: Record<string, string> = {
+	'&': '&amp;',
+	'<': '&lt;',
+	'>': '&gt;',
+	'"': '&quot;',
+	"'": '&#39;',
+};
+
+/** Escape text for both element content and attribute values. */
+function escapeHtml(text: string): string {
+	return text.replace(/[&<>"']/g, (char) => ESCAPES[char] ?? char);
+}
+
+const MONTHS = [
+	'January',
+	'February',
+	'March',
+	'April',
+	'May',
+	'June',
+	'July',
+	'August',
+	'September',
+	'October',
+	'November',
+	'December',
+];
+
+/**
+ * `YYYY-MM-DD` to `July 20, 2026` without Date, so rendering is deterministic
+ * and timezone-free. A malformed date degrades to its literal text.
+ */
+function formatDate(publishedOn: string): string {
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(publishedOn);
+	if (!match) return publishedOn;
+	const month = MONTHS[Number(match[2]) - 1];
+	if (!month) return publishedOn;
+	return `${month} ${Number(match[3])}, ${match[1]}`;
+}
+
+/** Only these schemes may become anchors; anything else stays literal text. */
+const LINK_PATTERN = /\[([^\]]+)\]\((https:\/\/|http:\/\/|mailto:)([^)\s]*)\)/g;
+
+/**
+ * Inline transforms over already-escaped text. Code spans are carved out
+ * first so their contents never receive link/emphasis markup.
+ */
+function renderInline(text: string, coverUrl: string | undefined): string {
+	return text
+		.split(/(`[^`]+`)/)
+		.map((part) => {
+			const codeSpan = /^`([^`]+)`$/.exec(part);
+			if (codeSpan) return `<code>${escapeHtml(codeSpan[1] ?? '')}</code>`;
+			let html = escapeHtml(part);
+			if (coverUrl !== undefined) {
+				// The only publishable image is the artifact's own cover.
+				html = html.replaceAll(
+					/!\[([^\]]*)\]\(cover\.png\)/g,
+					(_, alt: string) => `<img src="${coverUrl}" alt="${alt}">`,
+				);
+			}
+			html = html.replace(
+				LINK_PATTERN,
+				(_, label: string, scheme: string, rest: string) =>
+					`<a href="${scheme}${rest}">${label}</a>`,
+			);
+			html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+			html = html.replace(/\*([^*]+)\*/g, '<em>$1</em>');
+			return html;
+		})
+		.join('');
+}
+
+type Block =
+	| { kind: 'paragraph' | 'quote'; lines: string[] }
+	| { kind: 'code'; lines: string[] }
+	| { kind: 'heading'; level: 2 | 3; text: string }
+	| { kind: 'list'; ordered: boolean; items: string[] }
+	| { kind: 'rule' };
+
+function parseBlocks(body: string): Block[] {
+	const lines = body.replaceAll('\r\n', '\n').split('\n');
+	const blocks: Block[] = [];
+	let index = 0;
+
+	while (index < lines.length) {
+		const line = lines[index] ?? '';
+		if (line.trim() === '') {
+			index += 1;
+			continue;
+		}
+
+		if (/^```/.test(line)) {
+			const code: string[] = [];
+			index += 1;
+			while (index < lines.length && !/^```\s*$/.test(lines[index] ?? '')) {
+				code.push(lines[index] ?? '');
+				index += 1;
+			}
+			index += 1; // Consume the closing fence; an unclosed fence eats the rest.
+			blocks.push({ kind: 'code', lines: code });
+			continue;
+		}
+
+		const heading = /^(#{1,3}) (.+)$/.exec(line);
+		if (heading) {
+			// `#` demotes to h2: the page h1 is the artifact title. `####`+ fails
+			// the pattern and stays a literal paragraph.
+			blocks.push({
+				kind: 'heading',
+				level: heading[1] === '###' ? 3 : 2,
+				text: heading[2] ?? '',
+			});
+			index += 1;
+			continue;
+		}
+
+		if (/^---\s*$/.test(line)) {
+			blocks.push({ kind: 'rule' });
+			index += 1;
+			continue;
+		}
+
+		const unordered = /^- (.*)$/;
+		const ordered = /^\d+\. (.*)$/;
+		if (unordered.test(line) || ordered.test(line)) {
+			const isOrdered = ordered.test(line);
+			const pattern = isOrdered ? ordered : unordered;
+			const items: string[] = [];
+			while (index < lines.length) {
+				const item = pattern.exec(lines[index] ?? '');
+				if (!item) break;
+				items.push(item[1] ?? '');
+				index += 1;
+			}
+			blocks.push({ kind: 'list', ordered: isOrdered, items });
+			continue;
+		}
+
+		if (/^> ?/.test(line)) {
+			const quoted: string[] = [];
+			while (index < lines.length && /^> ?/.test(lines[index] ?? '')) {
+				quoted.push((lines[index] ?? '').replace(/^> ?/, ''));
+				index += 1;
+			}
+			blocks.push({ kind: 'quote', lines: quoted });
+			continue;
+		}
+
+		const paragraph: string[] = [];
+		while (index < lines.length) {
+			const current = lines[index] ?? '';
+			if (
+				current.trim() === '' ||
+				/^```/.test(current) ||
+				/^(#{1,3}) /.test(current) ||
+				/^---\s*$/.test(current) ||
+				unordered.test(current) ||
+				ordered.test(current) ||
+				/^> ?/.test(current)
+			) {
+				break;
+			}
+			paragraph.push(current);
+			index += 1;
+		}
+		blocks.push({ kind: 'paragraph', lines: paragraph });
+	}
+
+	return blocks;
+}
+
+function renderParagraphs(
+	lines: string[],
+	coverUrl: string | undefined,
+): string {
+	const paragraphs: string[][] = [[]];
+	for (const line of lines) {
+		if (line.trim() === '') {
+			if ((paragraphs.at(-1)?.length ?? 0) > 0) paragraphs.push([]);
+		} else {
+			paragraphs.at(-1)?.push(line);
+		}
+	}
+	return paragraphs
+		.filter((group) => group.length > 0)
+		.map((group) => `<p>${renderInline(group.join('\n'), coverUrl)}</p>`)
+		.join('\n');
+}
+
+function renderBlock(block: Block, coverUrl: string | undefined): string {
+	switch (block.kind) {
+		case 'paragraph':
+			return renderParagraphs(block.lines, coverUrl);
+		case 'heading':
+			return `<h${block.level}>${renderInline(block.text, coverUrl)}</h${block.level}>`;
+		case 'code':
+			return `<pre><code>${escapeHtml(block.lines.join('\n'))}</code></pre>`;
+		case 'rule':
+			return '<hr>';
+		case 'list': {
+			const tag = block.ordered ? 'ol' : 'ul';
+			const items = block.items
+				.map((item) => `<li>${renderInline(item, coverUrl)}</li>`)
+				.join('\n');
+			return `<${tag}>\n${items}\n</${tag}>`;
+		}
+		case 'quote':
+			return `<blockquote>\n${renderParagraphs(block.lines, coverUrl)}\n</blockquote>`;
+	}
+}
+
+/** Render the frozen Markdown-subset body to article HTML. */
+export function renderBody(body: string, coverUrl?: string): string {
+	return parseBlocks(body)
+		.map((block) => renderBlock(block, coverUrl))
+		.filter((html) => html !== '')
+		.join('\n');
+}
+
+/**
+ * Render the complete artifact page document. The output references only
+ * /assets/theark.css plus root-absolute sibling media, carries correct
+ * canonical/OG metadata as static tags, and contains no JavaScript.
+ */
+export function renderArtifactPage(page: ArkArtifactPage): string {
+	const canonical = `https://theark.so/${page.identity}/${page.slug}`;
+	const mediaBase = `/${page.identity}/${page.slug}`;
+	const coverUrl = page.media?.cover ? `${mediaBase}/cover.png` : undefined;
+
+	const title = escapeHtml(page.title);
+	const head = [
+		'<meta charset="utf-8">',
+		'<meta name="viewport" content="width=device-width, initial-scale=1">',
+		`<title>${title} · The Ark</title>`,
+		...(page.subtitle
+			? [`<meta name="description" content="${escapeHtml(page.subtitle)}">`]
+			: []),
+		`<link rel="canonical" href="${canonical}">`,
+		'<link rel="icon" href="/favicon.svg" type="image/svg+xml">',
+		'<link rel="stylesheet" href="/assets/theark.css">',
+		'<meta property="og:type" content="article">',
+		`<meta property="og:title" content="${title}">`,
+		`<meta property="og:url" content="${canonical}">`,
+		...(page.subtitle
+			? [
+					`<meta property="og:description" content="${escapeHtml(page.subtitle)}">`,
+				]
+			: []),
+		// OG images must be absolute; everything else on the page is
+		// root-relative so the document is origin-portable for local preview.
+		...(coverUrl
+			? [`<meta property="og:image" content="https://theark.so${coverUrl}">`]
+			: []),
+		`<meta property="article:published_time" content="${escapeHtml(page.publishedOn)}">`,
+	];
+
+	const header = [
+		'<header>',
+		`<time datetime="${escapeHtml(page.publishedOn)}">${
+			page.resonant ? '<span class="resonance" aria-hidden="true"></span>' : ''
+		}${escapeHtml(formatDate(page.publishedOn))}</time>`,
+		`<h1>${title}</h1>`,
+		...(page.subtitle
+			? [`<p class="subtitle">${escapeHtml(page.subtitle)}</p>`]
+			: []),
+		'</header>',
+	];
+
+	// A short-video artifact leads with its video: the video IS the
+	// expression; the body below carries the same words as text. The cover
+	// doubles as the poster. Narration audio ships as an addressable file but
+	// earns no player while the video already carries the narration track.
+	const video = page.media?.video
+		? [
+				'<figure class="artifact-video">',
+				`<video controls playsinline preload="metadata"${
+					coverUrl ? ` poster="${coverUrl}"` : ''
+				} src="${mediaBase}/video.mp4"></video>`,
+				'</figure>',
+			]
+		: [];
+
+	return [
+		'<!doctype html>',
+		'<html lang="en">',
+		'<head>',
+		...head,
+		'</head>',
+		'<body>',
+		'<main>',
+		'<article>',
+		...header,
+		...video,
+		renderBody(page.body, coverUrl),
+		'<footer><a href="/">The Ark</a></footer>',
+		'</article>',
+		'</main>',
+		'</body>',
+		'</html>',
+		'',
+	].join('\n');
+}

--- a/apps/theark/src/render.ts
+++ b/apps/theark/src/render.ts
@@ -314,20 +314,24 @@ export function renderBody(body: string, coverUrl?: string): string {
  * The frozen body opens with the lead `# Title` (Vault ADR-0059: the lead H1
  * becomes the web title). The line is consumed as plain text for the visible
  * h1 and the document metadata; it is never re-rendered into the article
- * body, and inline markup inside it is not interpreted.
+ * body, and inline markup inside it is not interpreted. The accepted pattern
+ * is character-identical to the Vault freeze gate's own check, so the two
+ * gates cannot disagree: the captured title must contain non-whitespace, and
+ * a whitespace-only `#  ` heading is the same contract violation here as a
+ * missing one, never an empty page title.
  */
 function splitLeadTitle(body: string): { title: string; rest: string } {
 	const lines = body.replaceAll('\r\n', '\n').split('\n');
 	let start = 0;
 	while (start < lines.length && (lines[start] ?? '').trim() === '') start += 1;
-	const lead = /^# (.+)$/.exec(lines[start] ?? '');
+	const lead = /^# (\S(?:.*\S)?)\s*$/.exec(lines[start] ?? '');
 	if (!lead) {
 		throw new Error(
 			'frozen body must open with its lead "# Title" heading (Vault ADR-0059); the Vault freeze gate owns this guarantee for Ark-bound artifacts',
 		);
 	}
 	return {
-		title: (lead[1] ?? '').trim(),
+		title: lead[1] ?? '',
 		rest: lines.slice(start + 1).join('\n'),
 	};
 }

--- a/apps/theark/wrangler.jsonc
+++ b/apps/theark/wrangler.jsonc
@@ -12,20 +12,30 @@
 	// this Worker, and short-video files can exceed the per-file asset limit.
 	// The asset layer serves literal paths (/assets/theark.css, /favicon.svg)
 	// before the Worker runs; every pretty URL falls through to the Worker.
-	// `html_handling: none` keeps /home.html and /not-found.html reachable at
-	// their literal paths; the default auto-trailing-slash mode 307-redirects
-	// them, which breaks the Worker's `ASSETS.fetch('/home.html')` handoff
-	// (same trap apps/api documents for its fallback shell). The Worker owns
-	// canonical pretty URLs, so extension magic buys nothing here.
+	// `html_handling: none` keeps /home.html and /not-found.html reachable to the
+	// Worker's Assets binding at their literal paths; the default
+	// auto-trailing-slash mode 307-redirects them, which breaks that internal
+	// handoff (same trap apps/api documents for its fallback shell).
+	// `run_worker_first` refuses those two implementation paths as public 200
+	// aliases while CSS and favicon remain asset-first. The Worker owns canonical
+	// pretty URLs, so extension magic buys nothing here.
 	"assets": {
 		"directory": "public",
 		"binding": "ASSETS",
-		"html_handling": "none"
+		"html_handling": "none",
+		"run_worker_first": ["/home.html", "/not-found.html"]
+	},
+	// The Worker is the cache origin. Cloudflare serves Range requests from a
+	// cached full response, so the Worker only streams complete R2 objects and
+	// owns freshness through its response Cache-Control headers.
+	"cache": {
+		"enabled": true
 	},
 	// --- R2: generated public projections, EU jurisdiction ---
-	// The publishing side writes human routes under `routes/` and artifact
-	// outputs under `artifacts/`; this Worker only resolves and streams them. Jurisdiction
-	// is a bucket property, not Worker placement: create the bucket with
+	// The publishing side writes one mirrored public subtree per expression:
+	// `<identity>/<slug>/index.html` plus any generated files beside it. This
+	// Worker only resolves and streams them. Jurisdiction is a bucket property,
+	// not Worker placement: create the bucket with
 	//   bunx wrangler r2 bucket create theark-projections --jurisdiction eu
 	// (jurisdiction is permanent once created). The binding has write
 	// capability the code never uses; see the ADR for why v1 accepts that

--- a/apps/theark/wrangler.jsonc
+++ b/apps/theark/wrangler.jsonc
@@ -48,16 +48,15 @@
 		}
 	],
 	// --- Custom domain: theark.so ---
-	// Commented out until theark.so's DNS is delegated to Cloudflare; today the
-	// domain sits on registrar nameservers, so a deploy with this route would
-	// fail to attach. Uncomment after delegation; deploy then auto-creates the
-	// DNS record.
-	// "routes": [
-	// 	{
-	// 		"pattern": "theark.so",
-	// 		"custom_domain": true
-	// 	}
-	// ],
+	// The Worker is the origin for every path on the canonical hostname.
+	// Deploying this source-of-truth route lets Cloudflare own the DNS record and
+	// certificate lifecycle; there is no parallel dashboard-owned route.
+	"routes": [
+		{
+			"pattern": "theark.so",
+			"custom_domain": true
+		}
+	],
 	"observability": {
 		"enabled": true
 	}

--- a/docs/adr/0160-the-ark-public-plane-is-a-plain-worker-streaming-eu-r2-projections.md
+++ b/docs/adr/0160-the-ark-public-plane-is-a-plain-worker-streaming-eu-r2-projections.md
@@ -5,8 +5,8 @@
 
 ## Context
 
-The Ark is the canonical public web home for approved Vault artifacts: frozen
-authored expressions with permanent, truthful permalinks
+The Ark is the canonical public web home for frozen Vault artifacts: exact
+authored expressions whose Publish was pressed, with permanent, truthful permalinks
 (`https://theark.so/braden/<artifact-slug>`). The Vault's publishing ADRs
 (its ADR-0059 and ADR-0064) settled the artifact semantics: one Markdown
 artifact owns its web, narration, and short-video outputs; the web projection
@@ -22,8 +22,8 @@ Vault ADRs continue to own artifact and projection semantics.
 **The Ark's public plane is `apps/theark`: a plain Cloudflare Worker in the
 Epicenter account that serves fixed deploy-time design assets from Workers
 Static Assets and streams rebuildable artifact projections from a dedicated
-EU-jurisdiction R2 bucket, `theark-projections`, that the publishing side
-writes and the Worker only reads.**
+EU-jurisdiction R2 bucket, `theark-projections`, that an authenticated Epicenter
+publisher writes and the Worker only reads.**
 
 Each concern has exactly one owner:
 
@@ -52,10 +52,12 @@ Each concern has exactly one owner:
   responses, so the Worker carries no byte-range implementation. The publisher
   owns bytes and content-type.
 - **A future authenticated creator application** (Epicenter login, workspace
-  access) is a separate deployable that publishes into the bucket. The public
-  plane holds none of its capabilities now: no auth, billing, Postgres,
-  Hyperdrive, Durable Objects, Epicenter blob-store bindings, or write
-  routes.
+  access) is a separate deployable that implements the Vault's injected
+  publisher port. It renders the complete frozen artifact, writes media first,
+  conditionally activates `index.html` last, verifies the canonical URL, and
+  returns only after the projection is public. The public plane holds none of
+  its capabilities now: no auth, billing, Postgres, Hyperdrive, Durable Objects,
+  Epicenter blob-store bindings, or write routes.
 
 The Worker is plain (`export default { fetch }`), not Hono: it has two route
 families and zero shared middleware, so a framework would own nothing. The

--- a/docs/adr/0160-the-ark-public-plane-is-a-plain-worker-streaming-eu-r2-projections.md
+++ b/docs/adr/0160-the-ark-public-plane-is-a-plain-worker-streaming-eu-r2-projections.md
@@ -167,8 +167,11 @@ Ownership within the publishing side:
   different frozen words, is refused. An exact retry reuses the first date
   rather than rewriting published history. Generated HTML and media are not
   hashed, so theme and output rebuilds stay free. Media writes precede
-  `index.html`; every object is
-  read-back-verified. No second database.
+  `index.html`. A store put is a checked durable write by contract (the
+  credential-holding adapter has R2 verify a content checksum server-side);
+  the kernel never re-downloads objects to prove its own writes, and the
+  caller proves the end result by fetching the canonical public URL. No
+  second database.
 - **The generated media vocabulary is closed**: `video.mp4`,
   `narration.mp3`, `cover.png` from the conditional short-video renderer.
   There is no general upload pipeline.

--- a/docs/adr/0160-the-ark-public-plane-is-a-plain-worker-streaming-eu-r2-projections.md
+++ b/docs/adr/0160-the-ark-public-plane-is-a-plain-worker-streaming-eu-r2-projections.md
@@ -138,26 +138,43 @@ is unchanged: no write route, no auth, no new bindings.
 
 Ownership within the publishing side:
 
-- **The renderer is total.** Publish freezes the artifact before projecting
-  it, so a renderer that rejects a frozen body would strand it permanently.
-  Everything outside the explicit Markdown subset (raw HTML, executable URL
-  schemes, tables, foreign images) renders as visibly escaped literal text.
-  Degradation is recoverable because projection HTML is disposable (Vault
-  ADR-0064): improve the renderer, rebuild the pages.
-- **The kernel owns route-last activation, idempotent retry, and collision
-  refusal.** One publicly-unroutable in-bucket ownership marker
-  (`<identity>/<slug>/.artifact`, holding the private artifact id; dotfiles
-  fail the public route allowlist by construction) is the entire route
-  registry the Decision's consequences called for. Reserve first, media next,
-  `index.html` last, read-back verification on every object. No second
-  database.
+- **The title is the frozen body's lead H1** (Vault ADR-0059: the lead H1
+  becomes the web title). The renderer consumes it as plain text for the
+  visible heading and document metadata; a mutable page-row title never
+  reaches a frozen page.
+- **The renderer is total below the lead title.** Publish freezes the
+  artifact before projecting it, so rejecting frozen content would strand it
+  permanently. Everything outside the explicit Markdown subset (raw HTML,
+  executable URL schemes, tables, foreign images) renders as visibly escaped
+  literal text. Degradation is recoverable because projection HTML is
+  disposable (Vault ADR-0064): improve the renderer, rebuild the pages. The
+  one structural throw is a missing lead title, which the Vault freeze gate
+  must make unreachable for Ark-bound artifacts.
+- **The kernel owns atomic reservation, route-last activation, idempotent
+  retry, and collision refusal.** One publicly-unroutable in-bucket
+  ownership marker (`<identity>/<slug>/.artifact`; dotfiles fail the public
+  route allowlist by construction) is the entire route registry the
+  Decision's consequences called for. It is claimed by atomic
+  create-if-absent (R2 conditional put, `onlyIf: { etagDoesNotMatch: '*' }`)
+  so racing publishers cannot both win, and it records the private artifact
+  id plus the immutable expression digest of Vault ADR-0064 (never
+  `integrity_digest`). Only an exact id-and-digest match converges; another
+  artifact, or the same artifact with different frozen words, is refused.
+  Generated HTML and media are not hashed, so theme and output rebuilds stay
+  free. Media writes precede `index.html`; every object is
+  read-back-verified. No second database.
 - **The generated media vocabulary is closed**: `video.mp4`,
   `narration.mp3`, `cover.png` from the conditional short-video renderer.
   There is no general upload pipeline.
 - **The caller owns credentials and public-URL verification.** The Vault's
   injected `ArkPublisher` port hands over the frozen artifact; the caller
-  must also supply the page title and receipt date (the port carries
-  neither) and verifies the expected canonical URL after the kernel returns.
+  must also supply the declared publication date (recorded on the canonical
+  receipt only after publish succeeds, so it is an input here, not a
+  preexisting fact) and the expression digest, and verifies the expected
+  canonical URL after the kernel returns. The port carries neither today,
+  and the Vault does not yet mint the ADR-0064 digest or enforce the
+  lead-title freeze gate; both are prerequisites for wiring the port to this
+  kernel and are recorded in the app README.
 
 An authenticated network endpoint (in `apps/api` or elsewhere) remains
 possible later; it would be a thin authenticated shell over this same kernel,

--- a/docs/adr/0160-the-ark-public-plane-is-a-plain-worker-streaming-eu-r2-projections.md
+++ b/docs/adr/0160-the-ark-public-plane-is-a-plain-worker-streaming-eu-r2-projections.md
@@ -157,24 +157,25 @@ Ownership within the publishing side:
   Decision's consequences called for. It is claimed by atomic
   create-if-absent (R2 conditional put, `onlyIf: { etagDoesNotMatch: '*' }`)
   so racing publishers cannot both win, and it records the private artifact
-  id plus the immutable expression digest of Vault ADR-0064 (never
-  `integrity_digest`). Only an exact id-and-digest match converges; another
-  artifact, or the same artifact with different frozen words, is refused.
-  Generated HTML and media are not hashed, so theme and output rebuilds stay
-  free. Media writes precede `index.html`; every object is
+  id, the immutable expression digest of Vault ADR-0064 (never
+  `integrity_digest`), and the first declared publication date. Only an exact
+  id-and-digest match converges; another artifact, or the same artifact with
+  different frozen words, is refused. An exact retry reuses the first date
+  rather than rewriting published history. Generated HTML and media are not
+  hashed, so theme and output rebuilds stay free. Media writes precede
+  `index.html`; every object is
   read-back-verified. No second database.
 - **The generated media vocabulary is closed**: `video.mp4`,
   `narration.mp3`, `cover.png` from the conditional short-video renderer.
   There is no general upload pipeline.
 - **The caller owns credentials and public-URL verification.** The Vault's
   injected `ArkPublisher` port hands over the frozen artifact; the caller
-  must also supply the declared publication date (recorded on the canonical
-  receipt only after publish succeeds, so it is an input here, not a
-  preexisting fact) and the expression digest, and verifies the expected
-  canonical URL after the kernel returns. The port carries neither today,
-  and the Vault does not yet mint the ADR-0064 digest or enforce the
-  lead-title freeze gate; both are prerequisites for wiring the port to this
-  kernel and are recorded in the app README.
+  must also supply the proposed publication date and expression digest, and
+  verifies the expected canonical URL after the kernel returns. The paired
+  Vault change enforces the lead-title freeze gate, computes the source-only
+  expression digest, carries both inputs through `ArkProjection`, and records
+  the authoritative date returned by the reservation. The remaining seam is
+  the credential-holding adapter itself.
 
 An authenticated network endpoint (in `apps/api` or elsewhere) remains
 possible later; it would be a thin authenticated shell over this same kernel,

--- a/docs/adr/0160-the-ark-public-plane-is-a-plain-worker-streaming-eu-r2-projections.md
+++ b/docs/adr/0160-the-ark-public-plane-is-a-plain-worker-streaming-eu-r2-projections.md
@@ -21,7 +21,7 @@ Vault ADRs continue to own artifact and projection semantics.
 
 **The Ark's public plane is `apps/theark`: a plain Cloudflare Worker in the
 Epicenter account that serves fixed deploy-time design assets from Workers
-Static Assets and streams immutable artifact projections from a dedicated
+Static Assets and streams rebuildable artifact projections from a dedicated
 EU-jurisdiction R2 bucket, `theark-projections`, that the publishing side
 writes and the Worker only reads.**
 
@@ -33,21 +33,24 @@ Each concern has exactly one owner:
   the per-file asset limit. `html_handling` is `none` because the Worker owns
   canonical pretty URLs and the asset shells must stay fetchable at literal
   `.html` paths.
-- **R2 owns generated projections** under two disjoint key families.
-  Human-readable person, facet, and artifact routes map to
-  `routes/<identity>[/<slug-or-facet>]/index.html`. Generated artifact outputs
-  map from `/_artifacts/<uuidv7>/<file>` to `artifacts/<uuidv7>/<file>`.
-  Separating route identity from artifact identity prevents `index.html`
-  aliases and keeps media addresses stable independently of human-readable
-  routing. Pages and per-artifact media ship by writing objects; the Worker
-  validates every path against these exact allowlists before any key is formed,
-  streams bodies without buffering, and answers GET/HEAD with correct ETag,
-  conditional, and Range behavior.
+- **R2 owns one generated public subtree per expression.** Person, facet, and
+  artifact pages map to `<identity>[/<slug-or-facet>]/index.html`; generated
+  media lives beside its artifact page at
+  `<identity>/<artifact-slug>/<file>`. The public path and object key therefore
+  describe the same person and expression, and no internal artifact UUID leaks
+  into the public product. Because canonical page URLs are slashless, the
+  constrained renderer emits root-absolute media URLs under that subtree rather
+  than bare relative filenames. Explicit `index.html` aliases are refused.
+  Pages and media ship by writing objects; the Worker validates every path
+  against these exact allowlists before any key is formed and streams bodies
+  without buffering.
 - **The Worker owns delivery policy only**: one cache policy
   (`public, max-age=300, must-revalidate`, since projection bytes are
   regenerable and never a second authored source), `no-store` for absence,
-  and 308 trailing-slash canonicalization. The publisher owns bytes and
-  content-type.
+  308 trailing-slash canonicalization, and a CSP that refuses executable
+  per-artifact code. Workers Caching serves Range requests from cached full
+  responses, so the Worker carries no byte-range implementation. The publisher
+  owns bytes and content-type.
 - **A future authenticated creator application** (Epicenter login, workspace
   access) is a separate deployable that publishes into the bucket. The public
   plane holds none of its capabilities now: no auth, billing, Postgres,
@@ -78,10 +81,17 @@ zero. If Cloudflare ships read-only R2 bindings, adopt them.
   `/assets/theark.css` URL rather than a hashed one.
 - The strict route allowlist means hostile and percent-encoded alias paths die
   before touching R2. Public identities and slugs must be lowercase-hyphenated
-  ASCII, and artifact-output paths must carry the artifact's UUIDv7 identity.
-  That matches the Vault's authored slug and artifact identity contracts.
-- The public plane cannot serve per-artifact interactive code, by
-  construction; a genuinely interactive product needs its own boundary.
+  ASCII; `assets` is reserved for deploy-time static design. Artifact UUIDv7
+  values remain private authored-row identities rather than a second public
+  routing vocabulary.
+- The second segment is one publisher-owned route namespace. Facets and
+  artifacts cannot claim the same `(identity, segment)`. The publisher reserves
+  first ownership, refuses cross-owner overwrites and duplicate media names,
+  writes media first, and conditionally activates `index.html` last. The Worker
+  remains ignorant of ownership. Rebuilds may replace bytes only for the same
+  private artifact owner.
+- The trusted constrained renderer plus the Worker's CSP refuse per-artifact
+  interactive code; a genuinely interactive product needs its own boundary.
 - The `theark.so` custom-domain route stays commented out until DNS is
   delegated to Cloudflare; until then deploys serve on `workers.dev`.
 - Writes to the bucket are governed by review of this app plus the
@@ -92,6 +102,11 @@ zero. If Cloudflare ships read-only R2 bindings, adopt them.
 - **Hono.** Lost: no repeated route or middleware behavior exists for it to
   own; a dependency with zero earned value on a security-sensitive public
   surface.
+- **Expose generated files through `/_artifacts/<uuidv7>/<file>`.** Lost: this
+  creates a second public identity for one expression, leaks a private row ID,
+  and makes future identity aliases govern two unrelated URL families. The
+  permanent artifact permalink already gives every generated file a truthful
+  home.
 - **Serve projections from Static Assets.** Lost: publishing would require a
   redeploy, and short videos can exceed the per-file asset limit.
 - **A second Worker or public bucket domain to make reads

--- a/docs/adr/0160-the-ark-public-plane-is-a-plain-worker-streaming-eu-r2-projections.md
+++ b/docs/adr/0160-the-ark-public-plane-is-a-plain-worker-streaming-eu-r2-projections.md
@@ -118,3 +118,48 @@ zero. If Cloudflare ships read-only R2 bindings, adopt them.
 - **Reuse `epicenter-blobs` or the Epicenter API Worker.** Lost: the public
   plane must not hold private-plane capabilities, and the private blob store
   is a different product boundary with different lifecycle and jurisdiction.
+
+## Amendment (2026-07-20): the publisher is colocated code, not a separate deployable
+
+The Decision above deferred publishing to "a future authenticated creator
+application," a separate deployable with Epicenter login. That framing
+predates the Vault's Publish collapse (its ADR-0065) and does not survive
+contact with it. Authentication is a property of the caller holding bucket
+credentials, not of a deployable: the only real publisher today is an
+operator at a terminal with Cloudflare credentials, and a network endpoint
+would invent a wire schema with zero network callers.
+
+**The trusted constrained renderer and the publisher kernel are Ark-owned
+library modules in `apps/theark` (`src/render.ts`, `src/publish.ts`) that the
+public Worker entry never imports.** The theme stylesheet and the HTML shape
+it styles must evolve together (a theme rebuild is "re-render every page,
+redeploy the stylesheet"), so they live in one app. The deployed public plane
+is unchanged: no write route, no auth, no new bindings.
+
+Ownership within the publishing side:
+
+- **The renderer is total.** Publish freezes the artifact before projecting
+  it, so a renderer that rejects a frozen body would strand it permanently.
+  Everything outside the explicit Markdown subset (raw HTML, executable URL
+  schemes, tables, foreign images) renders as visibly escaped literal text.
+  Degradation is recoverable because projection HTML is disposable (Vault
+  ADR-0064): improve the renderer, rebuild the pages.
+- **The kernel owns route-last activation, idempotent retry, and collision
+  refusal.** One publicly-unroutable in-bucket ownership marker
+  (`<identity>/<slug>/.artifact`, holding the private artifact id; dotfiles
+  fail the public route allowlist by construction) is the entire route
+  registry the Decision's consequences called for. Reserve first, media next,
+  `index.html` last, read-back verification on every object. No second
+  database.
+- **The generated media vocabulary is closed**: `video.mp4`,
+  `narration.mp3`, `cover.png` from the conditional short-video renderer.
+  There is no general upload pipeline.
+- **The caller owns credentials and public-URL verification.** The Vault's
+  injected `ArkPublisher` port hands over the frozen artifact; the caller
+  must also supply the page title and receipt date (the port carries
+  neither) and verifies the expected canonical URL after the kernel returns.
+
+An authenticated network endpoint (in `apps/api` or elsewhere) remains
+possible later; it would be a thin authenticated shell over this same kernel,
+adopted only when a caller exists that cannot hold bucket credentials
+directly.

--- a/docs/adr/0160-the-ark-public-plane-is-a-plain-worker-streaming-eu-r2-projections.md
+++ b/docs/adr/0160-the-ark-public-plane-is-a-plain-worker-streaming-eu-r2-projections.md
@@ -36,11 +36,15 @@ Each concern has exactly one owner:
 - **R2 owns one generated public subtree per expression.** Person, facet, and
   artifact pages map to `<identity>[/<slug-or-facet>]/index.html`; generated
   media lives beside its artifact page at
-  `<identity>/<artifact-slug>/<file>`. The public path and object key therefore
+  `<identity>/<artifact-slug>/<file>`, where `<file>` is exactly one of the
+  closed generated set (`video.mp4`, `narration.mp3`, `cover.png`). The public
+  path and object key therefore
   describe the same person and expression, and no internal artifact UUID leaks
   into the public product. Because canonical page URLs are slashless, the
   constrained renderer emits root-absolute media URLs under that subtree rather
-  than bare relative filenames. Explicit `index.html` aliases are refused.
+  than bare relative filenames. Explicit `index.html` aliases and any filename
+  outside the closed media set are refused, so even a stray bucket object is
+  publicly unroutable.
   Pages and media ship by writing objects; the Worker validates every path
   against these exact allowlists before any key is formed and streams bodies
   without buffering.


### PR DESCRIPTION
## What changed

- Make the public URL tree mirror one immutable R2 projection tree: /braden/<slug> and its closed media vocabulary.
- Add one constrained, script-free HTML renderer with a shared calm reading theme.
- Add a colocated publisher kernel that atomically reserves a permalink, binds the artifact expression digest and first publication date, writes media first, and activates index.html last.
- Keep the public Worker read-only in behavior: GET and HEAD only, strict route resolution, streamed R2 reads, explicit cache policy, and no Hono, database, authentication, or publishing endpoint.
- Align the Ark boundary with the Vault Publish lifecycle without inventing another review state or renderer registry.

## Why

The Ark should be the smallest public projection boundary that can make a frozen Vault artifact permanently readable. R2 stores rebuildable HTML and media, not another authored source. The Worker serves those projections; the trusted publisher owns the one irreversible write path.

This preserves the useful collapse: one Publish action freezes the expression, reserves its permanent URL, activates the generated projection, verifies it, and leaves the Vault to record the receipt.

## Reader and publisher impact

A future publication at https://theark.so/braden/example resolves directly to braden/example/index.html, with video.mp4, narration.mp3, and cover.png beside it when the artifact produced those files. Exact retries converge on the first reservation. A different artifact or changed frozen expression can never take over the permalink.

This PR deliberately does not add a creator dashboard, a login flow, a general Markdown engine, a plugin system, DNS cutover, or the credential-holding Vault adapter. Those are not prerequisites for merging the stable projection boundary.

## Validation

- 74 Ark tests pass.
- TypeScript typecheck passes.
- Biome passes for the Ark source and shared theme.
- Documentation path audit passes.
- Wrangler dry-run succeeds with the EU theark-projections binding.
- Fresh-context review findings for atomic reservation, expression identity, title ownership, publication-date preservation, and HTML attribute safety are covered by regression tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787127653&installation_id=128463665&pr_number=2462&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2462&signature=081139c25238ae68f3b270f815c79742a2067e36d5693c107845fcfb76504f1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->