### PR TITLE
docs: align Epicenter around one person, one database

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
     <img width="200" src="https://github.com/user-attachments/assets/9e210c52-2740-43b6-af3f-e6eaf4b5c397" alt="Epicenter">
   </a>
   <h1 align="center">Epicenter</h1>
-  <p align="center"><strong>Local-first apps that write to files you own.</strong></p>
-  <p align="center">Your data lives on your machine as plain Markdown and SQLite: grep it, version it, open it in Obsidian. When an app stops mattering, your files don't.</p>
+  <p align="center"><strong>What if you could manage your entire digital life in one SQLite database?</strong></p>
+  <p align="center">Epicenter is a collection of local-first apps built around a simple inversion: the database belongs to the person, not the application.</p>
+  <p align="center">Your notes, settings, documents, conversations, and history stay together on your devices. Each app gives you a different way to work with the same underlying data.</p>
   <p align="center">Start with <a href="https://whispering.epicenter.so">Whispering in the browser</a>, or run it as a native surface inside <a href="apps/epicenter">Epicenter</a>.</p>
-  <p align="center">Run the apps freely under AGPL-3.0; build on the developer toolkit freely under MIT. <a href="#license">What that means</a>.</p>
 </p>
 
 <p align="center">
@@ -25,17 +25,96 @@
 </p>
 
 <p align="center">
+  <a href="#one-person-one-epicenter">The Model</a> |
+  <a href="#what-were-building">Status</a> |
   <a href="#whispering">Whispering</a> |
+  <a href="#apps">Apps</a> |
   <a href="#build-with-the-toolkit">Toolkit</a> |
-  <a href="#how-it-works">How It Works</a> |
-  <a href="#status">Status</a> |
   <a href="#trust-boundaries">Trust</a> |
-  <a href="#repo-map">Repo Map</a> |
   <a href="#development">Development</a> |
   <a href="#license">License</a>
 </p>
 
 ---
+
+## One person. One Epicenter.
+
+The conventional model is one database per app, run by the vendor. Every app
+you adopt opens another silo. Every app you abandon strands another slice of
+your life: the notes in one company's cloud, the transcripts in another's, the
+history gone when a startup folds.
+
+Epicenter is built on the opposite premise. One person owns one logical
+database: their Epicenter. Each device keeps a full SQLite replica of it, with
+media and attachments beside it as ordinary files. Apps don't bring their own
+databases; they bring typed views over yours.
+
+```mermaid
+flowchart TB
+    subgraph apps ["Trusted apps"]
+        W["Whispering"]
+        N["Notes"]
+        T["Tabs"]
+    end
+    E[("Your Epicenter<br/>one logical database")]
+    W --> E
+    N --> E
+    T --> E
+    subgraph devices ["Your devices"]
+        L[("laptop<br/>SQLite replica")]
+        P[("phone<br/>SQLite replica")]
+        D[("desktop<br/>SQLite replica")]
+    end
+    E <--> L
+    E <--> P
+    E <--> D
+```
+
+Because everything lives in one place you control, you get properties no
+per-app cloud can offer:
+
+- **Yours to inspect.** It's SQLite. Open your own database read-only and
+  query it with plain SQL; take a complete portable export whenever you want.
+- **Yours to keep.** Apps may change or disappear. Your work, memory, and
+  accumulated context stay useful, because they never lived inside the app.
+- **More private, more personal.** Data stays on your devices instead of
+  scattering across vendor clouds, and each app can build on the context the
+  others created: transcripts inform notes, saved tabs become drafts, an
+  assistant sees the whole picture without an integration per app.
+
+Sync, when you turn it on, runs through your account's server: hosted
+Epicenter if you want convenience, self-hosted if you want the server in your
+own hands.
+
+The bet underneath all of it: the person, not the vendor, should be the
+permanent center of their digital life.
+
+## What we're building
+
+That model is the accepted destination, and this section is the honest line
+between it and today.
+
+Shipped now:
+
+- **Whispering**, in the browser and as a native surface inside the Epicenter
+  desktop host.
+- **Epicenter**, the Tauri desktop host that serves trusted app surfaces.
+- **Matter**, a standalone typed grid over folders of Markdown you own.
+- The **hosted API** and a community-supported **self-host reference**.
+
+In progress:
+
+- The one-database architecture above is decided and recorded (Proposed ADRs
+  0160 through 0182 and the one-Epicenter clean-break spec in this repo), but
+  the shipped data layer still organizes storage into per-app workspaces keyed
+  by ID. The migration deletes that second identity wave by wave.
+- Read-only live SQL over one stable `rows` relation and the portable
+  `.epicenter` export are part of that migration, not shipped behavior yet.
+
+Until those waves land, read the model section as direction. The current
+truth: local-first storage and sync work today through `@epicenter/workspace`;
+"one SQLite database per person" is what it is converging to, in the open, in
+this repo.
 
 ## Whispering
 
@@ -45,120 +124,7 @@ Press record, speak, optionally transform the transcript, and copy or deliver th
 
 [Open Whispering](https://whispering.epicenter.so) | [Read the app architecture](apps/whispering)
 
-## Build With The Toolkit
-
-The developer toolkit is MIT: build anything on it, including closed-source and commercial products, and you own what you build, with no obligation back to Epicenter. These are the packages meant to leave this repo: [`@epicenter/workspace`](packages/workspace), [`@epicenter/ui`](packages/ui), [`@epicenter/filesystem`](packages/filesystem), and [`@epicenter/sync`](packages/sync). They are pre-1.0 and tuned for our own apps, so treat them as fork-and-own rather than a stability-guaranteed SDK for now.
-
-The hard problem with local-first apps is synchronization. If each device has
-its own SQLite file or Markdown folder, how do you keep them in sync?
-[`@epicenter/workspace`](packages/workspace) is moving to a two-plane answer:
-bounded JSON rows live directly in runtime-native SQLite, while each row may
-own a lazy Yjs 14 document for collaborative rich content. SQLite remains the
-queryable scalar source rather than a mirror of one giant in-memory document.
-
-Alongside typed tables, local persistence, collaboration hooks, and validated actions, the package gives apps materializers, the writers that project state to disk.
-
-```typescript
-import { field } from '@epicenter/field';
-import { createWorkspace, defineTable } from '@epicenter/workspace';
-
-const notes = defineTable({
-  id: field.string(),
-  title: field.string(),
-  body: field.string(),
-});
-
-const workspace = createWorkspace({
-  id: 'notes',
-  tables: { notes },
-  kv: {},
-});
-
-workspace.tables.notes.set({
-  id: '1',
-  title: 'Hello',
-  body: 'Follow up on the README framing.',
-});
-
-// Materializers can project that row to Markdown files and SQLite rows.
-```
-
-[Read the workspace package docs](packages/workspace/README.md)
-
-## How It Works
-
-Epicenter separates app-owned data from user-owned Markdown. App output belongs under `apps/<name>/`; folders you own stay ordinary Markdown.
-
-```txt
-workspace/
-|-- apps/<name>/        generated app output; read, grep, quote, copy
-|-- .epicenter/         machine state; ignore
-|-- journal/            your Markdown; edit, commit, curate, publish
-|-- ideas/              your Markdown
-`-- publish/            your publishable artifacts
-```
-
-The rule is simple: `apps/<name>/` is for reading app output, not hand-editing it. To change app data, use the app or a CLI action validated against the app's schema. To keep something forever, copy it into a folder you own.
-
-Your folders are ordinary Markdown: grep them, open them in Obsidian, version them with Git, publish them with whatever static site stack you like.
-
-```txt
-purpose-built app
-  -> SQLite scalar rows for local queries and synchronization
-  -> lazy row-owned Yjs 14 documents for collaborative content
-  -> Markdown projection for human reading
-  -> curated Markdown when something is worth keeping
-```
-
-SQLite handles bounded rows, local SQL, and scalar synchronization. Yjs handles
-lazy rich documents, offline document edits, and live collaboration. Markdown
-gives you files you can read, quote, copy, version, and publish. This clean
-break is recorded in Proposed ADRs 0144 through 0147 and is still being
-implemented; the current package README labels the old and new paths explicitly.
-
-A generated Markdown projection is meant to be boring on purpose (this is the target shape):
-
-```md
----
-id: note_123
-title: Morning capture
-source: app
-updatedAt: "2026-06-10T16:49:59.180Z"
----
-Follow up on the README framing.
-```
-
-Matter applies the same SQLite-mirror idea to the folders you own: it keeps a disposable `matter.sqlite` mirror of each managed folder, so agents and scripts can query your Markdown as SQL:
-
-```bash
-sqlite3 matter.sqlite 'select "name" from "journal" limit 5;'
-```
-
-## Status
-
-Whispering is independently deployable as a browser SPA and is also mounted inside the Epicenter desktop host. Epicenter is the only native runtime; Whispering no longer ships a standalone desktop shell.
-
-The shared workspace for tabs, notes, drafts, and publishing is being built in public around `@epicenter/workspace`. [Matter](apps/matter) is an early app for user-owned Markdown folders: it edits ordinary Markdown directly and keeps `matter.sqlite` as a query mirror. Other app folders are public research and prototypes.
-
-## Trust Boundaries
-
-Pick the trust model you want.
-
-| Path | What leaves your device |
-| --- | --- |
-| Whispering in Epicenter with local GGUF transcription | Audio stays on your device. Transcripts and settings use Epicenter's local desktop storage. |
-| Whispering with a cloud transcription provider | Audio goes from your device to the provider you choose. Epicenter servers are not in that transcription path. |
-| Whispering transformations | Transcript text goes to the LLM provider you choose when you enable that step. |
-| Hosted Epicenter API or sync | Workspace updates, account/session data, and enabled hosted feature requests go to Epicenter servers. |
-| Self-hosted deployable | You control the server, secrets, deployment, and infrastructure boundary. |
-
-Signed-in workspace sync sends your Yjs updates to a trusted relay that reads them in plaintext. On hosted Epicenter the relay is ours, so that data sits inside our trust boundary; self-hosting puts the relay on infrastructure you control, so Epicenter never holds it. See the [trust model](docs/trust-model.md) for the details, including where this is heading with the anchor.
-
-The detailed privacy notes for Whispering live in [apps/whispering](apps/whispering).
-
-## Repo Map
-
-### Product And Workspace Surfaces
+## Apps
 
 | Surface | Status | Notes |
 | --- | --- | --- |
@@ -169,13 +135,20 @@ The detailed privacy notes for Whispering live in [apps/whispering](apps/whisper
 | [Self-host](apps/self-host) | Reference deployable | Community-supported single-partition instance without hosted billing. |
 | Other app folders | Research and prototypes | Useful history and experiments, not the current product lineup. |
 
-### Packages
+## Build With The Toolkit
 
-These packages carry the main architecture.
+The developer toolkit is MIT: build anything on it, including closed-source and commercial products, and you own what you build, with no obligation back to Epicenter. These are the packages meant to leave this repo: [`@epicenter/workspace`](packages/workspace), [`@epicenter/ui`](packages/ui), [`@epicenter/filesystem`](packages/filesystem), and [`@epicenter/sync`](packages/sync). They are pre-1.0 and tuned for our own apps, so treat them as fork-and-own rather than a stability-guaranteed SDK for now.
+
+The hard problem with local-first apps is synchronization. If each device has
+its own SQLite file, how do you keep them in sync?
+[`@epicenter/workspace`](packages/workspace) answers with two planes: bounded
+JSON rows live directly in runtime-native SQLite, while each row may own a
+lazy Yjs 14 document for collaborative rich content. SQLite is the queryable
+scalar source, not a mirror of one giant in-memory document.
 
 | Package | Role | License |
 | --- | --- | --- |
-| [`@epicenter/workspace`](packages/workspace) | Typed workspace API, queryable scalar replicas, lazy row documents, local persistence, actions, and runtime composition. | MIT |
+| [`@epicenter/workspace`](packages/workspace) | Typed data API, queryable scalar replicas, lazy row documents, local persistence, actions, and runtime composition. | MIT |
 | [`@epicenter/row-sync`](packages/row-sync) | Portable scalar row protocol, admission, deterministic field folding, and exact-retry digests. It owns no authority database. | MIT |
 | [`@epicenter/sqlite`](packages/sqlite) | Neutral embedded-SQLite driver and Browser, Bun, and Durable Object adapters. It owns no product schema. | MIT |
 | [`@epicenter/sync`](packages/sync) | Yjs document protocol encoding and provider behavior, separate from scalar row synchronization. | MIT |
@@ -183,6 +156,24 @@ These packages carry the main architecture.
 | [`@epicenter/filesystem`](packages/filesystem) | POSIX-style virtual filesystem helpers over workspace data. | MIT |
 | [`@epicenter/server`](packages/server) | Shared Hono server library composed by the hosted API and self-host reference deployable. | AGPL-3.0-or-later |
 | [`@epicenter/cli`](packages/cli) | The `epicenter` command and local or hosted API workflows. | AGPL-3.0-or-later |
+
+[Read the workspace package docs](packages/workspace/README.md)
+
+## Trust Boundaries
+
+Pick the trust model you want.
+
+| Path | What leaves your device |
+| --- | --- |
+| Whispering in Epicenter with local GGUF transcription | Audio stays on your device. Transcripts and settings use Epicenter's local desktop storage. |
+| Whispering with a cloud transcription provider | Audio goes from your device to the provider you choose. Epicenter servers are not in that transcription path. |
+| Whispering transformations | Transcript text goes to the LLM provider you choose when you enable that step. |
+| Hosted Epicenter API or sync | Synchronized data, account/session data, and enabled hosted feature requests go to Epicenter servers. |
+| Self-hosted deployable | You control the server, secrets, deployment, and infrastructure boundary. |
+
+Signed-in sync sends your updates to a trusted relay that reads them in plaintext. On hosted Epicenter the relay is ours, so that data sits inside our trust boundary; self-hosting puts the relay on infrastructure you control, so Epicenter never holds it. See the [trust model](docs/trust-model.md) for the details.
+
+The detailed privacy notes for Whispering live in [apps/whispering](apps/whispering).
 
 ## Architecture
 
@@ -248,7 +239,7 @@ bun run check
 
 ## Design Notes
 
-Implementation specs and design notes live in [specs/](specs). Start with [docs/README.md](docs/README.md) and [specs/README.md](specs/README.md).
+Durable decisions live in [docs/adr/](docs/adr); shared vocabulary in [docs/CONTEXT.md](docs/CONTEXT.md); in-flight implementation specs in [specs/](specs). Start with [docs/README.md](docs/README.md).
 
 ## Contributing
 
@@ -277,5 +268,5 @@ See the root [LICENSE](LICENSE), [FINANCIAL_SUSTAINABILITY.md](FINANCIAL_SUSTAIN
 </p>
 
 <p align="center">
-  <sub>When an app stops mattering, your files don't. Local-first, open source, built on Yjs.</sub>
+  <sub>One person. One Epicenter. Local-first, open source.</sub>
 </p>

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@
 
 ## One person. One Epicenter.
 
+This is the destination.
+
 The conventional model is one database per app, run by the vendor. Every app
 you adopt opens another silo. Every app you abandon strands another slice of
 your life: the notes in one company's cloud, the transcripts in another's, the
@@ -77,10 +79,11 @@ per-app cloud can offer:
   query it with plain SQL; take a complete portable export whenever you want.
 - **Yours to keep.** Apps may change or disappear. Your work, memory, and
   accumulated context stay useful, because they never lived inside the app.
-- **More private, more personal.** Data stays on your devices instead of
-  scattering across vendor clouds, and each app can build on the context the
-  others created: transcripts inform notes, saved tabs become drafts, an
-  assistant sees the whole picture without an integration per app.
+- **More private, more personal.** Data stays together on your devices instead
+  of scattering across a different vendor cloud for every app. Each app can
+  build on the context the others created: transcripts inform notes, saved tabs
+  become drafts, and an assistant sees the whole picture without an integration
+  per app.
 
 Sync, when you turn it on, runs through your account's server: hosted
 Epicenter if you want convenience, self-hosted if you want the server in your

--- a/README.md
+++ b/README.md
@@ -141,10 +141,10 @@ The developer toolkit is MIT: build anything on it, including closed-source and 
 
 The hard problem with local-first apps is synchronization. If each device has
 its own SQLite file, how do you keep them in sync?
-[`@epicenter/workspace`](packages/workspace) answers with two planes: bounded
-JSON rows live directly in runtime-native SQLite, while each row may own a
-lazy Yjs 14 document for collaborative rich content. SQLite is the queryable
-scalar source, not a mirror of one giant in-memory document.
+[`@epicenter/workspace`](packages/workspace) is moving to a two-plane answer:
+bounded JSON rows live directly in runtime-native SQLite, while each row may
+own a lazy Yjs 14 document for collaborative rich content. SQLite is the
+queryable scalar source, not a mirror of one giant in-memory document.
 
 | Package | Role | License |
 | --- | --- | --- |

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -5,6 +5,57 @@ thing the same way. Keep entries to one or two lines. When a design pass coins o
 sharpens a term, update it here in the same change. For the decisions behind these
 shapes, see `docs/adr/`.
 
+Two layers live in this file. The destination vocabulary names the accepted
+one-Epicenter model (Proposed ADRs 0160 through 0182); design work and new
+documentation use it. The transitional vocabulary names shipped code still
+built around the older Workspace noun; it leaves the tree wave by wave as the
+clean break lands (`specs/20260719T222716-one-epicenter-clean-break.md`). When
+the two disagree about where we are going, the destination vocabulary wins.
+
+## One Epicenter (destination)
+
+- **Epicenter**: one person's whole durable state: current rows, typed KV, one
+  latent row-owned Yjs document per ordinary row, and immutable blobs. One
+  selected owner has exactly one; there is no `WorkspaceId`, `DatabaseId`,
+  named logical database, or second platform store beneath a person
+  (ADR-0160).
+- **Owner**: the selected local Epicenter or one principal's server Epicenter.
+  Owner selection is the boot and storage decision (ADR-0181); applications
+  never choose local versus account storage independently.
+- **Replica**: one device's private durable copy of the selected Epicenter:
+  `epicenter.sqlite3` plus a `blobs/` sibling, with bounded sync state
+  (ADR-0161). On desktop and Bun the live database is readable in place,
+  read-only, through the stable `rows` relation; synchronized mutations enter
+  only through the typed TypeScript API, and a direct live-file write never
+  synchronizes.
+- **Lens**: the identity-free, release-local typed interpretation
+  (`defineEpicenter({ tables, kv })`) a trusted application brings to the
+  selected owner (ADR-0172). Several lenses read the same rows concurrently. A
+  lens is not an identity, a permission boundary, or a storage lifecycle, and
+  it cannot mint a named logical database.
+- **Row**: one generated ID under a permanent table key carrying schema-opaque
+  scalar fields. Projects, notebooks, folders, and collections are application
+  rows, never platform stores.
+- **Row document**: the latent Yjs 14 document whose lifetime is owned by one
+  row. It synchronizes on its own plane, independent of scalar rows
+  (ADR-0144).
+- **Blob**: immutable owner-scoped bytes addressed by an opaque `BlobId`. Rows
+  and KV may reference blobs; documents are bounded interactive CRDT state,
+  not a media plane.
+- **`rows` relation**: the one stable, lens-independent read-only SQL surface,
+  `rows(table_key, row_id, fields_json)` (ADR-0163). It replaces the
+  transitional `records` relation and every per-lens TEMP view.
+- **Portable artifact**: the detached `.epicenter` directory, a frozen editable
+  projection of one selected owner (ADR-0162, ADR-0165). The live replica is
+  never the portable format; deliberate editing happens on the artifact, not
+  the live file.
+- **Authority** (role): the hosted or self-hosted server side that orders
+  accepted scalar state, persists documents, and accepts blobs. Hosted
+  accepted state lives in one `EpicenterDurableObject` per principal
+  (ADR-0175); owner-data routes are ID-free and specific to each
+  synchronization plane (ADR-0179). Authority is a protocol role, never a
+  public product noun.
+
 ## Platform and topology
 
 - **Deployment**: one reachable Epicenter installation, hosted or self-hosted,
@@ -16,49 +67,23 @@ shapes, see `docs/adr/`.
   (ADR-0092). Cloud resolves many principals from Better Auth users; a
   self-hosted instance resolves every valid operator bearer to the literal
   `instance` principal. Durable namespaces use `principals/<principalId>/...`.
-  Billing is hosted-only and lives in `apps/api/worker/billing/`.
+  Billing is hosted-only and lives in `apps/api/worker/billing/`. One principal
+  owns exactly one Epicenter (ADR-0160).
 - **Account**: the runtime handle for one resolved principal inside one
   deployment. Credentials may rotate, but deployment identity plus `principalId`
   is the stable data identity; transport is how the runtime syncs.
-- **Workspace**: one stable app-defined local-first data and sync unit. It owns
-  workspace KV and tables; each table owns rows; each ordinary row owns scalar
-  fields plus one latent lifecycle-bound document.
-- **Storage owner**: the Device or one Account that owns a local workspace
-  store. Device and Account with the same Workspace ID remain separate owners;
-  owner-wide lifecycle never crosses between them.
-- **Workspace store**: the runtime-private SQLite family for one storage owner
-  and Workspace ID. Bun stores it at
-  `workspaces/device/<WorkspaceId>/store.sqlite3` or
-  `workspaces/accounts/<AccountKey>/<WorkspaceId>/store.sqlite3`; it is not a
-  portable workspace export or an app-visible file capability.
-- **Epicenter Home**: the trusted shell above registered workspaces. It owns
+- **Epicenter Home**: the trusted shell above the selected Epicenter. It owns
   navigation, assistant sessions, commands, approvals, and live interface
-  state; durable data such as conversations lives in ordinary workspaces.
+  state; durable data such as conversations lives in ordinary rows of the
+  selected owner (ADR-0180).
 - **Trusted app catalog**: the validated static SPAs Epicenter serves from one
   origin and grants one fixed app-window authority. Bundled output supplies the
   default catalog; user-built output may replace a member by app ID.
 - **App composition repository**: an ordinary user-owned Git tree whose
   `apps/<id>` source members build the trusted app catalog. It is source, not
   Epicenter app data, runtime installation state, or a permission registry.
-- **Device workspace**: a signed-out workspace owned only by the current device.
-  Runtime-native SQLite owns its scalar rows; a runtime-native provider owns its
-  row documents. It has no deployment, principal, credential, or sync transport.
-- **Account workspace**: a signed-in workspace inside the authenticated
-  principal's own partition. The route workspace id is a name in that
-  partition; no catalog, grant, or authorization lookup exists. Its scalar and
-  document stores remain independent client persistence owners.
-- **Adoption**: explicit Add, Delete, or Keep after sign-in. Add transfers
-  logical scalar state and documents through their native planes; source
-  deletion is a separate action after both destination stores are locally
-  durable.
-- **Account authority**: the one server runtime owner for everything an
-  authenticated principal stores: one actor and one SQLite database containing
-  every named workspace as a logical namespace. Its address derives
-  deterministically from the principal alone, so no request can reach another
-  principal's state. It orders scalar row synchronization and hosts the
-  separate row-document connections.
 - **Row-document connection**: one authenticated Yjs 14 WebSocket for one
-  currently open `(table key, row id)` inside a synchronized workspace. Its
+  currently open `(table key, row id)` of the synchronized Epicenter. Its
   structured route address is lifecycle identity, not a secret; it is separate
   from scalar push, pull, acquisition, and settlement.
 - **Row liveness**: the authority-local fact that a row address is currently
@@ -109,7 +134,7 @@ shapes, see `docs/adr/`.
 - **Cross-device planes**: cross-device work splits by responsibility. *Inference* (the
   chat brain) streams tokens from an OpenAI-compatible endpoint (ADR-0050),
   over the inference seam. *Scalar sync* carries queryable rows and KV through
-  the row authority. *Document sync* carries lazy Yjs history and row-scoped
+  the owner's authority. *Document sync* carries lazy Yjs history and row-scoped
   presence over row-document connections. *Invoke* (the agent's hands) is local
   to the host that owns the tool process, unless a future product re-earns a
   direct URL-addressed box surface.
@@ -133,13 +158,18 @@ shapes, see `docs/adr/`.
   environment. The monorepo root has no Infisical config, so local apps cannot
   silently inherit Epicenter's hosted/operator project.
 
-## Workspace API
+## Data API
 
-- **Workspace KV**: declared workspace-owned singleton values with no public row
-  identity, lifecycle, or query surface. Internally it may use a reserved row,
-  but public application code treats it as workspace-owned KV.
-- **Table key**: the permanent storage key that partitions rows in a workspace.
-  A release-local table name is not a rename lens over another key.
+These entries describe the typed data surface. Most survive the clean break
+unchanged because they were already identity-free; entries marked transitional
+are replaced by a destination concept above.
+
+- **Workspace KV** (transitional name; destination: the Epicenter's typed KV):
+  declared owner-level singleton values with no public row identity, lifecycle,
+  or query surface. Internally it may use a reserved row, but application code
+  treats it as owner-owned KV.
+- **Table key**: the permanent storage key that partitions rows. A
+  release-local table name is not a rename lens over another key.
 - **Row**: one identified application value in a table. It is the public
   lifecycle aggregate. Server deletion atomically tombstones its address and
   removes its document state; disconnected clients revoke handles and clean up
@@ -155,10 +185,10 @@ shapes, see `docs/adr/`.
   It has no public id, authority, or lifecycle independent from the row. Its
   runtime-native provider persists and synchronizes it independently from
   scalar row sync.
-- **Record**: not a platform lifecycle noun in the canonical workspace model.
-  Use row for the durable application aggregate, fields for JSON values, and
-  document for the row-owned CRDT state. Historical docs and transitional code
-  may still use record while they migrate.
+- **Record**: not a platform lifecycle noun in the canonical model. Use row for
+  the durable application aggregate, fields for JSON values, and document for
+  the row-owned CRDT state. Historical docs and transitional code may still
+  use record while they migrate.
 - **Conforming row**: a canonical row that satisfies the opened release's table
   lens. `get()` returns a typed row or `undefined` inside `Result`, or a
   `NonconformingRow` error; `scan()` returns conforming rows and
@@ -168,45 +198,24 @@ shapes, see `docs/adr/`.
   value when its field accepts null.
 - **Application repair**: ordinary bounded reads and typed patches authored by
   the application. Repair is explicit, retryable application work, not a
-  workspace migration API or an effect of reading.
-- **Logical workspace copy**: coordinated scalar rows, KV, compact Yjs 14
-  document states, and explicit document-availability diagnostics. It is not an
-  exact cross-plane instant and contains no SQLite pages, provider databases,
-  actors, cursors, receipts, or mutation history.
-- **Connection-local SQL view**: one read-only explicit-column `TEMP VIEW`
-  installed from the current table lens whenever a SQLite connection opens. It
-  stores no rows, reflects canonical commits immediately, and disappears with
-  the connection.
+  platform migration API or an effect of reading.
+- **Logical workspace copy** (transitional): coordinated scalar rows, KV,
+  compact Yjs 14 document states, and explicit document-availability
+  diagnostics. The destination replaces it with the portable `.epicenter`
+  artifact (ADR-0162, ADR-0165).
+- **Connection-local SQL view** (transitional): one read-only explicit-column
+  `TEMP VIEW` installed from the current table lens when a SQLite connection
+  opens. The destination refuses per-lens views and exposes only the stable
+  `rows` relation (ADR-0163).
 - **Row document handle**: the revocable handle returned by a lazy row document
   open. It exposes application roots, local provider durability, and document
   connection status. Releasing the final handle may unload live Yjs state but
   never deletes persisted or synchronized content.
 - **Row intent**: one schema-blind `create`, `update`, or `delete` sync unit. It
   carries scalar fields or the reserved KV representation, never document
-  updates. The workspace authority orders accepted intents and folds them into
+  updates. The owner's authority orders accepted intents and folds them into
   confirmed scalar state.
-- **Blob**: immutable bytes addressed by an opaque `BlobId` outside workspace
-  rows and KV. Rows and KV may reference blobs; row-owned documents are bounded
-  interactive CRDT state, not a media or large-file plane.
-- **Canonical workspace runtime**: the greenfield two-plane lane. Runtime-native
-  SQLite owns queryable scalar rows, TEMP views, and read-only SQL. Runtime-native
-  Yjs 14 providers own lazy row documents. The public workspace handle composes
-  them without promising cross-plane atomicity. This lane uses `@y/y` 14 only;
-  it has no Yjs 13 dependency, persisted reader, alias, dual wire, or fallback.
-- **Transitional root-Yjs workspace**: the still-active `@epicenter/workspace`
-  lane used by apps not yet migrated. Its `defineKv`, definition-owned
-  `create/connect/mount`, `.docs`, and `_v` behavior remain compatibility
-  surfaces for those apps, not the canonical SQLite design.
-- **Transitional `satisfiesWorkspace`**: the root-Yjs bundle-conformance helper
-  (renamed from the older `defineWorkspaceBundle`).
-- **Transitional actions and collaboration**: actions remain part of the
-  root-Yjs workspace bundle; collaboration is sync and presence only.
-- **Transitional root-Yjs child document**: a separate, lazy Y.Doc owned by one
-  row and reached through `ws.tables.X.docs.name.open(rowId)`. The workspace
-  derives its address from the workspace, table, a collision-resistant digest
-  of the full row ID, document name, and document format hash; the format
-  capability attaches the typed content handle after the runtime opens the doc.
-- **Worker**: running behavior that observes workspace state and writes results
+- **Worker**: running behavior that observes Epicenter state and writes results
   back. Workers may be local (every node runs them) or agent-bound (one
   configured agent answers). A conversation is answered by the client agent loop
   in the open tab, for every agent (ADR-0047); the daemon contributes data and
@@ -231,10 +240,72 @@ shapes, see `docs/adr/`.
   syncs across a person's peers uses the workspace loop (`createConversation`,
   finished messages in a Yjs child doc); a deliberately device-local transcript
   uses TanStack `createChat` (tab-manager, IndexedDB).
-- **Materializer**: a local, addressless worker that projects workspace data into
+- **Materializer**: a local, addressless worker that projects Epicenter data into
   another store (markdown, sqlite).
 - **`attach*` vs `create*`**: `attach*` are side-effectful primitives that register
   listeners at call time; `create*` are pure construction.
+
+## Transitional workspace vocabulary (shipped code, leaving)
+
+The shipped runtime still keys storage, synchronization, and routes by
+Workspace ID. These entries describe that code truthfully so it can be
+maintained until each replacement wave lands; do not design new surfaces
+against them.
+
+- **Workspace**: the shipped app-defined local-first data and sync unit; it
+  owns workspace KV and tables. In the destination, applications bring
+  identity-free lenses over the one selected Epicenter instead (ADR-0160,
+  ADR-0172).
+- **Storage owner**: the Device or one Account that owns a local workspace
+  store. Device and Account with the same Workspace ID remain separate owners;
+  owner-wide lifecycle never crosses between them.
+- **Workspace store**: the runtime-private SQLite family for one storage owner
+  and Workspace ID. Bun stores it at
+  `workspaces/device/<WorkspaceId>/store.sqlite3` or
+  `workspaces/accounts/<AccountKey>/<WorkspaceId>/store.sqlite3`. The
+  destination layout is one `epicenters/<owner>/epicenter.sqlite3` plus
+  `blobs/` per selected owner (ADR-0161).
+- **Device workspace**: a signed-out workspace owned only by the current device.
+  Runtime-native SQLite owns its scalar rows; a runtime-native provider owns its
+  row documents. It has no deployment, principal, credential, or sync transport.
+  The destination equivalent is the explicit local owner (ADR-0181).
+- **Account workspace**: a signed-in workspace inside the authenticated
+  principal's own partition. The route workspace id is a name in that
+  partition; no catalog, grant, or authorization lookup exists. The destination
+  removes the name axis entirely: one principal, one Epicenter (ADR-0160).
+- **Adoption**: explicit Add, Delete, or Keep after sign-in. Add transfers
+  logical scalar state and documents through their native planes; source
+  deletion is a separate action after both destination stores are locally
+  durable. The destination replaces Device Add with empty initialization or
+  whole-owner replacement (ADR-0166).
+- **Account authority**: the shipped server runtime owner for everything an
+  authenticated principal stores: one actor and one SQLite database containing
+  every named workspace as a logical namespace. The destination actor is
+  `EpicenterDurableObject`, with authority as a protocol role only (ADR-0175).
+- **Canonical workspace runtime**: the greenfield two-plane lane. Runtime-native
+  SQLite owns queryable scalar rows and read-only SQL. Runtime-native
+  Yjs 14 providers own lazy row documents. The public handle composes
+  them without promising cross-plane atomicity. This lane uses `@y/y` 14 only;
+  it has no Yjs 13 dependency, persisted reader, alias, dual wire, or fallback.
+  Its remaining Workspace-ID plurality is what the one-Epicenter waves delete.
+- **Transitional root-Yjs workspace**: the still-active `@epicenter/workspace`
+  lane used by apps not yet migrated. Its `defineKv`, definition-owned
+  `create/connect/mount`, `.docs`, and `_v` behavior remain compatibility
+  surfaces for those apps, not the canonical SQLite design.
+- **Transitional `satisfiesWorkspace`**: the root-Yjs bundle-conformance helper
+  (renamed from the older `defineWorkspaceBundle`).
+- **Transitional actions and collaboration**: actions remain part of the
+  root-Yjs workspace bundle; collaboration is sync and presence only.
+- **Transitional root-Yjs child document**: a separate, lazy Y.Doc owned by one
+  row and reached through `ws.tables.X.docs.name.open(rowId)`. The workspace
+  derives its address from the workspace, table, a collision-resistant digest
+  of the full row ID, document name, and document format hash; the format
+  capability attaches the typed content handle after the runtime opens the doc.
+- **Vault**: the designated, not-yet-built home for the one encryption that
+  survives ADR-0004: an explicitly encrypted, shared workspace for secrets only
+  (blind relay, Argon2-derived key). Its primitives were removed with the
+  encryption layer; it returns minimally if a secrets path is built. Distinct
+  from the Matter vault (a folder of Markdown).
 
 ## Transitional root-Yjs app composition
 
@@ -244,11 +315,6 @@ shapes, see `docs/adr/`.
 - **`session`**: the singleton holding the signed-in workspace lifecycle.
 - **deviceConfig vs workspace KV**: per-device settings (global shortcuts, machine
   collisions) versus synced settings (local shortcuts). The asymmetry is deliberate.
-- **Vault**: the designated, not-yet-built home for the one encryption that
-  survives ADR-0004: an explicitly encrypted, shared workspace for secrets only
-  (blind relay, Argon2-derived key). Its primitives were removed with the
-  encryption layer; it returns minimally if a secrets path is built. Distinct
-  from the Matter vault (a folder of Markdown).
 
 ## CLI and watcher
 

--- a/docs/adr/0160-one-principal-owns-exactly-one-epicenter.md
+++ b/docs/adr/0160-one-principal-owns-exactly-one-epicenter.md
@@ -21,8 +21,9 @@ One selected owner owns exactly one Epicenter. A hosted deployment resolves the
 authenticated principal and therefore the Epicenter. A self-hosted instance
 resolves every valid bearer to its literal `instance` principal. Explicit local
 use selects one independent local Epicenter. There is no `EpicenterId`,
-`WorkspaceId`, platform workspace catalog, or second Epicenter beneath one
-owner.
+`WorkspaceId`, `DatabaseId`, platform workspace or database catalog, or second
+Epicenter beneath one owner. Renaming the plurality does not readmit it: a
+named logical database is the same refused axis.
 
 An Epicenter contains current rows, typed KV, one latent row-owned Yjs document
 per ordinary row, and owner-scoped immutable blobs. Rows are addressed by their

--- a/docs/adr/0161-each-local-owner-persists-one-sqlite-database-and-one-blob-directory.md
+++ b/docs/adr/0161-each-local-owner-persists-one-sqlite-database-and-one-blob-directory.md
@@ -47,9 +47,19 @@ The boundary is semantic, never size-based. Yjs document bytes do not move into
 `blobs/` when large, and a small recording does not move into SQLite. Private
 physical tables and the live file itself are not the portable format.
 
+The live database is directly inspectable but never directly writable. On
+desktop and Bun, a person or external tool may open `epicenter.sqlite3`
+read-only and query the one stable, lens-independent `rows` relation that
+ADR-0163 defines; every other relation in the file stays private and free to
+change. Synchronized mutations enter only through Epicenter's typed TypeScript
+API. A direct write to the live file is unsupported and never synchronizes;
+deliberate offline editing belongs to the detached portable artifact
+(ADR-0162).
+
 Browser storage uses the same ownership model through its platform-native
 SQLite and blob backends even when it cannot expose this literal filesystem
-tree.
+tree. The browser preserves the same read-only `rows` semantics through the
+SQL API; it promises semantic access, not a filesystem path.
 
 ## Consequences
 

--- a/docs/adr/0163-read-only-sql-exposes-only-the-schema-opaque-rows-relation.md
+++ b/docs/adr/0163-read-only-sql-exposes-only-the-schema-opaque-rows-relation.md
@@ -33,10 +33,22 @@ transaction. SQL performs no hidden network work and does not claim an exact
 historical server checkpoint; different remotely accepted rows may become
 visible locally at different times.
 
-The runtime may implement `rows` as a protected table, view, or isolated query
-connection. That representation is private. Every implementation must make the
-relation incrementally readable: executing a query cannot rebuild or reinsert
-the complete visible dataset first.
+`rows` is also readable in place. On desktop and Bun, the live
+`epicenter.sqlite3` file itself contains a relation named `rows` (a real table
+or a view over private tables), so a person can open the database read-only
+with ordinary SQLite tools, or through an owner-level native reader (an
+`openEpicenterReader()`-style call that takes no database ID and no
+application definition), and query the same relation the API exposes. External
+connections are read-only (`query_only`); the platform supports no external
+write path to the live file, and a direct write never synchronizes (ADR-0161).
+In the browser, `rows` keeps the same semantics through the SQL API without a
+filesystem-path promise.
+
+Behind that name, the backing representation is private. Where no direct file
+access exists, the runtime may serve `rows` through an isolated query
+connection. Every implementation must make the relation incrementally
+readable: executing a query cannot rebuild or reinsert the complete visible
+dataset first.
 
 Only read-only `SELECT` and `WITH` statements are accepted. The executor compiles
 the bound statement and proves that it can address only `rows`; it rejects DDL,
@@ -53,6 +65,8 @@ returned rows there.
 
 - Several lenses can query the same local owner without registration or name
   collisions.
+- Live data is inspectable in place, read-only, without an export step.
+  Deliberate editing stays with the detached portable artifact (ADR-0162).
 - Queries spell JSON extraction and filter by permanent `table_key` values.
 - `rows` replaces `records` without a compatibility alias.
 - Table-valued JSON traversal is outside v1. A measured caller may reopen the

--- a/docs/adr/0172-applications-interpret-the-selected-epicenter-through-identity-free-lenses.md
+++ b/docs/adr/0172-applications-interpret-the-selected-epicenter-through-identity-free-lenses.md
@@ -51,6 +51,12 @@ selected Epicenter. A lens is not a permission boundary. App installation and
 uninstall never create or delete durable stores, and no installed-app workspace
 inventory survives.
 
+A lens also cannot mint a durable logical database identity under any noun.
+There is no `defineDatabase({ id })`, database ID or `database_id` column,
+named-database catalog, or per-application partition beneath the selected
+owner. Renaming the refused workspace plurality to "database" does not readmit
+it.
+
 ## Consequences
 
 - Two apps can interpret the same table differently without negotiating a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,12 @@
 # Epicenter architecture
 
-Epicenter is a local-first workspace platform. Apps define stable workspace
-families, clients keep complete local data, and a hosted or self-hosted star
-keeps devices synchronized while they sleep.
+Epicenter is a local-first platform: a collection of apps over one shared
+data layer. The accepted destination is one Epicenter per person, interpreted
+by trusted apps through identity-free lenses (Proposed ADRs 0160 through 0182
+and `docs/CONTEXT.md`). The shipped runtime this page maps still organizes
+data into app-defined workspaces while that migration lands. Clients keep
+complete local data, and a hosted or self-hosted star keeps devices
+synchronized while they sleep.
 
 This page is the five-minute map. Durable decisions live in
 [`docs/adr`](adr/README.md). Shared vocabulary lives in

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -29,10 +29,11 @@ are rows. When an app changes or disappears, the person's work, memory, and
 accumulated context stay useful, because they never lived inside the app.
 
 Shared local context is the payoff, twice over. More private, because the data
-stays on the person's devices instead of scattering across vendor clouds. More
-personal, because each app can see the context the others created: your
-transcripts can inform your notes, your saved tabs can become drafts, and an
-assistant can work across all of it without an integration per app.
+stays together on the person's devices instead of scattering across a different
+vendor cloud for every app. More personal, because each app can see the context
+the others created: your transcripts can inform your notes, your saved tabs can
+become drafts, and an assistant can work across all of it without an integration
+per app.
 
 Precision rule: "one database per person" is the product shorthand, and it is
 the shorthand to lead with. The technical claim behind it stays exact: one

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -6,41 +6,50 @@ Canonical positioning for Epicenter. This doc owns the public claims and the rul
 
 The product picture all messaging derives from. This section describes the end state, not public copy. Public copy quotes the Spine. The Destination is the compass, never quoted directly.
 
-One folder on your disk is one app. Drop an `epicenter.config.ts` into a folder
-and that folder becomes an Epicenter app; its name is your choice. The config
-default-exports one app, and that app's read-only Markdown projection, its
-machine state, and its sync all run from that one folder. A workspace is the
-folder where you keep those app folders side by side with the folders you own:
+One person owns one logical Epicenter: their notes, settings, documents,
+conversations, and history, together in one database. Each of their devices
+keeps one full SQLite replica of it, with media and attachments beside it.
+Every trusted Epicenter app works with that same database through its own
+release-local, identity-free lens: a transcription app, a notes app, a tab
+manager, each a different way of working with the same underlying data.
 
 ```txt
-~/workspace/
-|-- apps/
-|   |-- whispering/
-|   |   |-- epicenter.config.ts   default-exports the whispering app
-|   |   |-- recordings/           read-only Markdown projection of live app state
-|   |   `-- .epicenter/           machine state; ignore it
-|   `-- tabs/
-|       |-- epicenter.config.ts   default-exports the tabs app
-|       |-- saved/                read-only Markdown projection of live app state
-|       `-- .epicenter/           machine state; ignore it
-|-- journal/                      yours forever
-|-- ideas/                        yours forever
-`-- publish/                      yours forever
+        Whispering   Notes   Tabs   ...trusted apps
+              \        |       /
+               one logical Epicenter
+              /        |       \
+        laptop      phone      desktop
+     (SQLite replica on each device)
 ```
 
-Each app is its own folder, so each runs its own daemon and is its own sync
-peer; nothing multiplexes. Group the app folders however you like: the `apps/`
-container is convention, not a rule, and nothing reserves the name. Your own
-folders (`journal/`, `ideas/`, `publish/`) sit beside them as plain files you
-keep forever.
+The inversion this buys: the database belongs to the person, not the
+application. Apps do not own databases inside a person's Epicenter, not
+physical ones and not named logical ones. Projects, notebooks, and collections
+are rows. When an app changes or disappears, the person's work, memory, and
+accumulated context stay useful, because they never lived inside the app.
 
-You speak a thought into Whispering and it lands in your Whispering app folder as Markdown. You save tabs, draft entries, capture whatever, each through a purpose-built app, and every capture becomes a file you can grep. An agent reads the same files, queries the SQLite mirrors with plain SQL, and when it needs to change app state it goes through the same gate you do: a workspace action, validated against the app's schema and exposed to the agent as a tool. Nothing mutates by editing generated files; the projection is one-way on purpose.
+Shared local context is the payoff, twice over. More private, because the data
+stays on the person's devices instead of scattering across vendor clouds. More
+personal, because each app can see the context the others created: your
+transcripts can inform your notes, your saved tabs can become drafts, and an
+assistant can work across all of it without an integration per app.
 
-The loop is capture, curate, keep. App output is a disposable inbox, regenerable from the CRDT at any time. What matters graduates into folders you own: ordinary Markdown, tracked in git, still yours after every app in this repo is gone.
+Precision rule: "one database per person" is the product shorthand, and it is
+the shorthand to lead with. The technical claim behind it stays exact: one
+Epicenter per selected owner (a person's account, a self-hosted instance, or
+an explicit local owner), one SQLite replica per device, synchronized through
+that owner's server. Trusted apps are not permission boundaries; a real
+security boundary requires another principal or another deployment. Copy may
+compress; it may not conflate one person's Epicenter with an account holding
+many named databases.
 
-The quiet bet: the properties that make a workspace durable for you are the same ones that make it legible to agents. Plain files are the context window. SQLite is the query surface. The action registry is the tool list. Epicenter is the workspace where you and your agents are co-writers under one set of rules.
-
-What we refuse to build is the strategy. No partial sync: a workspace is one full local replica, which is what lets Yjs carry it instead of a private protocol. No row-level permissions: the app corpus is the unit of sharing; the folder is a local projection and runtime site for that corpus. No editing generated projections back into apps: one validated write path, for humans and agents alike. Each refusal pays for the simplicity of everything else.
+What we refuse to build is the strategy. No second database identity beneath
+the person: no per-app databases, no named logical databases, no database
+catalog. No partial sync: a device replicates the whole Epicenter, which is
+what keeps sync simple and the local copy complete. One validated write path:
+apps and agents mutate data through typed APIs, and the live database stays
+inspectable read-only rather than becoming a free-for-all write surface. Each
+refusal pays for the simplicity of everything else.
 
 ## The Spine
 
@@ -48,46 +57,58 @@ One message, cut to length and audience. Longer cuts add detail. No cut contradi
 
 One line, for one-line surfaces (GitHub About, social preview, link cards):
 
-> Local-first apps that write to files you own.
+> Local-first apps that share one database you own.
 
 The hero cut, for the root README hero:
 
-> **Local-first apps that write to files you own.** Your data lives on your machine as plain Markdown and SQLite: grep it, version it, open it in Obsidian. When an app stops mattering, your files don't.
+> **What if you could manage your entire digital life in one SQLite database?** Epicenter is a collection of local-first apps built around a simple inversion: the database belongs to the person, not the application.
 
 One paragraph, for anyone giving us thirty seconds (website about page, CONTRIBUTING, talk bios):
 
-> Most apps trap your data in their database. Epicenter apps keep live state in CRDTs and project everything to ordinary files on your machine: Markdown you can read and edit, SQLite you can query. When an app stops mattering, your files don't. Start with Whispering, our desktop speech-to-text app; the shared workspace behind it is being built in the open in the same repo.
+> Most apps keep your data in their own cloud database. Epicenter inverts that: one person owns one database, every device keeps a full local SQLite copy of it, and each app is a different way of working with the same data. Your notes, settings, conversations, and history stay together on your machines and outlive any app that touched them. Start with Whispering, our speech-to-text app.
 
 The developer cut, for `@epicenter/workspace` and other toolkit surfaces (npm, package READMEs, technical talks):
 
-> A local-first workspace engine for TypeScript apps: Yjs as the source of truth, Markdown and SQLite as the outputs.
+> A local-first data layer for TypeScript apps: typed tables and KV over per-device SQLite, lazy Yjs documents for collaborative content, and sync through a server you can self-host.
 
 The public cut, for epicenter.so and other general-audience surfaces:
 
-> Apps come and go. Your files shouldn't. Epicenter apps save everything you make as ordinary files in a folder on your computer, so what matters to you outlives every app that made it.
+> Apps come and go. What you make with them should stay yours. Epicenter apps keep everything you create in one place that belongs to you, on your own devices, so your work outlives every app that made it.
 
-The developer and public cuts are the only cuts with their own framing. The developer cut exists because npm readers evaluate an API, not a product. The public cut exists because epicenter.so readers are not evaluating an architecture: it restates the one-line cut with the vocabulary translated. Markdown, SQLite, local-first, CRDT, and Yjs stay out of public heroes; on a public surface the mechanism appears below the fold, after the benefit it guarantees, never as the headline. Everything else derives from the user-facing cuts above.
+The developer and public cuts are the only cuts with their own framing. The developer cut exists because npm readers evaluate an API, not a product. The public cut exists because epicenter.so readers are not evaluating an architecture: it restates the one-line cut with the vocabulary translated. SQLite, local-first, CRDT, and Yjs stay out of public heroes; on a public surface the mechanism appears below the fold, after the benefit it guarantees, never as the headline. (The README hero is the one deliberate exception: its audience is technical, and "one SQLite database" is the concrete claim that earns the read.)
 
 Headlines, tweets, launch posts, and package copy derive from these cuts but live in the surface that publishes them. If a derived surface needs a claim the spine does not make, fix the spine first.
 
 ## The Hook
 
-The long-form narrative, for surfaces with room to breathe (landing page body, launch posts, talks). It extends the spine with the claims the short cuts cannot carry: multiple apps share one workspace, and good captures graduate.
+The long-form narrative, for surfaces with room to breathe (landing page body, launch posts, talks). It extends the spine with the claims the short cuts cannot carry: apps share one person's context, and that context compounds.
 
-Most tools store your data in their own silo. Epicenter gives purpose-built apps a shared local-first workspace: app data can be browsed as Markdown, queried through SQLite, and curated into folders you control. Your folders are ordinary Markdown: grep them, open them in Obsidian, version them with Git, publish them with whatever static site stack you like. Your transcripts can inform your notes. Your saved tabs can become drafts. Good captures graduate into your long-term workspace instead of staying trapped in the app that caught them.
+The conventional model is one database per app, run by the vendor. Every app
+you adopt opens another silo; every app you abandon strands another slice of
+your life. Epicenter is built on the opposite premise: one person, one
+Epicenter. Your devices each hold a full SQLite replica. Apps bring typed
+lenses to that shared database instead of bringing their own database. So the
+transcription app and the notes app are not two silos with an export button
+between them; they are two views of one corpus that belongs to you.
 
-Under the hood, app-owned state lives in Yjs, materializes to SQLite for fast queries, and materializes to Markdown for human-readable projections. Sync happens over the Yjs protocol when you turn it on, through a relay that reads your data in plaintext: hosted Epicenter holds it, and self-hosting puts it on infrastructure you control. Privacy is a topology choice, not an encryption layer.
+Under the hood, bounded rows live in SQLite for fast local queries; each row
+can own a lazy Yjs document for collaborative rich content; media lives beside
+the database as ordinary files. You can open your own live database read-only
+and query it with plain SQL, and take a complete portable export whenever you
+want. Sync runs through your account's server: hosted Epicenter if you want
+convenience, self-hosted if you want the server in your hands. The relay reads
+plaintext either way; privacy is a topology choice, not an encryption layer.
 
 ## The Proof Line
 
 Every shipped surface longer than one line carries exactly one proof line, stated without caveats. The proof line is a claim, not finished copy: each surface writes its own sentence, in keeping with the rule that finished copy belongs to the surface that ships it. The sentence must carry:
 
 - Whispering, by name
-- desktop speech-to-text
-- you can install it today
-- macOS, Windows, and Linux, somewhere on the surface (platform badges or adjacent copy count)
+- speech-to-text
+- you can use it today
+- where it runs: the browser at whispering.epicenter.so, and natively inside the Epicenter desktop app
 
-Roadmap language stays out of heroes. "A refresh built on the workspace is in progress" and "being built in public" are Status-section sentences; in a hero they hedge the only shipped product and tell a first-time reader to wait.
+Roadmap language stays out of heroes. The one-database destination is ahead of the implementation, so surfaces that lead with it must carry an explicit status boundary ("what we are building" or equivalent) before making behavior-shaped claims. In a hero, hedging kills the read; immediately after the hero, honesty about status is mandatory.
 
 ## Earned Vocabulary
 
@@ -95,68 +116,68 @@ Some words are internal until the surface earns them. Do not use a term before t
 
 | Term | Earned by |
 |---|---|
-| workspace (the folder) | showing the directory tree first |
-| materializer | one defining clause at first use: "materializers, the writers that project state to disk" |
-| projection | showing a generated file next to the state it came from |
-| validated action | naming the validator: the app's schema |
-| workspace-native | never on public surfaces; say "built on the workspace" |
+| Epicenter (the database) | showing the one-database diagram or model first |
+| replica | one defining clause at first use: "a full local copy on each device" |
+| lens | one defining clause at first use: "the typed view an app brings to your data" |
+| owner | technical surfaces only; general copy says "you" or "your account" |
+| portable artifact / `.epicenter` export | showing what an export contains |
+| workspace | retired from destination copy; names old code only |
 
-"PKM substrate" is accurate but niche. Use it in technical talks and blog posts, never in a hero or README.
+Do not use "substrate", and do not describe Epicenter as generic infrastructure. Epicenter is a collection of real apps that also builds its own data layer; lead with the apps and the person, not the layer.
 
 Do not use hype words: `AI-native`, `agentic`, `next-gen`, `revolutionary`, `redefine`, `game changer`, `Web3`, `metaverse`. Do not stack buzzwords. "CRDT-powered AI-first encrypted next-gen offline-first workspace" is a sign to say less and prove more.
 
 ## What Epicenter Is
 
-- An **open-source, local-first workspace**: purpose-built apps plus Markdown folders you own
-- A **TypeScript library** (`@epicenter/workspace`) for building CRDT-backed apps with typed schemas, materializers, and actions
-- A **CLI** (`epicenter`) for running a headless watcher that syncs and materializes one workspace root
-- A **sync server** (AGPL, self-hostable) that relays CRDT updates between your devices
+- An **open-source collection of local-first apps** that share one database per person
+- A **TypeScript data layer** (`@epicenter/workspace`) for typed tables and KV over SQLite, with lazy Yjs documents for collaborative content
+- A **CLI** (`epicenter`) for local workflows against the same data
+- A **sync server** (AGPL, self-hostable) that orders one person's changes across their devices
 
 ## What Epicenter Is Not
 
-- Not a single app (many purpose-built apps share one workspace)
-- Not cloud-first (local-first by default, sync is optional)
-- Not a Notion or Obsidian clone (it is the workspace layer beneath capture, curation, and publishing tools)
+- Not a single app (many purpose-built apps, one shared database)
+- Not cloud-first (local-first by default; sync is optional and yours to place)
+- Not per-app storage (apps bring lenses, never their own databases)
+- Not a Notion or Obsidian clone (it is the apps plus the data layer beneath them)
 
-## Core Claims (Verifiable)
+## Core Claims
 
-Every claim we make publicly should be provable by inspecting the repo:
+Shipped claims, provable by inspecting the repo today:
 
 | Claim | Proof |
 |---|---|
-| "We ship" | Whispering installs on macOS, Windows, and Linux through normal release channels. |
-| "Readable Markdown and queryable SQLite" | Markdown materializers write `.md` files with YAML frontmatter. SQLite materializers keep rebuildable query mirrors. |
-| "A workspace you own" | The local project layout separates user-owned folders from generated app projections and hidden machine state. |
-| "CRDT-powered sync" | App-owned live state uses Yjs documents; sync uses the Yjs protocol over WebSocket. |
-| "Trusted relay, not an encryption layer" | The relay runs Yjs and reads plaintext. Privacy comes from who holds the data, not from a key we ship. See `docs/trust-model.md`. |
-| "Self-hostable" | Sync server is open source under AGPL. Run it on your infrastructure, so Epicenter never holds your data. |
-| "Bring your own model" | AI features use user-provided API keys. No middleman, no proxy required. |
+| "We ship" | Whispering runs in the browser at whispering.epicenter.so and as a native surface inside the Epicenter desktop host. |
+| "Local-first" | App state persists on-device; the apps work offline and sync is optional. |
+| "Self-hostable" | The server library is AGPL with a community single-partition reference deployable (`apps/self-host`). |
+| "Bring your own model" | AI features accept user-provided endpoints and API keys. |
+| "Trusted relay, not an encryption layer" | Sync reads plaintext at the relay. Privacy comes from who runs the server. See `docs/trust-model.md`. |
+
+Destination claims, decided and recorded but still being implemented (Proposed ADRs 0160 through 0182 and the one-Epicenter clean-break spec own them):
+
+| Claim | Decision record |
+|---|---|
+| "One person, one Epicenter" | ADR-0160 |
+| "One SQLite replica per device, media beside it" | ADR-0161 |
+| "Open your live database read-only; query one stable `rows` relation" | ADR-0161, ADR-0163 |
+| "Complete portable export you can edit" | ADR-0162, ADR-0165 |
+| "Apps bring identity-free lenses, never databases" | ADR-0172 |
+
+A surface may state a destination claim only beside an explicit status boundary. No surface claims that arbitrary direct writes to the live database synchronize; synchronized writes go through the typed API, and deliberate offline editing belongs to the portable export.
 
 ## Competitor Positioning
 
 ### vs Obsidian
-> Obsidian is a markdown editor with sync. Epicenter is the local-first workspace where purpose-built apps produce readable projections and curated Markdown stays yours.
+> Obsidian is a Markdown editor with sync. Epicenter is a collection of apps that share one database owned by the person, with Markdown projections where files are the right interface.
 
-- **Win**: App output can become durable workspace material without living in per-plugin storage. CRDT sync instead of file-level conflict resolution.
+- **Win**: Structured, queryable, app-shared data with CRDT sync; not per-plugin storage.
 - **Lose**: Obsidian's plugin ecosystem and years of UX polish. We're earlier.
 
 ### vs Anytype
-> Anytype is a purpose-built encrypted space ecosystem. Epicenter is the Yjs-backed workspace where apps project readable files and curated Markdown stays yours.
+> Anytype is an encrypted space ecosystem with its own protocol. Epicenter is one SQLite database per person, standard Yjs for collaborative content, and apps as lenses.
 
-- **Win**: Standard CRDT stack (Yjs, widely adopted and battle-tested) vs custom protocol. Developer-facing API with typed schemas, not just an end-user app.
-- **Lose**: Anytype's product is more complete today. Their P2P sync story is more mature.
-
-### vs Logseq
-> Logseq is an outliner-first app. Epicenter is the structured local-first storage engine that can power outline UIs without trapping data in a single app.
-
-- **Win**: SQL plus structured schemas. Purpose-built capture tools can project into a workspace you control. Self-hostable CRDT sync.
-- **Lose**: Logseq's block/journal UX is more native. Larger community.
-
-### vs Standard Notes
-> Standard Notes encrypts your notes. Epicenter is a whole local-first workspace that multiple apps share, with CRDTs, schemas, and materialized exports.
-
-- **Win**: Platform, not just "notes." Structured data with schemas. Materialized to files you can inspect.
-- **Lose**: Standard Notes' encryption UX is simpler to communicate. They've earned trust over years.
+- **Win**: Standard stack (SQLite, Yjs), plain-SQL inspectability, developer-facing typed API.
+- **Lose**: Anytype's product is more complete today; their P2P story is more mature.
 
 ### vs Notion
 > Notion is where your knowledge lives. Epicenter is where your knowledge stays.
@@ -164,23 +185,15 @@ Every claim we make publicly should be provable by inspecting the repo:
 - **Win**: Offline-first, local-first, open source, no cloud lock-in.
 - **Lose**: Notion's UX, templates, collaboration, and distribution are years ahead.
 
-### vs Karpathy's "Second Brain" System
-> Karpathy showed the folder. Epicenter is the local-first app layer around it.
-
-Karpathy's "second brain" post is the strongest entry point: three folders of Markdown, a schema file, and AI organizing everything. Epicenter keeps that philosophy and adds sync, schemas, and CLI actions.
-
-- **Win**: CRDT sync across devices, typed schemas, CLI automation: everything raw folders can't do.
-- **Lose**: Karpathy's system wins on simplicity. A folder of markdown files needs zero infrastructure.
-
 ### vs Jazz
-> Jazz syncs slices of a shared database to everyone. Epicenter materializes one whole workspace into a folder that belongs to you.
+> Jazz syncs slices of a shared database to many users. Epicenter gives one person one whole database, fully replicated on their own devices.
 
-The two stacks converged from opposite premises: typed tables, query subscriptions, local-first writes, collaborative text. The difference is scope. Jazz is a multi-user relational database with partial replication and row-level permissions. Epicenter is hyper-focused on personal apps, so a workspace is a full local replica, the unit of sharing is the folder, and we refuse partial sync, row permissions, and snapshotting on purpose. That refusal is what lets us build on Yjs and open standards instead of a custom sync engine. See [the long form](articles/20260531T160000-i-kept-reinventing-jazz-the-win-is-what-we-refuse.md).
+The two stacks converged on typed tables, local-first writes, and collaborative text from opposite premises. Jazz is a multi-user relational database with partial replication and row-level permissions. Epicenter is hyper-focused on one person, so a device replicates the whole Epicenter, apps are trusted lenses rather than tenants, and we refuse partial sync and row permissions on purpose. That refusal is what lets us build on SQLite and standard Yjs instead of a custom sync engine. See [the long form](articles/20260531T160000-i-kept-reinventing-jazz-the-win-is-what-we-refuse.md).
 
-- **Win**: One folder you own, plain text and SQLite you can grep without the app, built on standard Yjs rather than a private protocol. Less to learn because the scope is smaller.
-- **Lose**: Jazz scales to large shared datasets and multi-user row-level access that Epicenter deliberately won't. For a synced multi-user app database, Jazz is the better tool and further along.
+- **Win**: One database you own, plain SQL without the app, standard Yjs, less to learn because the scope is smaller.
+- **Lose**: Jazz scales to large shared datasets and multi-user access that Epicenter deliberately won't. For a synced multi-user app database, Jazz is the better tool and further along.
 
-Trigger to split: if Competitor Positioning stops deriving from the spine or grows beyond quick battlecards, move it into its own competitor file.
+Matter keeps its own positioning ("a folder of Markdown, queryable as SQLite", ADR-0065); it is a standalone disk-as-truth tool and does not derive from the one-database spine. Trigger to split: if Competitor Positioning stops deriving from the spine or grows beyond quick battlecards, move it into its own competitor file.
 
 ## Package Copy
 

--- a/specs/20260719T222716-one-epicenter-clean-break.md
+++ b/specs/20260719T222716-one-epicenter-clean-break.md
@@ -96,6 +96,12 @@ mode.
 - Read-only SQL exposes only
   `rows(table_key, row_id, fields_json)`, performs no full-dataset refresh, and
   never performs hidden synchronization.
+- The live desktop/Bun database is inspectable in place: an external read-only
+  connection sees the same stable `rows` relation. No surface claims direct
+  live-file writes synchronize; the detached artifact is the editable form.
+- No second durable database identity exists under any noun: no
+  `defineDatabase`, `DatabaseId`, `database_id` column, named-database catalog,
+  per-application partition, or database route parameter.
 - Scalar conflict resolution remains authority acceptance order. Pull
   checkpoints are lower bounds, not exact historical snapshots.
 - Scalar deletion markers and exact-retry state are bounded. A replica below
@@ -352,6 +358,17 @@ optimistic scalar work. It excludes KV and every private relation. SQL is
 read-only and sees one stable local SQLite transaction. It performs no network
 work and may observe mixed remote acceptance times across rows.
 
+`rows` is also readable in place. On desktop and Bun the live
+`epicenter.sqlite3` contains a relation named `rows` (table or view), so
+read-only inspection works with ordinary SQLite tools or through an
+owner-level native reader (an `openEpicenterReader()`-style call with no
+database ID and no application definition). External connections are read-only
+(`query_only`). Direct writes to the live file are unsupported and never
+synchronize; synchronized mutations enter only through the typed TypeScript
+API, and the detached portable artifact remains the formally editable surface
+(ADR-0162). The browser keeps the same `rows` semantics through the SQL API
+without a filesystem-path promise.
+
 The executor permits `SELECT` and `WITH`, bound parameters, scalar JSON
 functions, CTEs, joins, grouping, and aggregation. It rejects writes, DDL,
 `ATTACH`, private relations, mutating or private-layout pragmas, and virtual
@@ -526,6 +543,16 @@ Also refused: partial replication, query subscriptions, permission-aware
 fanout, scalar history, per-field causal clocks, event sourcing, SQLite
 WAL/page/session replication, reactive SQL automation, all-device discovery,
 automatic sign-in merge, compatibility aliases, and hidden fallback readers.
+
+Also refused: any second durable database identity under a renamed noun. No
+`defineDatabase({ id })`, `DatabaseId`, `database_id` column,
+`__epicenter_databases` catalog table, per-application database partition,
+`/api/databases/:databaseId/*` route, or definition-derived TEMP SQL view
+enters the destination. The rejected named-database proposal's useful ideas
+survive only in their adapted one-owner form: one physical SQLite store per
+selected owner, an incrementally maintained inspectable `rows` relation,
+structural read-only statement guarding, an owner-level native reader, and
+portability as the one `.epicenter` artifact.
 
 ## ADR Dependency Ledger
 
@@ -726,6 +753,8 @@ Build:
 
 - Implement `rows` directly over the chosen incremental visible-state
   representation.
+- Materialize `rows` inside the live desktop/Bun database file (table or view)
+  and add the owner-level native read-only reader.
 - Add structural read-only authorization and keep result validation in the
   caller realm.
 
@@ -739,6 +768,9 @@ Prove:
 - Writes, DDL, `ATTACH`, private tables, unsafe pragmas, and virtual opens fail.
 - Query setup performs zero full-dataset copies or refresh writes at all
   benchmark sizes.
+- An external read-only SQLite connection and the owner-level native reader
+  both see current `rows` content in the live desktop/Bun file without any
+  refresh step.
 
 Remove:
 


### PR DESCRIPTION
The architecture docs still taught application-owned workspaces even though the accepted destination is one owner with one logical Epicenter. That ambiguity left room for implementation to recreate workspace plurality under a new noun. This PR freezes the simpler model before the runtime migration begins.

```txt
Before: person -> application workspace -> app-owned storage
After:  person -> one Epicenter -> identity-free application lenses
                              -> one SQLite replica per device
```

The README and positioning now lead with that destination, then draw an explicit boundary between what ships today and what remains in progress. `docs/CONTEXT.md` and the architecture guide teach the destination vocabulary first while retaining the current workspace terminology only as transitional implementation context.

The decision records and clean-break spec make the operational contract precise: the live desktop and Bun database is inspectable read-only through one stable `rows` relation; synchronized writes enter through the typed TypeScript API; deliberate offline editing belongs to the portable artifact. They also refuse any second durable database identity, whether it is called a workspace, database, catalog entry, route parameter, or application partition.

This is documentation only. It does not change runtime code, rename `@epicenter/workspace`, add a legacy-data migrator, or mark the Proposed ADRs as accepted. Stacks on #2459 and merges into that PR branch.