### PR TITLE
Skill authoring tooling: link audit, routing collisions, trigger eval

### DIFF
--- a/.agents/skills/agent-instructions/SKILL.md
+++ b/.agents/skills/agent-instructions/SKILL.md
@@ -43,6 +43,7 @@ Every skill is a flat directory with a required `SKILL.md`:
 |-- references/   optional, detailed context loaded only when needed
 |-- scripts/      optional, executable helpers for repeatable fragile work
 |-- assets/       optional, files used in generated output
+|-- evals/        optional, stored prompt corpora and recorded runs
 ```
 
 Use `.agents/skills` for project-local portable skills. The Vercel CLI discovers this path, and Codex uses it as the project skill location.
@@ -90,6 +91,10 @@ decorative assets
 ```
 
 Those can exist in personal or system skill installations, but they are not the Vercel-backed skill format.
+
+The line is a second *format and discovery* validator, which the Vercel CLI
+already owns. A script that checks something the CLI does not look at, such as
+whether a Markdown link resolves, is a different job and is fine to keep.
 
 ## Create A Skill
 
@@ -188,6 +193,19 @@ Use this loop:
 5. Revise the description or core workflow first.
 6. Move detail to references only when it is conditionally useful.
 
+Two scripts make part of that loop mechanical:
+
+```bash
+bun run .agents/skills/agent-instructions/scripts/audit-skill-links.ts
+bun run .agents/skills/agent-instructions/scripts/run-trigger-eval.ts
+```
+
+The first checks every Markdown link and heading anchor under `.agents/skills`;
+nothing else in the repository does. The second runs the stored trigger corpus.
+Its default pass is offline and reports what descriptions claim, which is a
+smoke test on coverage and not evidence about routing; `--live` spawns the
+Claude CLI per case to measure what a model actually loads.
+
 Read [references/evaluation.md](references/evaluation.md) for trigger evals, execution trace review, and security checks.
 
 ## Validate With Vercel CLI
@@ -246,6 +264,7 @@ Use sharper review questions when the design still feels soft:
 - The description has concrete triggers and near-miss boundaries.
 - `SKILL.md` contains the core workflow, not a copied source essay.
 - References have clear load conditions.
+- `audit-skill-links.ts` reports no dead link or anchor.
 - Scripts are justified, non-interactive, and portable.
 - Required tools are stated as prerequisites; the skill does not imply access to apps, files, connectors, or credentials.
 - Optional frontmatter is intentional: keep cross-agent fields like `license`,

--- a/.agents/skills/agent-instructions/evals/routing.json
+++ b/.agents/skills/agent-instructions/evals/routing.json
@@ -1,0 +1,124 @@
+{
+	"about": "Trigger corpus for run-trigger-eval.ts. Two boundaries: the review/simplification cluster, where several skills legitimately overlap, and the consultation/delegation/handoff cluster, where picking the wrong one wastes a whole session. Every `anchor` must appear verbatim in its `prompt`; the runner rejects the corpus otherwise. `router` names the agent whose routing a case is about and defaults to `claude`; `--live` drives the Claude CLI, so it reports `codex` cases as not measured rather than failing them.",
+	"cases": [
+		{
+			"id": "review-second-pass",
+			"cluster": "review",
+			"prompt": "I just finished wiring the new blob store across four files. Do a second pass over what you changed before you reply.",
+			"anchors": ["second pass"],
+			"expect": "post-implementation-review",
+			"forbid": ["collapse-pass", "first-read-review"],
+			"why": "The hub owns the after-implementation sweep. A collapse pass is a different job with a different cadence."
+		},
+		{
+			"id": "review-collapse-pass",
+			"cluster": "review",
+			"prompt": "Run a collapse pass over packages/workspace and tell me which indirection can go.",
+			"anchors": ["collapse pass"],
+			"expect": "collapse-pass",
+			"forbid": ["post-implementation-review", "refactoring"],
+			"why": "Named phrase with a single owner. If the hub answers this, the hub's description is too broad."
+		},
+		{
+			"id": "review-nested-ifs",
+			"cluster": "review",
+			"prompt": "These nested ifs are unreadable. Can you simplify this handler?",
+			"anchors": ["nested ifs", "simplify this"],
+			"expect": "control-flow",
+			"forbid": [],
+			"why": "Two anchors on purpose. 'nested ifs' is control-flow's real hook; 'simplify this' is a phrase control-flow explicitly routes away, so the lexical layer should report it as disclaimed rather than owned."
+		},
+		{
+			"id": "review-asymmetric-win",
+			"cluster": "review",
+			"prompt": "Does the migration UI need to be pixel perfect, or is there an asymmetric win in dropping that promise?",
+			"anchors": ["asymmetric win", "pixel perfect"],
+			"expect": "asymmetric-wins",
+			"forbid": ["radical-options"],
+			"why": "The move owns its phrase. radical-options mentions asymmetric deletions in its body, which is the kind of near-neighbour that over-triggers."
+		},
+		{
+			"id": "review-disproportionate-complexity",
+			"cluster": "review",
+			"prompt": "Find the one change here that would delete disproportionate complexity for a small refusal.",
+			"anchors": ["delete disproportionate complexity"],
+			"expect": "asymmetric-wins",
+			"forbid": [],
+			"why": "Known genuine ambiguity: asymmetric-wins and greenfield-clean-breaks both carry this phrase. Recorded so a description edit that resolves it is visible."
+		},
+		{
+			"id": "review-one-sentence",
+			"cluster": "review",
+			"prompt": "What does the mount surface actually do? Give it to me in one sentence.",
+			"anchors": ["in one sentence", "actually do"],
+			"expect": "one-sentence-test",
+			"forbid": ["first-read-review"],
+			"why": "The move owns both phrases and should win over the readability lens."
+		},
+		{
+			"id": "review-plain-comprehension-near-miss",
+			"cluster": "review",
+			"prompt": "What does this regex actually do? Just explain it, no audit needed.",
+			"anchors": ["actually do"],
+			"expect": null,
+			"forbid": ["one-sentence-test"],
+			"why": "Near miss. one-sentence-test's near-miss clause says to answer a plain comprehension question directly, but that clause is prose the lexical layer cannot weigh, so this case is expected to look like an over-claim on the deterministic pass and resolve only under --live."
+		},
+		{
+			"id": "delegate-implementation",
+			"cluster": "delegation",
+			"prompt": "The direction is settled. Have Claude execute the implementation across those four packages while I step out.",
+			"anchors": ["have Claude execute"],
+			"expect": "delegate-claude",
+			"forbid": ["consult-claude", "handoff"],
+			"router": "codex",
+			"why": "Authorized implementation, not a decision and not a copy-paste artifact. delegate-claude is written for a Codex session ('Launch and supervise one durable Claude Code implementation session from Codex'), so only a Codex router can answer it; a Claude probe picked handoff 3/3."
+		},
+		{
+			"id": "consult-independent-investigation",
+			"cluster": "delegation",
+			"prompt": "Before we commit to this ownership boundary, consult Claude for an independent investigation.",
+			"anchors": ["consult Claude", "independent investigation"],
+			"expect": "consult-claude",
+			"forbid": ["delegate-claude", "fresh-context-review"],
+			"router": "codex",
+			"why": "Read-only adversarial memo on an unsettled decision, the opposite end of the same axis as delegate-claude. consult-claude is written for a Codex session ('a memo on Codex's grounded synthesis'), so only a Codex router can answer it; a Claude probe picked fresh-context-review 2/3 and nothing 1/3."
+		},
+		{
+			"id": "handoff-paste-prompt",
+			"cluster": "delegation",
+			"prompt": "Write me something I can copy and paste into a fresh Claude Code session on my laptop to continue this.",
+			"anchors": ["copy and paste into"],
+			"expect": "handoff",
+			"forbid": ["delegate-claude", "consult-claude"],
+			"why": "The user wants an artifact, not a launched worker. This is the boundary handoff and delegate-claude most often blur."
+		},
+		{
+			"id": "delegation-hand-off-near-miss",
+			"cluster": "delegation",
+			"prompt": "Hand off the deploy checklist to the on-call engineer and close the incident.",
+			"anchors": ["hand off"],
+			"expect": null,
+			"forbid": ["delegate-claude", "handoff"],
+			"why": "Near miss on an everyday phrase. 'hand off' is ordinary English; delegate-claude carries it inside 'hand off the implementation'."
+		},
+		{
+			"id": "fresh-eyes-diff",
+			"cluster": "delegation",
+			"prompt": "Give me fresh eyes on this diff, I have been staring at the state machine too long.",
+			"anchors": ["fresh eyes", "state machine"],
+			"expect": "fresh-context-review",
+			"forbid": ["consult-claude", "post-implementation-review"],
+			"why": "Independent review of a concrete diff, not a product decision and not the ordinary end-of-work sweep."
+		},
+		{
+			"id": "agent-goal-line",
+			"cluster": "delegation",
+			"prompt": "Write a /goal line for this long-running Codex work with a clear completion condition.",
+			"anchors": ["/goal", "completion condition"],
+			"expect": "agent-goal",
+			"forbid": ["handoff", "delegate-claude"],
+			"why": "A goal line is a third artifact next to the handoff prompt and the launched session."
+		}
+	]
+}

--- a/.agents/skills/agent-instructions/references/composition-audit.md
+++ b/.agents/skills/agent-instructions/references/composition-audit.md
@@ -53,6 +53,18 @@ let a hub or manual *open* with a move's name. (This check catches the case wher
 a manual was branded "Asymmetric-wins pass" while a dedicated `asymmetric-wins`
 move also existed.)
 
+A hit counts the phrase, not the intent. Add `--explain` to see whether each hit
+claims the phrase or routes it elsewhere:
+
+```bash
+bun run agent-instructions/scripts/audit-routing-collisions.ts --explain "simplify this"
+```
+
+That phrase reports one hit, which reads as clean routing, but the annotation
+shows `control-flow` only mentions it to send the reader to `collapse-pass`. One
+hit plus `[disclaims]` means the phrase has no owner at all. The flag does not
+change the hit count or the exit code.
+
 ### 2. Duplicated bodies
 
 Same `## Heading` living in many skills usually means a copied essay.
@@ -75,20 +87,22 @@ non-owners already delegate. A delegating repeat is resolved, not a smell.
 ### 3. Dead and orphan links
 
 ```bash
-# broken reference links: match real markdown links ](...) only, keep the
-# ../skill/ prefix, and resolve relative to the linking file's dir. Matching the
-# bare `references/x.md` tail (and dropping the prefix) gives false DEAD hits for
-# valid cross-skill links like ](../workspace-api/references/x.md) and for
-# backtick-wrapped prose like `references/api-errors.md`.
-grep -rnoE '\]\((\.\./[a-z0-9-]+/)*references/[a-z0-9-]+\.md\)' */SKILL.md | while IFS=: read -r f n match; do
-  link="${match#']('}"; link="${link%')'}"
-  [ -f "$(dirname "$f")/$link" ] || echo "DEAD REF: $f:$n -> $link"
-done
-# broken ../skill/SKILL.md cross-links
-grep -rho '\.\./[a-z0-9-]*/SKILL\.md' */SKILL.md | sort -u | while read -r l; do
-  [ -f "${l#../}" ] || echo "DEAD LINK: $l"
-done
-# skill dirs missing a SKILL.md (stubs/orphans)
+bun run agent-instructions/scripts/audit-skill-links.ts
+```
+
+Walks every Markdown file under the tree, not just `SKILL.md`, so links written
+*inside* a reference file are covered too. It strips fenced code and inline code
+first (skills carry example posts with placeholder links), resolves each target
+against the linking file's directory, and checks heading anchors as a separate
+`DEAD_ANCHOR` finding. Exit 1 means findings; `--json` for machine reading;
+`--root <dir>` to scan a tree elsewhere.
+
+Nothing else covers these links: `scripts/check-doc-paths.ts` excludes
+`.agents/` by design and only inspects backtick-wrapped repo-rooted paths.
+
+Stub directories are still a shell one-liner, since they are not a link:
+
+```bash
 for d in */; do [ -f "${d}SKILL.md" ] || echo "NO SKILL.md: $d"; done
 ```
 

--- a/.agents/skills/agent-instructions/references/evaluation.md
+++ b/.agents/skills/agent-instructions/references/evaluation.md
@@ -9,6 +9,7 @@ Load this when tuning description routing, comparing skill versions, diagnosing 
 - [Prompt Set](#prompt-set)
 - [Baseline](#baseline)
 - [Assertions](#assertions)
+- [Run The Harness](#run-the-harness)
 - [Output Quality Eval](#output-quality-eval)
 - [Skill Content Checklist](#skill-content-checklist)
 - [Script Requirements](#script-requirements)
@@ -72,6 +73,80 @@ Use assertions only when they can be checked with evidence:
 - Mechanical assertion: a script or command can verify the result.
 
 Avoid brittle phrase matching. Assertions should check outcomes, not exact wording.
+
+## Run The Harness
+
+`scripts/run-trigger-eval.ts` runs a stored corpus of should-trigger and
+near-miss prompts. The corpus lives at `evals/routing.json` and currently covers
+the two boundaries where a wrong pick costs the most: the review/simplification
+cluster, where several skills legitimately overlap, and the
+consultation/delegation/handoff cluster, where the wrong choice burns a whole
+session. Each case carries a prompt, the anchor phrases that prompt contains,
+the skill that should own it (`null` for a near miss), and the skills that must
+not answer.
+
+```bash
+bun run agent-instructions/scripts/run-trigger-eval.ts
+```
+
+The default pass is offline and free. It reports four conditions per anchor:
+nobody claims it, several skills claim it, the expected owner carries no hook
+for it, or a forbidden skill claims it.
+
+**That pass measures descriptions, not routing.** A description can carry a
+near-miss clause no substring scan can weigh, and a model can route correctly on
+intent with zero lexical overlap. Both happen in this library. Use the offline
+pass as a smoke test on description coverage, and never quote it as evidence
+that routing works.
+
+To measure routing, spend the quota:
+
+```bash
+bun run agent-instructions/scripts/run-trigger-eval.ts --live
+```
+
+`--live` spawns the Claude CLI once per case with the Skill tool as its only
+tool, tells it to load the skill it would use and stop, and records what it
+actually loaded. That is a real model decision over the real descriptions, and
+it is still a proxy: a session restricted to one tool and told not to work is
+not the session a skill gets selected in for real. It needs an authenticated
+CLI and is opt-in for that reason; the test suite never invokes it.
+
+Every live run is bounded. `--timeout-ms` kills one hung probe and records it as
+a timeout rather than a routing failure, `--budget-ms` (default 15 minutes) ends
+the run and exits non-zero with the count of cases that never ran, and `--limit`
+reports what it dropped. A missing `claude` on PATH is a usage error, not a
+silent skip.
+
+`--live` drives the Claude CLI, so it can only measure Claude-routed cases. A
+case carrying `"router": "codex"` is reported as `NOT MEASURED` and left out of
+the pass count. `consult-claude` and `delegate-claude` are written for a Codex
+session in their own descriptions, so a Claude probe answering them picks a
+neighbour every time; that is a category error in the measurement, not a defect
+in the description. Measuring those needs a Codex-side probe that does not exist
+yet. Do not edit a description on the strength of a probe that could not have
+routed to it.
+
+Routing varies between runs, so re-run rather than trusting one pass, as
+[Prompt Set](#prompt-set) says. `--runs <n>` does that per case and reports a
+pass rate, marking a case that passes some runs and fails others as `flaky`
+instead of letting the last run decide. For a model or effort sweep, run one
+cell per file and diff them:
+
+```bash
+bun run agent-instructions/scripts/run-trigger-eval.ts --live \
+  --model claude-opus-5 --effort high --out run-opus5-high.json
+```
+
+The result file records the model, effort, runs per case, whether the budget was
+exhausted, and which cases went unmeasured, so a stale or partial file cannot be
+mistaken for a clean one. Other flags: `--case <id>` to run one case, `--strict`
+to turn the offline pass into a gate, `--json` for machine reading.
+
+Extend the corpus when a routing bug shows up in real use. A case is only valid
+when each anchor appears verbatim in its prompt and every named skill exists;
+`bun test scripts/run-trigger-eval.test.ts` enforces both, so a renamed skill
+cannot leave a case silently measuring nothing.
 
 ## Output Quality Eval
 

--- a/.agents/skills/agent-instructions/scripts/audit-routing-collisions.test.ts
+++ b/.agents/skills/agent-instructions/scripts/audit-routing-collisions.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Routing collision contract tests.
+ *
+ * `references/composition-audit.md` documents this script's exit codes and its
+ * `phrase -> skill/SKILL.md` line format, so both are contract rather than
+ * implementation. These tests exist so the shared-catalog extraction and the
+ * `--explain` flag cannot drift them.
+ *
+ * The two content-coupled assertions are deliberate. "asymmetric wins" having
+ * exactly one owner and "simplify this" being disclaimed by control-flow are
+ * the two routing facts the composition audit is built around; if a
+ * description edit changes either, a failing test here is the report, not
+ * noise.
+ */
+
+import { expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = fileURLToPath(
+	new URL('./audit-routing-collisions.ts', import.meta.url),
+);
+
+function run(...args: string[]): {
+	code: number | null;
+	out: string;
+	err: string;
+} {
+	const result = spawnSync('bun', [scriptPath, ...args], { encoding: 'utf8' });
+	return { code: result.status, out: result.stdout, err: result.stderr };
+}
+
+test('no phrase is a usage error', () => {
+	const { code, err } = run();
+
+	expect(code).toBe(2);
+	expect(err).toContain('Usage:');
+});
+
+test('--help prints usage and succeeds', () => {
+	const { code, out } = run('--help');
+
+	expect(code).toBe(0);
+	expect(out).toContain('--explain');
+});
+
+test('a phrase no description mentions exits 1 with no owner', () => {
+	const { code, out, err } = run('zzz-no-skill-claims-this');
+
+	expect(code).toBe(1);
+	expect(out).toBe('');
+	expect(err).toContain('No skill description claims');
+});
+
+test('a single owner exits 0 in the documented line format', () => {
+	const { code, out } = run('asymmetric wins');
+
+	expect(code).toBe(0);
+	expect(out).toBe('asymmetric wins -> asymmetric-wins/SKILL.md\n');
+});
+
+test('--explain annotates without changing the line prefix or exit code', () => {
+	const plain = run('asymmetric wins');
+	const explained = run('--explain', 'asymmetric wins');
+
+	expect(explained.code).toBe(plain.code);
+	expect(explained.out).toBe(
+		'asymmetric wins -> asymmetric-wins/SKILL.md [claims]\n',
+	);
+});
+
+test('--explain separates a sole hit that routes the phrase away', () => {
+	// One hit still exits 0, matching the documented verdict. The annotation is
+	// what tells the reader the phrase has no real owner.
+	const { code, out } = run('--explain', 'simplify this');
+
+	expect(code).toBe(0);
+	expect(out).toContain('control-flow/SKILL.md [disclaims]');
+});
+
+test('multiple hits exit 1 and list every claimant', () => {
+	const { code, out, err } = run('delete disproportionate complexity');
+
+	expect(code).toBe(1);
+	expect(out).toContain('asymmetric-wins/SKILL.md');
+	expect(out).toContain('greenfield-clean-breaks/SKILL.md');
+	expect(err).toContain('Routing collision');
+});

--- a/.agents/skills/agent-instructions/scripts/audit-routing-collisions.ts
+++ b/.agents/skills/agent-instructions/scripts/audit-routing-collisions.ts
@@ -1,50 +1,64 @@
 #!/usr/bin/env bun
 
-import { readdir, readFile } from 'node:fs/promises';
+/**
+ * Report every skill description that mentions one trigger phrase.
+ *
+ * The verdict is unchanged and is what `references/composition-audit.md`
+ * documents: exactly one hit is clean routing, zero hits means the phrase has
+ * no owner, two or more is a collision. The `phrase -> skill/SKILL.md` line
+ * format and the exit codes are the contract; do not change them.
+ *
+ * `--explain` is additive. It annotates each hit with whether the sentence
+ * carrying the phrase claims it or routes it elsewhere, because a description
+ * that says "use collapse-pass instead" registers as a hit while meaning the
+ * opposite. The annotation informs the reader; it deliberately does not change
+ * the hit count or the exit code, so a caller that only reads the exit status
+ * keeps its behavior.
+ */
+
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { classifyClaim, readSkillCatalog } from './skill-catalog';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const defaultSkillsDir = join(scriptDir, '..', '..');
 
-const phrase = process.argv.slice(2).join(' ').trim();
+const USAGE = `Usage: bun run .agents/skills/agent-instructions/scripts/audit-routing-collisions.ts [--explain] "trigger phrase"
+
+Reports which skill descriptions mention the phrase.
+
+  --explain   annotate each hit as [claims] or [disclaims]
+
+Exit codes: 0 exactly one hit, 1 zero or multiple hits, 2 usage error.`;
+
+const argv = process.argv.slice(2);
+
+if (argv.includes('--help') || argv.includes('-h')) {
+	console.log(USAGE);
+	process.exit(0);
+}
+
+const isExplaining = argv.includes('--explain');
+const phrase = argv
+	.filter((arg) => arg !== '--explain')
+	.join(' ')
+	.trim();
 
 if (!phrase) {
-	console.error(
-		'Usage: bun run .agents/skills/agent-instructions/scripts/audit-routing-collisions.ts "trigger phrase"',
-	);
+	console.error(USAGE);
 	process.exit(2);
 }
 
-const skillDirs = await readdir(defaultSkillsDir, { withFileTypes: true });
-const matches: string[] = [];
-
-for (const entry of skillDirs) {
-	if (!entry.isDirectory()) {
-		continue;
-	}
-
-	const skillPath = join(defaultSkillsDir, entry.name, 'SKILL.md');
-	const contents = await readFile(skillPath, 'utf8').catch((error: unknown) => {
-		if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
-			return null;
-		}
-
-		throw error;
-	});
-
-	if (contents === null) {
-		continue;
-	}
-
-	const description = extractFrontmatterField(contents, 'description');
-	if (description.toLowerCase().includes(phrase.toLowerCase())) {
-		matches.push(entry.name);
-	}
-}
+const skills = await readSkillCatalog(defaultSkillsDir);
+const matches = skills.filter((skill) =>
+	skill.description.toLowerCase().includes(phrase.toLowerCase()),
+);
 
 for (const skill of matches) {
-	console.log(`${phrase} -> ${skill}/SKILL.md`);
+	const annotation = isExplaining
+		? ` [${classifyClaim(skill.description, phrase)}]`
+		: '';
+	console.log(`${phrase} -> ${skill.name}/SKILL.md${annotation}`);
 }
 
 if (matches.length === 1) {
@@ -60,40 +74,3 @@ console.error(
 	`Routing collision: ${matches.length} skill descriptions claim "${phrase}".`,
 );
 process.exit(1);
-
-function extractFrontmatterField(markdown: string, fieldName: string): string {
-	const lines = markdown.split(/\r?\n/);
-	if (lines[0] !== '---') {
-		return '';
-	}
-
-	const fieldPrefix = `${fieldName}:`;
-	const values: string[] = [];
-	let isReadingField = false;
-
-	for (const line of lines.slice(1)) {
-		if (line === '---') {
-			break;
-		}
-
-		const startsNewField = /^[A-Za-z0-9_-]+:/.test(line);
-		if (startsNewField) {
-			if (isReadingField) {
-				break;
-			}
-
-			if (line.startsWith(fieldPrefix)) {
-				isReadingField = true;
-				values.push(line.slice(fieldPrefix.length).trim());
-			}
-
-			continue;
-		}
-
-		if (isReadingField) {
-			values.push(line.trim());
-		}
-	}
-
-	return values.join(' ').replace(/^['"]|['"]$/g, '');
-}

--- a/.agents/skills/agent-instructions/scripts/audit-skill-links.test.ts
+++ b/.agents/skills/agent-instructions/scripts/audit-skill-links.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Skill link audit tests.
+ *
+ * These drive the script against throwaway skill trees rather than the real
+ * one, so the gate's rules stay pinned even as skills are added and renamed.
+ * The false-positive rules matter most: skills ship example posts and prompt
+ * templates full of placeholder links, and a checker that flags those gets
+ * turned off.
+ */
+
+import { expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = fileURLToPath(
+	new URL('./audit-skill-links.ts', import.meta.url),
+);
+
+function write(dir: string, rel: string, body: string): void {
+	const target = path.join(dir, rel);
+	mkdirSync(path.dirname(target), { recursive: true });
+	writeFileSync(target, body);
+}
+
+function run(root: string): { code: number | null; out: string } {
+	const result = spawnSync('bun', [scriptPath, '--root', root], {
+		encoding: 'utf8',
+	});
+	return { code: result.status, out: `${result.stdout}${result.stderr}` };
+}
+
+function withTree(fn: (dir: string) => void): void {
+	const dir = mkdtempSync(path.join(os.tmpdir(), 'skill-links-'));
+	try {
+		fn(dir);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+test('a reference link that resolves passes', () => {
+	withTree((dir) => {
+		write(
+			dir,
+			'alpha/SKILL.md',
+			'Read [notes](references/notes.md) when stuck.\n',
+		);
+		write(dir, 'alpha/references/notes.md', '# Notes\n');
+
+		const { code, out } = run(dir);
+
+		expect(code).toBe(0);
+		expect(out).toContain('no dead links or anchors');
+	});
+});
+
+test('a reference link that resolves nowhere is reported', () => {
+	withTree((dir) => {
+		write(dir, 'alpha/SKILL.md', 'Read [gone](references/gone.md).\n');
+
+		const { code, out } = run(dir);
+
+		expect(code).toBe(1);
+		expect(out).toContain('DEAD_LINK');
+		expect(out).toContain('alpha/SKILL.md:1');
+		expect(out).toContain('references/gone.md');
+	});
+});
+
+test('a cross-skill link resolves against the linking file, not the tree root', () => {
+	withTree((dir) => {
+		write(
+			dir,
+			'alpha/references/deep.md',
+			'See [beta](../../beta/SKILL.md).\n',
+		);
+		write(dir, 'alpha/SKILL.md', '# Alpha\n');
+		write(dir, 'beta/SKILL.md', '# Beta\n');
+
+		const { code, out } = run(dir);
+
+		expect(code).toBe(0);
+		expect(out).toContain('no dead links or anchors');
+	});
+});
+
+test('links inside fenced code blocks are not checked', () => {
+	withTree((dir) => {
+		write(
+			dir,
+			'alpha/SKILL.md',
+			'Template:\n\n```md\nSee [docs](references/never-exists.md).\n```\n',
+		);
+
+		const { code, out } = run(dir);
+
+		expect(code).toBe(0);
+		expect(out).toContain('no dead links or anchors');
+	});
+});
+
+test('a placeholder target that names no file is not a link claim', () => {
+	withTree((dir) => {
+		write(dir, 'alpha/SKILL.md', 'See the [full implementation here](link).\n');
+
+		const { code, out } = run(dir);
+
+		expect(code).toBe(0);
+		expect(out).toContain('no dead links or anchors');
+	});
+});
+
+test('external and anchor-only targets are skipped', () => {
+	withTree((dir) => {
+		write(
+			dir,
+			'alpha/SKILL.md',
+			'# Alpha\n\n## Setup\n\n[docs](https://example.com/x.md), [mail](mailto:a@b.co), [jump](#setup).\n',
+		);
+
+		const { code, out } = run(dir);
+
+		expect(code).toBe(0);
+		expect(out).toContain('no dead links or anchors');
+	});
+});
+
+test('an anchor that matches a heading in the target passes', () => {
+	withTree((dir) => {
+		write(
+			dir,
+			'alpha/SKILL.md',
+			'See [step](references/how.md#run-the-check).\n',
+		);
+		write(dir, 'alpha/references/how.md', '# How\n\n## Run The Check\n');
+
+		const { code, out } = run(dir);
+
+		expect(code).toBe(0);
+		expect(out).toContain('no dead links or anchors');
+	});
+});
+
+test('an anchor with no matching heading is reported separately from a dead link', () => {
+	withTree((dir) => {
+		write(
+			dir,
+			'alpha/SKILL.md',
+			'See [step](references/how.md#renamed-section).\n',
+		);
+		write(dir, 'alpha/references/how.md', '# How\n\n## Run The Check\n');
+
+		const { code, out } = run(dir);
+
+		expect(code).toBe(1);
+		expect(out).toContain('DEAD_ANCHOR');
+		expect(out).not.toContain('DEAD_LINK');
+	});
+});
+
+test('a heading inside a fenced block does not satisfy an anchor', () => {
+	withTree((dir) => {
+		write(dir, 'alpha/SKILL.md', 'See [step](references/how.md#fake).\n');
+		write(dir, 'alpha/references/how.md', '# How\n\n```md\n## Fake\n```\n');
+
+		const { code, out } = run(dir);
+
+		expect(code).toBe(1);
+		expect(out).toContain('DEAD_ANCHOR');
+	});
+});
+
+test('--json emits machine-readable findings', () => {
+	withTree((dir) => {
+		write(dir, 'alpha/SKILL.md', 'Read [gone](references/gone.md).\n');
+
+		const result = spawnSync('bun', [scriptPath, '--root', dir, '--json'], {
+			encoding: 'utf8',
+		});
+		const parsed = JSON.parse(result.stdout);
+
+		expect(result.status).toBe(1);
+		expect(parsed.findings).toHaveLength(1);
+		expect(parsed.findings[0]).toMatchObject({
+			kind: 'DEAD_LINK',
+			file: 'alpha/SKILL.md',
+			line: 1,
+			target: 'references/gone.md',
+		});
+	});
+});
+
+test('the real skill tree has no dead links or anchors', () => {
+	const skillsDir = fileURLToPath(new URL('../..', import.meta.url));
+	const { code, out } = run(skillsDir);
+
+	expect(out).not.toContain('DEAD_LINK');
+	expect(out).not.toContain('DEAD_ANCHOR');
+	expect(code).toBe(0);
+});

--- a/.agents/skills/agent-instructions/scripts/audit-skill-links.ts
+++ b/.agents/skills/agent-instructions/scripts/audit-skill-links.ts
@@ -1,0 +1,242 @@
+#!/usr/bin/env bun
+
+/**
+ * Fail when a Markdown link inside the skill tree points at nothing.
+ *
+ * Nothing else in this repository checks these links. `scripts/check-doc-paths.ts`
+ * excludes `.agents/` by design and only inspects backtick-wrapped repo-rooted
+ * paths, never `](target)` link syntax. So every `references/` link, every
+ * `../other-skill/SKILL.md` cross-link, and every heading anchor in a skill can
+ * rot silently through a rename, and only a reader clicking it finds out.
+ *
+ * The shell one-liners in `references/composition-audit.md` cover part of this,
+ * but only links written *from* a `SKILL.md` to a `references/*.md` file. Links
+ * inside reference files, links to `scripts/`, links to `assets/`, and anchors
+ * are all outside their reach. This walks every Markdown file under the skill
+ * tree instead.
+ *
+ * Resolution rules, chosen so the checker stays false-positive free:
+ *   - Fenced code blocks and inline code spans are stripped first. Skills carry
+ *     example posts and templates with placeholder links like `[here](link)`.
+ *   - A target is only treated as a file claim when it contains `/` or ends in
+ *     a filename extension. That skips the remaining placeholders.
+ *   - `http:`, `https:`, `mailto:`, and bare `#anchor` targets are skipped.
+ *   - A relative target resolves against the linking file's directory, so
+ *     `../workspace-api/references/x.md` resolves the same way a reader's
+ *     editor resolves it.
+ *   - A leading `/` resolves against the repo root.
+ *
+ * Existence is checked with the filesystem, not `git ls-files`, because a skill
+ * directory is portable: the Vercel CLI copies it out of this repository, and a
+ * script inside a skill must not require git to run.
+ */
+
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type LinkFinding = {
+	kind: 'DEAD_LINK' | 'DEAD_ANCHOR';
+	/** Path of the file containing the link, relative to the scanned root. */
+	file: string;
+	line: number;
+	target: string;
+};
+
+const USAGE = `Usage: bun run .agents/skills/agent-instructions/scripts/audit-skill-links.ts [options]
+
+Checks every Markdown link under the skill tree against the filesystem.
+
+  --root <dir>   directory to scan (default: the .agents/skills tree)
+  --json         emit findings as JSON on stdout
+  --help         show this message
+
+Exit codes: 0 no findings, 1 findings reported, 2 usage error.`;
+
+/** Strip fenced blocks and inline code, preserving line numbers. */
+export function stripCode(markdown: string): string {
+	const lines = markdown.split(/\r?\n/);
+	let fence: string | null = null;
+
+	return lines
+		.map((line) => {
+			const fenceMatch = line.match(/^\s*(```+|~~~+)/);
+			if (fenceMatch?.[1]) {
+				const marker = fenceMatch[1];
+				if (fence === null) {
+					fence = marker[0] ?? '`';
+					return '';
+				}
+				if (marker.startsWith(fence)) fence = null;
+				return '';
+			}
+			if (fence !== null) return '';
+			return line.replace(/`[^`]*`/g, '');
+		})
+		.join('\n');
+}
+
+/** GitHub-flavored heading slug, close enough for anchors people hand-write. */
+export function slugify(heading: string): string {
+	return heading
+		.trim()
+		.toLowerCase()
+		.replace(/[`*_~]/g, '')
+		.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+		.replace(/[^\p{L}\p{N} -]/gu, '')
+		.trim()
+		.replace(/\s+/g, '-');
+}
+
+export function collectHeadingSlugs(markdown: string): Set<string> {
+	const slugs = new Set<string>();
+	for (const line of stripCode(markdown).split(/\r?\n/)) {
+		const heading = line.match(/^#{1,6}\s+(.*)$/);
+		if (heading?.[1]) slugs.add(slugify(heading[1]));
+	}
+	return slugs;
+}
+
+// `[text](target)` with an optional title. Targets with whitespace or nested
+// parens are not link syntax we write, so the simple form is enough.
+const LINK = /\[[^\]\n]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+const EXTERNAL = /^(https?|mailto|tel|ftp|data):/i;
+
+/** Does this target name a file, rather than being prose or a placeholder? */
+function isFileClaim(target: string): boolean {
+	return target.includes('/') || /\.[A-Za-z0-9]+$/.test(target);
+}
+
+async function listMarkdownFiles(dir: string): Promise<string[]> {
+	const entries = await readdir(dir, { withFileTypes: true });
+	const files: string[] = [];
+
+	for (const entry of entries) {
+		if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) files.push(...(await listMarkdownFiles(full)));
+		else if (entry.name.endsWith('.md')) files.push(full);
+	}
+
+	return files.sort();
+}
+
+async function exists(path: string): Promise<boolean> {
+	return stat(path).then(
+		() => true,
+		() => false,
+	);
+}
+
+/** Nearest ancestor holding `.git`, used to resolve `/`-rooted link targets. */
+async function findRepoRoot(from: string): Promise<string | null> {
+	let dir = resolve(from);
+	for (;;) {
+		if (await exists(join(dir, '.git'))) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+export async function auditLinks(
+	root: string,
+	repoRoot: string | null,
+): Promise<LinkFinding[]> {
+	const findings: LinkFinding[] = [];
+	const headingCache = new Map<string, Set<string>>();
+
+	for (const file of await listMarkdownFiles(root)) {
+		const text = stripCode(await readFile(file, 'utf8'));
+
+		for (const [index, line] of text.split('\n').entries()) {
+			for (const match of line.matchAll(LINK)) {
+				const raw = match[1];
+				if (raw === undefined) continue;
+				if (EXTERNAL.test(raw) || raw.startsWith('#')) continue;
+
+				const [pathPart = '', anchor] = raw.split('#', 2);
+				if (!pathPart || !isFileClaim(pathPart)) continue;
+
+				const decoded = decodeTarget(pathPart);
+				const isRootRelative = decoded.startsWith('/');
+				// A `/`-rooted link is only checkable when we found a repo root.
+				if (isRootRelative && repoRoot === null) continue;
+				const resolved = isRootRelative
+					? join(repoRoot as string, decoded)
+					: resolve(dirname(file), decoded);
+
+				const finding = {
+					file: relative(root, file),
+					line: index + 1,
+					target: raw,
+				};
+
+				if (!(await exists(resolved))) {
+					findings.push({ kind: 'DEAD_LINK', ...finding });
+					continue;
+				}
+
+				if (!anchor || !resolved.endsWith('.md')) continue;
+
+				let slugs = headingCache.get(resolved);
+				if (!slugs) {
+					slugs = collectHeadingSlugs(await readFile(resolved, 'utf8'));
+					headingCache.set(resolved, slugs);
+				}
+				if (!slugs.has(anchor.toLowerCase()))
+					findings.push({ kind: 'DEAD_ANCHOR', ...finding });
+			}
+		}
+	}
+
+	return findings;
+}
+
+function decodeTarget(target: string): string {
+	try {
+		return decodeURIComponent(target);
+	} catch {
+		return target;
+	}
+}
+
+if (import.meta.main) {
+	const argv = process.argv.slice(2);
+
+	if (argv.includes('--help') || argv.includes('-h')) {
+		console.log(USAGE);
+		process.exit(0);
+	}
+
+	const rootFlag = argv.indexOf('--root');
+	if (rootFlag !== -1 && argv[rootFlag + 1] === undefined) {
+		console.error(USAGE);
+		process.exit(2);
+	}
+
+	const scriptDir = dirname(fileURLToPath(import.meta.url));
+	const root = resolve(
+		rootFlag === -1
+			? join(scriptDir, '..', '..')
+			: (argv[rootFlag + 1] as string),
+	);
+	const findings = await auditLinks(root, await findRepoRoot(root));
+
+	if (argv.includes('--json')) {
+		console.log(JSON.stringify({ root, findings }, null, 2));
+	} else {
+		for (const { kind, file, line, target } of findings)
+			console.log(`${kind}\t${file}:${line}\t${target}`);
+	}
+
+	if (findings.length === 0) {
+		console.error(`audit-skill-links: no dead links or anchors under ${root}.`);
+		process.exit(0);
+	}
+
+	console.error(
+		`audit-skill-links: ${findings.length} finding(s). Repoint each link, or delete it if the target is gone.`,
+	);
+	process.exit(1);
+}

--- a/.agents/skills/agent-instructions/scripts/run-trigger-eval.test.ts
+++ b/.agents/skills/agent-instructions/scripts/run-trigger-eval.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Trigger eval tests.
+ *
+ * Nothing here spawns the Claude CLI. `--live` costs quota and needs an
+ * authenticated CLI, so the live path is covered the way `consult-claude`
+ * covers its runner: pin the arguments and the transcript parser, and leave
+ * the call itself to a human who chose to pay for it.
+ *
+ * The corpus test is the anti-rot guard. A renamed or deleted skill silently
+ * turns a case into a measurement of nothing, and only a check against the
+ * real catalog notices.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import {
+	buildLiveArgs,
+	type EvalCase,
+	judge,
+	type Observation,
+	PROBE_ROUTER,
+	parseLoadedSkills,
+	partitionByRouter,
+	runLexicalPass,
+	summarize,
+	validateCorpus,
+} from './run-trigger-eval';
+import { readSkillCatalog } from './skill-catalog';
+
+const skillsDir = fileURLToPath(new URL('../..', import.meta.url));
+const corpusPath = fileURLToPath(
+	new URL('../evals/routing.json', import.meta.url),
+);
+const scriptPath = fileURLToPath(
+	new URL('./run-trigger-eval.ts', import.meta.url),
+);
+
+function makeCase(overrides: Partial<EvalCase> = {}): EvalCase {
+	return {
+		id: 'case-1',
+		prompt: 'Run a collapse pass over this package.',
+		anchors: ['collapse pass'],
+		expect: 'collapse-pass',
+		forbid: [],
+		...overrides,
+	};
+}
+
+describe('validateCorpus', () => {
+	const known = new Set(['collapse-pass', 'refactoring']);
+
+	test('accepts a well-formed case', () => {
+		expect(validateCorpus([makeCase()], known)).toEqual([]);
+	});
+
+	test('rejects an anchor the prompt does not contain', () => {
+		const problems = validateCorpus(
+			[makeCase({ anchors: ['asymmetric win'] })],
+			known,
+		);
+		expect(problems).toEqual([
+			'case-1: anchor "asymmetric win" does not appear in the prompt',
+		]);
+	});
+
+	test('rejects a case with no anchors', () => {
+		expect(validateCorpus([makeCase({ anchors: [] })], known)).toEqual([
+			'case-1: needs at least one anchor',
+		]);
+	});
+
+	test('rejects an expect that names no skill', () => {
+		expect(
+			validateCorpus([makeCase({ expect: 'ghost-skill' })], known),
+		).toEqual(['case-1: expect names no such skill: ghost-skill']);
+	});
+
+	test('rejects a forbid that names no skill', () => {
+		expect(validateCorpus([makeCase({ forbid: ['ghost'] })], known)).toEqual([
+			'case-1: forbid names no such skill: ghost',
+		]);
+	});
+
+	test('rejects a skill that is both expected and forbidden', () => {
+		const problems = validateCorpus(
+			[makeCase({ forbid: ['collapse-pass'] })],
+			known,
+		);
+		expect(problems).toContain(
+			'case-1: collapse-pass is both expected and forbidden',
+		);
+	});
+
+	test('rejects duplicate case ids', () => {
+		expect(validateCorpus([makeCase(), makeCase()], known)).toEqual([
+			'case-1: duplicate case id',
+		]);
+	});
+
+	test('accepts a near-miss case with a null expectation', () => {
+		expect(
+			validateCorpus(
+				[makeCase({ expect: null, forbid: ['collapse-pass'] })],
+				known,
+			),
+		).toEqual([]);
+	});
+});
+
+describe('runLexicalPass', () => {
+	const skills = [
+		{ name: 'owner', description: 'Use when the user says "collapse pass".' },
+		{ name: 'rival', description: 'Use for a collapse pass over a diff.' },
+		{
+			name: 'router',
+			description: 'Use for guards. For a collapse pass, use owner instead.',
+		},
+	];
+
+	test('reports nothing when exactly the expected skill claims the anchor', () => {
+		const findings = runLexicalPass(
+			[makeCase({ expect: 'owner' })],
+			[skills[0] as { name: string; description: string }],
+		);
+		expect(findings).toEqual([]);
+	});
+
+	test('reports an anchor no description claims', () => {
+		const findings = runLexicalPass(
+			[makeCase({ expect: null })],
+			[skills[2] as { name: string; description: string }],
+		);
+		expect(findings.map((f) => f.kind)).toEqual(['NO_OWNER']);
+		expect(findings[0]?.detail).toContain('disclaimed by router');
+	});
+
+	test('reports several claimants as ambiguous', () => {
+		const findings = runLexicalPass([makeCase({ expect: 'owner' })], skills);
+		expect(findings.map((f) => f.kind)).toEqual(['AMBIGUOUS']);
+		expect(findings[0]?.detail).toBe('claimed by owner, rival');
+	});
+
+	test('reports the expected owner carrying no hook for its own phrase', () => {
+		const findings = runLexicalPass(
+			[makeCase({ expect: 'router' })],
+			[skills[2] as { name: string; description: string }],
+		);
+		expect(findings.map((f) => f.kind)).toContain('UNOWNED_BY_EXPECTED');
+		expect(findings[0]?.detail).toContain('routes this phrase away');
+	});
+
+	test('reports a forbidden skill that claims the anchor', () => {
+		const findings = runLexicalPass(
+			[makeCase({ expect: 'owner', forbid: ['rival'] })],
+			skills,
+		);
+		expect(findings.map((f) => f.kind)).toContain('FORBIDDEN_CLAIM');
+	});
+});
+
+describe('buildLiveArgs', () => {
+	test('gives the probe only the Skill tool and never disables skills', () => {
+		const args = buildLiveArgs({});
+
+		expect(args).toContain('--tools');
+		expect(args[args.indexOf('--tools') + 1]).toBe('Skill');
+		expect(args).toContain('-p');
+		expect(args).toContain('--no-session-persistence');
+		expect(args.slice(args.indexOf('--output-format'))).toEqual([
+			'--output-format',
+			'stream-json',
+			'--verbose',
+		]);
+		// --safe-mode disables skills, which would make every probe return NONE.
+		expect(args).not.toContain('--safe-mode');
+	});
+
+	test('threads model and effort through for sweeps', () => {
+		const args = buildLiveArgs({ model: 'claude-opus-5', effort: 'high' });
+
+		expect(args[args.indexOf('--model') + 1]).toBe('claude-opus-5');
+		expect(args[args.indexOf('--effort') + 1]).toBe('high');
+	});
+
+	test('omits model and effort when unset so the CLI default applies', () => {
+		const args = buildLiveArgs({});
+
+		expect(args).not.toContain('--model');
+		expect(args).not.toContain('--effort');
+	});
+});
+
+describe('parseLoadedSkills', () => {
+	const event = (content: unknown) =>
+		`${JSON.stringify({ type: 'assistant', message: { content } })}\n`;
+
+	test('collects each skill the transcript shows being loaded', () => {
+		const stream =
+			event([
+				{ type: 'tool_use', name: 'Skill', input: { skill: 'collapse-pass' } },
+			]) + event([{ type: 'text', text: 'collapse-pass' }]);
+
+		expect(parseLoadedSkills(stream)).toEqual(['collapse-pass']);
+	});
+
+	test('ignores tool uses that are not the Skill tool', () => {
+		const stream = event([
+			{ type: 'tool_use', name: 'Read', input: { file_path: '/a.ts' } },
+		]);
+
+		expect(parseLoadedSkills(stream)).toEqual([]);
+	});
+
+	test('deduplicates a skill loaded twice', () => {
+		const block = { type: 'tool_use', name: 'Skill', input: { skill: 'git' } };
+
+		expect(parseLoadedSkills(event([block]) + event([block]))).toEqual(['git']);
+	});
+
+	test('survives non-JSON lines in the stream', () => {
+		const stream = `not json\n${event([
+			{ type: 'tool_use', name: 'Skill', input: { skill: 'handoff' } },
+		])}`;
+
+		expect(parseLoadedSkills(stream)).toEqual(['handoff']);
+	});
+
+	test('returns nothing for a transcript that loaded no skill', () => {
+		expect(parseLoadedSkills(event([{ type: 'text', text: 'NONE' }]))).toEqual(
+			[],
+		);
+	});
+});
+
+describe('judge', () => {
+	test('passes when the expected skill loaded', () => {
+		expect(judge(makeCase(), ['collapse-pass']).verdict).toBe('pass');
+	});
+
+	test('fails when a different skill loaded', () => {
+		const result = judge(makeCase(), ['refactoring']);
+
+		expect(result.verdict).toBe('fail');
+		expect(result.reason).toBe('expected collapse-pass, loaded refactoring');
+	});
+
+	test('fails on a forbidden skill even when the expected one also loaded', () => {
+		const result = judge(makeCase({ forbid: ['refactoring'] }), [
+			'collapse-pass',
+			'refactoring',
+		]);
+
+		expect(result.verdict).toBe('fail');
+		expect(result.reason).toContain('forbidden');
+	});
+
+	test('a near-miss case passes only when nothing loaded', () => {
+		const nearMiss = makeCase({ expect: null, forbid: [] });
+
+		expect(judge(nearMiss, []).verdict).toBe('pass');
+		expect(judge(nearMiss, ['collapse-pass']).verdict).toBe('fail');
+	});
+
+	test('reports loading nothing when a skill was expected', () => {
+		expect(judge(makeCase(), []).reason).toBe(
+			'expected collapse-pass, loaded nothing',
+		);
+	});
+});
+
+describe('summarize', () => {
+	const observation = (verdict: Observation['verdict']): Observation => ({
+		loaded: [],
+		verdict,
+		reason: '',
+	});
+
+	test('all passing is a pass at 100%', () => {
+		const result = summarize('c', [observation('pass'), observation('pass')]);
+
+		expect(result.verdict).toBe('pass');
+		expect(result.passRate).toBe(1);
+	});
+
+	test('none passing is a fail at 0%', () => {
+		expect(summarize('c', [observation('fail')]).verdict).toBe('fail');
+	});
+
+	test('a mixed result is flaky rather than the last run winning', () => {
+		const result = summarize('c', [
+			observation('pass'),
+			observation('fail'),
+			observation('pass'),
+		]);
+
+		expect(result.verdict).toBe('flaky');
+		expect(result.passRate).toBeCloseTo(2 / 3);
+	});
+
+	test('an errored run counts against the rate', () => {
+		expect(
+			summarize('c', [observation('pass'), observation('error')]).verdict,
+		).toBe('flaky');
+	});
+});
+
+describe('partitionByRouter', () => {
+	test('an unmarked case defaults to the router --live can drive', () => {
+		const { measurable, unmeasurable } = partitionByRouter([makeCase()]);
+
+		expect(PROBE_ROUTER).toBe('claude');
+		expect(measurable).toHaveLength(1);
+		expect(unmeasurable).toEqual([]);
+	});
+
+	test('a Codex-routed case is held back rather than judged', () => {
+		const { measurable, unmeasurable } = partitionByRouter([
+			makeCase({ id: 'a' }),
+			makeCase({ id: 'b', router: 'codex' }),
+		]);
+
+		expect(measurable.map((c) => c.id)).toEqual(['a']);
+		expect(unmeasurable.map((c) => c.id)).toEqual(['b']);
+	});
+});
+
+test('an unknown router is a corpus error', () => {
+	const problems = validateCorpus(
+		[makeCase({ router: 'gemini' as never })],
+		new Set(['collapse-pass']),
+	);
+
+	expect(problems).toContain('case-1: unknown router: gemini');
+});
+
+test('the shipped corpus is valid against the real skill catalog', async () => {
+	const corpus = JSON.parse(await readFile(corpusPath, 'utf8')) as {
+		cases: EvalCase[];
+	};
+	const known = new Set((await readSkillCatalog(skillsDir)).map((s) => s.name));
+
+	expect(validateCorpus(corpus.cases, known)).toEqual([]);
+	expect(corpus.cases.length).toBeGreaterThan(0);
+});
+
+test('only the Codex-actor cases are marked unmeasurable', async () => {
+	const corpus = JSON.parse(await readFile(corpusPath, 'utf8')) as {
+		cases: EvalCase[];
+	};
+	const { unmeasurable } = partitionByRouter(corpus.cases);
+
+	// These two skills say in their own descriptions that Codex invokes them.
+	expect(unmeasurable.map((c) => c.expect).sort()).toEqual([
+		'consult-claude',
+		'delegate-claude',
+	]);
+});
+
+test('the default invocation stays offline and says so', () => {
+	const result = spawnSync('bun', [scriptPath], { encoding: 'utf8' });
+
+	expect(result.status).toBe(0);
+	expect(result.stdout).toContain('not how a model routes');
+	// No --live flag, so nothing may spawn the CLI.
+	expect(result.stderr).toContain('Run --live to measure routing');
+});
+
+test('--strict turns the offline pass into a gate', () => {
+	const result = spawnSync('bun', [scriptPath, '--strict'], {
+		encoding: 'utf8',
+	});
+
+	expect(result.status).toBe(1);
+});
+
+test('the shipped corpus covers both boundaries and both directions', async () => {
+	const corpus = JSON.parse(await readFile(corpusPath, 'utf8')) as {
+		cases: EvalCase[];
+	};
+
+	const clusters = new Set(corpus.cases.map((c) => c.cluster));
+	expect(clusters).toEqual(new Set(['review', 'delegation']));
+	// A corpus with no near-miss cases only proves a skill can fire, never that
+	// it stays quiet.
+	expect(corpus.cases.some((c) => c.expect === null)).toBe(true);
+	expect(corpus.cases.some((c) => c.expect !== null)).toBe(true);
+});

--- a/.agents/skills/agent-instructions/scripts/run-trigger-eval.ts
+++ b/.agents/skills/agent-instructions/scripts/run-trigger-eval.ts
@@ -1,0 +1,560 @@
+#!/usr/bin/env bun
+
+/**
+ * Run the trigger corpus against the skill library.
+ *
+ * Two modes, and the difference between them is the whole point of the script.
+ *
+ * The default mode is deterministic and offline. It reads what each skill's
+ * `description` says about each anchor phrase and reports four conditions:
+ * the expected owner carries no hook for its own phrase, nobody claims the
+ * phrase, several skills claim it, or a skill the case forbids claims it.
+ * These are facts about descriptions. They are *not* routing results. A
+ * description can carry a near-miss clause that a substring scan cannot weigh
+ * (`one-sentence-test` tells the agent to answer plain comprehension questions
+ * directly, and no amount of lexical analysis sees that), and a model can route
+ * correctly on intent with no lexical overlap at all. Treat this mode as a
+ * cheap smoke test on description coverage, and never quote it as evidence
+ * that routing works.
+ *
+ * `--live` measures routing. It spawns the Claude CLI once per case with the
+ * Skill tool as its only tool, tells it to load the skill it would use and
+ * stop, and records which skills it actually loaded. That is a real model
+ * decision over the real descriptions. It is still a proxy rather than a
+ * transcript of normal use: a session restricted to one tool and told not to
+ * work is not the session the skill will really be selected in. It costs
+ * quota, needs an authenticated CLI, and is opt-in for exactly those reasons.
+ * The default test suite never invokes it.
+ *
+ * For a model or effort sweep, run `--live --model X --effort Y --out run-X-Y.json`
+ * once per cell and diff the result files. The result file records the model
+ * and effort it was produced under so a stale file cannot be mistaken for a
+ * fresh one.
+ */
+
+import { type ChildProcess, spawn } from 'node:child_process';
+import { writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { classifyClaim, readSkillCatalog } from './skill-catalog';
+
+/**
+ * Which agent's routing a case is about.
+ *
+ * `consult-claude` and `delegate-claude` are written for a Codex session
+ * ("Launch and supervise one durable Claude Code session from Codex"), so a
+ * Claude probe answering them picks a neighbour every time. That is a category
+ * error in the measurement, not a defect in the description, and marking the
+ * case is how the harness says so instead of reporting a failure it cannot
+ * justify.
+ */
+export type Router = 'claude' | 'codex';
+
+export const ROUTERS: Router[] = ['claude', 'codex'];
+
+/** `--live` drives the Claude CLI, so it can only measure Claude-routed cases. */
+export const PROBE_ROUTER: Router = 'claude';
+
+/** Split a batch into what this probe can measure and what it must not judge. */
+export function partitionByRouter(cases: EvalCase[]): {
+	measurable: EvalCase[];
+	unmeasurable: EvalCase[];
+} {
+	return {
+		measurable: cases.filter((c) => (c.router ?? 'claude') === PROBE_ROUTER),
+		unmeasurable: cases.filter((c) => (c.router ?? 'claude') !== PROBE_ROUTER),
+	};
+}
+
+export type EvalCase = {
+	id: string;
+	cluster?: string;
+	prompt: string;
+	anchors: string[];
+	/** Skill that should own this prompt, or null when nothing should trigger. */
+	expect: string | null;
+	forbid: string[];
+	/** Defaults to `claude`, the only router `--live` can currently drive. */
+	router?: Router;
+	why?: string;
+};
+
+export type LexicalFinding = {
+	kind: 'NO_OWNER' | 'UNOWNED_BY_EXPECTED' | 'AMBIGUOUS' | 'FORBIDDEN_CLAIM';
+	caseId: string;
+	anchor: string;
+	detail: string;
+};
+
+const USAGE = `Usage: bun run .agents/skills/agent-instructions/scripts/run-trigger-eval.ts [options]
+
+Default mode is offline and reports description coverage, not routing.
+
+  --corpus <file>   corpus JSON (default: ../evals/routing.json)
+  --case <id>       run one case (repeatable)
+  --strict          exit 1 when the offline pass reports findings
+  --json            emit results as JSON on stdout
+  --live            spawn the Claude CLI per case and record real routing
+  --model <name>    --live only: model to route under
+  --effort <level>  --live only: low | medium | high | xhigh | max
+  --limit <n>       --live only: stop after n cases (default: all)
+  --runs <n>        --live only: probes per case, reported as a pass rate (default: 1)
+  --timeout-ms <n>  --live only: per-probe timeout (default: 120000)
+  --budget-ms <n>   --live only: whole-run wall clock ceiling (default: 900000)
+  --out <file>      --live only: write the result file for sweeps
+  --help            show this message
+
+Exit codes: 0 clean, 1 findings (--strict or --live failures), 2 corpus or usage error.`;
+
+const PROBE_INSTRUCTION = `You are a routing probe. Do not perform the task in the user message.
+Load the one skill you would use with the Skill tool, then stop and reply with only that skill's name.
+If no skill applies, load nothing and reply with only: NONE`;
+
+/**
+ * CLI arguments for one live routing probe.
+ *
+ * The Skill tool is the only tool, which both bounds the turn and makes the
+ * transcript trivially parseable. `--safe-mode` is deliberately absent: it
+ * disables skills, which would make every probe return NONE.
+ */
+export function buildLiveArgs(options: {
+	model?: string;
+	effort?: string;
+}): string[] {
+	return [
+		'-p',
+		'--tools',
+		'Skill',
+		'--permission-mode',
+		'plan',
+		'--no-session-persistence',
+		'--no-chrome',
+		'--append-system-prompt',
+		PROBE_INSTRUCTION,
+		'--output-format',
+		'stream-json',
+		'--verbose',
+		...(options.model ? ['--model', options.model] : []),
+		...(options.effort ? ['--effort', options.effort] : []),
+	];
+}
+
+/** Pull every skill name the transcript shows the model loading. */
+export function parseLoadedSkills(streamJson: string): string[] {
+	const loaded: string[] = [];
+
+	for (const line of streamJson.split('\n')) {
+		if (!line.trim()) continue;
+
+		let event: unknown;
+		try {
+			event = JSON.parse(line);
+		} catch {
+			continue;
+		}
+
+		const content = (event as { message?: { content?: unknown } } | undefined)
+			?.message?.content;
+		if (!Array.isArray(content)) continue;
+
+		for (const block of content) {
+			const b = block as { type?: string; name?: string; input?: unknown };
+			if (b.type !== 'tool_use' || b.name !== 'Skill') continue;
+			const input = b.input as { skill?: string; name?: string } | undefined;
+			const skill = input?.skill ?? input?.name;
+			if (skill && !loaded.includes(skill)) loaded.push(skill);
+		}
+	}
+
+	return loaded;
+}
+
+/** Reject a corpus that cannot produce a meaningful result. */
+export function validateCorpus(
+	cases: EvalCase[],
+	knownSkills: Set<string>,
+): string[] {
+	const problems: string[] = [];
+	const seen = new Set<string>();
+
+	for (const testCase of cases) {
+		const { id, prompt, anchors, expect, forbid } = testCase;
+
+		if (!id) problems.push('a case is missing an id');
+		if (seen.has(id)) problems.push(`${id}: duplicate case id`);
+		seen.add(id);
+
+		if (!prompt) problems.push(`${id}: missing prompt`);
+		if (!Array.isArray(anchors) || anchors.length === 0)
+			problems.push(`${id}: needs at least one anchor`);
+
+		for (const anchor of anchors ?? []) {
+			// An anchor the prompt does not contain measures nothing.
+			if (!prompt?.toLowerCase().includes(anchor.toLowerCase()))
+				problems.push(
+					`${id}: anchor "${anchor}" does not appear in the prompt`,
+				);
+		}
+
+		if (testCase.router !== undefined && !ROUTERS.includes(testCase.router))
+			problems.push(`${id}: unknown router: ${testCase.router}`);
+
+		if (expect !== null && !knownSkills.has(expect))
+			problems.push(`${id}: expect names no such skill: ${expect}`);
+		for (const name of forbid ?? [])
+			if (!knownSkills.has(name))
+				problems.push(`${id}: forbid names no such skill: ${name}`);
+		if (expect !== null && (forbid ?? []).includes(expect))
+			problems.push(`${id}: ${expect} is both expected and forbidden`);
+	}
+
+	return problems;
+}
+
+export function runLexicalPass(
+	cases: EvalCase[],
+	skills: { name: string; description: string }[],
+): LexicalFinding[] {
+	const findings: LexicalFinding[] = [];
+
+	for (const testCase of cases) {
+		for (const anchor of testCase.anchors) {
+			const claimants = skills
+				.filter((s) => classifyClaim(s.description, anchor) === 'claims')
+				.map((s) => s.name);
+			const disclaimers = skills
+				.filter((s) => classifyClaim(s.description, anchor) === 'disclaims')
+				.map((s) => s.name);
+
+			const base = { caseId: testCase.id, anchor };
+
+			if (testCase.expect !== null && !claimants.includes(testCase.expect)) {
+				findings.push({
+					...base,
+					kind: 'UNOWNED_BY_EXPECTED',
+					detail: disclaimers.includes(testCase.expect)
+						? `${testCase.expect} routes this phrase away instead of claiming it`
+						: `${testCase.expect} carries no lexical hook for this phrase`,
+				});
+			}
+
+			if (claimants.length === 0) {
+				findings.push({
+					...base,
+					kind: 'NO_OWNER',
+					detail:
+						disclaimers.length > 0
+							? `no skill claims it; disclaimed by ${disclaimers.join(', ')}`
+							: 'no skill description mentions it',
+				});
+			} else if (claimants.length > 1) {
+				findings.push({
+					...base,
+					kind: 'AMBIGUOUS',
+					detail: `claimed by ${claimants.join(', ')}`,
+				});
+			}
+
+			for (const name of testCase.forbid) {
+				if (claimants.includes(name))
+					findings.push({
+						...base,
+						kind: 'FORBIDDEN_CLAIM',
+						detail: `${name} claims a phrase this case says it must not answer`,
+					});
+			}
+		}
+	}
+
+	return findings;
+}
+
+export type Observation = {
+	loaded: string[];
+	verdict: 'pass' | 'fail' | 'error';
+	reason: string;
+};
+
+export type CaseResult = {
+	caseId: string;
+	/** Fraction of runs that passed, so a flaky trigger is visible as a rate. */
+	passRate: number;
+	verdict: 'pass' | 'flaky' | 'fail';
+	runs: Observation[];
+};
+
+/** Decide one run's verdict from the skills the transcript shows loading. */
+export function judge(testCase: EvalCase, loaded: string[]): Observation {
+	const forbidden = loaded.filter((name) => testCase.forbid.includes(name));
+	if (forbidden.length > 0)
+		return {
+			loaded,
+			verdict: 'fail',
+			reason: `loaded forbidden skill(s): ${forbidden.join(', ')}`,
+		};
+
+	if (testCase.expect === null)
+		return loaded.length === 0
+			? { loaded, verdict: 'pass', reason: 'loaded nothing' }
+			: {
+					loaded,
+					verdict: 'fail',
+					reason: `expected no skill, loaded ${loaded.join(', ')}`,
+				};
+
+	return loaded.includes(testCase.expect)
+		? { loaded, verdict: 'pass', reason: `loaded ${testCase.expect}` }
+		: {
+				loaded,
+				verdict: 'fail',
+				reason: `expected ${testCase.expect}, loaded ${loaded.join(', ') || 'nothing'}`,
+			};
+}
+
+/**
+ * Collapse repeated runs into one verdict.
+ *
+ * Routing varies between runs, so a case that passes twice and fails once is
+ * neither a pass nor a failure. `flaky` keeps that distinction visible instead
+ * of letting the last run decide.
+ */
+export function summarize(caseId: string, runs: Observation[]): CaseResult {
+	const passed = runs.filter((r) => r.verdict === 'pass').length;
+	const passRate = runs.length === 0 ? 0 : passed / runs.length;
+
+	return {
+		caseId,
+		passRate,
+		verdict: passRate === 1 ? 'pass' : passRate === 0 ? 'fail' : 'flaky',
+		runs,
+	};
+}
+
+async function probe(
+	testCase: EvalCase,
+	options: { model?: string; effort?: string; timeoutMs: number; cwd: string },
+): Promise<Observation> {
+	const { CLAUDECODE: _ignored, ...env } = process.env;
+	const child: ChildProcess = spawn('claude', buildLiveArgs(options), {
+		cwd: options.cwd,
+		env,
+		stdio: ['pipe', 'pipe', 'pipe'],
+	});
+
+	let stdout = '';
+	let stderr = '';
+	child.stdout?.on('data', (chunk) => {
+		stdout += chunk;
+	});
+	child.stderr?.on('data', (chunk) => {
+		stderr += chunk;
+	});
+	child.stdin?.on('error', () => {
+		// The child exited before reading the prompt; the close handler reports it.
+	});
+	child.stdin?.end(testCase.prompt);
+
+	// A hung probe must end the probe, never the run. Recording the timeout as
+	// its own reason keeps it distinguishable from a CLI that failed fast.
+	let timedOut = false;
+	const timer = setTimeout(() => {
+		timedOut = true;
+		child.kill('SIGKILL');
+	}, options.timeoutMs);
+	const code = await new Promise<number | null>((done) => {
+		child.once('error', () => done(null));
+		child.once('close', done);
+	});
+	clearTimeout(timer);
+
+	if (timedOut)
+		return {
+			loaded: [],
+			verdict: 'error',
+			reason: `timed out after ${options.timeoutMs}ms; raise --timeout-ms or drop the case`,
+		};
+
+	if (code !== 0)
+		return {
+			loaded: [],
+			verdict: 'error',
+			reason: `claude exited ${code}: ${stderr.trim().slice(0, 200)}`,
+		};
+
+	return judge(testCase, parseLoadedSkills(stdout));
+}
+
+function flagValue(argv: string[], flag: string): string | undefined {
+	const index = argv.indexOf(flag);
+	return index === -1 ? undefined : argv[index + 1];
+}
+
+/** Every value following a repeatable flag, e.g. `--case a --case b`. */
+function flagValues(argv: string[], flag: string): string[] {
+	return argv.flatMap((arg, index) =>
+		arg === flag && argv[index + 1] !== undefined
+			? [argv[index + 1] as string]
+			: [],
+	);
+}
+
+if (import.meta.main) {
+	const argv = process.argv.slice(2);
+
+	if (argv.includes('--help') || argv.includes('-h')) {
+		console.log(USAGE);
+		process.exit(0);
+	}
+
+	const scriptDir = dirname(fileURLToPath(import.meta.url));
+	const skillsDir = join(scriptDir, '..', '..');
+	const corpusPath = resolve(
+		flagValue(argv, '--corpus') ??
+			join(scriptDir, '..', 'evals', 'routing.json'),
+	);
+
+	const corpusFile = Bun.file(corpusPath);
+	if (!(await corpusFile.exists())) {
+		console.error(`run-trigger-eval: no corpus at ${corpusPath}`);
+		process.exit(2);
+	}
+
+	const corpus = (await corpusFile.json()) as { cases: EvalCase[] };
+	const skills = await readSkillCatalog(skillsDir);
+	const known = new Set(skills.map((s) => s.name));
+
+	const problems = validateCorpus(corpus.cases, known);
+	if (problems.length > 0) {
+		console.error('run-trigger-eval: corpus is invalid.');
+		for (const problem of problems) console.error(`  ${problem}`);
+		process.exit(2);
+	}
+
+	const wanted = flagValues(argv, '--case');
+	const selected =
+		wanted.length === 0
+			? corpus.cases
+			: corpus.cases.filter((c) => wanted.includes(c.id));
+
+	if (selected.length === 0) {
+		console.error('run-trigger-eval: --case matched nothing.');
+		process.exit(2);
+	}
+
+	if (!argv.includes('--live')) {
+		const findings = runLexicalPass(selected, skills);
+
+		if (argv.includes('--json')) {
+			console.log(
+				JSON.stringify(
+					{ mode: 'lexical', cases: selected.length, findings },
+					null,
+					2,
+				),
+			);
+		} else {
+			console.log(
+				`# description coverage over ${selected.length} case(s) and ${skills.length} skills`,
+			);
+			console.log(
+				'# this reports what descriptions say, not how a model routes\n',
+			);
+			for (const { kind, caseId, anchor, detail } of findings)
+				console.log(`${kind}\t${caseId}\t"${anchor}"\t${detail}`);
+			if (findings.length === 0) console.log('(no findings)');
+		}
+
+		console.error(
+			`run-trigger-eval: ${findings.length} coverage finding(s). Run --live to measure routing.`,
+		);
+		process.exit(argv.includes('--strict') && findings.length > 0 ? 1 : 0);
+	}
+
+	if (!Bun.which('claude')) {
+		console.error(
+			'run-trigger-eval: --live needs an authenticated `claude` on PATH. The default offline pass needs no credentials.',
+		);
+		process.exit(2);
+	}
+
+	const model = flagValue(argv, '--model');
+	const effort = flagValue(argv, '--effort');
+	const limit = Number(flagValue(argv, '--limit') ?? selected.length);
+	const timeoutMs = Number(flagValue(argv, '--timeout-ms') ?? 120_000);
+	const budgetMs = Number(flagValue(argv, '--budget-ms') ?? 900_000);
+	const runsPerCase = Number(flagValue(argv, '--runs') ?? 1);
+	const cwd = resolve(skillsDir, '..', '..');
+
+	// Cases written for a Codex session cannot be judged by a Claude probe.
+	// Dropping them silently would manufacture failures, so name them instead.
+	const { measurable, unmeasurable } = partitionByRouter(
+		selected.slice(0, limit),
+	);
+	const batch = measurable;
+
+	if (measurable.length + unmeasurable.length < selected.length)
+		console.error(
+			`run-trigger-eval: --limit ${limit} drops ${selected.length - measurable.length - unmeasurable.length} case(s) from this run.`,
+		);
+
+	for (const testCase of unmeasurable)
+		console.error(
+			`run-trigger-eval: NOT MEASURED ${testCase.id}: routed by ${testCase.router}, and --live only drives ${PROBE_ROUTER}.`,
+		);
+
+	const startedAt = Date.now();
+	const results: CaseResult[] = [];
+	let budgetExhausted = false;
+
+	for (const [index, testCase] of batch.entries()) {
+		if (Date.now() - startedAt > budgetMs) {
+			budgetExhausted = true;
+			console.error(
+				`run-trigger-eval: --budget-ms ${budgetMs} exhausted; ${batch.length - index} case(s) never ran.`,
+			);
+			break;
+		}
+
+		const runs: Observation[] = [];
+		for (let attempt = 1; attempt <= runsPerCase; attempt++) {
+			console.error(
+				`run-trigger-eval: [${index + 1}/${batch.length}] ${testCase.id} run ${attempt}/${runsPerCase}`,
+			);
+			runs.push(await probe(testCase, { model, effort, timeoutMs, cwd }));
+		}
+		results.push(summarize(testCase.id, runs));
+	}
+
+	const run = {
+		mode: 'live' as const,
+		model: model ?? '(cli default)',
+		effort: effort ?? '(cli default)',
+		runsPerCase,
+		budgetExhausted,
+		notMeasured: unmeasurable.map((c) => ({ id: c.id, router: c.router })),
+		corpus: corpusPath,
+		results,
+	};
+
+	if (argv.includes('--json')) console.log(JSON.stringify(run, null, 2));
+	else
+		for (const { verdict, caseId, passRate, runs } of results)
+			console.log(
+				`${verdict.toUpperCase()}\t${caseId}\t${Math.round(passRate * 100)}%\t${runs
+					.map((r) => `[${r.loaded.join(', ')}]`)
+					.join(' ')}`,
+			);
+
+	const out = flagValue(argv, '--out');
+	if (out) {
+		await writeFile(resolve(out), `${JSON.stringify(run, null, 2)}\n`);
+		console.error(`run-trigger-eval: wrote ${resolve(out)}`);
+	}
+
+	const failed = results.filter((r) => r.verdict !== 'pass');
+	console.error(
+		`run-trigger-eval: ${results.length - failed.length}/${results.length} clean over ${runsPerCase} run(s) each, model=${run.model} effort=${run.effort}.`,
+	);
+	// An exhausted budget is an incomplete run, not a clean one.
+	process.exit(failed.length > 0 || budgetExhausted ? 1 : 0);
+}

--- a/.agents/skills/agent-instructions/scripts/skill-catalog.test.ts
+++ b/.agents/skills/agent-instructions/scripts/skill-catalog.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Skill catalog tests.
+ *
+ * The frontmatter reader has to survive the shapes descriptions are actually
+ * written in here: quoted scalars with embedded quotes, block scalars wrapped
+ * across lines, and sibling fields like `metadata` that must not bleed in.
+ *
+ * `classifyClaim` is the part worth defending. Substring matching reports a
+ * near-miss clause as a claim, which turns the routing audit into noise, so
+ * these tests pin the claim / disclaim / absent split.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { classifyClaim, extractFrontmatterField } from './skill-catalog';
+
+describe('extractFrontmatterField', () => {
+	test('reads a single-line field', () => {
+		const md =
+			'---\nname: svelte\ndescription: Svelte 5 patterns.\n---\n# Body\n';
+		expect(extractFrontmatterField(md, 'description')).toBe(
+			'Svelte 5 patterns.',
+		);
+	});
+
+	test('joins a wrapped description onto one line', () => {
+		const md = '---\nname: x\ndescription: First part\n  second part\n---\n';
+		expect(extractFrontmatterField(md, 'description')).toBe(
+			'First part second part',
+		);
+	});
+
+	test('strips surrounding quotes without eating inner ones', () => {
+		const md = '---\ndescription: "Use for \\"in one sentence\\"."\n---\n';
+		expect(extractFrontmatterField(md, 'description')).toBe(
+			'Use for \\"in one sentence\\".',
+		);
+	});
+
+	test('stops at the next top-level field', () => {
+		const md = '---\ndescription: Only this.\nmetadata:\n  version: 2\n---\n';
+		expect(extractFrontmatterField(md, 'description')).toBe('Only this.');
+	});
+
+	test('returns empty when there is no frontmatter', () => {
+		expect(extractFrontmatterField('# Just a heading\n', 'description')).toBe(
+			'',
+		);
+	});
+
+	test('returns empty when the field is missing', () => {
+		expect(extractFrontmatterField('---\nname: x\n---\n', 'description')).toBe(
+			'',
+		);
+	});
+});
+
+describe('classifyClaim', () => {
+	const controlFlow =
+		'Control flow: early returns, guard clauses, linearizing nested logic. ' +
+		'Use for "flatten these conditions", "too many nested ifs". ' +
+		'For a broad "simplify this" pass over a diff or package, use collapse-pass instead.';
+
+	test('claims a phrase carried by a trigger sentence', () => {
+		expect(classifyClaim(controlFlow, 'nested ifs')).toBe('claims');
+	});
+
+	test('disclaims a phrase carried only by a near-miss sentence', () => {
+		expect(classifyClaim(controlFlow, 'simplify this')).toBe('disclaims');
+	});
+
+	test('reports absent when the description never mentions the phrase', () => {
+		expect(classifyClaim(controlFlow, 'asymmetric win')).toBe('absent');
+	});
+
+	test('matches case-insensitively and as a substring', () => {
+		expect(
+			classifyClaim(
+				'Use when the user asks to Hand Off the implementation.',
+				'hand off',
+			),
+		).toBe('claims');
+	});
+
+	test('claims when one sentence routes the phrase away but another owns it', () => {
+		const mixed =
+			'Use for "fresh eyes" on a diff. Not for fresh eyes on a product decision.';
+		expect(classifyClaim(mixed, 'fresh eyes')).toBe('claims');
+	});
+
+	test('does not split on a dot inside a token', () => {
+		expect(
+			classifyClaim('Finds console.* in library code.', 'console.* in library'),
+		).toBe('claims');
+	});
+
+	test('treats an empty phrase as absent', () => {
+		expect(classifyClaim(controlFlow, '  ')).toBe('absent');
+	});
+});

--- a/.agents/skills/agent-instructions/scripts/skill-catalog.ts
+++ b/.agents/skills/agent-instructions/scripts/skill-catalog.ts
@@ -1,0 +1,144 @@
+/**
+ * Read the skill catalog and classify what a description claims.
+ *
+ * Three scripts need the same two primitives: enumerate `<skills>/*\/SKILL.md`
+ * and pull one frontmatter field out of it. This module owns both so the
+ * frontmatter parser has one definition rather than one copy per script.
+ *
+ * `classifyClaim` exists because substring matching over-reports. Descriptions
+ * in this repository carry near-miss clauses ("For a broad \"simplify this\"
+ * pass over a diff or package, use collapse-pass instead."), so a description
+ * that mentions a phrase is as likely to be *routing it away* as claiming it.
+ * Splitting the description into sentences and reading the sentence that
+ * carries the phrase separates the two cases. This is still lexical: it reports
+ * what a description says, never what a model does.
+ */
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export type SkillEntry = {
+	/** Directory name, which is also the skill name the CLI discovers. */
+	name: string;
+	/** The `description` frontmatter field, joined onto one line. */
+	description: string;
+	/** Absolute path to the skill's `SKILL.md`. */
+	skillPath: string;
+};
+
+/**
+ * What a description does with a phrase.
+ *
+ * - `claims`: at least one sentence carries the phrase as a trigger.
+ * - `disclaims`: every sentence carrying the phrase routes it elsewhere.
+ * - `absent`: the description never mentions the phrase.
+ */
+export type ClaimVerdict = 'claims' | 'disclaims' | 'absent';
+
+/**
+ * Enumerate every skill directory that has a `SKILL.md`, sorted by name.
+ *
+ * Directories without a `SKILL.md` are skipped rather than reported: the
+ * "stub directory" check belongs to the composition audit, not here.
+ */
+export async function readSkillCatalog(
+	skillsDir: string,
+): Promise<SkillEntry[]> {
+	const entries = await readdir(skillsDir, { withFileTypes: true });
+	const skills: SkillEntry[] = [];
+
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+
+		const skillPath = join(skillsDir, entry.name, 'SKILL.md');
+		const contents = await readFile(skillPath, 'utf8').catch(
+			(error: unknown) => {
+				if (
+					error instanceof Error &&
+					'code' in error &&
+					error.code === 'ENOENT'
+				)
+					return null;
+				throw error;
+			},
+		);
+		if (contents === null) continue;
+
+		skills.push({
+			name: entry.name,
+			description: extractFrontmatterField(contents, 'description'),
+			skillPath,
+		});
+	}
+
+	return skills.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Read one top-level frontmatter field, joining block scalars onto one line.
+ *
+ * Returns an empty string when the file has no frontmatter or no such field.
+ */
+export function extractFrontmatterField(
+	markdown: string,
+	fieldName: string,
+): string {
+	const lines = markdown.split(/\r?\n/);
+	if (lines[0] !== '---') return '';
+
+	const fieldPrefix = `${fieldName}:`;
+	const values: string[] = [];
+	let isReadingField = false;
+
+	for (const line of lines.slice(1)) {
+		if (line === '---') break;
+
+		const startsNewField = /^[A-Za-z0-9_-]+:/.test(line);
+		if (startsNewField) {
+			if (isReadingField) break;
+
+			if (line.startsWith(fieldPrefix)) {
+				isReadingField = true;
+				values.push(line.slice(fieldPrefix.length).trim());
+			}
+
+			continue;
+		}
+
+		if (isReadingField) values.push(line.trim());
+	}
+
+	return values.join(' ').replace(/^['"]|['"]$/g, '');
+}
+
+// A sentence routes a phrase away when it names another destination. These are
+// the forms the repository's descriptions actually use.
+const DISCLAIMER =
+	/\b(instead|rather than|not for|do not use|don't use|never use)\b/i;
+
+/**
+ * Decide whether `description` claims `phrase`, routes it away, or omits it.
+ *
+ * Matching is case-insensitive and substring-based, so "hand off" matches
+ * "hand off the implementation". A phrase that appears only inside near-miss
+ * sentences is reported as `disclaims`.
+ */
+export function classifyClaim(
+	description: string,
+	phrase: string,
+): ClaimVerdict {
+	const needle = phrase.toLowerCase().trim();
+	if (!needle) return 'absent';
+
+	// Split on sentence-ending punctuation followed by whitespace, which leaves
+	// `console.*` and `.agents/skills` intact.
+	const sentences = description.split(/(?<=[.;:])\s+/);
+	const carrying = sentences.filter((sentence) =>
+		sentence.toLowerCase().includes(needle),
+	);
+
+	if (carrying.length === 0) return 'absent';
+	return carrying.every((sentence) => DISCLAIMER.test(sentence))
+		? 'disclaims'
+		: 'claims';
+}

--- a/.agents/skills/cohesion-over-testability/SKILL.md
+++ b/.agents/skills/cohesion-over-testability/SKILL.md
@@ -133,7 +133,7 @@ to zero. The four invariants the test was asserting are now visible in
 ~6 lines of branch logic, type-enforced by `T extends Disposable`, and
 exercised on every app boot.
 
-Article: [Don't Split for the Test](../../docs/articles/20260513T120000-dont-split-for-the-test.md).
+Article: [Don't Split for the Test](../../../docs/articles/20260513T120000-dont-split-for-the-test.md).
 
 ## Common Forms of the Smell
 

--- a/.agents/skills/factory-function-composition/SKILL.md
+++ b/.agents/skills/factory-function-composition/SKILL.md
@@ -234,7 +234,7 @@ If a function is called both by return-object methods *and* by pre-return initia
 | Private helper (zone 3) | Direct call by name: `helperFn()` |
 | Both zones need it | Keep in zone 3, call by name everywhere |
 
-See [Closures Are Better Privacy Than Keywords](../../docs/articles/closures-are-better-privacy-than-keywords.md) for the full rationale and real codebase examples.
+See [Closures Are Better Privacy Than Keywords](../../../docs/articles/closures-are-better-privacy-than-keywords.md) for the full rationale and real codebase examples.
 
 ## Structural Contracts: Factories That Satisfy External Interfaces
 
@@ -314,11 +314,11 @@ createClient(...)  →  createService(client, ...)  →  service.method(...)
 
 See the full articles for more details:
 
-- [The Universal Factory Function Signature](../../docs/articles/universal-factory-signature.md): signature explained in depth
-- [Stop Passing Clients as Arguments](../../docs/articles/stop-passing-clients-as-arguments.md): practical guide
-- [The Factory Function Pattern](../../docs/articles/factory-function-pattern.md): detailed explanation
-- [Factory Method Patterns](../../docs/articles/factory-method-patterns.md): separating options and method patterns
-- [Closures Are Better Privacy Than Keywords](../../docs/articles/closures-are-better-privacy-than-keywords.md): internal anatomy and why closures beat class keywords
+- [The Universal Factory Function Signature](../../../docs/articles/universal-factory-signature.md): signature explained in depth
+- [Stop Passing Clients as Arguments](../../../docs/articles/stop-passing-clients-as-arguments.md): practical guide
+- [The Factory Function Pattern](../../../docs/articles/factory-function-pattern.md): detailed explanation
+- [Factory Method Patterns](../../../docs/articles/factory-method-patterns.md): separating options and method patterns
+- [Closures Are Better Privacy Than Keywords](../../../docs/articles/closures-are-better-privacy-than-keywords.md): internal anatomy and why closures beat class keywords
 
 Load on demand:
 

--- a/.agents/skills/method-shorthand-jsdoc/SKILL.md
+++ b/.agents/skills/method-shorthand-jsdoc/SKILL.md
@@ -231,9 +231,9 @@ The `this.method()` vs direct-call decision depends on which zone the function l
 
 When a helper needs to be in zone 3, its JSDoc won't be visible to consumers; that's correct, because it's a private implementation detail. Only zone 4 methods need consumer-facing JSDoc.
 
-See [Closures Are Better Privacy Than Keywords](../../docs/articles/closures-are-better-privacy-than-keywords.md) for the full factory function anatomy.
+See [Closures Are Better Privacy Than Keywords](../../../docs/articles/closures-are-better-privacy-than-keywords.md) for the full factory function anatomy.
 
 ## References
 
-- [docs/articles/method-shorthand-jsdoc-preservation.md](../../docs/articles/method-shorthand-jsdoc-preservation.md) - Same content as article
-- [docs/articles/closures-are-better-privacy-than-keywords.md](../../docs/articles/closures-are-better-privacy-than-keywords.md) - Factory function anatomy and zone system
+- [docs/articles/method-shorthand-jsdoc-preservation.md](../../../docs/articles/method-shorthand-jsdoc-preservation.md) - Same content as article
+- [docs/articles/closures-are-better-privacy-than-keywords.md](../../../docs/articles/closures-are-better-privacy-than-keywords.md) - Factory function anatomy and zone system

--- a/.agents/skills/typebox/SKILL.md
+++ b/.agents/skills/typebox/SKILL.md
@@ -65,5 +65,5 @@ and branded domain values.
 
 ## References
 
-- [TypeBox is a Beast](../../docs/articles/typebox-is-a-beast.md)
-- [The Schema Wars Just Shifted](../../docs/articles/20260429T120000-typebox-standard-schema-pivot.md)
+- [TypeBox is a Beast](../../../docs/articles/typebox-is-a-beast.md)
+- [The Schema Wars Just Shifted](../../../docs/articles/20260429T120000-typebox-standard-schema-pivot.md)


### PR DESCRIPTION
Five commits that landed on the wrong branch during a concurrent session and were parked on `skills/routing-eval-harness` so PR #2469 could stay scoped to the runtime-plane deletion. They touch only `.agents/skills/**` and share no files with that PR.

## What's here

- `skill-catalog.ts`: one shared frontmatter reader, replacing the parsing that `audit-routing-collisions` did inline.
- `audit-skill-links.ts`: checks every markdown link and anchor under the skill tree.
- Twelve article links repointed that were one directory level too shallow.
- `run-trigger-eval.ts`: runs a stored trigger corpus offline, and optionally against a model.
- `references/evaluation.md`: documents the harness and, deliberately, what it cannot prove.

## Provenance

I did not author these commits and have not reviewed their internals; I preserved them so they would not be lost or silently folded into an unrelated PR. Treat this as a normal review rather than a rubber stamp.

https://claude.ai/code/session_01VkK1jMNrZHpfQdjgWqY9v7

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788076649&installation_model_id=20236&pr_number=2470&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2470&signature=065a3cd269086bc345527152ef0a40789ef9b9933baf80769212615e218ba70a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->