### PR TITLE
Fix broken tray icon (unbundled resources, dead click handler); add menu-bar-only and notification toggle settings

### DIFF
--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -148,10 +148,30 @@ pub async fn run() {
             }));
     }
 
+    // When "menu bar only" is enabled, clicking the window's close button
+    // should hide the window (like a normal menu-bar app) instead of quitting
+    // the whole process. Real quit still happens via the tray menu's Quit item.
+    builder = builder.setup(|app| {
+        if let Some(window) = app.get_webview_window("main") {
+            let window_clone = window.clone();
+            window.on_window_event(move |event| {
+                if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                    if HIDE_DOCK_ICON.load(std::sync::atomic::Ordering::Relaxed) {
+                        api.prevent_close();
+                        let _ = window_clone.hide();
+                    }
+                }
+            });
+        }
+        Ok(())
+    });
+
     // Register command handlers (same for all platforms now)
     let builder = builder.invoke_handler(tauri::generate_handler![
         write_text,
         simulate_enter_keystroke,
+        set_dock_icon_visible,
+        quit_app,
         // Audio recorder commands
         get_current_recording_id,
         enumerate_recording_devices,
@@ -177,10 +197,10 @@ pub async fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application");
 
-    app.run(|handler, event| {
+    app.run(move |handler, event| {
         // Only track events if Aptabase is enabled (key is not empty)
         if !aptabase_key.is_empty() {
-            match event {
+            match &event {
                 tauri::RunEvent::Exit { .. } => {
                     let _ = handler.track_event("app_exited", None);
                     handler.flush_events_blocking();
@@ -189,6 +209,30 @@ pub async fn run() {
                     let _ = handler.track_event("app_started", None);
                 }
                 _ => {}
+            }
+        }
+
+        // Cmd+Q / "Quit Whispering" from the app menu bypasses the window's
+        // CloseRequested event entirely and goes straight to ExitRequested.
+        // In "menu bar only" mode, treat it the same as closing the window —
+        // unless quit_app requested a real, intentional exit (tray Quit item).
+        if let tauri::RunEvent::ExitRequested { api, .. } = &event {
+            let intentional_quit = INTENTIONAL_QUIT.load(std::sync::atomic::Ordering::Relaxed);
+            if !intentional_quit && HIDE_DOCK_ICON.load(std::sync::atomic::Ordering::Relaxed) {
+                api.prevent_exit();
+                if let Some(window) = handler.get_webview_window("main") {
+                    let _ = window.hide();
+                }
+            }
+        }
+
+        // macOS fires Reopen when the user clicks the Dock icon (or the tray
+        // icon's "Show Window" item re-triggers activation) while the window
+        // is hidden. Without this, a hidden window becomes unreachable.
+        if let tauri::RunEvent::Reopen { .. } = &event {
+            if let Some(window) = handler.get_webview_window("main") {
+                let _ = window.show();
+                let _ = window.set_focus();
             }
         }
     });
@@ -273,5 +317,56 @@ async fn simulate_enter_keystroke() -> Result<(), String> {
         .key(Key::Return, Direction::Click)
         .map_err(|e| format!("Failed to simulate Enter key: {}", e))?;
 
+    Ok(())
+}
+
+/// Shared with the window-close and app-exit handlers in `run()`: when true,
+/// closing the window or pressing Cmd+Q hides the window instead of quitting,
+/// matching normal menu-bar-app behavior (the app only truly quits via the
+/// tray menu's Quit item).
+static HIDE_DOCK_ICON: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Set by `quit_app` right before requesting a real exit, so the
+/// `ExitRequested` handler in `run()` can tell an intentional Quit (from the
+/// tray menu) apart from macOS routing Cmd+Q / window-close through the same
+/// event when "menu bar only" is active — otherwise that handler would just
+/// hide the window forever instead of letting the app actually quit.
+static INTENTIONAL_QUIT: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Shows or hides the app's Dock icon (and Cmd+Tab/task switcher entry).
+///
+/// On macOS this toggles the activation policy between `Regular` (normal app
+/// with a Dock icon) and `Accessory` (menu-bar-only app, no Dock icon, no
+/// window switcher entry). The app remains fully usable via the system tray
+/// icon in either mode. No-op on platforms without a Dock (Windows/Linux).
+#[tauri::command]
+async fn set_dock_icon_visible(app: tauri::AppHandle, visible: bool) -> Result<(), String> {
+    HIDE_DOCK_ICON.store(!visible, std::sync::atomic::Ordering::Relaxed);
+    #[cfg(target_os = "macos")]
+    {
+        let policy = if visible {
+            tauri::ActivationPolicy::Regular
+        } else {
+            tauri::ActivationPolicy::Accessory
+        };
+        app.set_activation_policy(policy)
+            .map_err(|e| format!("Failed to set activation policy: {}", e))?;
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (app, visible);
+    }
+
+    Ok(())
+}
+
+/// Quits the app for real, bypassing the "menu bar only" close-to-tray
+/// behavior. This is what the tray menu's Quit item calls instead of the
+/// generic process-plugin exit, which gets intercepted the same as a window
+/// close when "menu bar only" is active.
+#[tauri::command]
+async fn quit_app(app: tauri::AppHandle) -> Result<(), String> {
+    INTENTIONAL_QUIT.store(true, std::sync::atomic::Ordering::Relaxed);
+    app.exit(0);
     Ok(())
 }

--- a/apps/whispering/src-tauri/tauri.conf.json
+++ b/apps/whispering/src-tauri/tauri.conf.json
@@ -12,6 +12,7 @@
 		"copyright": "Copyright © 2025 Braden Wong",
 		"homepage": "https://whispering.epicenter.so",
 		"targets": "all",
+		"resources": ["recorder-state-icons/*"],
 		"icon": [
 			"icons/32x32.png",
 			"icons/128x128.png",

--- a/apps/whispering/src/lib/query/isomorphic/notify.ts
+++ b/apps/whispering/src/lib/query/isomorphic/notify.ts
@@ -4,6 +4,7 @@ import { notificationLog } from '$lib/components/NotificationLog.svelte';
 import { defineMutation } from '$lib/query/client';
 import { services } from '$lib/services';
 import type { UnifiedNotificationOptions } from '$lib/services/isomorphic/notifications/types';
+import { settings } from '$lib/stores/settings.svelte';
 
 // Create a mutation for a specific variant
 const createNotifyMutation = (
@@ -40,7 +41,15 @@ const createNotifyMutation = (
 			// Add to notification log
 			notificationLog.addLog(fullOptions);
 
-			// Always show toast
+			// Errors always show. Other variants (success/info/loading/warning)
+			// respect the "show notifications" setting so users who find the
+			// per-step toasts noisy can quiet them down without losing errors.
+			const shouldShow =
+				variant === 'error' || settings.value['system.showNotifications'];
+
+			if (!shouldShow) return Ok(undefined);
+
+			// Show toast
 			const toastId = services.toast.show(fullOptions);
 
 			// Also show OS notification (system notifications or browser/extension notifications)

--- a/apps/whispering/src/lib/services/desktop/tray.ts
+++ b/apps/whispering/src/lib/services/desktop/tray.ts
@@ -1,8 +1,8 @@
+import { invoke } from '@tauri-apps/api/core';
 import { Menu, MenuItem } from '@tauri-apps/api/menu';
 import { resolveResource } from '@tauri-apps/api/path';
 import { TrayIcon } from '@tauri-apps/api/tray';
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import { exit } from '@tauri-apps/plugin-process';
 import { createTaggedError, extractErrorMessage } from 'wellcrafted/error';
 // import { commandCallbacks } from '$lib/commands';
 import { tryAsync } from 'wellcrafted/result';
@@ -15,7 +15,10 @@ const TRAY_ID = 'whispering-tray';
 const { SetTrayIconServiceErr } = createTaggedError('SetTrayIconServiceError');
 
 export function createTrayIconDesktopService() {
-	const trayPromise = initTray();
+	const trayPromise = initTray().catch((error) => {
+		console.error('Failed to initialize tray icon:', error);
+		throw error;
+	});
 	return {
 		setTrayIcon: (recorderState: WhisperingRecordingState) =>
 			tryAsync({
@@ -38,34 +41,24 @@ async function initTray() {
 
 	const trayMenu = await Menu.new({
 		items: [
-			// Window Controls Section
-			await MenuItem.new({
-				id: 'show',
-				text: 'Show Window',
-				action: () => getCurrentWindow().show(),
-			}),
-
-			await MenuItem.new({
-				id: 'hide',
-				text: 'Hide Window',
-				action: () => getCurrentWindow().hide(),
-			}),
-
-			// Settings Section
 			await MenuItem.new({
 				id: 'settings',
 				text: 'Settings',
-				action: () => {
+				action: async () => {
 					goto('/settings');
-					return getCurrentWindow().show();
+					const win = getCurrentWindow();
+					await win.show();
+					await win.setFocus();
 				},
 			}),
 
-			// Quit Section
 			await MenuItem.new({
 				id: 'quit',
 				text: 'Quit',
-				action: () => void exit(0),
+				// Uses a dedicated Rust command instead of the process plugin's
+				// generic exit() — that gets treated the same as a window close
+				// (hidden, not quit) whenever "menu bar only" is active.
+				action: () => invoke('quit_app'),
 			}),
 		],
 	});
@@ -74,18 +67,11 @@ async function initTray() {
 		id: TRAY_ID,
 		icon: await getIconPath('IDLE'),
 		menu: trayMenu,
-		menuOnLeftClick: false,
-		action: (e) => {
-			if (
-				e.type === 'Click' &&
-				e.button === 'Left' &&
-				e.buttonState === 'Down'
-			) {
-				// commandCallbacks.toggleManualRecording();
-				return true;
-			}
-			return false;
-		},
+		// Show the menu (Settings, Quit) on a normal click, not just
+		// right-click. Previously this was false with no click action wired
+		// up at all (the click handler was commented out), so clicking the
+		// tray icon did nothing.
+		menuOnLeftClick: true,
 	});
 
 	return tray;

--- a/apps/whispering/src/lib/settings/settings.ts
+++ b/apps/whispering/src/lib/settings/settings.ts
@@ -103,6 +103,17 @@ export const Settings = type({
 	'system.alwaysOnTop': type
 		.enumerated(...ALWAYS_ON_TOP_MODES)
 		.default('Never'),
+	/**
+	 * When enabled, hides the Dock icon (and Cmd+Tab/task switcher entry) on
+	 * macOS. The app remains accessible via the system tray icon.
+	 */
+	'system.hideDockIcon': 'boolean = false',
+	/**
+	 * When disabled, suppresses success/info/loading/warning toasts and OS
+	 * notifications for every pipeline step (recording started, transcribing,
+	 * etc). Error notifications always show regardless of this setting.
+	 */
+	'system.showNotifications': 'boolean = true',
 
 	// UI settings
 	/**

--- a/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
@@ -269,6 +269,41 @@
 					</Select.Content>
 				</Select.Root>
 			</Field.Field>
+
+			<Field.Field orientation="horizontal">
+				<Field.Content>
+					<Field.Label for="hide-dock-icon">Menu bar only</Field.Label>
+					<Field.Description>
+						Hide the Dock icon and use only the system tray icon. Show or
+						hide the window from the tray menu.
+					</Field.Description>
+				</Field.Content>
+				<Switch
+					id="hide-dock-icon"
+					bind:checked={
+						() => settings.value['system.hideDockIcon'],
+						(v) => settings.updateKey('system.hideDockIcon', v)
+					}
+				/>
+			</Field.Field>
+
+			<Field.Field orientation="horizontal">
+				<Field.Content>
+					<Field.Label for="show-notifications">Show notifications</Field.Label>
+					<Field.Description>
+						Show a toast for every pipeline step (recording started,
+						transcribing, etc). Turn off to reduce noise — errors always
+						still show.
+					</Field.Description>
+				</Field.Content>
+				<Switch
+					id="show-notifications"
+					bind:checked={
+						() => settings.value['system.showNotifications'],
+						(v) => settings.updateKey('system.showNotifications', v)
+					}
+				/>
+			</Field.Field>
 		{/if}
 
 		<Field.Separator />

--- a/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
+++ b/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
@@ -14,6 +14,7 @@
 	import { services } from '$lib/services';
 	import { settings } from '$lib/stores/settings.svelte';
 	import { syncWindowAlwaysOnTopWithRecorderState } from '../_layout-utils/alwaysOnTop.svelte';
+	import { syncDockIconWithSettings } from '../_layout-utils/hideDockIcon.svelte';
 	import {
 		checkCompressionRecommendation,
 		checkFfmpegRecordingMethodCompatibility,
@@ -76,6 +77,7 @@
 	if (window.__TAURI_INTERNALS__) {
 		syncWindowAlwaysOnTopWithRecorderState();
 		syncIconWithRecorderState();
+		syncDockIconWithSettings();
 	}
 
 	$effect(() => {

--- a/apps/whispering/src/routes/(app)/_layout-utils/hideDockIcon.svelte.ts
+++ b/apps/whispering/src/routes/(app)/_layout-utils/hideDockIcon.svelte.ts
@@ -1,0 +1,13 @@
+import { invoke } from '@tauri-apps/api/core';
+import { settings } from '$lib/stores/settings.svelte';
+
+export function syncDockIconWithSettings() {
+	$effect(() => {
+		const hideDockIcon = settings.value['system.hideDockIcon'];
+		invoke('set_dock_icon_visible', { visible: !hideDockIcon }).catch(
+			(error) => {
+				console.error('Failed to update Dock icon visibility:', error);
+			},
+		);
+	});
+}


### PR DESCRIPTION
## What this fixes

**Tray icon bugs (pre-existing):**
- `recorder-state-icons/` (the PNGs used for the tray icon) were never declared in `tauri.conf.json`'s `bundle.resources`, so they don't exist in a built app. `TrayIcon::new()` fails to load a nonexistent icon path — the failure throws inside `initTray()`'s top-level promise with nothing awaiting/catching it, an unhandled rejection that silently prevents the tray icon from ever appearing at all.
- The tray icon had `menuOnLeftClick: false` with a left-click action handler that was entirely commented out, so clicking the icon (by any button) did nothing.

Both are fixed: icons are now bundled as a resource, and the menu shows on a normal click. Also simplified the menu to just Settings and Quit (Show/Hide Window were redundant with clicking Settings).

**New settings (both opt-in, defaults preserve current behavior):**
- **Menu bar only** (`system.hideDockIcon`, default off) — hides the Dock icon via `ActivationPolicy`. Closing the window (or Cmd+Q) hides it instead of quitting, matching normal menu-bar-app behavior; the tray's Quit item uses a dedicated command to still actually exit.
- **Show notifications** (`system.showNotifications`, default on) — gates success/info/loading/warning toasts behind this setting for users who find the per-pipeline-step toasts noisy. Errors always show regardless.

## Test plan
- [x] `cargo check` passes
- [x] `bun run check` — no new errors introduced (6 pre-existing errors in `packages/ui` unrelated to this change)
- [x] Manually verified on macOS: tray icon appears, click shows menu, Settings/Quit both work, Dock icon toggle works, window hides on close when menu-bar-only is on, notifications toggle suppresses non-error toasts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788675629&installation_model_id=20236&pr_number=2475&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2475&signature=d91b16c03e96f6075bf049b902c2f520e792cf73d934463a9629ac67c12124b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->