### PR TITLE
docs(dialectic): rebuild around directional articulation

### DIFF
--- a/.agents/skills/dialectic/SKILL.md
+++ b/.agents/skills/dialectic/SKILL.md
@@ -5,15 +5,22 @@ description: "Help the user discover and articulate a model they cannot yet stat
 
 # Dialectic
 
-The user is trying to articulate a model they cannot yet state. Judgment is
-cheaper than articulation: they can tell you a proposal is wrong, and often why
-it is wrong, long before they could have written the right one. Everything below
-runs on that gap. You carry a model far larger than any turn, and their
-reactions to what you put up become an articulation neither of you could have
-produced alone.
+Two people hold rich private models and neither can state theirs whole. The
+conversation works by putting a piece of yours into words and reading the
+direction in what comes back. You carry a model far larger than any turn, and
+their reactions become an articulation neither of you could have produced
+alone.
 
-The goal is not a proposal the user likes. It is a model they could not have
-specified in advance and can now state in their own words.
+The goal is a sentence the user can say in their own words. So keep supplying
+candidate sentences and let them take one over. You can draft faster than they
+can compose from nothing, which is why every turn ships a draft rather than an
+open question. That is a reason to always propose. It is never a reason to ask
+for a verdict.
+
+Their wrong articulation is the most informative thing available. "Yes" locates
+nothing, and a sentence that comes back dislocated shows you exactly which
+joint moved. So end where they can be usefully wrong: a claim with many
+interesting wrong answers, never a blank with one right one.
 
 ## Write The Turn Backward
 
@@ -31,7 +38,7 @@ to push against.
 
 Detail earns its place the same way the turn does. Something belongs here only
 if knowing it would change their answer. Mechanism, evidence, the alternative
-you already rejected, the derivation behind a claim — if none of it moves the
+you already rejected, the derivation behind a claim: if none of it moves the
 answer, it is yours to carry rather than theirs to read. Keep developing it
 between turns so they react to a view the conversation has not caught up to yet.
 
@@ -47,6 +54,46 @@ as badly as too much while failing more quietly.
 End on a position, a question, or a position with the question it raises. Do not
 staple a question on to solicit a reply, and do not withhold one that is
 genuinely the next thing to ask.
+
+## Write For The Ear
+
+Prefer a few connected sentences over a report, a framework, or a menu. Four
+tests, in the order they usually fail.
+
+Clarity. They should never read a sentence twice. If they have to, that is your
+defect and not their inattention. One idea per sentence, the verb near its
+subject, and no term the conversation has not already earned.
+
+Simplicity. Strip the words that protect you rather than inform them. "I think
+it might be the case that" is a hedge wearing a sentence. Say it, or do not put
+it up.
+
+Brevity. One move. Brevity is not a short turn, it is a turn holding nothing
+that is not the move. A patient explanation of one thing is brief; three crisp
+things are not.
+
+Humanity. Write to the person, not to the record. Say "you." Say what you are
+unsure of, and say when you were wrong last turn. A turn that reads like
+documentation gets treated like documentation, which means skimmed and filed
+rather than argued with.
+
+An analogy is a handle, not an explanation. Give the mechanism first and the
+analogy after, so it holds something they already understand. Ahead of the
+mechanism it becomes the only thing they hold, and it will be wrong in some
+small way neither of you can see.
+
+Bullets, tables, and diagrams are good tools and they cost the reader something
+to enter, so each earns its place the same way anything else does.
+
+- A diagram replaces prose, it never accompanies it. Draw the shape or explain
+  the shape. Doing both writes the turn twice and charges them for both. Label
+  the parts by what they do, not by what they are.
+- A table is for peers on one axis: several things, the same question asked of
+  each, the answers worth seeing side by side.
+- Bullets are for items that do not lead to each other. The moment one implies
+  the next they are an argument, and an argument needs the connective words
+  that bullets delete.
+- Any of them may carry the one move. None of them may smuggle in a second.
 
 ## Aim Where You Are Most Exposed
 
@@ -69,19 +116,26 @@ may not hide a real mismatch behind `or`, `also`, or `sometimes`.
 
 A reaction is evidence about a model the user cannot state directly yet. It is
 not an instruction to obey at face value. "Closer," "too ornate," "right
-structure, wrong premise," an irritated aside, an unstructured tangent — each
+structure, wrong premise," an irritated aside, an unstructured tangent, each
 marks a different boundary inside their private model. Interpret which one,
 update, and make the next thing you put up more discriminating.
 
+When they hand you a sentence, answer it before anything else. Say how close it
+is in the first few words, then name the exact word carrying the error rather
+than the whole sentence. "Almost, and the trouble is 'source'" tells them where
+they stand and what to fix before they have read a line of your reasoning.
+Their vocabulary is the material: keep the words that survive, and end by asking
+what becomes of the one that did not.
+
 Plain agreement is usually just agreement. Take it and move to the next edge
 rather than testing whether they meant it. The reply to worry about is one that
-leaves the model exactly where it was — and there, suspect your turn before you
+leaves the model exactly where it was, and there, suspect your turn before you
 suspect the user, because the repair is a sharper turn rather than a longer one.
 When the user rejects your articulation but keeps the idea, replace the sentence
 instead of defending it.
 
 Listen hardest for the reaction that does not correct the last turn but removes
-the need for it — a reply that makes a piece of the model unnecessary, or shows
+the need for it: a reply that makes a piece of the model unnecessary, or shows
 that the frame you were building inside was the wrong one. That is usually the
 largest thing available in the conversation, and it never announces itself.
 

--- a/.agents/skills/dialectic/SKILL.md
+++ b/.agents/skills/dialectic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dialectic
-description: "Help the user discover and articulate a model they cannot yet state, by carrying a model far larger than any turn, putting up the smallest thing they can judge, and reading their reactions as evidence about taste they cannot state directly, until the conversation converges on a shared model or an explicitly accepted destination. Use when the user wants to discover what they think, understand a subject together, shape a vision or architecture before a plan exists, or be pushed rather than agreed with. Do not use for interrogating an existing plan, comparing one bounded implementation choice, or ordinary implementation with a settled destination."
+description: "Help the user discover and articulate a model they cannot yet state, by carrying a model far larger than any turn, supplying candidate sentences one move at a time, and reading the direction in what comes back, until the conversation converges on a shared model or an explicitly accepted destination. Use when the user wants to discover what they think, understand a subject together, shape a vision or architecture before a plan exists, or be pushed rather than agreed with. Do not use for interrogating an existing plan, comparing one bounded implementation choice, or ordinary implementation with a settled destination."
 ---
 
 # Dialectic


### PR DESCRIPTION
The dialectic skill had settled on "judgment is cheaper than articulation," which cast the user as an evaluator and licensed turns that end by asking for a verdict or a missing word. Live sessions ran the other way. A user's wrong sentence locates the divergence precisely where "yes" locates nothing: an attempt like "Yjs owns source data, SQLite owns the mirror" pinpointed a misconception about storage that no amount of agreement could have surfaced. Turns ending on a blank the same turn had already answered read as quizzes and stalled the conversation.

This restores the symmetric frame the skill carried at 70d6bc6d41, where both participants articulate and reactions carry direction. The asymmetry survives only as the reason every turn ships a draft rather than an open question: the agent can draft faster than the user can compose from nothing. That is a reason to always propose, never a reason to ask for a verdict. Turns now end where the user can be usefully wrong, on a claim with many interesting wrong answers rather than a blank with one right one.

"Write for the ear" comes back with it, deleted in the same rebuild that introduced the judgment frame, now stated as Zinsser's four tests with a dialectic-specific failure named for each. Brevity is the one that bites: a turn holding nothing that is not the move, so a patient explanation of one thing is brief while three crisp things are not.

Bullets, tables, and diagrams stay, aimed rather than banned. A diagram replaces prose rather than accompanying it, a table is for peers on one axis, and bullets are for items that do not lead to each other. Any of them may carry the one move and none may smuggle in a second, which is the real defect in an overloaded turn: the devices were the vehicle, not the problem. Three further moves come from turns that worked in practice. Answer the user's sentence before anything else and name the exact word carrying the error. Place an analogy after the mechanism it is a handle for, never ahead of it. Label diagram parts by what they do rather than what they are.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789669678&installation_model_id=20236&pr_number=2478&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2478&signature=673e5cc1101372a5ada11329b342b740d23c40ab8a41794fda4ef5f2cfa90125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->