### PR TITLE
fix(epicenter): start desktop development on Linux

### DIFF
--- a/apps/epicenter/src-tauri/src/delivery.rs
+++ b/apps/epicenter/src-tauri/src/delivery.rs
@@ -1,6 +1,7 @@
 //! Native transcript delivery and synthetic keyboard commands for Whispering.
 
 use enigo::{Direction, Enigo, Key, Keyboard, Settings};
+#[cfg(target_os = "macos")]
 use tauri::Manager;
 use tauri_plugin_clipboard_manager::ClipboardExt;
 

--- a/apps/epicenter/src-tauri/src/lib.rs
+++ b/apps/epicenter/src-tauri/src/lib.rs
@@ -782,6 +782,7 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("failed to build Epicenter")
         .run(|app, event| match event {
+            #[cfg(target_os = "macos")]
             RunEvent::Reopen { .. } => request_window(app, BuiltInApp::Home),
             RunEvent::Exit => shutdown_host(app),
             _ => {}

--- a/apps/epicenter/src-tauri/tauri.conf.json
+++ b/apps/epicenter/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
 	"build": {
 		"beforeBuildCommand": "bun run build:desktop",
 		"beforeDevCommand": {
-			"script": "bun run build",
+			"script": "bun run build:desktop",
 			"wait": true
 		},
 		"frontendDist": "frontend-placeholder"


### PR DESCRIPTION
Linux desktop development currently fails before the Tauri window opens. Tauri validates the declared `epicenter-host` external binary before the package's existing development command has built it, and the host also compiles macOS-only reopen handling on Linux.

This changes the development startup command to build the desktop bundles and sidecar before Tauri validates the manifest. It also gates `RunEvent::Reopen` and the corresponding `Manager` import to macOS, where that event exists.

The result is a development startup path that works on Linux without weakening Vulkan support or removing the sidecar declaration.

## Changelog

- Fix Epicenter desktop development startup on Linux.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789910647&installation_model_id=20236&pr_number=2485&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2485&signature=e5fa5923497417211d6fccdc81f4a6f325ada8fb1f6451f4af99359d359bc020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->