### PR TITLE
fix(whispering): capture Linux Super chords

### DIFF
--- a/apps/whispering/src/lib/services/local-shortcut-manager.ts
+++ b/apps/whispering/src/lib/services/local-shortcut-manager.ts
@@ -3,8 +3,8 @@ import type { Brand } from 'wellcrafted/brand';
 import type { ShortcutEventState } from '$lib/commands';
 import {
 	bindingsEqual,
+	createModifierLatch,
 	domCodeToKey,
-	eventModifiers,
 	type Key,
 	type KeyBinding,
 } from '$lib/utils/key-binding';
@@ -49,11 +49,12 @@ export const LocalShortcutManagerLive = {
 		/**
 		 * Physical (non-modifier) keys currently held, by our `Key` space (from
 		 * `e.code` via {@link domCodeToKey}). Modifier codes map to `null` and never
-		 * land here; the modifier set is read live from the event flags instead, so
-		 * a swallowed modifier-keyup can never strand state. Combined with the live
-		 * modifiers into a `KeyBinding` and matched by set-equality.
+		 * land here. Modifier flags are read live, with a keydown-to-keyup fallback
+		 * latch for browsers that expose Linux Super without setting `metaKey`.
+		 * Combined into a `KeyBinding` and matched by set-equality.
 		 */
 		const pressedKeys = new Set<Key>();
+		const modifierLatch = createModifierLatch();
 		/**
 		 * Set tracking which shortcuts have already been triggered and are currently active.
 		 * This prevents key repeat spam when holding down keys - without this, holding
@@ -69,9 +70,9 @@ export const LocalShortcutManagerLive = {
 		 */
 		const activeShortcuts = new Set<CommandId>();
 
-		/** The gesture currently held: live modifier flags plus the pressed keys. */
-		const heldBinding = (e: KeyboardEvent): KeyBinding => ({
-			modifiers: eventModifiers(e),
+		/** The gesture currently held: resolved modifiers plus the pressed keys. */
+		const heldBinding = (modifiers: KeyBinding['modifiers']): KeyBinding => ({
+			modifiers,
 			keys: [...pressedKeys],
 		});
 
@@ -91,11 +92,11 @@ export const LocalShortcutManagerLive = {
 
 			// Physical key from `e.code` (layout-stable, no Option-character quirk).
 			// Modifier codes and keys off the bindable alphabet map to null and are
-			// not tracked here; modifiers come from the event flags via heldBinding.
+			// not tracked here; the modifier latch resolves the held modifier set.
 			const key = domCodeToKey(e.code);
 			if (key) pressedKeys.add(key);
 
-			const held = heldBinding(e);
+			const held = heldBinding(modifierLatch.keydown(e));
 
 			// Check all registered shortcuts for an exact set match.
 			for (const [id, binding] of shortcuts.entries()) {
@@ -126,12 +127,11 @@ export const LocalShortcutManagerLive = {
 			// Skip shortcut processing if user is typing in an input field
 			if (isTypingInInput()) return;
 
-			// Drop the released key, then recompute the held gesture. Modifiers read
-			// live from the event flags, so releasing a modifier shows up in `held`
-			// without tracking modifier keyups (no stuck-modifier class of bug).
+			// Drop the released key and its modifier fallback before recomputing the
+			// held gesture, so keyup can never re-add the key it just released.
 			const key = domCodeToKey(e.code);
 			if (key) pressedKeys.delete(key);
-			const held = heldBinding(e);
+			const held = heldBinding(modifierLatch.keyup(e));
 
 			// Any armed shortcut that no longer matches has been released. Iterating
 			// activeShortcuts (not all shortcuts) means only what actually fired can
@@ -159,6 +159,7 @@ export const LocalShortcutManagerLive = {
 			for (const id of activeShortcuts) onTrigger(id, 'Released');
 			activeShortcuts.clear();
 			pressedKeys.clear();
+			modifierLatch.reset();
 		};
 
 		/**

--- a/apps/whispering/src/lib/utils/key-binding.test.ts
+++ b/apps/whispering/src/lib/utils/key-binding.test.ts
@@ -87,7 +87,7 @@ test('eventModifiers treats WebKitGTK Super as the global meta modifier', () => 
 		shiftKey: false,
 		metaKey: false,
 		key: 'Super',
-	} as KeyboardEvent;
+	};
 
 	expect(eventModifiers(event)).toEqual(['meta']);
 });

--- a/apps/whispering/src/lib/utils/key-binding.test.ts
+++ b/apps/whispering/src/lib/utils/key-binding.test.ts
@@ -1,7 +1,9 @@
 /** Key binding serialization, capture vocabulary, and realized-reach behavior. */
 import { expect, test } from 'bun:test';
 import {
+	createModifierLatch,
 	domCodeToKey,
+	eventKeyModifier,
 	eventModifiers,
 	isRegistrableChord,
 	keyBindingToAccelerator,
@@ -80,16 +82,34 @@ test('domCodeToKey rejects modifier codes and anything off the chord alphabet', 
 	expect(domCodeToKey('Lang1')).toBeNull();
 });
 
-test('eventModifiers treats WebKitGTK Super as the global meta modifier', () => {
-	const event = {
+test('WebKitGTK Super enters the global meta modifier lifecycle', () => {
+	const superEvent = {
 		ctrlKey: false,
 		altKey: false,
 		shiftKey: false,
 		metaKey: false,
 		key: 'Super',
 	};
+	const physicalKeyEvent = { ...superEvent, key: 'd' };
 
-	expect(eventModifiers(event)).toEqual(['meta']);
+	expect(eventModifiers(superEvent)).toEqual([]);
+	expect(eventKeyModifier(superEvent)).toBe('meta');
+	const latch = createModifierLatch();
+	expect(latch.keydown(superEvent)).toEqual(['meta']);
+	expect(latch.keydown(physicalKeyEvent)).toEqual(['meta']);
+	expect(latch.keyup(superEvent)).toEqual([]);
+});
+
+test('Meta and OS use the same modifier-key fallback as Super', () => {
+	const event = {
+		ctrlKey: false,
+		altKey: false,
+		shiftKey: false,
+		metaKey: false,
+		key: 'Meta',
+	};
+	expect(eventKeyModifier(event)).toBe('meta');
+	expect(eventKeyModifier({ ...event, key: 'OS' })).toBe('meta');
 });
 
 test('domCodeToKey is the inverse of acceleratorKey for every chord key', () => {

--- a/apps/whispering/src/lib/utils/key-binding.test.ts
+++ b/apps/whispering/src/lib/utils/key-binding.test.ts
@@ -2,6 +2,7 @@
 import { expect, test } from 'bun:test';
 import {
 	domCodeToKey,
+	eventModifiers,
 	isRegistrableChord,
 	keyBindingToAccelerator,
 	realizedReach,
@@ -77,6 +78,18 @@ test('domCodeToKey rejects modifier codes and anything off the chord alphabet', 
 	// Outside the alphabet keyBindingToAccelerator can spell.
 	expect(domCodeToKey('Numpad1')).toBeNull();
 	expect(domCodeToKey('Lang1')).toBeNull();
+});
+
+test('eventModifiers treats WebKitGTK Super as the global meta modifier', () => {
+	const event = {
+		ctrlKey: false,
+		altKey: false,
+		shiftKey: false,
+		metaKey: false,
+		key: 'Super',
+	} as KeyboardEvent;
+
+	expect(eventModifiers(event)).toEqual(['meta']);
 });
 
 test('domCodeToKey is the inverse of acceleratorKey for every chord key', () => {

--- a/apps/whispering/src/lib/utils/key-binding.ts
+++ b/apps/whispering/src/lib/utils/key-binding.ts
@@ -2,8 +2,9 @@
  * The shared `KeyBinding` core: define, parse, serialize, label, and match the
  * structured physical binding both shortcut reaches speak. No Tauri dependency
  * and no DOM side effects; the only DOM contact is reading `KeyboardEvent` fields
- * (`.code`, the modifier flags) in {@link domCodeToKey} and {@link eventModifiers},
- * which is the capture side of the same physical-key model.
+ * (`.code`, the modifier flags, and modifier key names) in
+ * {@link domCodeToKey}, {@link eventModifiers}, and {@link eventKeyModifier},
+ * which form the capture side of the same physical-key model.
  */
 
 /**
@@ -370,27 +371,66 @@ type ModifierEvent = {
 	readonly key: string;
 };
 
-/**
- * Read the live modifier set from a keyboard event's boolean flags. Also read
- * the current modifier key itself: WebKitGTK exposes Linux Super as
- * `key === 'Super'` without setting `metaKey`, and the chord recorder needs that
- * keydown so it can carry Super into the following key. `OS` covers the older
- * browser spelling of the same key.
- *
- * Fn has no reliable browser event, so a webview capture or browser matcher can
- * never produce an Fn modifier. That is why an Fn gesture cannot be recorded or
- * fire, and is refused as a global shortcut (ADR-0117). Shared by the chord
- * recorder and browser matcher so both normalize modifiers the same way.
- */
+/** Read the modifiers the browser reports as currently held. */
 export function eventModifiers(e: ModifierEvent): Modifier[] {
 	const modifiers: Modifier[] = [];
-	if (e.ctrlKey || e.key === 'Control') modifiers.push('ctrl');
-	if (e.altKey || e.key === 'Alt') modifiers.push('alt');
-	if (e.shiftKey || e.key === 'Shift') modifiers.push('shift');
-	if (e.metaKey || e.key === 'Meta' || e.key === 'OS' || e.key === 'Super') {
-		modifiers.push('meta');
-	}
+	if (e.ctrlKey) modifiers.push('ctrl');
+	if (e.altKey) modifiers.push('alt');
+	if (e.shiftKey) modifiers.push('shift');
+	if (e.metaKey) modifiers.push('meta');
 	return modifiers;
+}
+
+/**
+ * Map a modifier keydown or keyup to our modifier space. WebKitGTK exposes
+ * Linux Super as `Super` without setting `metaKey`; `OS` is its older browser
+ * spelling. Fn has no reliable browser event and remains unsupported.
+ */
+export function eventKeyModifier(e: ModifierEvent): Modifier | null {
+	switch (e.key) {
+		case 'Control':
+			return 'ctrl';
+		case 'Alt':
+			return 'alt';
+		case 'Shift':
+			return 'shift';
+		case 'Meta':
+		case 'OS':
+		case 'Super':
+			return 'meta';
+		default:
+			return null;
+	}
+}
+
+/**
+ * Carry a modifier whose browser flag is missing from its keydown through the
+ * rest of that physical gesture. Keyup removes the fallback before matching,
+ * so the released modifier cannot strand a hold active.
+ */
+export function createModifierLatch() {
+	const fallbackModifiers = new Set<Modifier>();
+	const held = (e: ModifierEvent): Modifier[] => [
+		...new Set([...eventModifiers(e), ...fallbackModifiers]),
+	];
+
+	return {
+		keydown(e: ModifierEvent): Modifier[] {
+			const modifier = eventKeyModifier(e);
+			if (modifier !== null && !eventModifiers(e).includes(modifier)) {
+				fallbackModifiers.add(modifier);
+			}
+			return held(e);
+		},
+		keyup(e: ModifierEvent): Modifier[] {
+			const modifier = eventKeyModifier(e);
+			if (modifier !== null) fallbackModifiers.delete(modifier);
+			return held(e);
+		},
+		reset(): void {
+			fallbackModifiers.clear();
+		},
+	};
 }
 
 /** A binding with no modifiers and no keys can never fire; treat it as unset. */

--- a/apps/whispering/src/lib/utils/key-binding.ts
+++ b/apps/whispering/src/lib/utils/key-binding.ts
@@ -362,8 +362,16 @@ export function domCodeToKey(code: string): Key | null {
 	return null;
 }
 
+type ModifierEvent = {
+	readonly ctrlKey: boolean;
+	readonly altKey: boolean;
+	readonly shiftKey: boolean;
+	readonly metaKey: boolean;
+	readonly key: string;
+};
+
 /**
- * Read the live modifier set from a `KeyboardEvent`'s boolean flags. Also read
+ * Read the live modifier set from a keyboard event's boolean flags. Also read
  * the current modifier key itself: WebKitGTK exposes Linux Super as
  * `key === 'Super'` without setting `metaKey`, and the chord recorder needs that
  * keydown so it can carry Super into the following key. `OS` covers the older
@@ -374,7 +382,7 @@ export function domCodeToKey(code: string): Key | null {
  * fire, and is refused as a global shortcut (ADR-0117). Shared by the chord
  * recorder and browser matcher so both normalize modifiers the same way.
  */
-export function eventModifiers(e: KeyboardEvent): Modifier[] {
+export function eventModifiers(e: ModifierEvent): Modifier[] {
 	const modifiers: Modifier[] = [];
 	if (e.ctrlKey || e.key === 'Control') modifiers.push('ctrl');
 	if (e.altKey || e.key === 'Alt') modifiers.push('alt');

--- a/apps/whispering/src/lib/utils/key-binding.ts
+++ b/apps/whispering/src/lib/utils/key-binding.ts
@@ -363,20 +363,25 @@ export function domCodeToKey(code: string): Key | null {
 }
 
 /**
- * Read the live modifier set from a `KeyboardEvent`'s boolean flags rather than
- * its `.code`, so a gesture carries its modifiers no matter which key fired and
- * a stuck modifier-keyup can never strand state (the flags are always current).
- * Fn has no flag (and no `.code`), so a webview capture or the browser matcher
- * can never produce an Fn modifier: that is exactly why an Fn gesture cannot be
- * recorded or fire, and is refused as a global shortcut (ADR-0117). Shared by the
- * chord recorder and the browser matcher so both read modifiers the same way.
+ * Read the live modifier set from a `KeyboardEvent`'s boolean flags. Also read
+ * the current modifier key itself: WebKitGTK exposes Linux Super as
+ * `key === 'Super'` without setting `metaKey`, and the chord recorder needs that
+ * keydown so it can carry Super into the following key. `OS` covers the older
+ * browser spelling of the same key.
+ *
+ * Fn has no reliable browser event, so a webview capture or browser matcher can
+ * never produce an Fn modifier. That is why an Fn gesture cannot be recorded or
+ * fire, and is refused as a global shortcut (ADR-0117). Shared by the chord
+ * recorder and browser matcher so both normalize modifiers the same way.
  */
 export function eventModifiers(e: KeyboardEvent): Modifier[] {
 	const modifiers: Modifier[] = [];
-	if (e.ctrlKey) modifiers.push('ctrl');
-	if (e.altKey) modifiers.push('alt');
-	if (e.shiftKey) modifiers.push('shift');
-	if (e.metaKey) modifiers.push('meta');
+	if (e.ctrlKey || e.key === 'Control') modifiers.push('ctrl');
+	if (e.altKey || e.key === 'Alt') modifiers.push('alt');
+	if (e.shiftKey || e.key === 'Shift') modifiers.push('shift');
+	if (e.metaKey || e.key === 'Meta' || e.key === 'OS' || e.key === 'Super') {
+		modifiers.push('meta');
+	}
 	return modifiers;
 }
 

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/create-chord-recorder.ts
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/create-chord-recorder.ts
@@ -1,6 +1,7 @@
 import { on } from 'svelte/events';
 import {
 	domCodeToKey,
+	eventKeyModifier,
 	eventModifiers,
 	type Key,
 	type KeyBinding,
@@ -94,9 +95,15 @@ export function createChordRecorder({
 		// Union the modifiers (a combo built up over several presses), and take the
 		// latest physical key. A modifier-only keydown just extends the window so
 		// the user has time to add the key before it times out.
-		for (const modifier of eventModifiers(e)) {
-			if (!capturedModifiers.includes(modifier))
+		const modifiers = eventModifiers(e);
+		const currentModifier = eventKeyModifier(e);
+		if (currentModifier !== null && !modifiers.includes(currentModifier)) {
+			modifiers.push(currentModifier);
+		}
+		for (const modifier of modifiers) {
+			if (!capturedModifiers.includes(modifier)) {
 				capturedModifiers.push(modifier);
+			}
 		}
 		const key = domCodeToKey(e.code);
 		if (key) capturedKey = key;

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/create-chord-recorder.ts
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/create-chord-recorder.ts
@@ -73,8 +73,13 @@ export function createChordRecorder({
 		if (binding.keys.length > 0) onCapture(binding);
 	}
 
-	// Quiet for CAPTURE_WINDOW_MS after the last key change = the gesture is done.
-	const completeAfterWindow = debounce(commit, CAPTURE_WINDOW_MS);
+	// Quiet for CAPTURE_WINDOW_MS after the last key change = the gesture is done,
+	// but only once it contains a non-modifier key. A person may hold a modifier
+	// for as long as they need before adding the key; committing an incomplete
+	// modifier-only partial here would reset it and capture the later key alone.
+	const completeAfterWindow = debounce(() => {
+		if (capturedKey) commit();
+	}, CAPTURE_WINDOW_MS);
 
 	function onKeydown(e: KeyboardEvent) {
 		if (e.repeat) return; // auto-repeat is not a new key


### PR DESCRIPTION
On WebKitGTK, pressing a Super-based shortcut can arrive as `Super`, `OS`, or `Meta`, and the modifier-only event may be observed before the chord's physical key. Whispering currently drops that partial state, so chords such as `Super+8` cannot be captured reliably even though the native global-shortcut backend can register and deliver them.

This normalizes all three WebKitGTK names to Whispering's `meta` modifier and supplements the event with the currently held Control, Alt, and Shift state. The chord recorder now keeps modifier-only input pending until a non-modifier key completes the chord, while retaining the existing debounce for completed input.

This is related to #1264 and #1293, but addresses the current chord recorder's Linux WebKitGTK event shape rather than the older macOS multi-modifier timing problem.

## Changelog

- Fix capturing Super-based global shortcuts on Linux.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789910650&installation_model_id=20236&pr_number=2486&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2486&signature=ef4e71991365e2ee57621ee0d1e9bb268b91e18cd453bf7fb9e3cef351f004fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->