### PR TITLE
fix(whispering): recover from failed view transitions

### DIFF
--- a/apps/whispering/src/routes/+layout.svelte
+++ b/apps/whispering/src/routes/+layout.svelte
@@ -23,10 +23,15 @@
 		if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 
 		return new Promise((resolve) => {
-			document.startViewTransition(async () => {
+			const transition = document.startViewTransition(async () => {
 				resolve();
 				await navigation.complete;
 			});
+			// Named snapshots are an enhancement. If a browser cannot capture one
+			// (for example, while old and new route trees briefly overlap), force
+			// the navigation to finish without animation instead of leaving its
+			// rejected readiness promise to blank the WebView.
+			void transition.ready.catch(() => transition.skipTransition());
 		});
 	});
 </script>

--- a/apps/whispering/src/routes/+layout.svelte
+++ b/apps/whispering/src/routes/+layout.svelte
@@ -28,10 +28,18 @@
 				await navigation.complete;
 			});
 			// Named snapshots are an enhancement. If a browser cannot capture one
-			// (for example, while old and new route trees briefly overlap), force
-			// the navigation to finish without animation instead of leaving its
-			// rejected readiness promise to blank the WebView.
+			// (for example, while old and new route trees briefly overlap), skip the
+			// animation instead of leaving its rejected readiness promise to blank
+			// the WebView.
 			void transition.ready.catch(() => transition.skipTransition());
+			// A failed or superseded navigation also rejects the update callback and
+			// finished promises. They mirror navigation.complete after SvelteKit has
+			// already taken ownership of the navigation failure, so observe both to
+			// keep the browser from reporting unhandled transition rejections.
+			void Promise.allSettled([
+				transition.updateCallbackDone,
+				transition.finished,
+			]);
 		});
 	});
 </script>


### PR DESCRIPTION
WebKit can reject `ViewTransition.ready` when the old and new Svelte route trees briefly expose the same named transition snapshot. The route navigation itself succeeds, but the unhandled readiness rejection leaves Whispering's desktop WebView blank.

The root layout now treats named view transitions as progressive enhancement. It still uses the existing animated navigation when snapshot capture succeeds; when readiness rejects, it calls `skipTransition()` so the new route can paint without animation.

No matching upstream issue or pull request was found for this WebKit-specific failure.

## Changelog

- Prevent route navigation from blanking the desktop app when WebKit cannot capture a view-transition snapshot.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789910653&installation_model_id=20236&pr_number=2487&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2487&signature=949c2ac7595400217b1d7d64cdb3e9d03da204cef5228c6d4e63bdb927348bba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->