### PR TITLE
fix(transcription): surface nested runtime error details

### DIFF
--- a/apps/epicenter/src-tauri/src/transcription/error.rs
+++ b/apps/epicenter/src-tauri/src/transcription/error.rs
@@ -1,5 +1,6 @@
 use super::UnavailableReason;
 use serde::{Deserialize, Serialize};
+use std::error::Error as StdError;
 use thiserror::Error;
 
 #[derive(Error, Debug, Serialize, Deserialize, specta::Type)]
@@ -33,4 +34,71 @@ pub enum TranscriptionError {
     /// Operational: inference itself failed.
     #[error("Transcription error: {message}")]
     TranscriptionError { message: String },
+}
+
+/// Flatten an error and its `source()` chain into one user-facing message.
+///
+/// Upstream wrappers sometimes use a fixed Display label (for example the old
+/// Parakeet `ORT error` variant) while the actionable ONNX / runtime detail
+/// lives only on the nested source. Walking the chain keeps "More details"
+/// useful instead of repeating a bare opaque string.
+pub(crate) fn format_error_chain(err: &dyn StdError) -> String {
+    let mut parts = vec![err.to_string()];
+    let mut current = err.source();
+    while let Some(source) = current {
+        let text = source.to_string();
+        if !text.is_empty() && parts.last().is_none_or(|prev| prev != &text) {
+            parts.push(text);
+        }
+        current = source.source();
+    }
+    parts.join(": ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_error_chain;
+    use std::error::Error;
+    use std::fmt;
+
+    #[derive(Debug)]
+    struct Leaf(&'static str);
+
+    impl fmt::Display for Leaf {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(self.0)
+        }
+    }
+
+    impl Error for Leaf {}
+
+    #[derive(Debug)]
+    struct Wrapper {
+        label: &'static str,
+        source: Leaf,
+    }
+
+    impl fmt::Display for Wrapper {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(self.label)
+        }
+    }
+
+    impl Error for Wrapper {
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            Some(&self.source)
+        }
+    }
+
+    #[test]
+    fn format_error_chain_includes_nested_source() {
+        let err = Wrapper {
+            label: "ORT error",
+            source: Leaf("Failed to allocate 2147483647 bytes"),
+        };
+        assert_eq!(
+            format_error_chain(&err),
+            "ORT error: Failed to allocate 2147483647 bytes"
+        );
+    }
 }

--- a/apps/epicenter/src-tauri/src/transcription/mod.rs
+++ b/apps/epicenter/src-tauri/src/transcription/mod.rs
@@ -203,7 +203,7 @@ pub async fn transcribe_recording(
         read_blob_samples(&app_handle, &audio_blob_id)
     })
     .map_err(|e| TranscriptionError::AudioReadError {
-        message: e.to_string(),
+        message: error::format_error_chain(&e),
     })?;
 
     let cache = model_cache.inner().clone();

--- a/apps/epicenter/src-tauri/src/transcription/model_cache.rs
+++ b/apps/epicenter/src-tauri/src/transcription/model_cache.rs
@@ -1,5 +1,5 @@
 use super::catalog::{describe, installed_model_path};
-use super::error::TranscriptionError;
+use super::error::{format_error_chain, TranscriptionError};
 use super::settings::{LocalTranscriptionSettings, UnloadPolicy};
 use super::{
     AppliedHints, LocalTranscriptionReadiness, TranscriptionHints, TranscriptionOutcome,
@@ -365,8 +365,13 @@ fn load_gguf_model(model_path: &Path) -> Result<Model, String> {
         backend: default_backend(),
         gpu_device: 0,
     };
-    Model::load_with(model_path, &options)
-        .map_err(|e| format!("Failed to load GGUF model {}: {}", model_path.display(), e))
+    Model::load_with(model_path, &options).map_err(|e| {
+        format!(
+            "Failed to load GGUF model {}: {}",
+            model_path.display(),
+            format_error_chain(&e)
+        )
+    })
 }
 
 /// Open a session on the resident model and run one batch transcription. Whisper
@@ -418,7 +423,10 @@ fn run_gguf(
     let mut session = model
         .session()
         .map_err(|e| TranscriptionError::ModelLoadError {
-            message: format!("Failed to create transcription session: {e}"),
+            message: format!(
+                "Failed to create transcription session: {}",
+                format_error_chain(&e)
+            ),
         })?;
 
     let accepts_prompt = session.model().supports(Feature::InitialPrompt);
@@ -451,7 +459,7 @@ fn run_gguf(
         .run(samples, &run_options)
         .map(|transcript| (transcript.text.trim().to_string(), applied))
         .map_err(|e| TranscriptionError::TranscriptionError {
-            message: e.to_string(),
+            message: format_error_chain(&e),
         })
 }
 


### PR DESCRIPTION
Local transcription failures that wrap a runtime error behind an opaque Display label (such as ORT error) now include the full Error::source chain in the message shown under More details. Fixes #2457.