### PR TITLE
fix(whispering): show self-hosted host and modelId in selector

### DIFF
--- a/apps/whispering/src/lib/components/settings/selectors/TranscriberRow.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TranscriberRow.svelte
@@ -51,12 +51,11 @@
 	</div>
 	<div class="flex-1 min-w-0">
 		<div class="font-medium text-sm truncate">{transcriber.title}</div>
-		<!-- Preserve the exact model confirmation from #2337 in the expanded row;
-		the compact trigger only needs the transcriber identity. -->
+		<!-- Self-hosted / keyed routes surface the selected model id (#2337). -->
 		{#if transcriber.modelId}
 			<div class="text-xs text-muted-foreground truncate">
 				{#if transcriber.endpointHost}
-					{transcriber.modelId} · {transcriber.endpointHost}
+					{transcriber.endpointHost} · {transcriber.modelId}
 				{:else}
 					{transcriber.modelId}
 				{/if}

--- a/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
@@ -60,12 +60,20 @@
 			: !!selectedService && !isSelectedServiceReady,
 	);
 
-	// The pipeline trigger surfaces the active transcriber: a curated on-device
-	// model name or a remote provider name. Exact remote model ids stay in the
-	// expanded rows and settings.
-	const pipelineLabel = $derived(
-		activeTranscriber?.title ?? selectedService?.label ?? 'Choose model',
-	);
+	// The pipeline trigger surfaces the active transcriber. For self-hosted
+	// endpoints, show host · modelId so the closed selector confirms which
+	// Speaches model is selected (#2337); other routes keep the provider name.
+	const pipelineLabel = $derived.by(() => {
+		if (
+			activeTranscriber?.access === 'endpoint' &&
+			activeTranscriber.modelId
+		) {
+			return activeTranscriber.endpointHost
+				? `${activeTranscriber.endpointHost} · ${activeTranscriber.modelId}`
+				: activeTranscriber.modelId;
+		}
+		return activeTranscriber?.title ?? selectedService?.label ?? 'Choose model';
+	});
 
 	// The pipeline pill already shows the transcriber name, so its tooltip
 	// describes the action. The icon-only standalone switcher keeps the exact
@@ -77,13 +85,19 @@
 				: 'Choose transcription model';
 		}
 		if (activeTranscriber) {
+			if (
+				activeTranscriber.access === 'endpoint' &&
+				activeTranscriber.modelId
+			) {
+				const selection = activeTranscriber.endpointHost
+					? `${activeTranscriber.endpointHost} · ${activeTranscriber.modelId}`
+					: activeTranscriber.modelId;
+				return `${activeTranscriber.title} - ${selection}`;
+			}
 			const model = activeTranscriber.modelId
 				? ` - ${activeTranscriber.modelId}`
 				: '';
-			const host = activeTranscriber.endpointHost
-				? ` · ${activeTranscriber.endpointHost}`
-				: '';
-			return `${activeTranscriber.title}${model}${host}`;
+			return `${activeTranscriber.title}${model}`;
 		}
 		return selectedService
 			? selectedService.label

--- a/apps/whispering/src/lib/settings/transcription-switcher.ts
+++ b/apps/whispering/src/lib/settings/transcription-switcher.ts
@@ -103,8 +103,8 @@ function toTranscriber(
 			};
 		}
 		case 'endpoint': {
-			// Preserve #2337's exact model confirmation without making an arbitrary
-			// server identifier the compact trigger's primary label.
+			// Carry host + modelId so the selector can show `host · modelId`
+			// for the active self-hosted route (#2337).
 			const endpoint = deviceConfig.get(entry.endpointConfigKey);
 			const modelId = deviceConfig.get(entry.modelIdConfigKey);
 			return {


### PR DESCRIPTION
The closed transcription selector and Speaches row subtext now show host · modelId so the active self-hosted model is visible. Fixes #2337.