### PR TITLE
fix(api): disable retired epicenter-cli OAuth client on seed

### DIFF
--- a/apps/api/scripts/seed-oauth-clients.ts
+++ b/apps/api/scripts/seed-oauth-clients.ts
@@ -12,6 +12,12 @@
  * origin, a Tauri deep link, an extension id), so the rows are the same for
  * every deployment; only the database this points at differs.
  *
+ * After upserting, the script disables every id in `RETIRED_OAUTH_CLIENT_IDS`
+ * (kept for audit, never deleted). The upsert alone cannot revoke a client
+ * that left the trusted set: `epicenter-cli` was seeded while the deleted CLI
+ * existed and would otherwise survive as valid client metadata at /authorize
+ * and /token. The disable is idempotent, so re-running the seed is safe.
+ *
  *   bun run oauth:seed:local     seed the local dev database
  *   bun run oauth:seed:remote    seed production (wrapped with Infisical)
  *
@@ -32,6 +38,7 @@
  * the committed local default, matching `drizzle.config.ts`.
  */
 import {
+	RETIRED_OAUTH_CLIENT_IDS,
 	buildTrustedOAuthClients,
 	projectTrustedOAuthClientToRow,
 } from '@epicenter/constants/oauth-seed';
@@ -62,6 +69,12 @@ const UPSERT = `
 		require_pkce = EXCLUDED.require_pkce
 `;
 
+const RETIRE = `
+	UPDATE oauth_client
+	SET disabled = true, skip_consent = false, updated_at = NOW()
+	WHERE client_id = ANY($1)
+`;
+
 const client = new pg.Client({ connectionString });
 await client.connect();
 try {
@@ -87,6 +100,8 @@ try {
 		]);
 	}
 	console.log(`Seeded ${clients.length} first-party OAuth client(s)`);
+	const retired = await client.query(RETIRE, [[...RETIRED_OAUTH_CLIENT_IDS]]);
+	console.log(`Disabled ${retired.rowCount ?? 0} retired OAuth client(s)`);
 } finally {
 	await client.end();
 }

--- a/packages/constants/src/oauth-seed.test.ts
+++ b/packages/constants/src/oauth-seed.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Retired OAuth client tests
+ *
+ * Guards the deploy seed's revoke path: ids that left the trusted set stay
+ * disabled instead of surviving as valid client metadata at /authorize and
+ * /token. The seed upserts the trusted set and then disables this list, so
+ * these tests pin the one invariant that makes that safe.
+ *
+ * Key behaviors:
+ * - epicenter-cli stays on the retired list (the row seeded while the CLI existed)
+ * - no retired id ever re-enters the trusted set
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+	RETIRED_OAUTH_CLIENT_IDS,
+	buildTrustedOAuthClients,
+} from './oauth-seed.js';
+
+describe('retired OAuth clients stay revoked', () => {
+	test('epicenter-cli remains on the retired list', () => {
+		expect([...RETIRED_OAUTH_CLIENT_IDS]).toContain('epicenter-cli');
+	});
+
+	test('no retired id appears in the trusted set', () => {
+		const trustedIds: Set<string> = new Set(
+			buildTrustedOAuthClients().map((client) => client.clientId),
+		);
+		for (const retiredId of RETIRED_OAUTH_CLIENT_IDS) {
+			expect({ id: retiredId, trusted: trustedIds.has(retiredId) }).toEqual({
+				id: retiredId,
+				trusted: false,
+			});
+		}
+	});
+});

--- a/packages/constants/src/oauth-seed.ts
+++ b/packages/constants/src/oauth-seed.ts
@@ -105,6 +105,22 @@ export function buildTrustedOAuthClients() {
 }
 
 /**
+ * OAuth client ids that must stay disabled.
+ *
+ * `epicenter-cli` was seeded before the terminal machine-auth surface was
+ * deleted, and the seed script only upserts, so the row survives in every
+ * database that was seeded while the CLI existed. It no longer skips consent
+ * and its `/cli-callback` redirect target is gone, but Better Auth still reads
+ * it as valid client metadata at `/authorize` and `/token` unless `disabled`
+ * is true (see the `disabled` field on the `oauthClient` table: "indicates if
+ * the current application is disabled"). The deploy seed disables these rows
+ * after upserting the trusted set, keeping the row for audit instead of
+ * deleting it. Never re-add an id from this list to
+ * {@link buildTrustedOAuthClients}.
+ */
+export const RETIRED_OAUTH_CLIENT_IDS = ['epicenter-cli'] as const;
+
+/**
  * Project a checked-in trusted client into Better Auth's `oauth_client` row.
  *
  * Used by the `apps/api` `oauth:seed` deploy script and by the auth tests that


### PR DESCRIPTION
<!--
Write narrative prose, not a form.

Open with why this change exists, then explain the shape of the change.
Do not include Summary, Changes, Testing, Test Plan, or Verification sections.
Mention commands run in the agent or chat final response, not the PR body.

For API changes, include before/after code examples.
For structural refactors, include a small before/after shape or composition tree.
Do not list files changed. The diff tab already does that.

For feat: and fix: PRs only, add:

## Changelog
- Add or fix the user-visible outcome

Omit Changelog for chore:, refactor:, docs:, test:, build:, and ci: PRs.

Use Closes #123 only when the PR fully resolves an issue.

Paste screenshots or recordings for UI changes.

PRs touching apps/api/, apps/self-host/, packages/sync/, or packages/server/ require @braden-w review per CODEOWNERS.
-->
## Problem

The deploy seed (`apps/api/scripts/seed-oauth-clients.ts`) only upserts.
`epicenter-cli` was removed from `buildTrustedOAuthClients()` when the CLI
was deleted, but every database seeded before that still holds its row, valid
client metadata at `/authorize` and `/token` with a dead `/cli-callback`
redirect. Tracked in `BACKLOG.md` ("Revoke the `epicenter-cli` OAuth client
row in each deployed database").

## What this does

- Adds `RETIRED_OAUTH_CLIENT_IDS = ['epicenter-cli']` in
  `packages/constants/src/oauth-seed.ts`, beside the trusted set it complements.
- The seed disables those ids after upserting
  (`disabled=true, skip_consent=false`), idempotent, row kept for audit.
- Adds `packages/constants/src/oauth-seed.test.ts` pinning the
  retired-never-trusted invariant.

Explicit retired list over `NOT IN (trusted)`: a bug returning an empty
trusted set must fail closed, never wipe all clients.

## Rollout

Prod still needs `oauth:seed:remote` (Infisical, maintainer-only) on the next
`apps/api` deploy; then the BACKLOG item can close.

## Changelog

- Disable the retired epicenter-cli sign-in on deploy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791184844&installation_model_id=20236&pr_number=2497&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2497&signature=e68062e4fd3f61c61cc066103ca6701a0088c35c2da1687af8b6c790838eedd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->