### PR TITLE
fix(transcription): let a missing GPU runtime fall back to CPU

### DIFF
--- a/apps/epicenter/src-tauri/src/transcription/model_cache.rs
+++ b/apps/epicenter/src-tauri/src/transcription/model_cache.rs
@@ -358,11 +358,19 @@ impl ModelCache {
 }
 
 /// Load a GGUF model through transcribe.cpp, initializing the compute backends
-/// once on first use. The backend (Metal / Vulkan / CPU) is chosen per target.
+/// once on first use.
+///
+/// `Backend::Auto` takes the first GPU device that initializes and falls back to
+/// CPU when none does. ggml registers devices in build-time priority order, so
+/// this still selects Metal on Apple and Vulkan on Windows/Linux without naming
+/// them here. Naming one is a hard requirement, not a preference: a specific
+/// `Backend::Vulkan` request on a machine whose Vulkan runtime is missing returns
+/// `TRANSCRIBE_ERR_BACKEND` and fails the load even though a working CPU backend
+/// is registered.
 fn load_gguf_model(model_path: &Path) -> Result<Model, String> {
     init_transcribe_cpp_backends();
     let options = ModelOptions {
-        backend: default_backend(),
+        backend: Backend::Auto,
         gpu_device: 0,
     };
     Model::load_with(model_path, &options)
@@ -479,31 +487,6 @@ fn init_transcribe_cpp_backends() {
             Err(e) => warn!("Failed to initialize transcribe-cpp backends: {}", e),
         }
     });
-}
-
-/// The GGU compute backend to request per target. transcribe.cpp appends a CPU
-/// fallback, so a GPU-init failure degrades to CPU rather than failing the load.
-fn default_backend() -> Backend {
-    #[cfg(target_os = "macos")]
-    {
-        Backend::Metal
-    }
-    #[cfg(all(windows, target_arch = "x86_64"))]
-    {
-        Backend::Vulkan
-    }
-    #[cfg(target_os = "linux")]
-    {
-        Backend::Vulkan
-    }
-    #[cfg(not(any(
-        target_os = "macos",
-        all(windows, target_arch = "x86_64"),
-        target_os = "linux"
-    )))]
-    {
-        Backend::Cpu
-    }
 }
 
 /// Replace NaN/Inf with 0.0 and cap length so a malformed sample buffer never


### PR DESCRIPTION
#840 reports Whispering failing to load a local model on Windows machines without a working Vulkan runtime, and asks for a CPU fallback that actually engages. On this path there is none.

`load_gguf_model` picked the compute backend by target: `Metal` on macOS, `Vulkan` on Windows x86_64 and Linux, `Cpu` everywhere else. Naming a backend in `ModelOptions` is a hard requirement rather than a preference — transcribe.cpp appends the CPU backend only after the requested GPU backend initializes, so an explicit `Backend::Vulkan` on a machine whose Vulkan runtime is missing returns `TRANSCRIBE_ERR_BACKEND` and fails the load outright, even though a working CPU backend is registered and sitting there. Only `Backend::Auto` falls through to it. The doc comment on `default_backend` asserted the opposite — "transcribe.cpp appends a CPU fallback, so a GPU-init failure degrades to CPU rather than failing the load" — which is presumably why the posture read as safe.

The same issue notes that `TRANSCRIBE_RS_ACCEL=cpu` does not rescue it, and that is expected: the name does not appear anywhere in the tree. There is no environment override on this path at all, so the hard-coded ladder was the only thing choosing a backend.

Every arm carried the defect, and the macOS one is arguably worse than the Windows one: on a pre-Apple7 GPU the library honours an explicit `Metal` request with a warning and yields garbage transcripts, where `Auto` skips that device. The ladder was also redundant. ggml registers devices in build-time priority order, so `Auto` still lands on Metal on Apple and Vulkan on Windows and Linux — the same choices the ladder was making, minus the failure mode. `Backend::Auto` is the library's own default, "best available device; CPU is the always-present fallback", and it is already what `bench/backend-latency` requests.

So `load_gguf_model` asks for `Backend::Auto` and `default_backend` goes away.

Two caveats worth stating rather than burying. The reporter is on a 7.5.0 binary and the desktop host has moved a good deal since, so I cannot claim this is the whole of what they hit — I have left the issue open for you to judge and close. And the host does not currently compile on Windows at all, which is #2498; that is unrelated to this change, but it is why this one cannot be checked on Windows on its own.

## Changelog

- Fix local model loading failing on machines without a working GPU runtime, including CPU-only Windows systems

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791415714&installation_model_id=20236&pr_number=2499&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2499&signature=c9f1059a6a84a4c3e2d26a96ef2bc5993d77c2ea122d091ddf0c0abf0b4f0561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->