### PR TITLE
fix(epicenter): make recording save and the dev data root resolve on Windows

### DIFF
--- a/apps/epicenter/src-tauri/src/app_data.rs
+++ b/apps/epicenter/src-tauri/src/app_data.rs
@@ -8,6 +8,13 @@
 //! question; until it is settled this is the second implementation of one path,
 //! and the equality is pinned by a test rather than by inspection.
 //!
+//! Mirroring the authority means mirroring its *inputs*, not just its result on
+//! one config. This resolves the platform directory and joins the shared
+//! identifier constant, exactly as the TypeScript does; it deliberately does not
+//! use Tauri's `app_data_dir()`, whose answer moves with the bundle identifier
+//! and so split dev builds away from the sidecar (see
+//! [`EPICENTER_BUNDLE_IDENTIFIER`]).
+//!
 //! The override is part of that equality and not an extra. Rust used to compute
 //! the root and pass it to the sidecar in `EPICENTER_DATA_DIR`, which meant an
 //! ambient value was overwritten and could not split the two. The sidecar now
@@ -24,13 +31,36 @@ use tauri::{AppHandle, Manager, Runtime};
 /// The one override for the one root, read by the sidecar, every CLI, and here.
 const DATA_ROOT_OVERRIDE: &str = "EPICENTER_DATA_DIR";
 
+/// Mirrors `EPICENTER_BUNDLE_IDENTIFIER` in `packages/constants/src/app-data.ts`,
+/// which is the authority on this path.
+///
+/// Deliberately a constant rather than the running bundle's identifier. Tauri's
+/// `app_data_dir()` is `data_dir()` joined with the *config's* identifier, and
+/// `tauri.dev.conf.json` overrides that identifier to `so.epicenter.dev` so the
+/// dev build is a separate application (its own window state, webview data and
+/// deep-link registration). The data root is not part of that separation: the
+/// sidecar resolves `so.epicenter` unconditionally, so a dev host built on
+/// `app_data_dir()` wrote recordings to a `blobs/` the sidecar never served and
+/// every dev dictation 404'd before it could be transcribed. Joining the shared
+/// constant keeps the two implementations equal under every config, which is the
+/// only property that matters here.
+const EPICENTER_BUNDLE_IDENTIFIER: &str = "so.epicenter";
+
 /// The root this machine's Epicenter stores everything under.
 pub fn epicenter_data_root<R: Runtime>(app: &AppHandle<R>) -> Result<PathBuf> {
     resolve_data_root(std::env::var_os(DATA_ROOT_OVERRIDE).as_deref(), || {
-        app.path()
-            .app_data_dir()
-            .context("resolve the Tauri application-data directory")
+        platform_root(app)
     })
+}
+
+/// The platform data directory joined with the shared bundle identifier: the
+/// same two steps, in the same order, as `epicenterDataRoot()` in TypeScript.
+fn platform_root<R: Runtime>(app: &AppHandle<R>) -> Result<PathBuf> {
+    Ok(app
+        .path()
+        .data_dir()
+        .context("resolve the platform application-data directory")?
+        .join(EPICENTER_BUNDLE_IDENTIFIER))
 }
 
 /// Apply the override rule to a platform root.
@@ -138,13 +168,43 @@ mod tests {
             .build(context)
             .expect("build a mock Tauri app for its path resolver");
 
-        let native = resolve_data_root(None, || {
-            app.path()
-                .app_data_dir()
-                .context("resolve the Tauri application-data directory")
-        })
-        .unwrap();
+        let native = resolve_data_root(None, || platform_root(app.handle())).unwrap();
 
         assert_eq!(native, typescript_data_root());
+    }
+
+    /// The dev bundle is a separate *application*, not a separate data root.
+    ///
+    /// `tauri.dev.conf.json` overrides the identifier to `so.epicenter.dev`. When
+    /// this resolver was built on `app_data_dir()` that override moved the root
+    /// with it, so `bun dev:epicenter` wrote recordings to
+    /// `<data>/so.epicenter.dev/blobs` while the sidecar served
+    /// `<data>/so.epicenter/blobs`, and every dev dictation failed with a 404
+    /// before it could reach transcription. The equality test above could not
+    /// catch it: it reads `tauri.conf.json`, so it only ever saw the production
+    /// identifier. This pins the property that actually matters, that no config's
+    /// identifier moves the root at all.
+    #[test]
+    fn the_dev_identifier_does_not_move_the_root() {
+        let dev_config: serde_json::Value =
+            serde_json::from_str(include_str!("../tauri.dev.conf.json")).unwrap();
+        let dev_identifier = dev_config["identifier"].as_str().unwrap().to_string();
+        assert_ne!(
+            dev_identifier,
+            bundle_identifier(),
+            "this test is only meaningful while the dev config overrides the identifier"
+        );
+
+        let mut context = tauri::test::mock_context(tauri::test::noop_assets());
+        context.config_mut().identifier = dev_identifier;
+        let app = tauri::test::mock_builder()
+            .build(context)
+            .expect("build a mock Tauri app for its path resolver");
+
+        assert_eq!(
+            platform_root(app.handle()).unwrap(),
+            typescript_data_root(),
+            "the dev identifier must not split the recorder from the sidecar"
+        );
     }
 }

--- a/apps/epicenter/src-tauri/src/recorder/blob.rs
+++ b/apps/epicenter/src-tauri/src/recorder/blob.rs
@@ -20,7 +20,12 @@
 //! partial byte stream: incomplete capture has temporary staging state and no
 //! permanent blob identity.
 
+// `File` is read-only-open territory: the `cfg(unix)` `sync_directory` below and
+// the tests' `File::create`. Windows non-test builds compile neither, so the
+// import is gated to match or it warns as unused there.
+#[cfg(any(unix, test))]
 use std::fs::File;
+use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -341,10 +346,20 @@ pub fn read_blob_samples(app: &AppHandle, id: &str) -> Result<Vec<f32>, Recorder
 ///
 /// By path rather than by handle because the writer that produced the file has
 /// already been consumed by the time it is published: `hound`'s `finalize` takes
-/// the writer by value. Opening read-only is enough, since `fsync` acts on the
-/// file the descriptor names rather than on the descriptor's access mode.
+/// the writer by value.
+///
+/// Opened for *writing* rather than reading, even though nothing is written
+/// here. `sync_all` is `FlushFileBuffers` on Windows, which the API documents as
+/// requiring a handle with write access: a read-only handle fails it with
+/// `ERROR_ACCESS_DENIED` (os error 5), which took down every native recording
+/// on Windows at the first rung of `publish`'s durability ladder. Unix `fsync`
+/// is happy either way, so one write-opened handle serves both platforms and
+/// there is no `cfg` to keep in step (unlike `sync_directory` below, where the
+/// two platforms genuinely differ).
 fn sync_file(path: &Path) -> Result<(), RecorderError> {
-    File::open(path)
+    OpenOptions::new()
+        .write(true)
+        .open(path)
         .and_then(|file| file.sync_all())
         .map_err(|error| RecorderError::failed(format!("sync {}: {error}", path.display())))
 }


### PR DESCRIPTION
Two defects in `apps/epicenter`'s host, each of which on its own stops dictation on Windows before a transcript can exist. Neither is reachable from a Linux or macOS run, and until the crate could be built and its tests started on Windows at all (#2498) nothing here had ever executed on the platform.

The first is that no native recording could ever be saved. `sync_file` opened the staged blob read-only and called `sync_all`, which on Windows is `FlushFileBuffers` — an API documented as requiring a handle with write access, and which fails a read-only handle with `ERROR_ACCESS_DENIED`. That call is the first rung of `publish`'s durability ladder, so publishing died there every time. Unix `fsync` is happy with a read-only descriptor, which is why this never surfaced anywhere else. Opening for writing is enough; nothing is actually written, and one write-opened handle serves both platforms, so unlike `sync_directory` just below it there is no `cfg` pair to keep in step.

The second splits the data root in dev builds. This module exists to mirror `epicenterDataRoot()` in `packages/constants/src/app-data.ts`, which is the authority, and the equality is pinned by a test rather than by inspection — but it mirrored the authority's *result on one config* instead of its inputs. It called Tauri's `app_data_dir()`, which is the platform data directory joined with the running config's bundle identifier, while the TypeScript joins a constant. `tauri.dev.conf.json` overrides the identifier to `so.epicenter.dev` so the dev build is a separate application, with its own window state, webview data and deep-link registration. The data root is not part of that separation: the sidecar resolves `so.epicenter` unconditionally. So a dev host wrote recordings into a `blobs/` the sidecar never served, and every dev dictation 404'd before it could reach transcription. Resolving `data_dir()` and joining the shared identifier constant performs the authority's two steps in the authority's order, and no config's identifier can move the root again.

The equality test could not have caught that, because it reads `tauri.conf.json` and so only ever saw the production identifier. The test added here loads the dev config instead, asserts that it does still override the identifier — otherwise the test proves nothing and says so — and pins the property that actually matters: that the override does not move the root.

One thing I found in this file and deliberately did not touch: `resolve_data_root` refuses a relative override in order to match `epicenterDataRoot` exactly, but on Windows Rust's `Path::is_absolute` requires a drive or UNC prefix where Node's `isAbsolute` accepts a bare rooted path, so the two disagree about a value like `\data\epicenter` and this module's one invariant does not actually hold there. Which of the two should move is a decision about the authority rather than about this change, so it is not in here.

This is not stacked on anything. It touches `app_data.rs` and `recorder/blob.rs`, which are disjoint from both #2498 (`Cargo.toml`, `build.rs`, `icons/`, `lib.rs`) and #2499 (`transcription/model_cache.rs`), so the three merge in any order. The one dependency is for checking rather than merging: until #2498 lands, this branch on its own cannot be compiled or tested on Windows.

## Changelog

- Fix recordings failing to save on Windows
- Fix a dev build writing recordings to a directory the sidecar does not serve

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/2502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791455963&installation_model_id=20236&pr_number=2502&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F2502&signature=1362b6abc537029529538da0f939628d762fd787e9809627ce9ddf003f570a66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->